### PR TITLE
Fetch master for downloaddiff

### DIFF
--- a/scripts/downloadDiff.ps1
+++ b/scripts/downloadDiff.ps1
@@ -21,6 +21,7 @@ Import-Module .\scripts\utility.ps1 -Force
 $branch = &git rev-parse --abbrev-ref HEAD
 Write-Host "downloadDiff.ps1 - Current branch: $branch"
 if ($branch -ne $targetBranch) {
+    git fetch origin $targetBranch | Write-Host
     git checkout $targetBranch | Write-Host
     $branch = &git rev-parse --abbrev-ref HEAD
     Write-Host "downloadDiff.ps1 - Current branch: $branch"


### PR DESCRIPTION
TIL: AZDO does a `git init` locally, adds the remote: origin, and only fetches the head commit of master in a detached state.  So I need to fetch master.