### PR TITLE
Add Custom Query Parameters To CalendarView Nav Property

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -97,6 +97,31 @@
         <xsl:element name="Annotation" use-attribute-sets="LongDescriptionNavigable"/>
       </xsl:copy>
     </xsl:template>
+    
+    <!-- Add custom query options to calendarView -->
+    <xsl:attribute-set name="StartDateTimeQueryOption">
+      <xsl:attribute name="Term">Org.OData.Capabilities.V1.CustomQueryOptions</xsl:attribute>
+      <xsl:attribute name="Name">StartDateTime</xsl:attribute>
+      <xsl:attribute name="Required">true</xsl:attribute>
+    </xsl:attribute-set>
+    <xsl:attribute-set name="EndDateTimeQueryOption">
+      <xsl:attribute name="Term">Org.OData.Capabilities.V1.CustomQueryOptions</xsl:attribute>
+      <xsl:attribute name="Name">EndDateTime</xsl:attribute>
+      <xsl:attribute name="Required">true</xsl:attribute>
+    </xsl:attribute-set>
+  
+    <xsl:template match="
+                    edm:Annotations[@Target='microsoft.graph.user/calendarView']|
+                    edm:Annotations[@Target='microsoft.graph.group/calendarView']|
+                    edm:Annotations[@Target='microsoft.graph.calendar/calendarView']|
+                    edm:Annotations[@Target='microsoft.graph.bookingBusiness/calendarView']
+                    ">
+      <xsl:copy>
+        <xsl:apply-templates select="@* | node()"/>
+        <xsl:element name="Annotation" use-attribute-sets="StartDateTimeQueryOption"/>
+        <xsl:element name="Annotation" use-attribute-sets="EndDateTimeQueryOption"/>
+      </xsl:copy>
+    </xsl:template>
 
     <!-- Remove attribute -->
     <xsl:template match="edm:EntityType[@Name='onenotePage']/@HasStream|

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1,21 +1,21 @@
 <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:edm="http://docs.oasis-open.org/odata/ns/edm"
                 xmlns="http://docs.oasis-open.org/odata/ns/edm">
-  <xsl:output method="xml" indent="yes"/>
-  <xsl:strip-space elements="*"/> <!-- Remove empty space after deletions. -->
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:strip-space elements="*"/> <!-- Remove empty space after deletions. -->
 
-  <!-- DO NOT FORMAT ON SAVE or else the match templates will become unreadable. -->
+    <!-- DO NOT FORMAT ON SAVE or else the match templates will become unreadable. -->
 
-  <!-- Copies the entire document. -->
-  <xsl:template match="@* | node()">
-    <xsl:copy>
-      <xsl:apply-templates select="@* | node()"/>
-    </xsl:copy>
-  </xsl:template>
+    <!-- Copies the entire document. -->
+    <xsl:template match="@* | node()">
+      <xsl:copy>
+        <xsl:apply-templates select="@* | node()"/>
+      </xsl:copy>
+    </xsl:template>
 
-  <!-- Adds ContainsTarget attribute to navigation properties -->
+    <!-- Adds ContainsTarget attribute to navigation properties -->
 
