### PR TITLE
Pipeline and XSLT updates for namespaces release

### DIFF
--- a/pipelines/validateCleanedMetadata_beta.yml
+++ b/pipelines/validateCleanedMetadata_beta.yml
@@ -23,7 +23,7 @@ resources:
     type: github
     endpoint: microsoftgraph
     name: microsoftgraph/msgraph-beta-sdk-dotnet
-    ref: zengin/namespacesBase # checkout the master branch
+    ref: master # checkout the master branch
   - repository: microsoft-graph-docs
     type: github
     endpoint: microsoftgraph
@@ -107,7 +107,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: '$(Build.SourcesDirectory)/msgraph-metadata/scripts/runTypewriter.ps1'
-    arguments: '-verbosity Info -metadata $(pathToInputMetadata) -output $(outputPath) -generationMode TransformWithDocs -t https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/zengin/xsltNamespaces/transforms/csdl/preprocess_csdl.xsl -d $(pathToDocsRepoRoot) -cleanup $false -e beta'
+    arguments: '-verbosity Info -metadata $(pathToInputMetadata) -output $(outputPath) -generationMode TransformWithDocs -t https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/transforms/csdl/preprocess_csdl.xsl -d $(pathToDocsRepoRoot) -cleanup $false -e beta'
     workingDirectory: '$(Build.SourcesDirectory)'
   enabled: true
 
@@ -144,7 +144,6 @@ steps:
     solution: '$(Build.SourcesDirectory)/msgraph-beta-sdk-dotnet/**/Microsoft.Graph.Beta.csproj'
     configuration: debug
     clean: true
-    msbuildArguments: '-v:d'
   enabled: true
 
 # Artifact will be used in another pipeline to checkin the clean metadata into

--- a/pipelines/validateCleanedMetadata_beta.yml
+++ b/pipelines/validateCleanedMetadata_beta.yml
@@ -107,7 +107,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: '$(Build.SourcesDirectory)/msgraph-metadata/scripts/runTypewriter.ps1'
-    arguments: '-verbosity Info -metadata $(pathToInputMetadata) -output $(outputPath) -generationMode TransformWithDocs -t https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/transforms/csdl/preprocess_csdl.xsl -d $(pathToDocsRepoRoot) -cleanup $false -e beta'
+    arguments: '-verbosity Info -metadata $(pathToInputMetadata) -output $(outputPath) -generationMode TransformWithDocs -t https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/zengin/xsltNamespaces/transforms/csdl/preprocess_csdl.xsl -d $(pathToDocsRepoRoot) -cleanup $false -e beta'
     workingDirectory: '$(Build.SourcesDirectory)'
   enabled: true
 

--- a/pipelines/validateCleanedMetadata_beta.yml
+++ b/pipelines/validateCleanedMetadata_beta.yml
@@ -23,7 +23,7 @@ resources:
     type: github
     endpoint: microsoftgraph
     name: microsoftgraph/msgraph-beta-sdk-dotnet
-    ref: master # checkout the master branch
+    ref: zengin/namespacesBase # checkout the master branch
   - repository: microsoft-graph-docs
     type: github
     endpoint: microsoftgraph
@@ -125,7 +125,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: '$(Build.SourcesDirectory)/msgraph-metadata/scripts/copyGeneratedFiles.ps1'
-    arguments: '@("$(outputPath)/com/microsoft/graph/model/", "$(outputPath)/com/microsoft/graph/requests/") @("$(Build.SourcesDirectory)/msgraph-beta-sdk-dotnet/src/Microsoft.Graph/Models/Generated/", "$(Build.SourcesDirectory)/msgraph-beta-sdk-dotnet/src/Microsoft.Graph/Requests/Generated/")'
+    arguments: '@("$(outputPath)/com/microsoft/graph/") @("$(Build.SourcesDirectory)/msgraph-beta-sdk-dotnet/src/Microsoft.Graph/Generated/")'
     workingDirectory: '$(Build.SourcesDirectory)' # Set the root for a multi-repo pipeline. /s
   enabled: true
 
@@ -153,6 +153,7 @@ steps:
   inputs:
     PathtoPublish: '$(outputPath)\cleanMetadataWithDescriptionsbeta.xml'
     ArtifactName: 'clean_beta_metadata'
+    msbuildArguments: '-v:d'
   enabled: true
 
 # Send a notification to our Graph Tooling channel to let us know that

--- a/pipelines/validateCleanedMetadata_beta.yml
+++ b/pipelines/validateCleanedMetadata_beta.yml
@@ -144,6 +144,7 @@ steps:
     solution: '$(Build.SourcesDirectory)/msgraph-beta-sdk-dotnet/**/Microsoft.Graph.Beta.csproj'
     configuration: debug
     clean: true
+    msbuildArguments: '-v:d'
   enabled: true
 
 # Artifact will be used in another pipeline to checkin the clean metadata into
@@ -153,7 +154,6 @@ steps:
   inputs:
     PathtoPublish: '$(outputPath)\cleanMetadataWithDescriptionsbeta.xml'
     ArtifactName: 'clean_beta_metadata'
-    msbuildArguments: '-v:d'
   enabled: true
 
 # Send a notification to our Graph Tooling channel to let us know that

--- a/pipelines/validateCleanedMetadata_v1.0.yml
+++ b/pipelines/validateCleanedMetadata_v1.0.yml
@@ -21,7 +21,7 @@ resources:
     type: github
     endpoint: microsoftgraph
     name: microsoftgraph/msgraph-sdk-dotnet
