### PR TITLE
Added containsTarget to teamsApp navigation

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -16,46 +16,48 @@
     <!-- Adds ContainsTarget attribute to navigation properties -->
 
     <xsl:template match="
-                  edm:EntityType[@Name='plannerUser']/edm:NavigationProperty[@Name='plans']|
-                  edm:EntityType[@Name='plannerUser']/edm:NavigationProperty[@Name='tasks']|
-                  edm:EntityType[@Name='plannerPlan']/edm:NavigationProperty[@Name='tasks']|
-                  edm:EntityType[@Name='plannerPlan']/edm:NavigationProperty[@Name='buckets']|
-                  edm:EntityType[@Name='plannerBucket']/edm:NavigationProperty[@Name='tasks']|
-                  edm:EntityType[@Name='plannerGroup']/edm:NavigationProperty[@Name='plans']|
-                  edm:EntityType[@Name='plannerUser']/edm:NavigationProperty[@Name='all']|
-                  edm:EntityType[@Name='itemActivityStat']/edm:NavigationProperty[@Name='activities']|
-                  edm:EntityType[@Name='windowsWifiEnterpriseEAPConfiguration']/edm:NavigationProperty[@Name='rootCertificatesForServerValidation']|
-                  edm:EntityType[@Name='iosEnterpriseWiFiConfiguration']/edm:NavigationProperty[@Name='rootCertificatesForServerValidation']|
-                  edm:EntityType[@Name='windowsUniversalAppX']/edm:NavigationProperty[@Name='committedContainedApps']|
                   edm:EntityType[@Name='androidDeviceOwnerScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
+                  edm:EntityType[@Name='androidForWorkImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:EntityType[@Name='androidForWorkPkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:EntityType[@Name='androidForWorkScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
-                  edm:EntityType[@Name='androidForWorkImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:EntityType[@Name='androidImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:EntityType[@Name='androidPkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:EntityType[@Name='androidScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:EntityType[@Name='androidWorkProfilePkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:EntityType[@Name='androidWorkProfileScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
+                  edm:EntityType[@Name='appVulnerabilityTask']/edm:NavigationProperty[@Name='managedDevices']|
+                  edm:EntityType[@Name='appVulnerabilityTask']/edm:NavigationProperty[@Name='mobileApps']|
+                  edm:EntityType[@Name='deviceManagementAbstractComplexSettingInstance']/edm:NavigationProperty[@Name='value']|
+                  edm:EntityType[@Name='deviceManagementCollectionSettingInstance']/edm:NavigationProperty[@Name='value']|
+                  edm:EntityType[@Name='deviceManagementComplexSettingInstance']/edm:NavigationProperty[@Name='value']|
+                  edm:EntityType[@Name='iosEnterpriseWiFiConfiguration']/edm:NavigationProperty[@Name='rootCertificatesForServerValidation']|
+                  edm:EntityType[@Name='iosImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
+                  edm:EntityType[@Name='iosPkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
+                  edm:EntityType[@Name='iosScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
+                  edm:EntityType[@Name='itemActivityStat']/edm:NavigationProperty[@Name='activities']|
                   edm:EntityType[@Name='macOSImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:EntityType[@Name='macOSPkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:EntityType[@Name='macOSScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
-                  edm:EntityType[@Name='iosPkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
-                  edm:EntityType[@Name='iosScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
-                  edm:EntityType[@Name='iosImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
-                  edm:EntityType[@Name='windows10ImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
-                  edm:EntityType[@Name='windowsPhone81ImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
-                  edm:EntityType[@Name='windows10CertificateProfileBase']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
-                  edm:EntityType[@Name='windows81SCEPCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
-                  edm:EntityType[@Name='deviceManagementCollectionSettingInstance']/edm:NavigationProperty[@Name='value']|
-                  edm:EntityType[@Name='deviceManagementAbstractComplexSettingInstance']/edm:NavigationProperty[@Name='value']|
-                  edm:EntityType[@Name='deviceManagementComplexSettingInstance']/edm:NavigationProperty[@Name='value']|
                   edm:EntityType[@Name='onPremisesAgent']/edm:NavigationProperty[@Name='agentGroups']|
-                  edm:EntityType[@Name='publishedResource']/edm:NavigationProperty[@Name='agentGroups']|
                   edm:EntityType[@Name='onPremisesAgentGroup']/edm:NavigationProperty[@Name='agents']|
                   edm:EntityType[@Name='onPremisesAgentGroup']/edm:NavigationProperty[@Name='publishedResources']|
-                  edm:EntityType[@Name='appVulnerabilityTask']/edm:NavigationProperty[@Name='managedDevices']|
-                  edm:EntityType[@Name='appVulnerabilityTask']/edm:NavigationProperty[@Name='mobileApps']|
-                  edm:EntityType[@Name='onPremisesPublishingProfile']/edm:NavigationProperty[@Name='agents']">
+                  edm:EntityType[@Name='onPremisesPublishingProfile']/edm:NavigationProperty[@Name='agents']|
+                  edm:EntityType[@Name='plannerBucket']/edm:NavigationProperty[@Name='tasks']|
+                  edm:EntityType[@Name='plannerGroup']/edm:NavigationProperty[@Name='plans']|
+                  edm:EntityType[@Name='plannerPlan']/edm:NavigationProperty[@Name='buckets']|
+                  edm:EntityType[@Name='plannerPlan']/edm:NavigationProperty[@Name='tasks']|
+                  edm:EntityType[@Name='plannerUser']/edm:NavigationProperty[@Name='all']|
+                  edm:EntityType[@Name='plannerUser']/edm:NavigationProperty[@Name='plans']|
+                  edm:EntityType[@Name='plannerUser']/edm:NavigationProperty[@Name='tasks']|
+                  edm:EntityType[@Name='publishedResource']/edm:NavigationProperty[@Name='agentGroups']|
+                  edm:EntityType[@Name='teamsApp']/edm:NavigationProperty[@Name='appDefinitions']|
+                  edm:EntityType[@Name='windows10CertificateProfileBase']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
+                  edm:EntityType[@Name='windows10ImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
+                  edm:EntityType[@Name='windows81SCEPCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
+                  edm:EntityType[@Name='windowsPhone81ImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
+                  edm:EntityType[@Name='windowsUniversalAppX']/edm:NavigationProperty[@Name='committedContainedApps']|
+                  edm:EntityType[@Name='windowsWifiEnterpriseEAPConfiguration']/edm:NavigationProperty[@Name='rootCertificatesForServerValidation']                         
+                         ">
       <!-- Didn't add the rule for teamsAppDefinition and unifiedRoleDefinition since it doesn't
            look like we applied it, and I don't see any issues because of it.
            Didn't apply the rule for labelPolicy as it appears the API changed since this was set. -->


### PR DESCRIPTION
`edm:EntityType[@Name='teamsApp']/edm:NavigationProperty[@Name='appDefinitions']`

Sorted the containsTarget rules

Why? Because teamsAppDefinition isn't in an entityset.


      <EntityType Name="teamsApp" BaseType="graph.entity">
        <Property Name="externalId" Type="Edm.String" />
        <Property Name="displayName" Type="Edm.String" />
        <Property Name="distributionMethod" Type="graph.teamsAppDistributionMethod" />
        <NavigationProperty Name="appDefinitions" Type="Collection(graph.teamsAppDefinition)" />
      </EntityType>
      <EntityType Name="teamsAppDefinition" BaseType="graph.entity">
        <Property Name="teamsAppId" Type="Edm.String" />
        <Property Name="displayName" Type="Edm.String" />
        <Property Name="version" Type="Edm.String" />
      </EntityType>
 
This is a mitigation until the fix goes in to the metadata.