### PR TITLE
Consistency level header

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -357,6 +357,50 @@
       </xsl:element>
     </xsl:template>
 
+    <!-- Add custom headers (ConsistencyLevel) to AAD objects -->
+    <xsl:template name="ConsistencyLevelHeaderTemplate">
+      <xsl:element name="Record" namespace="{namespace-uri()}">
+        <xsl:element name="PropertyValue">
+          <xsl:attribute name="Property">CustomHeaders</xsl:attribute>
+          <xsl:element name="Collection">
+            <xsl:element name="Record">
+              <xsl:element name="PropertyValue">
+                <xsl:attribute name="Property">Name</xsl:attribute>
+                <xsl:attribute name="String">ConsistencyLevel</xsl:attribute>
+              </xsl:element>
+              <xsl:element name="PropertyValue">
+                <xsl:attribute name="Property">Description</xsl:attribute>
+                <xsl:attribute name="String">Indicates the requested consistency level.</xsl:attribute>
+              </xsl:element>
+              <xsl:element name="PropertyValue">
+                <xsl:attribute name="Property">DocumentationURL</xsl:attribute>
+                <xsl:attribute name="String">https://developer.microsoft.com/en-us/office/blogs/microsoft-graph-advanced-queries-for-directory-objects-are-now-generally-available/</xsl:attribute>
+              </xsl:element>
+              <xsl:element name="PropertyValue">
+                <xsl:attribute name="Property">Required</xsl:attribute>
+                <xsl:attribute name="Bool">false</xsl:attribute>
+              </xsl:element>
+              <xsl:element name="PropertyValue">
+                <xsl:attribute name="Property">ExampleValues</xsl:attribute>
+                <xsl:element name="Collection">
+                  <xsl:element name="Record">
+                    <xsl:element name="PropertyValue">
+                      <xsl:attribute name="Property">Value</xsl:attribute>
+                      <xsl:attribute name="String">eventual</xsl:attribute>
+                    </xsl:element>
+                    <xsl:element name="PropertyValue">
+                      <xsl:attribute name="Property">Description</xsl:attribute>
+                      <xsl:attribute name="String">$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.</xsl:attribute>
+                    </xsl:element>
+                  </xsl:element>
+                </xsl:element>
+              </xsl:element>
+            </xsl:element>
+          </xsl:element>
+        </xsl:element>
+      </xsl:element>
+    </xsl:template>
+
     <xsl:template match="
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='users']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='groups']
@@ -416,50 +460,6 @@
       </xsl:copy>
     </xsl:template>
 
-    <xsl:template name="ConsistencyLevelHeaderTemplate">
-      <xsl:element name="Record" namespace="{namespace-uri()}">
-        <xsl:element name="PropertyValue">
-          <xsl:attribute name="Property">CustomHeaders</xsl:attribute>
-          <xsl:element name="Collection">
-            <xsl:element name="Record">
-              <xsl:element name="PropertyValue">
-                <xsl:attribute name="Property">Name</xsl:attribute>
-                <xsl:attribute name="String">ConsistencyLevel</xsl:attribute>
-              </xsl:element>
-              <xsl:element name="PropertyValue">
-                <xsl:attribute name="Property">Description</xsl:attribute>
-                <xsl:attribute name="String">Indicates the requested consistency level.</xsl:attribute>
-              </xsl:element>
-              <xsl:element name="PropertyValue">
-                <xsl:attribute name="Property">DocumentationURL</xsl:attribute>
-                <xsl:attribute name="String">https://developer.microsoft.com/en-us/office/blogs/microsoft-graph-advanced-queries-for-directory-objects-are-now-generally-available/</xsl:attribute>
-              </xsl:element>
-              <xsl:element name="PropertyValue">
-                <xsl:attribute name="Property">Required</xsl:attribute>
-                <xsl:attribute name="Bool">false</xsl:attribute>
-              </xsl:element>
-              <xsl:element name="PropertyValue">
-                <xsl:attribute name="Property">ExampleValues</xsl:attribute>
-                <xsl:element name="Collection">
-                  <xsl:element name="Record">
-                    <xsl:element name="PropertyValue">
-                      <xsl:attribute name="Property">Value</xsl:attribute>
-                      <xsl:attribute name="String">eventual</xsl:attribute>
-                    </xsl:element>
-                    <xsl:element name="PropertyValue">
-                      <xsl:attribute name="Property">Description</xsl:attribute>
-                      <xsl:attribute name="String">$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.</xsl:attribute>
-                    </xsl:element>
-                  </xsl:element>
-                </xsl:element>
-              </xsl:element>
-            </xsl:element>
-          </xsl:element>
-        </xsl:element>
-      </xsl:element>
-    </xsl:template>
-
-    <!-- Add CustomHeaders (ConsistencyLevel) to AAD object -->
   <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='applications']|
                        edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='servicePrincipals']|
                        edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='administrativeUnits']|

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -388,6 +388,10 @@
             </xsl:element>
           </xsl:element>
         </xsl:element>
