### PR TITLE
Validate cleaned CSDL metadata with typewriter

### DIFF
--- a/pipelines/validateCleanedMetadata_beta.yml
+++ b/pipelines/validateCleanedMetadata_beta.yml
@@ -1,0 +1,182 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Validates that the /beta CSDL is actually clean before we publish an artifact.
+
+# This pipeline clones the msgraph-metadata, msgraph-beta-sdk-dotnet, and the microsoft-graph-docs
+# repos. It transforms the metadata using typewriter.exe transform options and
+# applies documentation annotations from the docs repo. It then generates the .NET
+# code files, and validates that the generated code files will successfully compile.
+# The clean metadata is then published as an artifact so that it can be consumed
+# in a chained pipeline that will publish the clean metadata to our metadata repo.
+
+name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+
+trigger: none # disable triggers based on commits.
+pr: none # disable triggers based on pull requests.
+
+# TODO: verify that this triggers the rest of the beta pipeline.
+
+resources:
+  repositories:
+  - repository: msgraph-beta-sdk-dotnet # The name used to reference this repository in the checkout step
+    type: github
+    endpoint: microsoftgraph
+    name: microsoftgraph/msgraph-beta-sdk-dotnet
+    ref: master # checkout the master branch
+  - repository: microsoft-graph-docs
+    type: github
+    endpoint: microsoftgraph
+    name: microsoftgraph/microsoft-graph-docs
+  pipelines:
+  - pipeline: prepareMetadata # This pipeline produces an metadata artifact that we need to validate.
+    source: (beta - 1) msgraph-capture-metadata
+    trigger: # TODO: validate that this pipeline triggers as expected.
+      branches:
+      - master
+
+pool:
+  name: Hosted VS2017
+  demands:
+  - msbuild
+
+variables:
+  - group: MicrosoftGraph # Variable group, where variables not set here come from.
+  - name: endpoint
+    value: beta
+
+steps:
+- checkout: self # msgraph-metadata, or whatever repo contains
+  clean: true
+  fetchDepth: 1
+- checkout: msgraph-beta-sdk-dotnet
+  clean: true
+  fetchDepth: 1
+- checkout: microsoft-graph-docs
+  clean: true
+  fetchDepth: 1
+
+- task: PowerShell@2 # Setup environment variables and make them available to all tasks. See [1] for more info.
+  displayName: 'Calculate and set pipeline variables for this job'
+  inputs:
+    targetType: inline
+    script: |
+
+      if ($env:endpoint -eq 'beta')
+      {
+        $pathToInputMetadata = $env:System_ArtifactsDirectory + "\metadata_beta\" + $env:metadata_betafilename
+      }
+      else
+      {
+        $pathToInputMetadata = $env:System_ArtifactsDirectory + "\metadata_v10\" + $env:metadata_v10filename
+      }
+      Write-Host "Path to input metadata is $pathToInputMetadata"
+      Write-Host "##vso[task.setvariable variable=pathToInputMetadata]$pathToInputMetadata"
+
+      $pathToDocsRepoRoot = Join-Path $env:Build_SourcesDirectory "microsoft-graph-docs" -Resolve
+      Write-Host "Path to docs repo is $pathToDocsRepoRoot"
+      Write-Host "##vso[task.setvariable variable=pathToDocsRepoRoot]$pathToDocsRepoRoot"
+
+      $outputPath = Join-Path $env:Build_SourcesDirectory "output"
+      Write-Host "Path to typewriter.exe output $outputPath"
+      Write-Host "##vso[task.setvariable variable=outputPath]$outputPath"
+
+      $cleanMetadataDescriptionFileName = "cleanMetadataWithDescriptions" + $env:endpoint + ".xml"
+      $cleanMetadata = Join-Path $outputPath $cleanMetadataDescriptionFileName
+      Write-Host "Path to clean metadata $cleanMetadata"
+      Write-Host "##vso[task.setvariable variable=cleanMetadata]$cleanMetadata"
+
+- task: PowerShell@2
+  displayName: 'DEBUG: Script to show how to access the pipeline variables'
+  inputs:
+    targetType: inline
+    script: |
+      Write-Host "Path to input $env:pathToInputMetadata"
+      Write-Host "Path to repo root $env:pathToDocsRepoRoot"
+
+- task: DownloadBuildArtifacts@0
+  displayName: 'Download documented and clean beta CSDL metadata artifact'
+  inputs:
+    buildType: specific
+    project: '2f15a0d3-3217-4778-8334-4e61181c4029'
+    pipeline: 2264
+    specificBuildWithTriggering: true
+    artifactName: 'metadata_beta'
+    downloadPath: '$(System.ArtifactsDirectory)'
+
+- task: PowerShell@2
+  displayName: 'Typewriter: transform via preprocess_csdl.xsl and add documentation to the CSDL'
+  inputs:
+    targetType: filePath
+    filePath: '$(Build.SourcesDirectory)/msgraph-metadata/scripts/runTypewriter.ps1'
+    arguments: '-verbosity Info -metadata $(pathToInputMetadata) -output $(outputPath) -generationMode TransformWithDocs -t https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/transforms/csdl/preprocess_csdl.xsl -d $(pathToDocsRepoRoot) -cleanup $false -e beta'
+    workingDirectory: '$(Build.SourcesDirectory)'
+  enabled: true
+
+- task: PowerShell@2
+  displayName: 'Typewriter: generate beta .NET files'
+  inputs:
+    targetType: filePath
+    filePath: '$(Build.SourcesDirectory)/msgraph-metadata/scripts/runTypewriter.ps1'
+    arguments: '-verbosity Info -metadata $(cleanMetadata) -output $(outputPath) -generationMode Files -e beta'
+    workingDirectory: '$(Build.SourcesDirectory)' # Set the root for a multi-repo pipeline. /s
+  enabled: true
+
+- task: PowerShell@2
+  displayName: 'Copy generated files'
+  inputs:
+    targetType: filePath
+    filePath: '$(Build.SourcesDirectory)/msgraph-metadata/scripts/copyGeneratedFiles.ps1'
+    arguments: '@("$(outputPath)/com/microsoft/graph/model/", "$(outputPath)/com/microsoft/graph/requests/") @("$(Build.SourcesDirectory)/msgraph-beta-sdk-dotnet/src/Microsoft.Graph/Models/Generated/", "$(Build.SourcesDirectory)/msgraph-beta-sdk-dotnet/src/Microsoft.Graph/Requests/Generated/")'
+    workingDirectory: '$(Build.SourcesDirectory)' # Set the root for a multi-repo pipeline. /s
+  enabled: true
+
+# Restore and build the .NET client library. If it doesn't build, then fail the task.
+- task: DotNetCoreCLI@2
+  displayName: 'Restore Nuget packages'
+  inputs:
+    command: 'restore'
+    projects: '$(Build.SourcesDirectory)/msgraph-beta-sdk-dotnet/**/*.csproj'
+    feedsToUse: 'select'
+  enabled: true
+
+- task: MSBuild@1
+  displayName: 'Build .NET solution with generated files as smoke test'
+  inputs:
+    solution: '$(Build.SourcesDirectory)/msgraph-beta-sdk-dotnet/**/*.sln'
+    configuration: debug
+    clean: true
+  enabled: true
+
+# Artifact will be used in another pipeline to checkin the clean metadata into
+# the GitHub repo. Then it will be used by other pipelines to generate the files.
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: clean beta metadata to checkin with the next pipeline'
+  inputs:
+    PathtoPublish: '$(outputPath)\cleanMetadataWithDescriptionsbeta.xml'
+    ArtifactName: 'clean_beta_metadata'
+  enabled: true
+
+# Send a notification to our Graph Tooling channel to let us know that
+# automated build failed.
+
+- task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0
+  displayName: 'Graph Client Tooling pipeline fail notification'
+  inputs:
+    addressType: serviceEndpoint
+    serviceEndpointName: 'microsoftgraph pipeline status'
+    title: '$(Build.DefinitionName) failure notification'
+    text: 'This pipeline has failed. View the build details for further information. This is a blocking failure. '
+  condition: and(failed(), ne(variables['Build.Reason'], 'Manual')) # Only notify if the automated build failed.
+  enabled: true
+
+# References:
+# [0] https://docs.microsoft.com/en-us/azure/devops/pipelines/library/variable-groups?view=azure-devops&tabs=yaml
+# [1] https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#resources
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#pipeline-triggers
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/?view=azure-devops
+
+# Potential next steps
+# - refactor and templatize much of this and share with the validateCleanedMetadata_v1.0.yml pipeline.