-  <xsl:template match="
+    <xsl:template match="
                   edm:EntityType[@Name='androidDeviceOwnerImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:EntityType[@Name='androidDeviceOwnerScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:EntityType[@Name='androidForWorkImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
@@ -65,169 +65,169 @@
                   edm:EntityType[@Name='windowsUniversalAppX']/edm:NavigationProperty[@Name='committedContainedApps']|
                   edm:EntityType[@Name='windowsWifiEnterpriseEAPConfiguration']/edm:NavigationProperty[@Name='rootCertificatesForServerValidation']
                          ">
-    <!-- Didn't add the rule for teamsAppDefinition and unifiedRoleDefinition since it doesn't
+      <!-- Didn't add the rule for teamsAppDefinition and unifiedRoleDefinition since it doesn't
            look like we applied it, and I don't see any issues because of it.
            Didn't apply the rule for labelPolicy as it appears the API changed since this was set. -->
 
-    <xsl:copy>
-      <!-- Select all attributes, add an ContainsTarget attribute, apply to the current node. -->
-      <xsl:apply-templates select="@*"/>
-      <xsl:attribute name="ContainsTarget">true</xsl:attribute>
-      <xsl:apply-templates select="node()"/>
-    </xsl:copy>
-  </xsl:template>
+      <xsl:copy>
+        <!-- Select all attributes, add an ContainsTarget attribute, apply to the current node. -->
+        <xsl:apply-templates select="@*"/>
+        <xsl:attribute name="ContainsTarget">true</xsl:attribute>
+        <xsl:apply-templates select="node()"/>
+      </xsl:copy>
+    </xsl:template>
 
-  <!-- Remove all capability annotations-->
+    <!-- Remove all capability annotations-->
 
-  <xsl:template match="edm:Annotations//edm:Annotation[starts-with(@Term, 'Org.OData.Capabilities')]"/>
+    <xsl:template match="edm:Annotations//edm:Annotation[starts-with(@Term, 'Org.OData.Capabilities')]"/>
 
-  <!-- Remove namespaces-->
+    <!-- Remove namespaces-->
 
-  <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']"/>
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']"/>
 
-  <!-- Add annotations -->
-  <xsl:attribute-set name="LongDescriptionNavigable">
-    <xsl:attribute name="Term">Org.OData.Core.V1.LongDescription</xsl:attribute>
-    <xsl:attribute name="String">navigable</xsl:attribute>
-  </xsl:attribute-set>
+    <!-- Add annotations -->
+    <xsl:attribute-set name="LongDescriptionNavigable">
+      <xsl:attribute name="Term">Org.OData.Core.V1.LongDescription</xsl:attribute>
+      <xsl:attribute name="String">navigable</xsl:attribute>
+    </xsl:attribute-set>
 
-  <xsl:template match="edm:ComplexType[@Name='thumbnail']">
-    <xsl:copy>
-      <xsl:apply-templates select="@* | node()"/>
-      <xsl:element name="Annotation" use-attribute-sets="LongDescriptionNavigable"/>
-    </xsl:copy>
-  </xsl:template>
+    <xsl:template match="edm:ComplexType[@Name='thumbnail']">
+      <xsl:copy>
+        <xsl:apply-templates select="@* | node()"/>
+        <xsl:element name="Annotation" use-attribute-sets="LongDescriptionNavigable"/>
+      </xsl:copy>
+    </xsl:template>
 
-  <!-- Add custom query options to calendarView navigation property -->
-  <xsl:template name="CalendarViewRestrictedPopertyTemplate">
-    <xsl:param name = "propertyPath" />
-    <xsl:param name = "startDateTimeName" />
-    <xsl:param name = "endDateTimeName" />
-    <xsl:element name="Record">
-      <xsl:element name="PropertyValue">
-        <xsl:attribute name="Property">NavigationProperty</xsl:attribute>
-        <xsl:element name="PropertyPath">
-          <xsl:value-of select = "$propertyPath" />
-        </xsl:element>
-      </xsl:element>
-      <xsl:element name="PropertyValue">
-        <xsl:attribute name="Property">ReadRestrictions</xsl:attribute>
-        <xsl:element name="Record">
-          <xsl:element name="PropertyValue">
-            <xsl:attribute name="Property">CustomQueryOptions</xsl:attribute>
-            <xsl:element name="Collection">
-              <xsl:element name="Record">
-                <xsl:element name="PropertyValue">
-                  <xsl:attribute name="Property">Name</xsl:attribute>
-                  <xsl:attribute name="String">
-                    <xsl:value-of select = "$startDateTimeName" />
-                  </xsl:attribute>
-                </xsl:element>
-                <xsl:element name="PropertyValue">
-                  <xsl:attribute name="Property">Description</xsl:attribute>
-                  <xsl:attribute name="String">The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00</xsl:attribute>
-                </xsl:element>
-                <xsl:element name="PropertyValue">
-                  <xsl:attribute name="Property">Required</xsl:attribute>
-                  <xsl:attribute name="Bool">true</xsl:attribute>
-                </xsl:element>
-              </xsl:element>
-              <xsl:element name="Record">
-                <xsl:element name="PropertyValue">
-                  <xsl:attribute name="Property">Name</xsl:attribute>
-                  <xsl:attribute name="String">
-                    <xsl:value-of select = "$endDateTimeName" />
-                  </xsl:attribute>
-                </xsl:element>
-                <xsl:element name="PropertyValue">
-                  <xsl:attribute name="Property">Description</xsl:attribute>
-                  <xsl:attribute name="String">The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00</xsl:attribute>
-                </xsl:element>
-                <xsl:element name="PropertyValue">
-                  <xsl:attribute name="Property">Required</xsl:attribute>
-                  <xsl:attribute name="Bool">true</xsl:attribute>
-                </xsl:element>
-              </xsl:element>
-            </xsl:element>
-          </xsl:element>
-        </xsl:element>
-      </xsl:element>
-    </xsl:element>
-  </xsl:template>
-
-  <xsl:template match="
-                edm:EntitySet[@Name='users']|
-                edm:EntitySet[@Name='groups']
-                    ">
-    <xsl:copy>
-      <xsl:apply-templates select="@* | node()"/>
-      <xsl:element name="Annotation">
-        <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
-        <xsl:element name="Record" namespace="{namespace-uri()}">
-          <xsl:element name="PropertyValue">
-            <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
-            <xsl:element name="Collection">
-              <xsl:call-template name="CalendarViewRestrictedPopertyTemplate">
-                <xsl:with-param name="propertyPath">calendarView</xsl:with-param>
-                <xsl:with-param name="startDateTimeName">startDateTime</xsl:with-param>
-                <xsl:with-param name="endDateTimeName">endDateTime</xsl:with-param>
-              </xsl:call-template>
-              <xsl:call-template name="CalendarViewRestrictedPopertyTemplate">
-                <xsl:with-param name="propertyPath">calendar/calendarView</xsl:with-param>
-                <xsl:with-param name="startDateTimeName">startDateTime</xsl:with-param>
-                <xsl:with-param name="endDateTimeName">endDateTime</xsl:with-param>
-              </xsl:call-template>
-              <xsl:call-template name="CalendarViewRestrictedPopertyTemplate">
-                <xsl:with-param name="propertyPath">calendars/calendarView</xsl:with-param>
-                <xsl:with-param name="startDateTimeName">startDateTime</xsl:with-param>
-                <xsl:with-param name="endDateTimeName">endDateTime</xsl:with-param>
-              </xsl:call-template>
-            </xsl:element>
-          </xsl:element>
-        </xsl:element>
-      </xsl:element>
-    </xsl:copy>
-  </xsl:template>
-
-  <xsl:template match="edm:EntitySet[@Name='bookingBusinesses']">
-    <xsl:copy>
-      <xsl:apply-templates select="@* | node()"/>
-      <xsl:element name="Annotation">
-        <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
-        <xsl:element name="Record" namespace="{namespace-uri()}">
-          <xsl:element name="PropertyValue">
-            <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
-            <xsl:element name="Collection">
-              <xsl:call-template name="CalendarViewRestrictedPopertyTemplate">
-                <xsl:with-param name="propertyPath">calendarView</xsl:with-param>
-                <xsl:with-param name="startDateTimeName">start</xsl:with-param>
-                <xsl:with-param name="endDateTimeName">end</xsl:with-param>
-              </xsl:call-template>
-            </xsl:element>
-          </xsl:element>
-        </xsl:element>
-      </xsl:element>
-    </xsl:copy>
-  </xsl:template>
-
-  <!-- Remove attribute -->
-  <xsl:template match="edm:EntityType[@Name='onenotePage']/@HasStream|
+    <!-- Remove attribute -->
+    <xsl:template match="edm:EntityType[@Name='onenotePage']/@HasStream|
                          edm:EntityType[@Name='onenoteResource']/@HasStream">
-    <xsl:apply-templates select="@* | node()"/>
-  </xsl:template>
+        <xsl:apply-templates select="@* | node()"/>
+    </xsl:template>
 
-  <!-- Reorder action parameters -->
+    <!-- Reorder action parameters -->
 
-  <!-- These actions have the same parameters that need reordering. Will need to create a new template
+    <!-- These actions have the same parameters that need reordering. Will need to create a new template
          for each reordering. -->
-  <xsl:template match="edm:Action[@Name='accept'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]|
+    <xsl:template match="edm:Action[@Name='accept'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]|
                          edm:Action[@Name='decline'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]|
                          edm:Action[@Name='tentativelyAccept'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]">
-    <xsl:copy>
-      <xsl:apply-templates select="@*"/>
-      <xsl:apply-templates select="edm:Parameter[@Name='bindingParameter'][@Type='graph.event']" />
-      <xsl:apply-templates select="edm:Parameter[@Name='Comment']" />
-      <xsl:apply-templates select="edm:Parameter[@Name='SendResponse']" />
-    </xsl:copy>
-  </xsl:template>
+        <xsl:copy>
+            <xsl:apply-templates select="@*"/>
+            <xsl:apply-templates select="edm:Parameter[@Name='bindingParameter'][@Type='graph.event']" />
+            <xsl:apply-templates select="edm:Parameter[@Name='Comment']" />
+            <xsl:apply-templates select="edm:Parameter[@Name='SendResponse']" />
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Add custom query options to calendarView navigation property -->
+    <xsl:template name="CalendarViewRestrictedPopertyTemplate">
+      <xsl:param name = "propertyPath" />
+      <xsl:param name = "startDateTimeName" />
+      <xsl:param name = "endDateTimeName" />
+      <xsl:element name="Record">
+        <xsl:element name="PropertyValue">
+          <xsl:attribute name="Property">NavigationProperty</xsl:attribute>
+          <xsl:element name="PropertyPath">
+            <xsl:value-of select = "$propertyPath" />
+          </xsl:element>
+        </xsl:element>
+        <xsl:element name="PropertyValue">
+          <xsl:attribute name="Property">ReadRestrictions</xsl:attribute>
+          <xsl:element name="Record">
+            <xsl:element name="PropertyValue">
+              <xsl:attribute name="Property">CustomQueryOptions</xsl:attribute>
+              <xsl:element name="Collection">
+                <xsl:element name="Record">
+                  <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">Name</xsl:attribute>
+                    <xsl:attribute name="String">
+                      <xsl:value-of select = "$startDateTimeName" />
+                    </xsl:attribute>
+                  </xsl:element>
+                  <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">Description</xsl:attribute>
+                    <xsl:attribute name="String">The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00</xsl:attribute>
+                  </xsl:element>
+                  <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">Required</xsl:attribute>
+                    <xsl:attribute name="Bool">true</xsl:attribute>
+                  </xsl:element>
+                </xsl:element>
+                <xsl:element name="Record">
+                  <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">Name</xsl:attribute>
+                    <xsl:attribute name="String">
+                      <xsl:value-of select = "$endDateTimeName" />
+                    </xsl:attribute>
+                  </xsl:element>
+                  <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">Description</xsl:attribute>
+                    <xsl:attribute name="String">The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00</xsl:attribute>
+                  </xsl:element>
+                  <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">Required</xsl:attribute>
+                    <xsl:attribute name="Bool">true</xsl:attribute>
+                  </xsl:element>
+                </xsl:element>
+              </xsl:element>
+            </xsl:element>
+          </xsl:element>
+        </xsl:element>
+      </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="
+                  edm:EntitySet[@Name='users']|
+                  edm:EntitySet[@Name='groups']
+                      ">
+      <xsl:copy>
+        <xsl:apply-templates select="@* | node()"/>
+        <xsl:element name="Annotation">
+          <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
+          <xsl:element name="Record" namespace="{namespace-uri()}">
+            <xsl:element name="PropertyValue">
+              <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
+              <xsl:element name="Collection">
+                <xsl:call-template name="CalendarViewRestrictedPopertyTemplate">
+                  <xsl:with-param name="propertyPath">calendarView</xsl:with-param>
+                  <xsl:with-param name="startDateTimeName">startDateTime</xsl:with-param>
+                  <xsl:with-param name="endDateTimeName">endDateTime</xsl:with-param>
+                </xsl:call-template>
+                <xsl:call-template name="CalendarViewRestrictedPopertyTemplate">
+                  <xsl:with-param name="propertyPath">calendar/calendarView</xsl:with-param>
+                  <xsl:with-param name="startDateTimeName">startDateTime</xsl:with-param>
+                  <xsl:with-param name="endDateTimeName">endDateTime</xsl:with-param>
+                </xsl:call-template>
+                <xsl:call-template name="CalendarViewRestrictedPopertyTemplate">
+                  <xsl:with-param name="propertyPath">calendars/calendarView</xsl:with-param>
+                  <xsl:with-param name="startDateTimeName">startDateTime</xsl:with-param>
+                  <xsl:with-param name="endDateTimeName">endDateTime</xsl:with-param>
+                </xsl:call-template>
+              </xsl:element>
+            </xsl:element>
+          </xsl:element>
+        </xsl:element>
+      </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="edm:EntitySet[@Name='bookingBusinesses']">
+      <xsl:copy>
+        <xsl:apply-templates select="@* | node()"/>
+        <xsl:element name="Annotation">
+          <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
+          <xsl:element name="Record" namespace="{namespace-uri()}">
+            <xsl:element name="PropertyValue">
+              <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
+              <xsl:element name="Collection">
+                <xsl:call-template name="CalendarViewRestrictedPopertyTemplate">
+                  <xsl:with-param name="propertyPath">calendarView</xsl:with-param>
+                  <xsl:with-param name="startDateTimeName">start</xsl:with-param>
+                  <xsl:with-param name="endDateTimeName">end</xsl:with-param>
+                </xsl:call-template>
+              </xsl:element>
+            </xsl:element>
+          </xsl:element>
+        </xsl:element>
+      </xsl:copy>
+    </xsl:template>
 </xsl:stylesheet>

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1,21 +1,21 @@
 <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:edm="http://docs.oasis-open.org/odata/ns/edm"
                 xmlns="http://docs.oasis-open.org/odata/ns/edm">
-    <xsl:output method="xml" indent="yes"/>
-    <xsl:strip-space elements="*"/> <!-- Remove empty space after deletions. -->
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:strip-space elements="*"/> <!-- Remove empty space after deletions. -->
 
-    <!-- DO NOT FORMAT ON SAVE or else the match templates will become unreadable. -->
+  <!-- DO NOT FORMAT ON SAVE or else the match templates will become unreadable. -->
 
-    <!-- Copies the entire document. -->
-    <xsl:template match="@* | node()">
-      <xsl:copy>
-        <xsl:apply-templates select="@* | node()"/>
-      </xsl:copy>
-    </xsl:template>
+  <!-- Copies the entire document. -->
+  <xsl:template match="@* | node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+    </xsl:copy>
+  </xsl:template>
 
-    <!-- Adds ContainsTarget attribute to navigation properties -->
+  <!-- Adds ContainsTarget attribute to navigation properties -->
 
-    <xsl:template match="
+  <xsl:template match="
                   edm:EntityType[@Name='androidDeviceOwnerImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:EntityType[@Name='androidDeviceOwnerScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:EntityType[@Name='androidForWorkImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
@@ -65,82 +65,169 @@
                   edm:EntityType[@Name='windowsUniversalAppX']/edm:NavigationProperty[@Name='committedContainedApps']|
                   edm:EntityType[@Name='windowsWifiEnterpriseEAPConfiguration']/edm:NavigationProperty[@Name='rootCertificatesForServerValidation']
                          ">
-      <!-- Didn't add the rule for teamsAppDefinition and unifiedRoleDefinition since it doesn't
+    <!-- Didn't add the rule for teamsAppDefinition and unifiedRoleDefinition since it doesn't
            look like we applied it, and I don't see any issues because of it.
            Didn't apply the rule for labelPolicy as it appears the API changed since this was set. -->
 
-      <xsl:copy>
-        <!-- Select all attributes, add an ContainsTarget attribute, apply to the current node. -->
-        <xsl:apply-templates select="@*"/>
-        <xsl:attribute name="ContainsTarget">true</xsl:attribute>
-        <xsl:apply-templates select="node()"/>
-      </xsl:copy>
-    </xsl:template>
+    <xsl:copy>
+      <!-- Select all attributes, add an ContainsTarget attribute, apply to the current node. -->
+      <xsl:apply-templates select="@*"/>
+      <xsl:attribute name="ContainsTarget">true</xsl:attribute>
+      <xsl:apply-templates select="node()"/>
+    </xsl:copy>
+  </xsl:template>
 
-    <!-- Remove all capability annotations-->
+  <!-- Remove all capability annotations-->
 
-    <xsl:template match="edm:Annotations//edm:Annotation[starts-with(@Term, 'Org.OData.Capabilities')]"/>
+  <xsl:template match="edm:Annotations//edm:Annotation[starts-with(@Term, 'Org.OData.Capabilities')]"/>
 
-    <!-- Remove namespaces-->
+  <!-- Remove namespaces-->
 
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']"/>
+  <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']"/>
 
-    <!-- Add annotations -->
-    <xsl:attribute-set name="LongDescriptionNavigable">
-      <xsl:attribute name="Term">Org.OData.Core.V1.LongDescription</xsl:attribute>
-      <xsl:attribute name="String">navigable</xsl:attribute>
-    </xsl:attribute-set>
+  <!-- Add annotations -->
+  <xsl:attribute-set name="LongDescriptionNavigable">
+    <xsl:attribute name="Term">Org.OData.Core.V1.LongDescription</xsl:attribute>
+    <xsl:attribute name="String">navigable</xsl:attribute>
+  </xsl:attribute-set>
 
-    <xsl:template match="edm:ComplexType[@Name='thumbnail']">
-      <xsl:copy>
-        <xsl:apply-templates select="@* | node()"/>
-        <xsl:element name="Annotation" use-attribute-sets="LongDescriptionNavigable"/>
-      </xsl:copy>
-    </xsl:template>
-    
-    <!-- Add custom query options to calendarView -->
-    <xsl:attribute-set name="StartDateTimeQueryOption">
-      <xsl:attribute name="Term">Org.OData.Capabilities.V1.CustomQueryOptions</xsl:attribute>
-      <xsl:attribute name="Name">StartDateTime</xsl:attribute>
-      <xsl:attribute name="Required">true</xsl:attribute>
-    </xsl:attribute-set>
-    <xsl:attribute-set name="EndDateTimeQueryOption">
-      <xsl:attribute name="Term">Org.OData.Capabilities.V1.CustomQueryOptions</xsl:attribute>
-      <xsl:attribute name="Name">EndDateTime</xsl:attribute>
-      <xsl:attribute name="Required">true</xsl:attribute>
-    </xsl:attribute-set>
-  
-    <xsl:template match="
-                    edm:Annotations[@Target='microsoft.graph.user/calendarView']|
-                    edm:Annotations[@Target='microsoft.graph.group/calendarView']|
-                    edm:Annotations[@Target='microsoft.graph.calendar/calendarView']|
-                    edm:Annotations[@Target='microsoft.graph.bookingBusiness/calendarView']
+  <xsl:template match="edm:ComplexType[@Name='thumbnail']">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+      <xsl:element name="Annotation" use-attribute-sets="LongDescriptionNavigable"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Add custom query options to calendarView navigation property -->
+  <xsl:template name="CalendarViewRestrictedPopertyTemplate">
+    <xsl:param name = "propertyPath" />
+    <xsl:param name = "startDateTimeName" />
+    <xsl:param name = "endDateTimeName" />
+    <xsl:element name="Record">
+      <xsl:element name="PropertyValue">
+        <xsl:attribute name="Property">NavigationProperty</xsl:attribute>
+        <xsl:element name="PropertyPath">
+          <xsl:value-of select = "$propertyPath" />
+        </xsl:element>
+      </xsl:element>
+      <xsl:element name="PropertyValue">
+        <xsl:attribute name="Property">ReadRestrictions</xsl:attribute>
+        <xsl:element name="Record">
+          <xsl:element name="PropertyValue">
+            <xsl:attribute name="Property">CustomQueryOptions</xsl:attribute>
+            <xsl:element name="Collection">
+              <xsl:element name="Record">
+                <xsl:element name="PropertyValue">
+                  <xsl:attribute name="Property">Name</xsl:attribute>
+                  <xsl:attribute name="String">
+                    <xsl:value-of select = "$startDateTimeName" />
+                  </xsl:attribute>
+                </xsl:element>
+                <xsl:element name="PropertyValue">
+                  <xsl:attribute name="Property">Description</xsl:attribute>
+                  <xsl:attribute name="String">The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00</xsl:attribute>
+                </xsl:element>
+                <xsl:element name="PropertyValue">
+                  <xsl:attribute name="Property">Required</xsl:attribute>
+                  <xsl:attribute name="Bool">true</xsl:attribute>
+                </xsl:element>
+              </xsl:element>
+              <xsl:element name="Record">
+                <xsl:element name="PropertyValue">
+                  <xsl:attribute name="Property">Name</xsl:attribute>
+                  <xsl:attribute name="String">
+                    <xsl:value-of select = "$endDateTimeName" />
+                  </xsl:attribute>
+                </xsl:element>
+                <xsl:element name="PropertyValue">
+                  <xsl:attribute name="Property">Description</xsl:attribute>
+                  <xsl:attribute name="String">The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00</xsl:attribute>
+                </xsl:element>
+                <xsl:element name="PropertyValue">
+                  <xsl:attribute name="Property">Required</xsl:attribute>
+                  <xsl:attribute name="Bool">true</xsl:attribute>
+                </xsl:element>
+              </xsl:element>
+            </xsl:element>
+          </xsl:element>
+        </xsl:element>
+      </xsl:element>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="
+                edm:EntitySet[@Name='users']|
+                edm:EntitySet[@Name='groups']
                     ">
-      <xsl:copy>
-        <xsl:apply-templates select="@* | node()"/>
-        <xsl:element name="Annotation" use-attribute-sets="StartDateTimeQueryOption"/>
-        <xsl:element name="Annotation" use-attribute-sets="EndDateTimeQueryOption"/>
-      </xsl:copy>
-    </xsl:template>
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+      <xsl:element name="Annotation">
+        <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
+        <xsl:element name="Record" namespace="{namespace-uri()}">
+          <xsl:element name="PropertyValue">
+            <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
+            <xsl:element name="Collection">
+              <xsl:call-template name="CalendarViewRestrictedPopertyTemplate">
+                <xsl:with-param name="propertyPath">calendarView</xsl:with-param>
+                <xsl:with-param name="startDateTimeName">startDateTime</xsl:with-param>
+                <xsl:with-param name="endDateTimeName">endDateTime</xsl:with-param>
+              </xsl:call-template>
+              <xsl:call-template name="CalendarViewRestrictedPopertyTemplate">
+                <xsl:with-param name="propertyPath">calendar/calendarView</xsl:with-param>
+                <xsl:with-param name="startDateTimeName">startDateTime</xsl:with-param>
+                <xsl:with-param name="endDateTimeName">endDateTime</xsl:with-param>
+              </xsl:call-template>
+              <xsl:call-template name="CalendarViewRestrictedPopertyTemplate">
+                <xsl:with-param name="propertyPath">calendars/calendarView</xsl:with-param>
+                <xsl:with-param name="startDateTimeName">startDateTime</xsl:with-param>
+                <xsl:with-param name="endDateTimeName">endDateTime</xsl:with-param>
+              </xsl:call-template>
+            </xsl:element>
+          </xsl:element>
+        </xsl:element>
+      </xsl:element>
+    </xsl:copy>
+  </xsl:template>
 
-    <!-- Remove attribute -->
-    <xsl:template match="edm:EntityType[@Name='onenotePage']/@HasStream|
+  <xsl:template match="edm:EntitySet[@Name='bookingBusinesses']">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+      <xsl:element name="Annotation">
+        <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
+        <xsl:element name="Record" namespace="{namespace-uri()}">
+          <xsl:element name="PropertyValue">
+            <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
+            <xsl:element name="Collection">
+              <xsl:call-template name="CalendarViewRestrictedPopertyTemplate">
+                <xsl:with-param name="propertyPath">calendarView</xsl:with-param>
+                <xsl:with-param name="startDateTimeName">start</xsl:with-param>
+                <xsl:with-param name="endDateTimeName">end</xsl:with-param>
+              </xsl:call-template>
+            </xsl:element>
+          </xsl:element>
+        </xsl:element>
+      </xsl:element>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Remove attribute -->
+  <xsl:template match="edm:EntityType[@Name='onenotePage']/@HasStream|
                          edm:EntityType[@Name='onenoteResource']/@HasStream">
-        <xsl:apply-templates select="@* | node()"/>
-    </xsl:template>
+    <xsl:apply-templates select="@* | node()"/>
+  </xsl:template>
 
-    <!-- Reorder action parameters -->
+  <!-- Reorder action parameters -->
 
-    <!-- These actions have the same parameters that need reordering. Will need to create a new template
+  <!-- These actions have the same parameters that need reordering. Will need to create a new template
          for each reordering. -->
-    <xsl:template match="edm:Action[@Name='accept'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]|
+  <xsl:template match="edm:Action[@Name='accept'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]|
                          edm:Action[@Name='decline'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]|
                          edm:Action[@Name='tentativelyAccept'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]">
-        <xsl:copy>
-            <xsl:apply-templates select="@*"/>
-            <xsl:apply-templates select="edm:Parameter[@Name='bindingParameter'][@Type='graph.event']" />
-            <xsl:apply-templates select="edm:Parameter[@Name='Comment']" />
-            <xsl:apply-templates select="edm:Parameter[@Name='SendResponse']" />
-        </xsl:copy>
-    </xsl:template>
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:apply-templates select="edm:Parameter[@Name='bindingParameter'][@Type='graph.event']" />
+      <xsl:apply-templates select="edm:Parameter[@Name='Comment']" />
+      <xsl:apply-templates select="edm:Parameter[@Name='SendResponse']" />
+    </xsl:copy>
+  </xsl:template>
 </xsl:stylesheet>

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -20,6 +20,14 @@
                 <Property Name="name" Type="Edm.String" Nullable="false" />
                 <NavigationProperty Name="tasks" Type="Collection(graph.plannerTask)" />
             </EntityType>
+            <EntityType Name="user" BaseType="graph.directoryObject">
+              <Property Name="displayName" Type="Edm.String" Nullable="false" />
+              <NavigationProperty Name="calendarView" Type="Collection(graph.event)" ContainsTarget="true" />>
+            </EntityType>
+            <EntityType Name="calendar" BaseType="graph.entity">
+              <Property Name="name" Type="Edm.String" Nullable="false" />
+              <NavigationProperty Name="calendarView" Type="Collection(graph.event)" ContainsTarget="true" />
+            </EntityType>
             <Annotations Target="graph.activityHistoryItem">
                 <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
                     <Record>
@@ -33,6 +41,20 @@
                 </Annotation>
                 <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false" />
                 <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+            </Annotations>
+            <Annotations Target="microsoft.graph.user/calendarView">
+              <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+                <Record>
+                  <PropertyValue Property="Supported" Bool="true"/>
+                </Record>
+              </Annotation>
+            </Annotations>
+            <Annotations Target="microsoft.graph.calendar/calendarView">
+              <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+                <Record>
+                  <PropertyValue Property="Supported" Bool="true"/>
+                </Record>
+              </Annotation>
             </Annotations>
             <ComplexType Name="thumbnail">
                 <Property Name="content" Type="Edm.Stream" />

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -20,14 +20,6 @@
                 <Property Name="name" Type="Edm.String" Nullable="false" />
                 <NavigationProperty Name="tasks" Type="Collection(graph.plannerTask)" />
             </EntityType>
-            <EntityType Name="user" BaseType="graph.directoryObject">
-              <Property Name="displayName" Type="Edm.String" Nullable="false" />
-              <NavigationProperty Name="calendarView" Type="Collection(graph.event)" ContainsTarget="true" />>
-            </EntityType>
-            <EntityType Name="calendar" BaseType="graph.entity">
-              <Property Name="name" Type="Edm.String" Nullable="false" />
-              <NavigationProperty Name="calendarView" Type="Collection(graph.event)" ContainsTarget="true" />
-            </EntityType>
             <Annotations Target="graph.activityHistoryItem">
                 <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
                     <Record>
@@ -41,20 +33,6 @@
                 </Annotation>
                 <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false" />
                 <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
-            </Annotations>
-            <Annotations Target="microsoft.graph.user/calendarView">
-              <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
-                <Record>
-                  <PropertyValue Property="Supported" Bool="true"/>
-                </Record>
-              </Annotation>
-            </Annotations>
-            <Annotations Target="microsoft.graph.calendar/calendarView">
-              <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
-                <Record>
-                  <PropertyValue Property="Supported" Bool="true"/>
-                </Record>
-              </Annotation>
             </Annotations>
             <ComplexType Name="thumbnail">
                 <Property Name="content" Type="Edm.Stream" />
@@ -104,7 +82,6 @@
                 <NavigationProperty Name="publishedResources" Type="Collection(graph.publishedResource)" ContainsTarget="true" />
             </EntityType>
             <EntitySet Name="bookingBusinesses" EntityType="microsoft.graph.bookingBusiness"/>
-            <EntitySet Name="users" EntityType="microsoft.graph.user" />
             <EntitySet Name="groups" EntityType="microsoft.graph.group" />
             <Action Name="accept" IsBound="true">
                 <Parameter Name="bindingParameter" Type="graph.event" />

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -103,6 +103,9 @@
                 <NavigationProperty Name="agentGroups" Type="Collection(graph.onPremisesAgentGroup)" ContainsTarget="true" />
                 <NavigationProperty Name="publishedResources" Type="Collection(graph.publishedResource)" ContainsTarget="true" />
             </EntityType>
+            <EntitySet Name="bookingBusinesses" EntityType="microsoft.graph.bookingBusiness"/>
+            <EntitySet Name="users" EntityType="microsoft.graph.user" />
+            <EntitySet Name="groups" EntityType="microsoft.graph.group" />
             <Action Name="accept" IsBound="true">
                 <Parameter Name="bindingParameter" Type="graph.event" />
                 <Parameter Name="SendResponse" Type="Edm.Boolean" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -73,6 +73,118 @@
         <NavigationProperty Name="agentGroups" Type="Collection(graph.onPremisesAgentGroup)" ContainsTarget="true" />
         <NavigationProperty Name="publishedResources" Type="Collection(graph.publishedResource)" ContainsTarget="true" />
       </EntityType>
+      <EntitySet Name="bookingBusinesses" EntityType="microsoft.graph.bookingBusiness">
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="RestrictedProperties">
+              <Collection>
+                <Record>
+                  <PropertyValue Property="NavigationProperty">
+                    <PropertyPath>calendarView</PropertyPath>
+                  </PropertyValue>
+                  <PropertyValue Property="ReadRestrictions">
+                    <Record>
+                      <PropertyValue Property="CustomQueryOptions">
+                        <Collection>
+                          <Record>
+                            <PropertyValue Property="Name" String="start" />
+                            <PropertyValue Property="Description" String="The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00" />
+                            <PropertyValue Property="Required" Bool="true" />
+                          </Record>
+                          <Record>
+                            <PropertyValue Property="Name" String="end" />
+                            <PropertyValue Property="Description" String="The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
+                            <PropertyValue Property="Required" Bool="true" />
+                          </Record>
+                        </Collection>
+                      </PropertyValue>
+                    </Record>
+                  </PropertyValue>
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </EntitySet>
+      <EntitySet Name="groups" EntityType="microsoft.graph.group">
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="RestrictedProperties">
+              <Collection>
+                <Record>
+                  <PropertyValue Property="NavigationProperty">
+                    <PropertyPath>calendarView</PropertyPath>
+                  </PropertyValue>
+                  <PropertyValue Property="ReadRestrictions">
+                    <Record>
+                      <PropertyValue Property="CustomQueryOptions">
+                        <Collection>
+                          <Record>
+                            <PropertyValue Property="Name" String="startDateTime" />
+                            <PropertyValue Property="Description" String="The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00" />
+                            <PropertyValue Property="Required" Bool="true" />
+                          </Record>
+                          <Record>
+                            <PropertyValue Property="Name" String="endDateTime" />
+                            <PropertyValue Property="Description" String="The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
+                            <PropertyValue Property="Required" Bool="true" />
+                          </Record>
+                        </Collection>
+                      </PropertyValue>
+                    </Record>
+                  </PropertyValue>
+                </Record>
+                <Record>
+                  <PropertyValue Property="NavigationProperty">
+                    <PropertyPath>calendar/calendarView</PropertyPath>
+                  </PropertyValue>
+                  <PropertyValue Property="ReadRestrictions">
+                    <Record>
+                      <PropertyValue Property="CustomQueryOptions">
+                        <Collection>
+                          <Record>
+                            <PropertyValue Property="Name" String="startDateTime" />
+                            <PropertyValue Property="Description" String="The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00" />
+                            <PropertyValue Property="Required" Bool="true" />
+                          </Record>
+                          <Record>
+                            <PropertyValue Property="Name" String="endDateTime" />
+                            <PropertyValue Property="Description" String="The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
+                            <PropertyValue Property="Required" Bool="true" />
+                          </Record>
+                        </Collection>
+                      </PropertyValue>
+                    </Record>
+                  </PropertyValue>
+                </Record>
+                <Record>
+                  <PropertyValue Property="NavigationProperty">
+                    <PropertyPath>calendars/calendarView</PropertyPath>
+                  </PropertyValue>
+                  <PropertyValue Property="ReadRestrictions">
+                    <Record>
+                      <PropertyValue Property="CustomQueryOptions">
+                        <Collection>
+                          <Record>
+                            <PropertyValue Property="Name" String="startDateTime" />
+                            <PropertyValue Property="Description" String="The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00" />
+                            <PropertyValue Property="Required" Bool="true" />
+                          </Record>
+                          <Record>
+                            <PropertyValue Property="Name" String="endDateTime" />
+                            <PropertyValue Property="Description" String="The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
+                            <PropertyValue Property="Required" Bool="true" />
+                          </Record>
+                        </Collection>
+                      </PropertyValue>
+                    </Record>
+                  </PropertyValue>
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </EntitySet>
       <Action Name="accept" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event" />
         <Parameter Name="Comment" Type="Edm.String" Unicode="false" />


### PR DESCRIPTION
This PR fixes https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/64 issue by adding [CustomQueryOptions](https://github.com/oasis-tcs/odata-vocabularies/blob/master/vocabularies/Org.OData.Capabilities.V1.xml#L915) capability annotation to `users`, `groups` and `bookingBusinesses` `EntitySets`. 

Custom Properties Added:
| [Users/CalendarView](https://docs.microsoft.com/en-us/graph/api/user-list-calendarview?view=graph-rest-beta&tabs=http) | [Groups/CalendarView](https://docs.microsoft.com/en-us/graph/api/group-list-calendarview?view=graph-rest-beta&tabs=http) | [BookingBusinesses/CalendarView](https://docs.microsoft.com/en-us/graph/api/bookingbusiness-list-calendarview?view=graph-rest-beta&tabs=http)  |
| ------------- |:-------------:| -----:|
| startDateTime | startDateTime | start |
| endDateTime | endDateTime | end |


To test:
1. Open Visual Studio without a project.
2. Open `preprocess_csdl_test_input.xml`.
3. Select the **XML** menu from the top menu.
4. Select the **Start XSLT Without Debugging** option.

The generated file should match preprocess_csdl_test_output.xml.
The generated file should not match preprocess_csdl_test_input.xml.
The corresponding OpenAPI docs will then have the custom query options - `startDateTime` & `endDateTime`:
![image](https://user-images.githubusercontent.com/7061532/80153414-4f371f80-8572-11ea-80a1-1a80c7cf67aa.png)
