### PR TITLE
Update downloadDiff.ps1 to fix read-only variable

### DIFF
--- a/scripts/downloadDiff.ps1
+++ b/scripts/downloadDiff.ps1
@@ -7,9 +7,12 @@
 #
 #.Parameter endpointVersion
 #   Specifies the metadata endpoint to target. Expected values are "v1.0" and "beta"
+#.Parameter targetBranch
+#   Optional. Specifies the branch to target. The default value is 'master'.
 #>
 
-param([parameter(Mandatory = $true)][String]$endpointVersion)
+param([parameter(Mandatory = $true)]  [String] $endpointVersion,
+      [parameter(Mandatory = $false)] [String] $targetBranch = 'master')
 
 # Contains Format-Xml function.
 Import-Module .\scripts\utility.ps1 -Force
@@ -17,11 +20,11 @@ Import-Module .\scripts\utility.ps1 -Force
 # Are we on master? If not, we will want our changes committed on master.
 $branch = &git rev-parse --abbrev-ref HEAD
 Write-Host "downloadDiff.ps1 - Current branch: $branch"
-if ($branch -ne "master") {
-    git checkout master | Write-Host
+if ($branch -ne $targetBranch) {
+    git checkout $targetBranch | Write-Host
     $branch = &git rev-parse --abbrev-ref HEAD
     Write-Host "downloadDiff.ps1 - Current branch: $branch"
-    git pull origin master --allow-unrelated-histories | Write-Host
+    git pull origin $targetBranch --allow-unrelated-histories | Write-Host
 }
 
 # Download the metadata from livesite.
@@ -71,4 +74,4 @@ else {
 
 git add $metadataFileName | Write-Host
 git commit -m "downloadDiff.ps1 - Updated $metadataFileName from downloadDiff.ps1" | Write-Host
-git push origin master | Write-Host
+git push origin $targetBranch | Write-Host

--- a/scripts/downloadDiff.ps1
+++ b/scripts/downloadDiff.ps1
@@ -64,9 +64,8 @@ elseif ($result |Where {$_ -notmatch '^\?\?'}) {
 }
 else {
     # tree is clean
-    Write-Host "downloadDiff.ps1 - No changes reported. Build is aborted as succeeded."
-    Write-Host "##vso[task.setvariable variable=agent.jobstatus;]canceled"
-    Write-Host "##vso[task.complete result=Canceled;]DONE"
+    # make sure that pipelines have failOnStderr:true and errorActionPreference:stop set.
+    Write-Error "downloadDiff.ps1 - No changes reported. Cancel pipeline."
     Exit
 }
 


### PR DESCRIPTION
The `agent.jobstatus` environment variable has been set to read only (breaking change for us). We need to this pipeline to error when there are no changes to the metadata so that subsequent pipelines don't consider this pipeline a successful completion.

```log
##[error]Unable to process command '##vso[task.setvariable variable=agent.jobstatus;]canceled' successfully. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=817296)
##[error]Overwriting readonly variable 'agent.jobstatus' is not permitted. See https://github.com/microsoft/azure-pipelines-yaml/blob/master/design/readonly-variables.md for details.
```

- [ ] re-enable tasks for (v1.0 - 1) msgraph-capture-metadata after this PR.