--- a/pipelines/validateCleanedMetadata_v1.0.yml
+++ b/pipelines/validateCleanedMetadata_v1.0.yml
@@ -1,0 +1,180 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Validates that the /v1.0 CSDL is actually clean before we publish an artifact.
+
+# This pipeline clones the msgraph-metadata, msgraph-sdk-dotnet, and the microsoft-graph-docs
+# repos. It transforms the metadata using typewriter.exe transform options and
+# applies documentation annotations from the docs repo. It then generates the .NET
+# code files, and validates that the generated code files will successfully compile.
+# The clean metadata is then published as an artifact so that it can be consumed
+# in a chained pipeline that will publish the clean metadata to our metadata repo.
+
+name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+
+trigger: none # disable triggers based on commits.
+pr: none # disable triggers based on pull requests.
+
+resources:
+  repositories:
+  - repository: msgraph-sdk-dotnet # The name used to reference this repository in the checkout step
+    type: github
+    endpoint: microsoftgraph
+    name: microsoftgraph/msgraph-sdk-dotnet
+    ref: dev # checkout the dev branch
+  - repository: microsoft-graph-docs
+    type: github
+    endpoint: microsoftgraph
+    name: microsoftgraph/microsoft-graph-docs
+  pipelines:
+  - pipeline: prepareMetadata # This pipeline produces an metadata artifact that we need to validate.
+    source: (v1.0 - 1) msgraph-capture-metadata
+    trigger: # TODO: validate that this pipeline triggers as expected.
+      branches:
+      - master
+
+pool:
+  name: Hosted VS2017
+  demands:
+  - msbuild
+
+variables:
+  - group: MicrosoftGraph # Variable group, where variables not set here come from.
+  - name: endpoint
+    value: v1.0
+
+steps:
+- checkout: self # msgraph-metadata, or whatever repo contains
+  clean: true
+  fetchDepth: 1
+- checkout: msgraph-sdk-dotnet
+  clean: true
+  fetchDepth: 1
+- checkout: microsoft-graph-docs
+  clean: true
+  fetchDepth: 1
+
+- task: PowerShell@2 # Setup environment variables and make them available to all tasks. See [1] for more info.
+  displayName: 'Calculate and set pipeline variables for this job'
+  inputs:
+    targetType: inline
+    script: |
+
+      if ($env:endpoint -eq 'beta')
+      {
+        $pathToInputMetadata = $env:System_ArtifactsDirectory + "\metadata_beta\" + $env:metadata_betafilename
+      }
+      else
+      {
+        $pathToInputMetadata = $env:System_ArtifactsDirectory + "\metadata_v10\" + $env:metadata_v10filename
+      }
+      Write-Host "Path to input metadata is $pathToInputMetadata"
+      Write-Host "##vso[task.setvariable variable=pathToInputMetadata]$pathToInputMetadata"
+
+      $pathToDocsRepoRoot = Join-Path $env:Build_SourcesDirectory "microsoft-graph-docs" -Resolve
+      Write-Host "Path to docs repo is $pathToDocsRepoRoot"
+      Write-Host "##vso[task.setvariable variable=pathToDocsRepoRoot]$pathToDocsRepoRoot"
+
+      $outputPath = Join-Path $env:Build_SourcesDirectory "output"
+      Write-Host "Path to typewriter.exe output $outputPath"
+      Write-Host "##vso[task.setvariable variable=outputPath]$outputPath"
+
+      $cleanMetadataDescriptionFileName = "cleanMetadataWithDescriptions" + $env:endpoint + ".xml"
+      $cleanMetadata = Join-Path $outputPath $cleanMetadataDescriptionFileName
+      Write-Host "Path to clean metadata $cleanMetadata"
+      Write-Host "##vso[task.setvariable variable=cleanMetadata]$cleanMetadata"
+
+- task: PowerShell@2
+  displayName: 'DEBUG: Script to show how to access the pipeline variables'
+  inputs:
+    targetType: inline
+    script: |
+      Write-Host "Path to input $env:pathToInputMetadata"
+      Write-Host "Path to repo root $env:pathToDocsRepoRoot"
+
+- task: DownloadBuildArtifacts@0
+  displayName: 'Download documented and clean v1.0 CSDL metadata artifact'
+  inputs:
+    buildType: specific
+    project: '2f15a0d3-3217-4778-8334-4e61181c4029'
+    pipeline: 2202
+    specificBuildWithTriggering: true
+    artifactName: 'metadata_v10'
+    downloadPath: '$(System.ArtifactsDirectory)'
+
+- task: PowerShell@2
+  displayName: 'Typewriter: transform via preprocess_csdl.xsl and add documentation to the CSDL'
+  inputs:
+    targetType: filePath
+    filePath: '$(Build.SourcesDirectory)/msgraph-metadata/scripts/runTypewriter.ps1'
+    arguments: '-verbosity Info -metadata $(pathToInputMetadata) -output $(outputPath) -generationMode TransformWithDocs -t https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/transforms/csdl/preprocess_csdl.xsl -d $(pathToDocsRepoRoot) -cleanup $false'
+    workingDirectory: '$(Build.SourcesDirectory)'
+  enabled: true
+
+- task: PowerShell@2
+  displayName: 'Typewriter: generate v1.0 .NET files'
+  inputs:
+    targetType: filePath
+    filePath: '$(Build.SourcesDirectory)/msgraph-metadata/scripts/runTypewriter.ps1'
+    arguments: '-verbosity Info -metadata $(cleanMetadata) -output $(outputPath) -generationMode Files'
+    workingDirectory: '$(Build.SourcesDirectory)' # Set the root for a multi-repo pipeline. /s
+  enabled: true
+
+- task: PowerShell@2
+  displayName: 'Copy generated files'
+  inputs:
+    targetType: filePath
+    filePath: '$(Build.SourcesDirectory)/msgraph-metadata/scripts/copyGeneratedFiles.ps1'
+    arguments: '@("$(outputPath)/com/microsoft/graph/model/", "$(outputPath)/com/microsoft/graph/requests/") @("$(Build.SourcesDirectory)/msgraph-sdk-dotnet/src/Microsoft.Graph/Models/Generated/", "$(Build.SourcesDirectory)/msgraph-sdk-dotnet/src/Microsoft.Graph/Requests/Generated/")'
+    workingDirectory: '$(Build.SourcesDirectory)' # Set the root for a multi-repo pipeline. /s
+  enabled: true
+
+# Restore and build the .NET client library. If it doesn't build, then fail the task.
+- task: DotNetCoreCLI@2
+  displayName: 'Restore Nuget packages'
+  inputs:
+    command: 'restore'
+    projects: '$(Build.SourcesDirectory)/msgraph-sdk-dotnet/**/*.csproj'
+    feedsToUse: 'select'
+  enabled: true
+
+- task: MSBuild@1
+  displayName: 'Build .NET solution with generated files as smoke test'
+  inputs:
+    solution: '$(Build.SourcesDirectory)/msgraph-sdk-dotnet/**/*.sln'
+    configuration: debug
+    clean: true
+  enabled: true
+
+# Artifact will be used in another pipeline to checkin the clean metadata into
+# the GitHub repo. Then it will be used by other pipelines to generate the files.
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: clean v1.0 metadata to checkin with the next pipeline'
+  inputs:
+    PathtoPublish: '$(outputPath)\cleanMetadataWithDescriptionsv1.0.xml'
+    ArtifactName: 'clean_v10_metadata'
+  enabled: true
+
+# Send a notification to our Graph Tooling channel to let us know that
+# automated build failed.
+
+- task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0
+  displayName: 'Graph Client Tooling pipeline fail notification'
+  inputs:
+    addressType: serviceEndpoint
+    serviceEndpointName: 'microsoftgraph pipeline status'
+    title: '$(Build.DefinitionName) failure notification'
+    text: 'This pipeline has failed. View the build details for further information. This is a blocking failure. '
+  condition: and(failed(), ne(variables['Build.Reason'], 'Manual')) # Only notify if the automated build failed.
+  enabled: true
+
+# References:
+# [0] https://docs.microsoft.com/en-us/azure/devops/pipelines/library/variable-groups?view=azure-devops&tabs=yaml
+# [1] https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#resources
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#pipeline-triggers
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/?view=azure-devops
+
+# Potential next steps
+# - refactor and templatize much of this and share with the validateCleanedMetadata_v1.0.yml pipeline.

