### PR TITLE
Apply ConsistencyLevel header to directoryObjects EntitySet.

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -488,6 +488,7 @@
                        edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='servicePrincipals']|
                        edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='administrativeUnits']|
                        edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='contacts']|
+                       edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='directoryObjects']|
                        edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='devices']">
     <xsl:copy>
       <xsl:apply-templates select="@* | node()"/>

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -33,6 +33,9 @@
             <EntityType Name="servicePrincipal" BaseType="graph.directoryObject" OpenType="true">
                 <Property Name="appId" Type="Edm.String"/>
             </EntityType>
+            <EntityType Name="directoryObject" BaseType="graph.entity" OpenType="true">
+                <Property Name="deletedDateTime" Type="Edm.DateTimeOffset" />
+            </EntityType>
             <Annotations Target="graph.activityHistoryItem">
                 <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
                     <Record>
@@ -116,6 +119,7 @@
               <EntitySet Name="bookingBusinesses" EntityType="microsoft.graph.bookingBusiness"/>
               <EntitySet Name="groups" EntityType="microsoft.graph.group" />
               <EntitySet Name="servicePrincipals" EntityType="microsoft.graph.servicePrincipal" />
+              <EntitySet Name="directoryObjects" EntityType="microsoft.graph.directoryObject" />
             </EntityContainer>
             <Action Name="accept" IsBound="true">
                 <Parameter Name="bindingParameter" Type="graph.event" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -42,6 +42,9 @@
       <EntityType Name="servicePrincipal" BaseType="graph.directoryObject" OpenType="true">
         <Property Name="appId" Type="Edm.String" />
       </EntityType>
+      <EntityType Name="directoryObject" BaseType="graph.entity" OpenType="true">
+        <Property Name="deletedDateTime" Type="Edm.DateTimeOffset" />
+      </EntityType>
       <Annotations Target="graph.activityHistoryItem">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
       </Annotations>
@@ -245,6 +248,30 @@
           </Annotation>
         </EntitySet>
         <EntitySet Name="servicePrincipals" EntityType="microsoft.graph.servicePrincipal">
+          <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+            <Record>
+              <PropertyValue Property="CustomHeaders">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="Name" String="ConsistencyLevel" />
+                    <PropertyValue Property="Description" String="Indicates the requested consistency level." />
+                    <PropertyValue Property="DocumentationURL" String="https://developer.microsoft.com/en-us/office/blogs/microsoft-graph-advanced-queries-for-directory-objects-are-now-generally-available/" />
+                    <PropertyValue Property="Required" Bool="false" />
+                    <PropertyValue Property="ExampleValues">
+                      <Collection>
+                        <Record>
+                          <PropertyValue Property="Value" String="eventual" />
+                          <PropertyValue Property="Description" String="$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'." />
+                        </Record>
+                      </Collection>
+                    </PropertyValue>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="directoryObjects" EntityType="microsoft.graph.directoryObject">
           <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
             <Record>
               <PropertyValue Property="CustomHeaders">


### PR DESCRIPTION
This PR applies `ConsistencyLevel` header to directoryObjects EntitySet. This header will be used by AutoREST.PowerShell to generate the right request header for directoryObjects entitySet.

Closes #45.