### PR TITLE
Add transform script, remove property, add action

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -39,7 +39,7 @@
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='iosPkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='iosScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='itemActivityStat']/edm:NavigationProperty[@Name='activities']|
-                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='MacOSEnterpriseWiFiConfiguration']/edm:NavigationProperty[@Name='rootCertificatesForServerValidation']|
+                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSEnterpriseWiFiConfiguration']/edm:NavigationProperty[@Name='rootCertificatesForServerValidation']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSPkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
@@ -97,6 +97,7 @@
     <!-- Remove namespaces -->
 
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']"/>
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph.termStore']"/>
 
     <!-- Remove singleton -->
 

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -99,6 +99,7 @@
     <!-- Remove singleton -->
 
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:Singleton[@Name='conditionalAccess']"/>
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:Singleton[contains(@Name, 'settings') and contains(@Type, 'microsoft.graph.entitlementManagementSettings')]" /> <!-- Tempfix: requested this change of the owners. Check whether this is still needed. -->
   
     <!-- Add annotations -->
     <xsl:attribute-set name="LongDescriptionNavigable">

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1,7 +1,7 @@
 <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:edm="http://docs.oasis-open.org/odata/ns/edm"
                 xmlns="http://docs.oasis-open.org/odata/ns/edm"
-                exclude-result-prefixes="edm">
+                >
     <xsl:output method="xml" indent="yes"/>
     <xsl:strip-space elements="*"/> <!-- Remove empty space after deletions. -->
 
@@ -134,19 +134,11 @@
         </xsl:copy>
     </xsl:template>
 
-    <!-- Add action -->
-    <!-- This should be a temp fix to the scenario where a property was added to the CreateUploadSession action.
-         We have a request to have the metadata fixed. -->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
-      <xsl:copy>
-        <xsl:apply-templates select="@* | node()"/>
-          <Action Name="createUploadSession" IsBound="true">   
-            <Parameter Name="bindingParameter" Type="graph.driveItem" />
-            <Parameter Name="item" Type="graph.driveItemUploadableProperties" />
-            <ReturnType Type="graph.uploadSession" />
-          </Action>
-      </xsl:copy>
-    </xsl:template>    
+    <!-- Remove action parameters -->
+    <!-- This should be a temp fix, tracking: https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/261 -->
+    <!-- <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='createUploadSession']/edm:Parameter[@Name='deferCommit']"/> -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='createUploadSession']/edm:Parameter[@Name='deferCommit']"/>
+
 
     <!-- Add custom query options to calendarView navigation property -->
     <xsl:template name="CalendarViewRestrictedPopertyTemplate">

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -39,7 +39,7 @@
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='iosPkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='iosScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='itemActivityStat']/edm:NavigationProperty[@Name='activities']|
-                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='MacOSEnterpriseWiFiConfiguration']/edm:NavigationProperty[@Name='rootCertificateForServerValidation']|
+                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='MacOSEnterpriseWiFiConfiguration']/edm:NavigationProperty[@Name='rootCertificatesForServerValidation']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSPkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
@@ -55,6 +55,7 @@
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='plannerUser']/edm:NavigationProperty[@Name='plans']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='plannerUser']/edm:NavigationProperty[@Name='tasks']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='printJob']/edm:NavigationProperty[@Name='documents']|
+                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='printJob']/edm:NavigationProperty[@Name='tasks']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='printService']/edm:NavigationProperty[@Name='endpoints']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='printer']/edm:NavigationProperty[@Name='allowedGroups']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='printer']/edm:NavigationProperty[@Name='allowedUsers']|

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -39,6 +39,7 @@
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='iosPkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='iosScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='itemActivityStat']/edm:NavigationProperty[@Name='activities']|
+                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='MacOSEnterpriseWiFiConfiguration']/edm:NavigationProperty[@Name='rootCertificateForServerValidation']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSPkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1,6 +1,7 @@
 <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:edm="http://docs.oasis-open.org/odata/ns/edm"