--- a/scripts/copyGeneratedFiles.ps1
+++ b/scripts/copyGeneratedFiles.ps1
@@ -4,7 +4,7 @@
 <#
 .Synopsis
     Moves files from a source array of directories into the destination array
-    of directories.
+    of directories.  NOTE: all files will be removed from the destination array prior to copy.
 
 .Example
     .\scripts\copyGeneratedFiles.ps1 @("D:\temp\democopy\from\1", "D:\temp\democopy\from\2") @("D:\temp\democopy\to\3", "D:\temp\democopy\to\4")

--- a/scripts/copyGeneratedFiles.ps1
+++ b/scripts/copyGeneratedFiles.ps1
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+.Synopsis
+    Moves files from a source array of directories into the destination array
+    of directories.
+
+.Example
+    .\scripts\copyGeneratedFiles.ps1 @("D:\temp\democopy\from\1", "D:\temp\democopy\from\2") @("D:\temp\democopy\to\3", "D:\temp\democopy\to\4")
+
+.Parameter fromPath
+    Required. An array of strings that represent the fully qualified directory
+    paths for copying generated files. The order of directory names is significant.
+
+.Parameter toPath
+    Required. An array of strings that represent the fully qualified destination
+    directory paths for copying generated files. The order of directory names is significant.
+#>
+Param(
+    [parameter(Mandatory = $true)][string[]]$fromPath,
+    [parameter(Mandatory = $true)][string[]]$toPath
+)
+
+# Validate arguments
+if ($fromPath.Count -ne $toPath.Count)
+{
+    Write-Host "The fromPath and toPath arrays must have matching elements." -ForegroundColor Red
+    Write-Host "##vso[task.complete result=Failed;]DONE"
+    exit 1
+}
+$allPaths = $fromPath + $toPath
+foreach ($dirPath in $allPaths)
+{
+    if ((Test-Path -PathType Container -Path $dirPath) -ne $true)
+    {
+        Write-Host "Argument contains invalid path to a directory: $dirPath" -ForegroundColor Red
+        Write-Host "##vso[task.complete result=Failed;]DONE"
+        exit 1
+    }
+}
+
+# Remove the code files from the toPath
+foreach ($destination in $toPath)
+{
+    Remove-Item -Recurse $destination
+    Write-Host "Removed the existing generated files in $destination" -ForegroundColor Green
+}
+
+# Copy generated files to the repo.
+for ($i=0; $i -lt $toPath.Count; $i++)
+{
+    $from = $fromPath[$i]
+    $to = $toPath[$i]
+
+    Move-Item $from $to
+    Write-Host "Moved the code files from $from into $to." -ForegroundColor Green
+}

