### PR TITLE
adds containsTarget=true to cloudPcProvisioningPolicy.assignments

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -72,7 +72,8 @@
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windowsPhone81ImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windowsPhone81SCEPCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windowsUniversalAppX']/edm:NavigationProperty[@Name='committedContainedApps']|
-                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windowsWifiEnterpriseEAPConfiguration']/edm:NavigationProperty[@Name='rootCertificatesForServerValidation']
+                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windowsWifiEnterpriseEAPConfiguration']/edm:NavigationProperty[@Name='rootCertificatesForServerValidation']|
+                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='cloudPcProvisioningPolicy']/edm:NavigationProperty[@Name='assignments']
                          ">
       <!-- Didn't add the rule for teamsAppDefinition and unifiedRoleDefinition since it doesn't
            look like we applied it, and I don't see any issues because of it.

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -65,6 +65,9 @@
                 <Property Name="tenantId" Type="Edm.Guid" Nullable="false" />
                 <Property Name="resourceData" Type="graph.resourceData" />
             </ComplexType>
+            <EntityType Name="cloudPcProvisioningPolicy" BaseType="graph.entity">
+                <NavigationProperty Name="assignments" Type="Collection(graph.cloudPcProvisioningPolicyAssignment)" />
+            </EntityType>
             <EntityType Name="onenoteResource" BaseType="graph.onenoteEntityBaseModel" HasStream="true">
                 <Property Name="content" Type="Edm.Stream" />
             </EntityType>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -63,6 +63,9 @@
         <Property Name="tenantId" Type="Edm.Guid" Nullable="false" />
         <Property Name="resourceData" Type="graph.resourceData" />
       </ComplexType>
+      <EntityType Name="cloudPcProvisioningPolicy" BaseType="graph.entity">
+        <NavigationProperty Name="assignments" Type="Collection(graph.cloudPcProvisioningPolicyAssignment)" ContainsTarget="true" />
+      </EntityType>
       <EntityType Name="onenoteResource" BaseType="graph.onenoteEntityBaseModel">
         <Property Name="content" Type="Edm.Stream" />
       </EntityType>


### PR DESCRIPTION
Unblocks beta generation in staging so that the Raptor pipeline can continue validating.

The team is informed to get this fixed in actual metadata.