-                xmlns="http://docs.oasis-open.org/odata/ns/edm">
+                xmlns="http://docs.oasis-open.org/odata/ns/edm"
+                exclude-result-prefixes="edm">
     <xsl:output method="xml" indent="yes"/>
     <xsl:strip-space elements="*"/> <!-- Remove empty space after deletions. -->
 
@@ -78,16 +79,20 @@
         <xsl:apply-templates select="node()"/>
       </xsl:copy>
     </xsl:template>
+    
+    <!-- Remove Property -->
 
-    <!-- Remove NavigationProperty-->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:ComplexType[@Name='changeNotification']/edm:Property[@Name='sequenceNumber']"/>
+
+    <!-- Remove NavigationProperty -->
       
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='approval']/edm:NavigationProperty[@Name='request']"/>
-  
-    <!-- Remove all capability annotations-->
+
+    <!-- Remove all capability annotations -->
 
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations//edm:Annotation[starts-with(@Term, 'Org.OData.Capabilities')]"/>
 
-    <!-- Remove namespaces-->
+    <!-- Remove namespaces -->
 
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']"/>
 
@@ -128,6 +133,20 @@
             <xsl:apply-templates select="edm:Parameter[@Name='SendResponse']" />
         </xsl:copy>
     </xsl:template>
+
+    <!-- Add action -->
+    <!-- This should be a temp fix to the scenario where a property was added to the CreateUploadSession action.
+         We have a request to have the metadata fixed. -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
+      <xsl:copy>
+        <xsl:apply-templates select="@* | node()"/>
+          <Action Name="createUploadSession" IsBound="true">   
+            <Parameter Name="bindingParameter" Type="graph.driveItem" />
+            <Parameter Name="item" Type="graph.driveItemUploadableProperties" />
+            <ReturnType Type="graph.uploadSession" />
+          </Action>
+      </xsl:copy>
+    </xsl:template>    
 
     <!-- Add custom query options to calendarView navigation property -->
     <xsl:template name="CalendarViewRestrictedPopertyTemplate">

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -122,6 +122,12 @@
                 <Parameter Name="SendResponse" Type="Edm.Boolean" />
                 <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
             </Action>
+            <Action Name="createUploadSession" IsBound="true">
+                <Parameter Name="bindingParameter" Type="graph.driveItem" />
+                <Parameter Name="item" Type="graph.driveItemUploadableProperties" />
+                <Parameter Name="deferCommit" Type="Edm.Boolean" />
+                <ReturnType Type="graph.uploadSession" />
+            </Action>
         </Schema>
         <Schema Namespace="microsoft.graph.callRecords" xmlns="http://docs.oasis-open.org/odata/ns/edm">
             <EnumType Name="callType">

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -98,6 +98,8 @@
                 <NavigationProperty Name="publishedResources" Type="Collection(graph.publishedResource)" ContainsTarget="true" />
             </EntityType>
             <EntityContainer Name="GraphService">
+              <Singleton Name="settings" Type="microsoft.graph.entitlementManagementSettings" />
+              <Singleton Name="settings" EntityType="microsoft.graph.FAILTYPE" />
               <Singleton Name="conditionalAccess" Type="microsoft.graph.conditionalAccessRoot" />
               <EntitySet Name="bookingBusinesses" EntityType="microsoft.graph.bookingBusiness"/>
               <EntitySet Name="groups" EntityType="microsoft.graph.group" />

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -46,6 +46,17 @@
                 <Property Name="url" Type="Edm.String" />
                 <Property Name="width" Type="Edm.Int32" />
             </ComplexType>
+            <ComplexType Name="changeNotification">
+                <Property Name="id" Type="Edm.String" />
+                <Property Name="sequenceNumber" Type="Edm.Int32" Nullable="false" />
+                <Property Name="subscriptionId" Type="Edm.Guid" Nullable="false" />
+                <Property Name="subscriptionExpirationDateTime" Type="Edm.DateTimeOffset" Nullable="false" />
+                <Property Name="clientState" Type="Edm.String" />
+                <Property Name="changeType" Type="graph.changeType" Nullable="false" />
+                <Property Name="resource" Type="Edm.String" Nullable="false" />
+                <Property Name="tenantId" Type="Edm.Guid" Nullable="false" />
+                <Property Name="resourceData" Type="graph.resourceData" />
+            </ComplexType>
             <EntityType Name="onenoteResource" BaseType="graph.onenoteEntityBaseModel" HasStream="true">
                 <Property Name="content" Type="Edm.Stream" />
             </EntityType>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -86,6 +86,7 @@
         <NavigationProperty Name="publishedResources" Type="Collection(graph.publishedResource)" ContainsTarget="true" />
       </EntityType>
       <EntityContainer Name="GraphService">