+        <xsl:element name="Annotation">
+          <xsl:attribute name="Term">Org.OData.Capabilities.V1.ReadRestrictions</xsl:attribute>
+          <xsl:call-template name="ConsistencyLevelHeaderTemplate"/>
+        </xsl:element>
       </xsl:copy>
     </xsl:template>
 
@@ -411,4 +415,62 @@
         </xsl:element>
       </xsl:copy>
     </xsl:template>
+
+    <xsl:template name="ConsistencyLevelHeaderTemplate">
+      <xsl:element name="Record" namespace="{namespace-uri()}">
+        <xsl:element name="PropertyValue">
+          <xsl:attribute name="Property">CustomHeaders</xsl:attribute>
+          <xsl:element name="Collection">
+            <xsl:element name="Record">
+              <xsl:element name="PropertyValue">
+                <xsl:attribute name="Property">Name</xsl:attribute>
+                <xsl:attribute name="String">ConsistencyLevel</xsl:attribute>
+              </xsl:element>
+              <xsl:element name="PropertyValue">
+                <xsl:attribute name="Property">Description</xsl:attribute>
+                <xsl:attribute name="String">Indicates the requested consistency level.</xsl:attribute>
+              </xsl:element>
+              <xsl:element name="PropertyValue">
+                <xsl:attribute name="Property">DocumentationURL</xsl:attribute>
+                <xsl:attribute name="String">https://developer.microsoft.com/en-us/office/blogs/microsoft-graph-advanced-queries-for-directory-objects-are-now-generally-available/</xsl:attribute>
+              </xsl:element>
+              <xsl:element name="PropertyValue">
+                <xsl:attribute name="Property">Required</xsl:attribute>
+                <xsl:attribute name="Bool">false</xsl:attribute>
+              </xsl:element>
+              <xsl:element name="PropertyValue">
+                <xsl:attribute name="Property">ExampleValues</xsl:attribute>
+                <xsl:element name="Collection">
+                  <xsl:element name="Record">
+                    <xsl:element name="PropertyValue">
+                      <xsl:attribute name="Property">Value</xsl:attribute>
+                      <xsl:attribute name="String">eventual</xsl:attribute>
+                    </xsl:element>
+                    <xsl:element name="PropertyValue">
+                      <xsl:attribute name="Property">Description</xsl:attribute>
+                      <xsl:attribute name="String">$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.</xsl:attribute>
+                    </xsl:element>
+                  </xsl:element>
+                </xsl:element>
+              </xsl:element>
+            </xsl:element>
+          </xsl:element>
+        </xsl:element>
+      </xsl:element>
+    </xsl:template>
+
+    <!-- Add CustomHeaders (ConsistencyLevel) to AAD object -->
+  <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='applications']|
+                       edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='servicePrincipals']|
+                       edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='administrativeUnits']|
+                       edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='contacts']|
+                       edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='devices']">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+      <xsl:element name="Annotation">
+        <xsl:attribute name="Term">Org.OData.Capabilities.V1.ReadRestrictions</xsl:attribute>
+        <xsl:call-template name="ConsistencyLevelHeaderTemplate"/>
+      </xsl:element>
+    </xsl:copy>
+  </xsl:template>
 </xsl:stylesheet>

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -29,7 +29,10 @@
                 <NavigationProperty Name="members" Type="Collection(graph.directoryObject)">
                   <Annotation Term="Org.OData.Core.V1.Description" String="Users and groups that are members of this group. HTTP Methods: GET (supported for all groups), POST (supported for Microsoft 365 groups, security groups and mail-enabled security groups), DELETE (supported for Microsoft 365 groups and security groups) Nullable." />
                 </NavigationProperty>
