### PR TITLE
Fix signatures of Accept, Decline and TentativelyAccept actions

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -279,6 +279,67 @@
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']/edm:Function[@Name='getDirectRoutingCalls']"/>
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='delta'][edm:Parameter[@Name='token']][edm:Parameter[@Type='Collection(graph.site)']]"/>
 
+    <!-- Reorder action parameters -->
+
+    <!-- These actions have the same parameters that need reordering. Will need to create a new template
+         for each reordering. -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
+      <xsl:copy>
+        <xsl:apply-templates select="@* | node()"/>
+        <xsl:element name="Action">
+          <xsl:attribute name="Name">accept</xsl:attribute>
+          <xsl:attribute name="IsBound">true</xsl:attribute>
+          <xsl:element name="Parameter">
+            <xsl:attribute name="Name">bindingParameter</xsl:attribute>
+            <xsl:attribute name="Type">graph.event</xsl:attribute>
+          </xsl:element>
+          <xsl:element name="Parameter">
+            <xsl:attribute name="Name">Comment</xsl:attribute>
+            <xsl:attribute name="Type">Edm.String</xsl:attribute>
+            <xsl:attribute name="Unicode">false</xsl:attribute>
+          </xsl:element>
+          <xsl:element name="Parameter">
+            <xsl:attribute name="Name">SendResponse</xsl:attribute>
+            <xsl:attribute name="Type">Edm.Boolean</xsl:attribute>
+          </xsl:element>
+        </xsl:element>
+        <xsl:element name="Action">
+          <xsl:attribute name="Name">decline</xsl:attribute>
+          <xsl:attribute name="IsBound">true</xsl:attribute>
+          <xsl:element name="Parameter">
+            <xsl:attribute name="Name">bindingParameter</xsl:attribute>
+            <xsl:attribute name="Type">graph.event</xsl:attribute>
+          </xsl:element>
+          <xsl:element name="Parameter">
+            <xsl:attribute name="Name">Comment</xsl:attribute>
+            <xsl:attribute name="Type">Edm.String</xsl:attribute>
+            <xsl:attribute name="Unicode">false</xsl:attribute>
+          </xsl:element>
+          <xsl:element name="Parameter">
+            <xsl:attribute name="Name">SendResponse</xsl:attribute>
+            <xsl:attribute name="Type">Edm.Boolean</xsl:attribute>
+          </xsl:element>
+        </xsl:element>
+        <xsl:element name="Action">
+          <xsl:attribute name="Name">tentativelyAccept</xsl:attribute>
+          <xsl:attribute name="IsBound">true</xsl:attribute>
+          <xsl:element name="Parameter">
+            <xsl:attribute name="Name">bindingParameter</xsl:attribute>
+            <xsl:attribute name="Type">graph.event</xsl:attribute>
+          </xsl:element>
+          <xsl:element name="Parameter">
+            <xsl:attribute name="Name">Comment</xsl:attribute>
+            <xsl:attribute name="Type">Edm.String</xsl:attribute>
+            <xsl:attribute name="Unicode">false</xsl:attribute>
+          </xsl:element>
+          <xsl:element name="Parameter">
+            <xsl:attribute name="Name">SendResponse</xsl:attribute>
+            <xsl:attribute name="Type">Edm.Boolean</xsl:attribute>
+          </xsl:element>
+        </xsl:element>
+      </xsl:copy>
+    </xsl:template>
+
     <!-- Remove action parameters -->
     <!-- This should be a temp fix, tracking: https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/261 -->
     <!-- <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='createUploadSession']/edm:Parameter[@Name='deferCommit']"/> -->

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -279,21 +279,6 @@
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']/edm:Function[@Name='getDirectRoutingCalls']"/>
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='delta'][edm:Parameter[@Name='token']][edm:Parameter[@Type='Collection(graph.site)']]"/>
 
-    <!-- Reorder action parameters -->
-
-    <!-- These actions have the same parameters that need reordering. Will need to create a new template
-         for each reordering. -->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='accept'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='decline'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='tentativelyAccept'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]">
-        <xsl:copy>
-            <xsl:apply-templates select="@*"/>
-            <xsl:apply-templates select="edm:Parameter[@Name='bindingParameter'][@Type='graph.event']" />
-            <xsl:apply-templates select="edm:Parameter[@Name='Comment']" />
-            <xsl:apply-templates select="edm:Parameter[@Name='SendResponse']" />
-        </xsl:copy>
-    </xsl:template>
-
     <!-- Remove action parameters -->
     <!-- This should be a temp fix, tracking: https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/261 -->
     <!-- <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='createUploadSession']/edm:Parameter[@Name='deferCommit']"/> -->

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -279,10 +279,8 @@
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']/edm:Function[@Name='getDirectRoutingCalls']"/>
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='delta'][edm:Parameter[@Name='token']][edm:Parameter[@Type='Collection(graph.site)']]"/>
 