+        <Singleton Name="settings" EntityType="microsoft.graph.FAILTYPE" />
         <EntitySet Name="bookingBusinesses" EntityType="microsoft.graph.bookingBusiness">
           <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
             <Record>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='preprocess_csdl.xsl'?>
-<edmx:Edmx Version="4.0" 
-  xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
   <edmx:DataServices>
-    <Schema Namespace="microsoft.graph" Alias="graph" 
-      xmlns="http://docs.oasis-open.org/odata/ns/edm">
+    <Schema Namespace="microsoft.graph" Alias="graph" xmlns="http://docs.oasis-open.org/odata/ns/edm">
       <EntityType Name="approval" BaseType="graph.entity">
         <NavigationProperty Name="pendingSteps" Type="Collection(graph.approvalStep)" ContainsTarget="true" />
         <NavigationProperty Name="completedSteps" Type="Collection(graph.approvalStep)" ContainsTarget="true" />
@@ -36,6 +34,16 @@
         <Property Name="url" Type="Edm.String" />
         <Property Name="width" Type="Edm.Int32" />
         <Annotation Term="Org.OData.Core.V1.LongDescription" String="navigable" />
+      </ComplexType>
+      <ComplexType Name="changeNotification">
+        <Property Name="id" Type="Edm.String" />
+        <Property Name="subscriptionId" Type="Edm.Guid" Nullable="false" />
+        <Property Name="subscriptionExpirationDateTime" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="clientState" Type="Edm.String" />
+        <Property Name="changeType" Type="graph.changeType" Nullable="false" />
+        <Property Name="resource" Type="Edm.String" Nullable="false" />
+        <Property Name="tenantId" Type="Edm.Guid" Nullable="false" />
+        <Property Name="resourceData" Type="graph.resourceData" />
       </ComplexType>
       <EntityType Name="onenoteResource" BaseType="graph.onenoteEntityBaseModel">
         <Property Name="content" Type="Edm.Stream" />
@@ -210,6 +218,11 @@
         <Parameter Name="bindingParameter" Type="graph.event" />
         <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
         <Parameter Name="SendResponse" Type="Edm.Boolean" />
+      </Action>
+      <Action Name="createUploadSession" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.driveItem" />
+        <Parameter Name="item" Type="graph.driveItemUploadableProperties" />
+        <ReturnType Type="graph.uploadSession" />
       </Action>
     </Schema>
   </edmx:DataServices>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -3,7 +3,8 @@
 <edmx:Edmx Version="4.0" 
   xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
   <edmx:DataServices>
-    <Schema Namespace="microsoft.graph" Alias="graph" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+    <Schema Namespace="microsoft.graph" Alias="graph" 
+      xmlns="http://docs.oasis-open.org/odata/ns/edm">
       <EntityType Name="approval" BaseType="graph.entity">
         <NavigationProperty Name="pendingSteps" Type="Collection(graph.approvalStep)" ContainsTarget="true" />
         <NavigationProperty Name="completedSteps" Type="Collection(graph.approvalStep)" ContainsTarget="true" />
@@ -76,118 +77,120 @@
         <NavigationProperty Name="agentGroups" Type="Collection(graph.onPremisesAgentGroup)" ContainsTarget="true" />
         <NavigationProperty Name="publishedResources" Type="Collection(graph.publishedResource)" ContainsTarget="true" />
       </EntityType>