-              </EntityType>
+            </EntityType>
+            <EntityType Name="servicePrincipal" BaseType="graph.directoryObject" OpenType="true">
+                <Property Name="appId" Type="Edm.String"/>
+            </EntityType>
             <Annotations Target="graph.activityHistoryItem">
                 <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
                     <Record>
@@ -111,6 +114,7 @@
               <Singleton Name="conditionalAccess" Type="microsoft.graph.conditionalAccessRoot" />
               <EntitySet Name="bookingBusinesses" EntityType="microsoft.graph.bookingBusiness"/>
               <EntitySet Name="groups" EntityType="microsoft.graph.group" />
+              <EntitySet Name="servicePrincipals" EntityType="microsoft.graph.servicePrincipal" />
             </EntityContainer>
             <Action Name="accept" IsBound="true">
                 <Parameter Name="bindingParameter" Type="graph.event" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -39,6 +39,9 @@
           </Annotation>
         </NavigationProperty>
       </EntityType>
+      <EntityType Name="servicePrincipal" BaseType="graph.directoryObject" OpenType="true">
+        <Property Name="appId" Type="Edm.String" />
+      </EntityType>
       <Annotations Target="graph.activityHistoryItem">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
       </Annotations>
@@ -210,6 +213,52 @@
                           </Collection>
                         </PropertyValue>
                       </Record>
+                    </PropertyValue>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+            <Record>
+              <PropertyValue Property="CustomHeaders">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="Name" String="ConsistencyLevel" />
+                    <PropertyValue Property="Description" String="Indicates the requested consistency level." />
+                    <PropertyValue Property="DocumentationURL" String="https://developer.microsoft.com/en-us/office/blogs/microsoft-graph-advanced-queries-for-directory-objects-are-now-generally-available/" />
+                    <PropertyValue Property="Required" Bool="false" />
+                    <PropertyValue Property="ExampleValues">
+                      <Collection>
+                        <Record>
+                          <PropertyValue Property="Value" String="eventual" />
+                          <PropertyValue Property="Description" String="$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'." />
+                        </Record>
+                      </Collection>
+                    </PropertyValue>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="servicePrincipals" EntityType="microsoft.graph.servicePrincipal">
+          <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+            <Record>
+              <PropertyValue Property="CustomHeaders">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="Name" String="ConsistencyLevel" />
+                    <PropertyValue Property="Description" String="Indicates the requested consistency level." />
+                    <PropertyValue Property="DocumentationURL" String="https://developer.microsoft.com/en-us/office/blogs/microsoft-graph-advanced-queries-for-directory-objects-are-now-generally-available/" />
+                    <PropertyValue Property="Required" Bool="false" />
+                    <PropertyValue Property="ExampleValues">
+                      <Collection>
+                        <Record>
+                          <PropertyValue Property="Value" String="eventual" />
+                          <PropertyValue Property="Description" String="$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'." />
+                        </Record>
+                      </Collection>
                     </PropertyValue>
                   </Record>
                 </Collection>

--- a/transforms/csdl/transform.ps1
+++ b/transforms/csdl/transform.ps1
@@ -28,4 +28,9 @@ $outputFullPath = Join-Path $PWD $outputPath
 
 $xslt = [System.Xml.Xsl.XslCompiledTransform]::new($dbg) 
 $xslt.Load((Join-Path $PWD $xslPath))
-$xslt.Transform($inputFullPath, $outputFullPath)
+try {
+    $xslt.Transform($inputFullPath, $outputFullPath)
+}
+catch {
+    Write-Error $_.Exception
+}


### PR DESCRIPTION
This PR adds consistency level header to the following AAD entity sets:
- applications
- administrativeUnits
- contacts
- devices
- groups
- servicePrincipals
- users

Closes #38 