-    <!-- Reorder action parameters -->
-
-    <!-- These actions have the same parameters that need reordering. Will need to create a new template
-         for each reordering. -->
+    <!-- accept, decline and tentativelyAccept action signatures have changed. Following rule set keeps the old signaure in the clean metadata.
+    New signatures are copied as is, so we have redundant implmenetations to avoid breaking change for existing client applications. -->
     <xsl:template name="BackwardsCompatibleEventAction">
       <xsl:param name="actionName" />
       <xsl:element name="Action">

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -283,61 +283,40 @@
 
     <!-- These actions have the same parameters that need reordering. Will need to create a new template
          for each reordering. -->
+    <xsl:template name="BackwardsCompatibleEventAction">
+      <xsl:param name="actionName" />
+      <xsl:element name="Action">
+        <xsl:attribute name="Name"><xsl:value-of select = "$actionName" /></xsl:attribute>
+        <xsl:attribute name="IsBound">true</xsl:attribute>
+        <xsl:element name="Parameter">
+          <xsl:attribute name="Name">bindingParameter</xsl:attribute>
+          <xsl:attribute name="Type">graph.event</xsl:attribute>
+        </xsl:element>
+        <xsl:element name="Parameter">
+          <xsl:attribute name="Name">Comment</xsl:attribute>
+          <xsl:attribute name="Type">Edm.String</xsl:attribute>
+          <xsl:attribute name="Unicode">false</xsl:attribute>
+        </xsl:element>
+        <xsl:element name="Parameter">
+          <xsl:attribute name="Name">SendResponse</xsl:attribute>
+          <xsl:attribute name="Type">Edm.Boolean</xsl:attribute>
+        </xsl:element>
+      </xsl:element>
+    </xsl:template>
+
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
       <xsl:copy>
         <xsl:apply-templates select="@* | node()"/>
-        <xsl:element name="Action">
-          <xsl:attribute name="Name">accept</xsl:attribute>
-          <xsl:attribute name="IsBound">true</xsl:attribute>
-          <xsl:element name="Parameter">
-            <xsl:attribute name="Name">bindingParameter</xsl:attribute>
-            <xsl:attribute name="Type">graph.event</xsl:attribute>
-          </xsl:element>
-          <xsl:element name="Parameter">
-            <xsl:attribute name="Name">Comment</xsl:attribute>
-            <xsl:attribute name="Type">Edm.String</xsl:attribute>
-            <xsl:attribute name="Unicode">false</xsl:attribute>
-          </xsl:element>
-          <xsl:element name="Parameter">
-            <xsl:attribute name="Name">SendResponse</xsl:attribute>
-            <xsl:attribute name="Type">Edm.Boolean</xsl:attribute>
-          </xsl:element>
-        </xsl:element>
-        <xsl:element name="Action">
-          <xsl:attribute name="Name">decline</xsl:attribute>
-          <xsl:attribute name="IsBound">true</xsl:attribute>
-          <xsl:element name="Parameter">
-            <xsl:attribute name="Name">bindingParameter</xsl:attribute>
-            <xsl:attribute name="Type">graph.event</xsl:attribute>
-          </xsl:element>
-          <xsl:element name="Parameter">
-            <xsl:attribute name="Name">Comment</xsl:attribute>
-            <xsl:attribute name="Type">Edm.String</xsl:attribute>
-            <xsl:attribute name="Unicode">false</xsl:attribute>
-          </xsl:element>
-          <xsl:element name="Parameter">
-            <xsl:attribute name="Name">SendResponse</xsl:attribute>
-            <xsl:attribute name="Type">Edm.Boolean</xsl:attribute>
-          </xsl:element>
-        </xsl:element>
-        <xsl:element name="Action">
-          <xsl:attribute name="Name">tentativelyAccept</xsl:attribute>
-          <xsl:attribute name="IsBound">true</xsl:attribute>
-          <xsl:element name="Parameter">
-            <xsl:attribute name="Name">bindingParameter</xsl:attribute>
-            <xsl:attribute name="Type">graph.event</xsl:attribute>
-          </xsl:element>
-          <xsl:element name="Parameter">
-            <xsl:attribute name="Name">Comment</xsl:attribute>
-            <xsl:attribute name="Type">Edm.String</xsl:attribute>
-            <xsl:attribute name="Unicode">false</xsl:attribute>
-          </xsl:element>
-          <xsl:element name="Parameter">
-            <xsl:attribute name="Name">SendResponse</xsl:attribute>
-            <xsl:attribute name="Type">Edm.Boolean</xsl:attribute>
-          </xsl:element>
-        </xsl:element>
-      </xsl:copy>
+        <xsl:call-template name="BackwardsCompatibleEventAction">
+          <xsl:with-param name="actionName">accept</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="BackwardsCompatibleEventAction">
+          <xsl:with-param name="actionName">decline</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="BackwardsCompatibleEventAction">
+          <xsl:with-param name="actionName">tentativelyAccept</xsl:with-param>
+        </xsl:call-template>
+        </xsl:copy>
     </xsl:template>
 
     <!-- Remove action parameters -->

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -122,18 +122,15 @@
                 <Parameter Name="SendResponse" Type="Edm.Boolean" />
                 <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
             </Action>