-    ref: zengin/namespacesBase # checkout the dev branch
+    ref: dev # checkout the dev branch
   - repository: microsoft-graph-docs
     type: github
     endpoint: microsoftgraph
@@ -105,7 +105,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: '$(Build.SourcesDirectory)/msgraph-metadata/scripts/runTypewriter.ps1'
-    arguments: '-verbosity Info -metadata $(pathToInputMetadata) -output $(outputPath) -generationMode TransformWithDocs -t https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/zengin/xsltNamespaces/transforms/csdl/preprocess_csdl.xsl -d $(pathToDocsRepoRoot) -cleanup $false'
+    arguments: '-verbosity Info -metadata $(pathToInputMetadata) -output $(outputPath) -generationMode TransformWithDocs -t https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/transforms/csdl/preprocess_csdl.xsl -d $(pathToDocsRepoRoot) -cleanup $false'
     workingDirectory: '$(Build.SourcesDirectory)'
   enabled: true
 
@@ -142,7 +142,6 @@ steps:
     solution: '$(Build.SourcesDirectory)/msgraph-sdk-dotnet/**/*.sln'
     configuration: debug
     clean: true
-    msbuildArguments: '-v:d'
   enabled: true
 
 # Artifact will be used in another pipeline to checkin the clean metadata into

--- a/pipelines/validateCleanedMetadata_v1.0.yml
+++ b/pipelines/validateCleanedMetadata_v1.0.yml
@@ -142,6 +142,7 @@ steps:
     solution: '$(Build.SourcesDirectory)/msgraph-sdk-dotnet/**/*.sln'
     configuration: debug
     clean: true
+    msbuildArguments: '-v:d'
   enabled: true
 
 # Artifact will be used in another pipeline to checkin the clean metadata into

--- a/pipelines/validateCleanedMetadata_v1.0.yml
+++ b/pipelines/validateCleanedMetadata_v1.0.yml
@@ -21,7 +21,7 @@ resources:
     type: github
     endpoint: microsoftgraph
     name: microsoftgraph/msgraph-sdk-dotnet
-    ref: dev # checkout the dev branch
+    ref: zengin/namespacesBase # checkout the dev branch
   - repository: microsoft-graph-docs
     type: github
     endpoint: microsoftgraph
@@ -105,7 +105,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: '$(Build.SourcesDirectory)/msgraph-metadata/scripts/runTypewriter.ps1'
-    arguments: '-verbosity Info -metadata $(pathToInputMetadata) -output $(outputPath) -generationMode TransformWithDocs -t https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/transforms/csdl/preprocess_csdl.xsl -d $(pathToDocsRepoRoot) -cleanup $false'
+    arguments: '-verbosity Info -metadata $(pathToInputMetadata) -output $(outputPath) -generationMode TransformWithDocs -t https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/zengin/xsltNamespaces/transforms/csdl/preprocess_csdl.xsl -d $(pathToDocsRepoRoot) -cleanup $false'
     workingDirectory: '$(Build.SourcesDirectory)'
   enabled: true
 
@@ -123,7 +123,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: '$(Build.SourcesDirectory)/msgraph-metadata/scripts/copyGeneratedFiles.ps1'
-    arguments: '@("$(outputPath)/com/microsoft/graph/model/", "$(outputPath)/com/microsoft/graph/requests/") @("$(Build.SourcesDirectory)/msgraph-sdk-dotnet/src/Microsoft.Graph/Models/Generated/", "$(Build.SourcesDirectory)/msgraph-sdk-dotnet/src/Microsoft.Graph/Requests/Generated/")'
+    arguments: '@("$(outputPath)/com/microsoft/graph/") @("$(Build.SourcesDirectory)/msgraph-sdk-dotnet/src/Microsoft.Graph/Generated/")'
     workingDirectory: '$(Build.SourcesDirectory)' # Set the root for a multi-repo pipeline. /s
   enabled: true
 

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -95,11 +95,6 @@
 
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations//edm:Annotation[starts-with(@Term, 'Org.OData.Capabilities')]"/>
 
-    <!-- Remove namespaces -->
-
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']"/>
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph.termStore']"/>
-
     <!-- Remove singleton -->
 
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:Singleton[@Name='conditionalAccess']"/>

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -119,6 +119,10 @@
         <xsl:apply-templates select="@* | node()"/>
     </xsl:template>
 
+    <!--Remove functions that are blocking beta generation-->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']/edm:Function[@Name='getPstnCalls']"/>
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']/edm:Function[@Name='getDirectRoutingCalls']"/>
+
     <!-- Reorder action parameters -->
 
     <!-- These actions have the same parameters that need reordering. Will need to create a new template

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -226,5 +226,13 @@
         <ReturnType Type="graph.uploadSession" />
       </Action>
     </Schema>
+    <Schema Namespace="microsoft.graph.callRecords" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EnumType Name="callType">
+        <Member Name="unknown" Value="0" />
+        <Member Name="groupCall" Value="1" />
+        <Member Name="peerToPeer" Value="2" />
+        <Member Name="unknownFutureValue" Value="3" />
+      </EnumType>
+    </Schema>
   </edmx:DataServices>
 </edmx:Edmx>


### PR DESCRIPTION
Changes include the following:
1. Remove the condition that drops namespaces
2. Update the test data to have additional namespaces
3. Update pipelines to reflect the new folder structure in `msgraph-sdk-dotnet` and `msgraph-beta-sdk-dotnet` repos.
4. Add a new rule to XSLT to address the issue that blocks generating Beta SDK. Tracking issue to fix the underlying problem in generator is opened at https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/277

[AB#5024](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/5024)