-      <EntitySet Name="bookingBusinesses" EntityType="microsoft.graph.bookingBusiness">
-        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
-          <Record>
-            <PropertyValue Property="RestrictedProperties">
-              <Collection>
-                <Record>
-                  <PropertyValue Property="NavigationProperty">
-                    <PropertyPath>calendarView</PropertyPath>
-                  </PropertyValue>
-                  <PropertyValue Property="ReadRestrictions">
-                    <Record>
-                      <PropertyValue Property="CustomQueryOptions">
-                        <Collection>
-                          <Record>
-                            <PropertyValue Property="Name" String="start" />
-                            <PropertyValue Property="Description" String="The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00" />
-                            <PropertyValue Property="Required" Bool="true" />
-                          </Record>
-                          <Record>
-                            <PropertyValue Property="Name" String="end" />
-                            <PropertyValue Property="Description" String="The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
-                            <PropertyValue Property="Required" Bool="true" />
-                          </Record>
-                        </Collection>
-                      </PropertyValue>
-                    </Record>
-                  </PropertyValue>
-                </Record>
-              </Collection>
-            </PropertyValue>
-          </Record>
-        </Annotation>
-      </EntitySet>
-      <EntitySet Name="groups" EntityType="microsoft.graph.group">
-        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
-          <Record>
-            <PropertyValue Property="RestrictedProperties">
-              <Collection>
-                <Record>
-                  <PropertyValue Property="NavigationProperty">
-                    <PropertyPath>calendarView</PropertyPath>
-                  </PropertyValue>
-                  <PropertyValue Property="ReadRestrictions">
-                    <Record>
-                      <PropertyValue Property="CustomQueryOptions">
-                        <Collection>
-                          <Record>
-                            <PropertyValue Property="Name" String="startDateTime" />
-                            <PropertyValue Property="Description" String="The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00" />
-                            <PropertyValue Property="Required" Bool="true" />
-                          </Record>
-                          <Record>
-                            <PropertyValue Property="Name" String="endDateTime" />
-                            <PropertyValue Property="Description" String="The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
-                            <PropertyValue Property="Required" Bool="true" />
-                          </Record>
-                        </Collection>
-                      </PropertyValue>
-                    </Record>
-                  </PropertyValue>
-                </Record>
-                <Record>
-                  <PropertyValue Property="NavigationProperty">
-                    <PropertyPath>calendar/calendarView</PropertyPath>
-                  </PropertyValue>
-                  <PropertyValue Property="ReadRestrictions">
-                    <Record>
-                      <PropertyValue Property="CustomQueryOptions">
-                        <Collection>
-                          <Record>
-                            <PropertyValue Property="Name" String="startDateTime" />
-                            <PropertyValue Property="Description" String="The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00" />
-                            <PropertyValue Property="Required" Bool="true" />
-                          </Record>
-                          <Record>
-                            <PropertyValue Property="Name" String="endDateTime" />
-                            <PropertyValue Property="Description" String="The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
-                            <PropertyValue Property="Required" Bool="true" />
-                          </Record>
-                        </Collection>
-                      </PropertyValue>
-                    </Record>
-                  </PropertyValue>
-                </Record>
-                <Record>
-                  <PropertyValue Property="NavigationProperty">
-                    <PropertyPath>calendars/calendarView</PropertyPath>
-                  </PropertyValue>
-                  <PropertyValue Property="ReadRestrictions">
-                    <Record>
-                      <PropertyValue Property="CustomQueryOptions">
-                        <Collection>
-                          <Record>
-                            <PropertyValue Property="Name" String="startDateTime" />
-                            <PropertyValue Property="Description" String="The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00" />
-                            <PropertyValue Property="Required" Bool="true" />
-                          </Record>
-                          <Record>
-                            <PropertyValue Property="Name" String="endDateTime" />
-                            <PropertyValue Property="Description" String="The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
-                            <PropertyValue Property="Required" Bool="true" />
-                          </Record>
-                        </Collection>
-                      </PropertyValue>
-                    </Record>
-                  </PropertyValue>
-                </Record>
-              </Collection>
-            </PropertyValue>
-          </Record>
-        </Annotation>
-      </EntitySet>
+      <EntityContainer Name="GraphService">
+        <EntitySet Name="bookingBusinesses" EntityType="microsoft.graph.bookingBusiness">
+          <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+            <Record>
+              <PropertyValue Property="RestrictedProperties">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="NavigationProperty">
+                      <PropertyPath>calendarView</PropertyPath>
+                    </PropertyValue>
+                    <PropertyValue Property="ReadRestrictions">
+                      <Record>
+                        <PropertyValue Property="CustomQueryOptions">
+                          <Collection>
+                            <Record>
+                              <PropertyValue Property="Name" String="start" />
+                              <PropertyValue Property="Description" String="The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00" />
+                              <PropertyValue Property="Required" Bool="true" />
+                            </Record>
+                            <Record>
+                              <PropertyValue Property="Name" String="end" />
+                              <PropertyValue Property="Description" String="The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
+                              <PropertyValue Property="Required" Bool="true" />
+                            </Record>
+                          </Collection>
+                        </PropertyValue>
+                      </Record>
+                    </PropertyValue>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="groups" EntityType="microsoft.graph.group">
+          <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+            <Record>
+              <PropertyValue Property="RestrictedProperties">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="NavigationProperty">
+                      <PropertyPath>calendarView</PropertyPath>
+                    </PropertyValue>
+                    <PropertyValue Property="ReadRestrictions">
+                      <Record>
+                        <PropertyValue Property="CustomQueryOptions">
+                          <Collection>
+                            <Record>
+                              <PropertyValue Property="Name" String="startDateTime" />
+                              <PropertyValue Property="Description" String="The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00" />
+                              <PropertyValue Property="Required" Bool="true" />
+                            </Record>
+                            <Record>
+                              <PropertyValue Property="Name" String="endDateTime" />
+                              <PropertyValue Property="Description" String="The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
+                              <PropertyValue Property="Required" Bool="true" />
+                            </Record>
+                          </Collection>
+                        </PropertyValue>
+                      </Record>
+                    </PropertyValue>
+                  </Record>
+                  <Record>
+                    <PropertyValue Property="NavigationProperty">
+                      <PropertyPath>calendar/calendarView</PropertyPath>
+                    </PropertyValue>
+                    <PropertyValue Property="ReadRestrictions">
+                      <Record>
+                        <PropertyValue Property="CustomQueryOptions">
+                          <Collection>
+                            <Record>
+                              <PropertyValue Property="Name" String="startDateTime" />
+                              <PropertyValue Property="Description" String="The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00" />
+                              <PropertyValue Property="Required" Bool="true" />
+                            </Record>
+                            <Record>
+                              <PropertyValue Property="Name" String="endDateTime" />
+                              <PropertyValue Property="Description" String="The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
+                              <PropertyValue Property="Required" Bool="true" />
+                            </Record>
+                          </Collection>
+                        </PropertyValue>
+                      </Record>
+                    </PropertyValue>
+                  </Record>
+                  <Record>
+                    <PropertyValue Property="NavigationProperty">
+                      <PropertyPath>calendars/calendarView</PropertyPath>
+                    </PropertyValue>
+                    <PropertyValue Property="ReadRestrictions">
+                      <Record>
+                        <PropertyValue Property="CustomQueryOptions">
+                          <Collection>
+                            <Record>
+                              <PropertyValue Property="Name" String="startDateTime" />
+                              <PropertyValue Property="Description" String="The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00" />
+                              <PropertyValue Property="Required" Bool="true" />
+                            </Record>
+                            <Record>
+                              <PropertyValue Property="Name" String="endDateTime" />
+                              <PropertyValue Property="Description" String="The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
+                              <PropertyValue Property="Required" Bool="true" />
+                            </Record>
+                          </Collection>
+                        </PropertyValue>
+                      </Record>
+                    </PropertyValue>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+      </EntityContainer>
       <Action Name="accept" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event" />
         <Parameter Name="Comment" Type="Edm.String" Unicode="false" />