-            <Action Name="accept" IsBound="true">
-                <Parameter Name="bindingParameter" Type="graph.eventMessage" />
-                <Parameter Name="SendResponse" Type="Edm.Boolean" />
-                <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
-            </Action>
             <Action Name="decline" IsBound="true">
                 <Parameter Name="bindingParameter" Type="graph.event" />
+                <Parameter Name="ProposedNewTime" Type="graph.timeSlot" />
                 <Parameter Name="SendResponse" Type="Edm.Boolean" />
                 <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
             </Action>
             <Action Name="tentativelyAccept" IsBound="true">
                 <Parameter Name="bindingParameter" Type="graph.event" />
+                <Parameter Name="ProposedNewTime" Type="graph.timeSlot" />
                 <Parameter Name="SendResponse" Type="Edm.Boolean" />
                 <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
             </Action>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -298,6 +298,21 @@
         <Parameter Name="bindingParameter" Type="Collection(graph.site)" />
         <ReturnType Type="Collection(graph.site)" />
       </Function>
+      <Action Name="accept" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.event" />
+        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
+        <Parameter Name="SendResponse" Type="Edm.Boolean" />
+      </Action>
+      <Action Name="decline" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.event" />
+        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
+        <Parameter Name="SendResponse" Type="Edm.Boolean" />
+      </Action>
+      <Action Name="tentativelyAccept" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.event" />
+        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
+        <Parameter Name="SendResponse" Type="Edm.Boolean" />
+      </Action>
     </Schema>
     <Schema Namespace="microsoft.graph.callRecords" xmlns="http://docs.oasis-open.org/odata/ns/edm">
       <EnumType Name="callType">

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -271,8 +271,8 @@
       </EntityContainer>
       <Action Name="accept" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event" />
-        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
         <Parameter Name="SendResponse" Type="Edm.Boolean" />
+        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>
       <Action Name="accept" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.eventMessage" />
@@ -281,13 +281,13 @@
       </Action>
       <Action Name="decline" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event" />
-        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
         <Parameter Name="SendResponse" Type="Edm.Boolean" />
+        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>
       <Action Name="tentativelyAccept" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event" />
-        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
         <Parameter Name="SendResponse" Type="Edm.Boolean" />
+        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>
       <Action Name="createUploadSession" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.driveItem" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -274,18 +274,15 @@
         <Parameter Name="SendResponse" Type="Edm.Boolean" />
         <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>
-      <Action Name="accept" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.eventMessage" />
-        <Parameter Name="SendResponse" Type="Edm.Boolean" />
-        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
-      </Action>
       <Action Name="decline" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event" />
+        <Parameter Name="ProposedNewTime" Type="graph.timeSlot" />
         <Parameter Name="SendResponse" Type="Edm.Boolean" />
         <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>
       <Action Name="tentativelyAccept" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event" />
+        <Parameter Name="ProposedNewTime" Type="graph.timeSlot" />
         <Parameter Name="SendResponse" Type="Edm.Boolean" />
         <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>


### PR DESCRIPTION
Previous XSLT rule was replacing accept, decline and tentativelyAccept actions with a parameter reordering. The reason for the rule was to keep the code backwards compatible.

Our long term solution should be to have a parameters object which can extend freely with nullable properties.

The change I propose in this PR is changing the "replace" rule with an "add" rule, which adds the backwards compatible signature. Since I remove the replace rule, the original signatures from metadata gets copied as is.

See type summary comparisons between the following two files.
[typeSummary_accept_decline_base.txt](https://github.com/microsoftgraph/msgraph-metadata/files/5823336/typeSummary_accept_decline_base.txt)
[typeSummary_accept_decline_new.txt](https://github.com/microsoftgraph/msgraph-metadata/files/5823338/typeSummary_accept_decline_new.txt)

---
## Old state:
#### Through backwards compatible "replace" rules from XSLT
```
accept(Comment, SendResponse)
decline(Comment, SendResponse)
tentativelyAccept(Comment, SendResponse)
```
#### No compatible signatures with the actual metadata and docs
---
## New state:
#### Through backwards compatible "add" rules from XSLT
```
accept(Comment, SendResponse)
decline(Comment, SendResponse)
tentativelyAccept(Comment, SendResponse)
```
#### By keeping signatures from original metadata
```
accept(SendResponse, Comment)
decline(ProposedNewTime, SendResponse, Comment)
tentativelyAccept(ProposedNewTime, SendResponse, Comment)
```
---

I have updated the test input XML file to match the actual metadata and updated output XML by running the new transform.

Fixes #21 

Fixes 3 C# Beta and 3 C# V1 Raptor tests. @baywet, I think this will fix some Java tests too.