--- a/scripts/runTypewriter.ps1
+++ b/scripts/runTypewriter.ps1
@@ -62,6 +62,10 @@
 .Parameter generationMode
     Optional. Specifies the typewriter.exe generation mode.
     See https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator#using-typewriter for more information.
+
+.Parameter cleanup
+    Optional, with a default value of $true. Specifies whether this script should remove the downloaded
+    typewrites files.
 #>
 
 Param(
@@ -88,9 +92,7 @@ $typewriter = Join-Path $tempDir "typewriter.exe"
 
 # Create our temporary working directory.
 if ((Test-Path -PathType Container -Path $tempDir)) {
-    # Remove-Item $tempDir -Force -Recurse
-    # Write-Host "Deleted $tempDir"
-    Write-Host "$tempDir already exists"
+    Write-Host "$tempDir already exists" # We may want to run this script multiple times in a pipeline.
 } else {
     New-Item -Path $tempDir -Type Directory
     Write-Host "Created $tempDir"
@@ -125,6 +127,8 @@ if ((Test-Path -Path $typewriter -PathType leaf) -ne $true)
     else {
         Write-Error 'typewriter.zip was not found using the release API. Check the release on GitHub. Make sure that
         you have not changed the name of the file, or that the GitHub API has not changed.'
+        Write-Host "##vso[task.complete result=Failed;]DONE"
+        exit 1
     }
 
     # Unzip and move typewriter.exe to the temp directory.
@@ -140,6 +144,8 @@ Write-Host "With options: $options"  -ForegroundColor Green
 if ($LASTEXITCODE)
 {
     Write-Error "Typewriter failed to complete with the following options: $options"
+    Write-Host "##vso[task.complete result=Failed;]DONE"
+    exit 1
 }
 
 # Delete typewriter files.

--- a/scripts/runTypewriter.ps1
+++ b/scripts/runTypewriter.ps1
@@ -65,7 +65,7 @@
 
 .Parameter cleanup
     Optional, with a default value of $true. Specifies whether this script should remove the downloaded
-    typewrites files.
+    typewrites files at the end of this script.
 #>
 
 Param(
@@ -92,11 +92,13 @@ $typewriter = Join-Path $tempDir "typewriter.exe"
 
 # Create our temporary working directory.
 if ((Test-Path -PathType Container -Path $tempDir)) {
-    Write-Host "$tempDir already exists" # We may want to run this script multiple times in a pipeline.
-} else {
-    New-Item -Path $tempDir -Type Directory
-    Write-Host "Created $tempDir"
+    Write-Host "$tempDir already exists"
+    Remove-Item $tempDir -Force -Recurse
+    Write-Host "Removed $tempDir"
 }
+New-Item -Path $tempDir -Type Directory
+Write-Host "Created $tempDir"
+
 
 # Create the typewriter.exe command line arguments from script arguments.
 $options = @()
@@ -112,6 +114,7 @@ if ($transform)              { $options += "-t"; $options += "$transform"}
 if ($output)                 { $options += "-o"; $options += "$output"}
 if ($generationMode)         { $options += "-g"; $options += "$generationMode"}
 
+# Only attempt to download and unpack typewriter if it isn't available.
 if ((Test-Path -Path $typewriter -PathType leaf) -ne $true)
 {
     # Get information about the GitHub releases.

--- a/scripts/runTypewriter.ps1
+++ b/scripts/runTypewriter.ps1
@@ -1,0 +1,150 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+.Synopsis
+    Runs typewriter.exe to generate code files from the metadata.
+
+.Description
+    Uses the GitHub Release API to get the latest typewriter.exe release from the
+    MSGraph-SDK-Code-Generator repo. typewriter.exe is run against the metadata
+    and the generated files are put into the repo. At this point, the changes
+    can be manually commited and pushed. This script is expected to work locally
+    and via Azure Pipelines.
+
+    Run this script at the repo root.
+
+.Example
+    .\scripts\runTypewriter.ps1 -verbosity Info -metadata https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/v1.0_metadata.xml -output D:\repos\temp -generationMode Transform -t https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/transforms/csdl/preprocess_csdl.xsl
+
+.Example
+    .\scripts\runTypewriter.ps1 -verbosity Info -metadata https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/v1.0_metadata.xml -output D:\repos\temp -generationMode TransformWithDocs -t https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/transforms/csdl/preprocess_csdl.xsl -d D:\repos\microsoft-graph-docs
+
+.Example
+    .\scripts\runTypewriter.ps1 -verbosity Info -metadata https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsv1.0.xml -output D:\repos\temp -generationMode Files
+
+.Parameter metadata
+    Required. Specifies the URI of the metadata used for generation.
+    See https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator#using-typewriter for more information.
+
+.Parameter language
+    Optional. Specifies the language to use when generating code files. CSharp is the default.
+    See https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator#using-typewriter for more information.
+
+.Parameter verbosity
+    Optional. Specifies the typewriter.exe verbosity.
+    See https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator#using-typewriter for more information.
+
+.Parameter docs
+    Optional. Specifies the path to the root of the local documentation repo.
+    See https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator#using-typewriter for more information.
+
+.Parameter outputMetadataFileName
+    Optional. Specifies the name of the output metadata file name.
+    See https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator#using-typewriter for more information.
+
+.Parameter endpointVersion
+    Optional. Specifies the 'v1.0' or 'beta' endpoint name. The default is 'v1.0'.
+    See https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator#using-typewriter for more information.
+
+.Parameter properties
+    Optional. Custom properties to be passed to the generator.
+    See https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator#using-typewriter for more information.
+
+.Parameter transform
+    Optional. The path to the transform XSLT for cleaning up the metadata file.
+    See https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator#using-typewriter for more information.
+
+.Parameter output
+    Optional. The output path of the generated files. Typewriter creates this directory if it doesn't exist.
+    See https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator#using-typewriter for more information.
+
+.Parameter generationMode
+    Optional. Specifies the typewriter.exe generation mode.
+    See https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator#using-typewriter for more information.
+#>
+
+Param(
+    [parameter(Mandatory = $false)][string]$metadata,
+    [parameter(Mandatory = $false)][string]$language,
+    [parameter(Mandatory = $false)][string]$verbosity,
+    [parameter(Mandatory = $false)][string]$docs,
+    [parameter(Mandatory = $false)][string]$outputMetadataFileName,
+    [parameter(Mandatory = $false)][string]$endpointVersion,
+    [parameter(Mandatory = $false)][string]$properties,
+    [parameter(Mandatory = $false)][string]$transform,
+    [parameter(Mandatory = $false)][string]$output,
+    [parameter(Mandatory = $false)][string]$generationMode,
+    [parameter(Mandatory = $false)][bool]$cleanup = $true
+)
+
+# VARIABLES
+$gh_owner_and_repo = 'microsoftgraph/MSGraph-SDK-Code-Generator'    # Org and repo where typewriter.exe is released.
+$tempDir           = '.\temp'
+$LASTEXITCODE      = $null
+$typewriterZipDrop = "$tempDir\typewriter.zip"
+$typewriterFilesDir = "$tempDir\Release\*"
+$typewriter = Join-Path $tempDir "typewriter.exe"
+
+# Create our temporary working directory.
+if ((Test-Path -PathType Container -Path $tempDir)) {
+    # Remove-Item $tempDir -Force -Recurse
+    # Write-Host "Deleted $tempDir"
+    Write-Host "$tempDir already exists"
+} else {
+    New-Item -Path $tempDir -Type Directory
+    Write-Host "Created $tempDir"
+}
+
+# Create the typewriter.exe command line arguments from script arguments.
+$options = @()
+
+if ($verbosity)              { $options += "-v"; $options += "$verbosity" }
+if ($metadata)               { $options += "-m"; $options += "$metadata"}
+if ($language)               { $options += "-l"; $options += "$language"}
+if ($docs)                   { $options += "-d"; $options += "$docs"}
+if ($outputMetadataFileName) { $options += "-f"; $options += "$outputMetadataFileName"}
+if ($endpointVersion)        { $options += "-e"; $options += "$endpointVersion"}
+if ($properties)             { $options += "-p"; $options += "$properties"}
+if ($transform)              { $options += "-t"; $options += "$transform"}
+if ($output)                 { $options += "-o"; $options += "$output"}
+if ($generationMode)         { $options += "-g"; $options += "$generationMode"}
+
+if ((Test-Path -Path $typewriter -PathType leaf) -ne $true)
+{
+    # Get information about the GitHub releases.
+    $feedQuery = "https://api.github.com/repos/$gh_owner_and_repo/releases"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $jsonObject = Invoke-WebRequest -Uri $feedQuery -UseBasicParsing | ConvertFrom-Json
+
+    # Download typewriter from the latest GitHub release.
+    if ($jsonObject.assets[0].name -eq 'typewriter.zip') {
+        $downloadURL = $jsonObject.assets[0].browser_download_url # GitHub release API provides the latest
+        Invoke-WebRequest -Uri $downloadURL -OutFile $typewriterZipDrop -UseBasicParsing -Verbose | Write-Host
+    }
+    else {
+        Write-Error 'typewriter.zip was not found using the release API. Check the release on GitHub. Make sure that
+        you have not changed the name of the file, or that the GitHub API has not changed.'
+    }
+
+    # Unzip and move typewriter.exe to the temp directory.
+    Expand-Archive -LiteralPath $typewriterZipDrop -DestinationPath $tempDir -Force -Verbose | Write-Host
+    Move-Item $typewriterFilesDir $tempDir -Force -Verbose | Write-Host
+}
+
+# Run typewriter with input metadata and output generated code files.
+Write-Host "Running typewriter, $typewriter..."  -ForegroundColor Green
+Write-Host "With options: $options"  -ForegroundColor Green
+& $typewriter $options
+
+if ($LASTEXITCODE)
+{
+    Write-Error "Typewriter failed to complete with the following options: $options"
+}
+
+# Delete typewriter files.
+if ($cleanup -eq $true)
+{
+    Remove-Item -Recurse $tempDir | Write-Host
+    Write-Host 'Removed typewriter files.'  -ForegroundColor Green
+}


### PR DESCRIPTION
* Created v1.0 validation pipeline - this has run successfully.
* Created beta validation pipeline - this still needs validation, requires XSLT changes.
* Created script to download and run the latest release of typewriter.
* Created script to copy generated files.

Script example usage in script files. Expect that we will need to still
validate these changes against a scheduled build to make sure it is
configured appropriately.

	new file:   pipelines/validateCleanedMetadata_beta.yml
	new file:   pipelines/validateCleanedMetadata_v1.0.yml
	new file:   scripts/copyGeneratedFiles.ps1
	new file:   scripts/runTypewriter.ps1