--- a/transforms/csdl/readme.md
+++ b/transforms/csdl/readme.md
@@ -16,11 +16,16 @@ Please use fully qualified and precise template match statements so as not to pe
 4. Make the transform change in *preprocess_csdl.xsl*.
 5. Add corresponding test input to *preprocess_csdl_test_input.xml*.
 6. Give the *preprocess_csdl_test_input.xml* file focus.
-7. From the top menu in Visual Studio, select XML > Start XSLT Without Debugging or Alt + F5. This will result in a file named *preprocess_csdl_test_input.xml* which will be created in your %AppData%.
+7. From the top menu in Visual Studio, select XML > Start XSLT Without Debugging or Alt + F5. This will result in a file named *preprocess_csdl_test_input.xml* which will be created in your %AppData%. See [command line instructions](#command-line-instructions-for-running-the-transform) if you prefer command line.
 8. Inspect the transformed file output named *preprocess_csdl_test_input.xml* for the expected changes.
-9. Perform a simple text diff of the output *preprocess_csdl_test_input.xml* with the *preprocess_csdl_test_output.xml* file and check for unexpected changes.
+9.  Perform a simple text diff of the output *preprocess_csdl_test_input.xml* with the *preprocess_csdl_test_output.xml* file and check for unexpected changes.
 10. Add the expected output to *preprocess_csdl_test_output.xml*.
 11. Check in changes and open your pull request.
+
+## Command line instructions for running the transform
+1. Start PowerShell
+2. `cd` into `transforms\csdl` folder
+3. Run `transform.ps1 <xsl_file> <input_file> <output_file>`. If files are not specified, the script will apply transformations from  *preprocess_csdl.xsl* on  *preprocess_csdl_test_input.xml* and override *preprocess_csdl_test_output.xml* file.
 
 ## Instructions for running transform against Microsoft Graph metadata
 

--- a/transforms/csdl/transform.ps1
+++ b/transforms/csdl/transform.ps1
@@ -7,7 +7,9 @@ param (
     [string]
     $inputPath = "preprocess_csdl_test_input.xml",
     [string]
-    $outputPath = "preprocess_csdl_test_output.xml"
+    $outputPath = "preprocess_csdl_test_output.xml",
+    [bool]
+    $dbg = $false
 )
 
 $xslFullPath = Join-Path $PWD $xslPath
@@ -24,6 +26,6 @@ if (!(Test-Path $inputFullPath)) {
 
 $outputFullPath = Join-Path $PWD $outputPath
 
-$xslt = New-Object System.Xml.Xsl.XslCompiledTransform
+$xslt = [System.Xml.Xsl.XslCompiledTransform]::new($dbg) 
 $xslt.Load((Join-Path $PWD $xslPath))
-$xslt.Transform($inputFullPath, $outputFullPath) 
+$xslt.Transform($inputFullPath, $outputFullPath)

--- a/transforms/csdl/transform.ps1
+++ b/transforms/csdl/transform.ps1
@@ -1,0 +1,29 @@
+# applies XSL transformations from an XSL file onto an XML file
+
+[CmdletBinding()]
+param (
+    [string]
+    $xslPath = "preprocess_csdl.xsl",
+    [string]
+    $inputPath = "preprocess_csdl_test_input.xml",
+    [string]
+    $outputPath = "preprocess_csdl_test_output.xml"
+)
+
+$xslFullPath = Join-Path $PWD $xslPath
+if (!(Test-Path $xslFullPath)) {
+    Write-Host "please provide a path to XSL relative to working directory" -ForegroundColor Red
+    exit
+}
+
+$inputFullPath = Join-Path $PWD $inputPath
+if (!(Test-Path $inputFullPath)) {
+    Write-Host "please provide a path to input XML relative to working directory" -ForegroundColor Red
+    exit
+}
+
+$outputFullPath = Join-Path $PWD $outputPath
+
+$xslt = New-Object System.Xml.Xsl.XslCompiledTransform
+$xslt.Load((Join-Path $PWD $xslPath))
+$xslt.Transform($inputFullPath, $outputFullPath) 


### PR DESCRIPTION
The createUploadSession action was set with an additional parameter which is a breaking change for Java since Java doesn't support optional parameters (which only works when there aren't any non-nullable parameters after a nullable parameter).  I've added the original overload and have requested from the API owner that they add it back into the metadata.

Also removing an erroneous property from changeNotification, which should have been removed this week.

Added script from https://github.com/microsoftgraph/msgraph-metadata/pull/23.

@nikchett