### PR TITLE
Mitigate missing print service metadata

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -50,6 +50,10 @@
                   edm:EntityType[@Name='plannerUser']/edm:NavigationProperty[@Name='all']|
                   edm:EntityType[@Name='plannerUser']/edm:NavigationProperty[@Name='plans']|
                   edm:EntityType[@Name='plannerUser']/edm:NavigationProperty[@Name='tasks']|
+                  edm:EntityType[@Name='printJob']/edm:NavigationProperty[@Name='documents']|
+                  edm:EntityType[@Name='printService']/edm:NavigationProperty[@Name='endpoints']|
+                  edm:EntityType[@Name='printer']/edm:NavigationProperty[@Name='allowedGroups']|
+                  edm:EntityType[@Name='printer']/edm:NavigationProperty[@Name='allowedUsers']|
                   edm:EntityType[@Name='publishedResource']/edm:NavigationProperty[@Name='agentGroups']|
                   edm:EntityType[@Name='teamsApp']/edm:NavigationProperty[@Name='appDefinitions']|
                   edm:EntityType[@Name='windows10CertificateProfileBase']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -63,12 +63,12 @@
                 <NavigationProperty Name="identityCertificateForClientAuthentication" Type="graph.iosCertificateProfileBase" />
                 <NavigationProperty Name="derivedCredentialSettings" Type="graph.deviceManagementDerivedCredentialSettings" />
             </EntityType>
-          <EntityType Name="printJob" BaseType="graph.entity">
-            <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false" />
-            <Property Name="status" Type="graph.printJobStatus" />
-            <Property Name="createdBy" Type="graph.userIdentity" />
-            <NavigationProperty Name="documents" Type="Collection(graph.printDocument)" />
-          </EntityType>
+            <EntityType Name="printJob" BaseType="graph.entity">
+              <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false" />
+              <Property Name="status" Type="graph.printJobStatus" />
+              <Property Name="createdBy" Type="graph.userIdentity" />
+              <NavigationProperty Name="documents" Type="Collection(graph.printDocument)" />
+            </EntityType>
             <EntityType Name="publishedResource" BaseType="graph.entity">
                 <Property Name="displayName" Type="Edm.String" />
                 <Property Name="resourceName" Type="Edm.String" />

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -63,6 +63,12 @@
                 <NavigationProperty Name="identityCertificateForClientAuthentication" Type="graph.iosCertificateProfileBase" />
                 <NavigationProperty Name="derivedCredentialSettings" Type="graph.deviceManagementDerivedCredentialSettings" />
             </EntityType>
+          <EntityType Name="printJob" BaseType="graph.entity">
+            <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false" />
+            <Property Name="status" Type="graph.printJobStatus" />
+            <Property Name="createdBy" Type="graph.userIdentity" />
+            <NavigationProperty Name="documents" Type="Collection(graph.printDocument)" />
+          </EntityType>
             <EntityType Name="publishedResource" BaseType="graph.entity">
                 <Property Name="displayName" Type="Edm.String" />
                 <Property Name="resourceName" Type="Edm.String" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='preprocess_csdl.xsl'?>
-<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+<edmx:Edmx Version="4.0" 
+  xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
   <edmx:DataServices>
-    <Schema Namespace="microsoft.graph" Alias="graph" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+    <Schema Namespace="microsoft.graph" Alias="graph" 
+      xmlns="http://docs.oasis-open.org/odata/ns/edm">
       <EntityType Name="plannerUser" BaseType="graph.entity">
         <NavigationProperty Name="tasks" Type="Collection(graph.plannerTask)" ContainsTarget="true" />
         <NavigationProperty Name="plans" Type="Collection(graph.plannerPlan)" ContainsTarget="true" />
@@ -52,6 +54,12 @@
         <NavigationProperty Name="rootCertificatesForServerValidation" Type="Collection(graph.iosTrustedRootCertificate)" ContainsTarget="true" />
         <NavigationProperty Name="identityCertificateForClientAuthentication" Type="graph.iosCertificateProfileBase" />
         <NavigationProperty Name="derivedCredentialSettings" Type="graph.deviceManagementDerivedCredentialSettings" />
+      </EntityType>
+      <EntityType Name="printJob" BaseType="graph.entity">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="status" Type="graph.printJobStatus" />
+        <Property Name="createdBy" Type="graph.userIdentity" />
+        <NavigationProperty Name="documents" Type="Collection(graph.printDocument)" ContainsTarget="true" />
       </EntityType>
       <EntityType Name="publishedResource" BaseType="graph.entity">
         <Property Name="displayName" Type="Edm.String" />


### PR DESCRIPTION
This fixes the issue found when [validating the beta metadata](https://o365exchange.visualstudio.com/O365%20Sandbox/_build/results?buildId=2664366&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=71c7159a-2554-5189-e11d-21665ca4648a).

To test these changes:
1. Open Visual Studio without a project.
2. Open `preprocess_csdl_test_input.xml`.
3. Select the **XML** menu from the top menu.
4. Select the **Start XSLT Without Debugging** option.

The generated file should match preprocess_csdl_test_output.xml.
The generated file should not match preprocess_csdl_test_input.xml.

Changes to be committed:
	modified:   transforms/csdl/preprocess_csdl.xsl
	modified:   transforms/csdl/preprocess_csdl_test_input.xml
	modified:   transforms/csdl/preprocess_csdl_test_output.xml