### PR TITLE
Revert metadata to last known good state

### DIFF
--- a/beta_metadata.xml
+++ b/beta_metadata.xml
@@ -14,13 +14,6 @@
         <Member Name="reportOnlyNotApplied" Value="8" />
         <Member Name="reportOnlyInterrupted" Value="9" />
       </EnumType>
-      <EnumType Name="authenticationMethodFeature">
-        <Member Name="ssprRegistered" Value="0" />
-        <Member Name="ssprEnabled" Value="1" />
-        <Member Name="ssprCapable" Value="2" />
-        <Member Name="passwordlessCapable" Value="3" />
-        <Member Name="mfaCapable" Value="4" />
-      </EnumType>
       <EnumType Name="authMethodsType">
         <Member Name="email" Value="0" />
         <Member Name="mobileSMS" Value="1" />
@@ -72,19 +65,6 @@
         <Member Name="unifiedGroups" Value="0" />
         <Member Name="azureAD" Value="1" />
         <Member Name="unknownFutureValue" Value="2" />
-      </EnumType>
-      <EnumType Name="includedUserRoles">
-        <Member Name="all" Value="0" />
-        <Member Name="privilegedAdmin" Value="1" />
-        <Member Name="admin" Value="2" />
-        <Member Name="user" Value="3" />
-        <Member Name="unknownFutureValue" Value="4" />
-      </EnumType>
-      <EnumType Name="includedUserTypes">
-        <Member Name="all" Value="0" />
-        <Member Name="member" Value="1" />
-        <Member Name="guest" Value="2" />
-        <Member Name="unknownFutureValue" Value="3" />
       </EnumType>
       <EnumType Name="initiatorType">
         <Member Name="user" Value="0" />
@@ -346,12 +326,7 @@
         <Member Name="endpointConnectivityCheckUnknownError" Value="399" />
         <Member Name="aadConnectivityCheckUnknownError" Value="499" />
         <Member Name="resourceAvailabilityCheckNoSubnetIP" Value="500" />
-        <Member Name="resourceAvailabilityCheckSubscriptionDisabled" Value="501" />
         <Member Name="resourceAvailabilityCheckUnknownError" Value="599" />
-        <Member Name="permissionCheckNoSubscriptionReaderRole" Value="600" />
-        <Member Name="permissionCheckNoResourceGroupOwnerRole" Value="601" />
-        <Member Name="permissionCheckNoVNetContributorRole" Value="602" />
-        <Member Name="permissionCheckUnknownError" Value="699" />
         <Member Name="internalServerUnknownError" Value="999" />
       </EnumType>
       <EnumType Name="cloudPcOnPremisesConnectionStatus">
@@ -372,14 +347,62 @@
         <Member Name="upgrading" Value="3" />
         <Member Name="inGracePeriod" Value="4" />
         <Member Name="deprovisioning" Value="5" />
-        <Member Name="failed" Value="6" />
+        <Member Name="upgradeFailed" Value="6" />
+        <Member Name="provisionFailed" Value="7" />
+        <Member Name="deprovisionFailed" Value="8" />
+        <Member Name="reprovisionFailed" Value="9" />
       </EnumType>
-      <EnumType Name="usageRightState">
-        <Member Name="active" Value="0" />
-        <Member Name="inactive" Value="1" />
-        <Member Name="warning" Value="2" />
-        <Member Name="suspended" Value="3" />
-        <Member Name="unknownFutureValue" Value="4" />
+      <EnumType Name="caseAction">
+        <Member Name="contentExport" Value="0" />
+        <Member Name="tag" Value="1" />
+        <Member Name="convertToPdf" Value="2" />
+        <Member Name="index" Value="3" />
+        <Member Name="search" Value="4" />
+        <Member Name="addDataToReviewSet" Value="5" />
+      </EnumType>
+      <EnumType Name="caseOperationStatus">
+        <Member Name="notStarted" Value="0" />
+        <Member Name="submissionFailed" Value="1" />
+        <Member Name="running" Value="2" />
+        <Member Name="succeeded" Value="3" />
+        <Member Name="partiallySucceeded" Value="4" />
+        <Member Name="failed" Value="5" />
+      </EnumType>
+      <EnumType Name="caseStatus" UnderlyingType="Edm.Byte">
+        <Member Name="unknown" Value="0" />
+        <Member Name="active" Value="1" />
+        <Member Name="pendingDelete" Value="2" />
+        <Member Name="closing" Value="3" />
+        <Member Name="closed" Value="4" />
+        <Member Name="closedWithError" Value="5" />
+      </EnumType>
+      <EnumType Name="custodianStatus">
+        <Member Name="active" Value="1" />
+        <Member Name="released" Value="2" />
+      </EnumType>
+      <EnumType Name="exportFileStructure">
+        <Member Name="none" Value="0" />
+        <Member Name="directory" Value="1" />
+        <Member Name="pst" Value="2" />
+        <Member Name="unknownFutureValue" Value="3" />
+      </EnumType>
+      <EnumType Name="exportOptions" IsFlags="true">
+        <Member Name="originalFiles" Value="1" />
+        <Member Name="text" Value="2" />
+        <Member Name="pdfReplacement" Value="4" />
+        <Member Name="fileInfo" Value="8" />
+        <Member Name="tags" Value="16" />
+        <Member Name="unknownFutureValue" Value="32" />
+      </EnumType>
+      <EnumType Name="legalHoldStatus">
+        <Member Name="Pending" Value="0" />
+        <Member Name="Error" Value="1" />
+        <Member Name="Success" Value="2" />
+        <Member Name="UnknownFutureValue" Value="3" />
+      </EnumType>
+      <EnumType Name="sourceType" IsFlags="true">
+        <Member Name="mailbox" Value="1" />
+        <Member Name="site" Value="2" />
       </EnumType>
       <EnumType Name="identityUserFlowAttributeDataType">
         <Member Name="string" Value="1" />
@@ -460,28 +483,9 @@
         <Member Name="private" Value="2" />
         <Member Name="unknownFutureValue" Value="3" />
       </EnumType>
-      <EnumType Name="lobbyBypassScope">
-        <Member Name="organizer" Value="0" />
-        <Member Name="organization" Value="1" />
-        <Member Name="organizationAndFederated" Value="2" />
-        <Member Name="everyone" Value="3" />
-        <Member Name="unknownFutureValue" Value="4" />
-      </EnumType>
       <EnumType Name="mlClassificationMatchTolerance" IsFlags="true">
         <Member Name="exact" Value="1" />
         <Member Name="near" Value="2" />
-      </EnumType>
-      <EnumType Name="onlineMeetingForwarders">
-        <Member Name="everyone" Value="0" />
-        <Member Name="organizer" Value="1" />
-        <Member Name="unknownFutureValue" Value="2" />
-      </EnumType>
-      <EnumType Name="onlineMeetingPresenters">
-        <Member Name="everyone" Value="0" />
-        <Member Name="organization" Value="1" />
-        <Member Name="roleIsPresenter" Value="2" />
-        <Member Name="organizer" Value="3" />
-        <Member Name="unknownFutureValue" Value="4" />
       </EnumType>
       <EnumType Name="overrideOption">
         <Member Name="notAllowed" Value="0" />
@@ -566,11 +570,6 @@
       <EnumType Name="bodyType">
         <Member Name="text" Value="0" />
         <Member Name="html" Value="1" />
-      </EnumType>
-      <EnumType Name="educationAddedStudentAction">
-        <Member Name="none" Value="0" />
-        <Member Name="assignIfOpen" Value="1" />
-        <Member Name="unknownFutureValue" Value="2" />
       </EnumType>
       <EnumType Name="educationAssignmentStatus">
         <Member Name="draft" Value="0" />
@@ -4503,10 +4502,6 @@
         <Member Name="High" Value="1" />
         <Member Name="Low" Value="2" />
       </EnumType>
-      <EnumType Name="plannerContainerType">
-        <Member Name="group" Value="1" />
-        <Member Name="unknownFutureValue" Value="2" />
-      </EnumType>
       <EnumType Name="plannerPreviewType">
         <Member Name="automatic" Value="0" />
         <Member Name="noPreview" Value="1" />
@@ -4593,11 +4588,6 @@
         <Member Name="expert" Value="4" />
         <Member Name="unknownFutureValue" Value="5" />
       </EnumType>
-      <EnumType Name="translationBehavior">
-        <Member Name="Ask" Value="0" />
-        <Member Name="Yes" Value="1" />
-        <Member Name="No" Value="2" />
-      </EnumType>
       <EnumType Name="approvalState">
         <Member Name="pending" Value="0" />
         <Member Name="approved" Value="1" />
@@ -4663,40 +4653,26 @@
       </EnumType>
       <EnumType Name="printerProcessingStateDetail">
         <Member Name="paused" Value="0" />
+        <Member Name="disconnected" Value="1" />
         <Member Name="mediaJam" Value="2" />
         <Member Name="mediaNeeded" Value="3" />
         <Member Name="mediaLow" Value="4" />
         <Member Name="mediaEmpty" Value="5" />
         <Member Name="coverOpen" Value="6" />
         <Member Name="interlockOpen" Value="7" />
+        <Member Name="queueFull" Value="8" />
         <Member Name="outputTrayMissing" Value="9" />
         <Member Name="outputAreaFull" Value="10" />
         <Member Name="markerSupplyLow" Value="11" />
         <Member Name="markerSupplyEmpty" Value="12" />
         <Member Name="inputTrayMissing" Value="13" />
-        <Member Name="outputAreaAlmostFull" Value="14" />
+        <Member Name="outputAlmostFull" Value="14" />
         <Member Name="markerWasteAlmostFull" Value="15" />
         <Member Name="markerWasteFull" Value="16" />
         <Member Name="fuserOverTemp" Value="17" />
         <Member Name="fuserUnderTemp" Value="18" />
         <Member Name="other" Value="19" />
-        <Member Name="none" Value="20" />
-        <Member Name="movingToPaused" Value="21" />
-        <Member Name="shutdown" Value="22" />
-        <Member Name="connectingToDevice" Value="23" />
-        <Member Name="timedOut" Value="24" />
-        <Member Name="stopping" Value="25" />
-        <Member Name="stoppedPartially" Value="26" />
-        <Member Name="tonerLow" Value="27" />
-        <Member Name="tonerEmpty" Value="28" />
-        <Member Name="spoolAreaFull" Value="29" />
-        <Member Name="doorOpen" Value="30" />
-        <Member Name="opticalPhotoConductorNearEndOfLife" Value="31" />
-        <Member Name="opticalPhotoConductorLifeOver" Value="32" />
-        <Member Name="developerLow" Value="33" />
-        <Member Name="developerEmpty" Value="34" />
-        <Member Name="interpreterResourceUnavailable" Value="35" />
-        <Member Name="unknownFutureValue" Value="36" />
+        <Member Name="unknownFutureValue" Value="20" />
       </EnumType>
       <EnumType Name="printerProcessingStateReason">
         <Member Name="paused" Value="0" />
@@ -5104,6 +5080,13 @@
         <Member Name="skypeForBusinessVoipPhone" Value="3" />
         <Member Name="unknownFutureValue" Value="4" />
       </EnumType>
+      <EnumType Name="lobbyBypassScope">
+        <Member Name="organizer" Value="0" />
+        <Member Name="organization" Value="1" />
+        <Member Name="organizationAndFederated" Value="2" />
+        <Member Name="everyone" Value="3" />
+        <Member Name="unknownFutureValue" Value="4" />
+      </EnumType>
       <EnumType Name="mediaDirection">
         <Member Name="inactive" Value="0" />
         <Member Name="sendOnly" Value="1" />
@@ -5126,6 +5109,13 @@
         <Member Name="videoBasedScreenSharing" Value="3" />
         <Member Name="data" Value="4" />
         <Member Name="unknownFutureValue" Value="5" />
+      </EnumType>
+      <EnumType Name="onlineMeetingPresenters">
+        <Member Name="everyone" Value="0" />
+        <Member Name="organization" Value="1" />
+        <Member Name="roleIsPresenter" Value="2" />
+        <Member Name="organizer" Value="3" />
+        <Member Name="unknownFutureValue" Value="4" />
       </EnumType>
       <EnumType Name="onlineMeetingRole">
         <Member Name="attendee" Value="0" />
@@ -5312,7 +5302,6 @@
         <Member Name="standard" Value="0" />
         <Member Name="private" Value="1" />
         <Member Name="unknownFutureValue" Value="2" />
-        <Member Name="shared" Value="3" />
       </EnumType>
       <EnumType Name="chatMessageImportance">
         <Member Name="normal" Value="0" />
@@ -5398,8 +5387,6 @@
         <Member Name="unarchiveTeam" Value="3" />
         <Member Name="createTeam" Value="4" />
         <Member Name="unknownFutureValue" Value="5" />
-        <Member Name="teamifyGroup" Value="6" />
-        <Member Name="createChannel" Value="7" />
       </EnumType>
       <EnumType Name="teamSpecialization">
         <Member Name="none" Value="0" />
@@ -5420,9 +5407,6 @@
       <EnumType Name="teamworkActivityTopicSource">
         <Member Name="entityUrl" Value="0" />
         <Member Name="text" Value="1" />
-      </EnumType>
-      <EnumType Name="teamworkTagType">
-        <Member Name="standard" Value="0" />
       </EnumType>
       <EnumType Name="userIdentityType">
         <Member Name="aadUser" Value="0" />
@@ -5736,26 +5720,6 @@
         <Property Name="registrationCount" Type="Edm.Int64" Nullable="false" />
         <Property Name="registrationStatus" Type="graph.registrationStatusType" Nullable="false" />
       </ComplexType>
-      <ComplexType Name="userRegistrationFeatureCount">
-        <Property Name="feature" Type="graph.authenticationMethodFeature" Nullable="false" />
-        <Property Name="userCount" Type="Edm.Int64" Nullable="false" />
-      </ComplexType>
-      <ComplexType Name="userRegistrationFeatureSummary">
-        <Property Name="totalUserCount" Type="Edm.Int64" Nullable="false" />
-        <Property Name="userRegistrationFeatureCounts" Type="Collection(graph.userRegistrationFeatureCount)" Nullable="false" />
-        <Property Name="userRoles" Type="graph.includedUserRoles" />
-        <Property Name="userTypes" Type="graph.includedUserTypes" />
-      </ComplexType>
-      <ComplexType Name="userRegistrationMethodCount">
-        <Property Name="authenticationMethod" Type="Edm.String" Nullable="false" />
-        <Property Name="userCount" Type="Edm.Int64" Nullable="false" />
-      </ComplexType>
-      <ComplexType Name="userRegistrationMethodSummary">
-        <Property Name="totalUserCount" Type="Edm.Int64" Nullable="false" />
-        <Property Name="userRegistrationMethodCounts" Type="Collection(graph.userRegistrationMethodCount)" Nullable="false" />
-        <Property Name="userRoles" Type="graph.includedUserRoles" />
-        <Property Name="userTypes" Type="graph.includedUserTypes" />
-      </ComplexType>
       <EntityType Name="applicationSignInDetailedSummary" BaseType="graph.entity">
         <Property Name="aggregatedEventDateTime" Type="Edm.DateTimeOffset" />
         <Property Name="appDisplayName" Type="Edm.String" Nullable="false" />
@@ -5852,7 +5816,6 @@
       <EntityType Name="restrictedSignIn" BaseType="graph.signIn">
         <Property Name="targetTenantId" Type="Edm.Guid" />
       </EntityType>
-      <EntityType Name="authenticationMethodsRoot" BaseType="graph.entity" />
       <EntityType Name="azureADFeatureUsage" BaseType="graph.entity">
         <Property Name="featureName" Type="Edm.String" Nullable="false" />
         <Property Name="snapshotDateTime" Type="Edm.DateTimeOffset" Nullable="false" />
@@ -5905,7 +5868,6 @@
       </EntityType>
       <EntityType Name="reportRoot" BaseType="graph.entity">
         <NavigationProperty Name="applicationSignInDetailedSummary" Type="Collection(graph.applicationSignInDetailedSummary)" ContainsTarget="true" />
-        <NavigationProperty Name="authenticationMethods" Type="graph.authenticationMethodsRoot" ContainsTarget="true" />
         <NavigationProperty Name="credentialUserRegistrationDetails" Type="Collection(graph.credentialUserRegistrationDetails)" ContainsTarget="true" />
         <NavigationProperty Name="userCredentialUsageDetails" Type="Collection(graph.userCredentialUsageDetails)" ContainsTarget="true" />
         <NavigationProperty Name="dailyPrintUsageSummariesByPrinter" Type="Collection(graph.PrintUsageSummaryByPrinter)" ContainsTarget="true" />
@@ -6015,7 +5977,6 @@
         <Property Name="schools" Type="Collection(Edm.String)" />
         <Property Name="skills" Type="Collection(Edm.String)" />
         <NavigationProperty Name="analytics" Type="graph.userAnalytics" ContainsTarget="true" />
-        <NavigationProperty Name="usageRights" Type="Collection(graph.usageRight)" ContainsTarget="true" />
         <NavigationProperty Name="informationProtection" Type="graph.informationProtection" ContainsTarget="true" />
         <NavigationProperty Name="appRoleAssignments" Type="Collection(graph.appRoleAssignment)" ContainsTarget="true" />
         <NavigationProperty Name="createdObjects" Type="Collection(graph.directoryObject)" />
@@ -6077,11 +6038,6 @@
       <EntityType Name="userAnalytics" BaseType="graph.entity">
         <Property Name="settings" Type="graph.settings" />
         <NavigationProperty Name="activityStatistics" Type="Collection(graph.activityStatistics)" ContainsTarget="true" />
-      </EntityType>
-      <EntityType Name="usageRight" BaseType="graph.entity">
-        <Property Name="catalogId" Type="Edm.String" Nullable="false" />
-        <Property Name="serviceIdentifier" Type="Edm.String" Nullable="false" />
-        <Property Name="state" Type="graph.usageRightState" Nullable="false" />
       </EntityType>
       <EntityType Name="informationProtection" BaseType="graph.entity">
         <NavigationProperty Name="bitlocker" Type="graph.bitlocker" ContainsTarget="true" />
@@ -6428,7 +6384,6 @@
       <EntityType Name="mailFolder" BaseType="graph.entity">
         <Property Name="childFolderCount" Type="Edm.Int32" />
         <Property Name="displayName" Type="Edm.String" />
-        <Property Name="isHidden" Type="Edm.Boolean" />
         <Property Name="parentFolderId" Type="Edm.String" />
         <Property Name="totalItemCount" Type="Edm.Int32" />
         <Property Name="unreadItemCount" Type="Edm.Int32" />
@@ -6824,7 +6779,6 @@
         <Property Name="enrollmentProfileName" Type="Edm.String" />
         <Property Name="enrollmentType" Type="Edm.String" />
         <Property Name="extensionAttributes" Type="graph.onPremisesExtensionAttributes" />
-        <Property Name="hostnames" Type="Collection(Edm.String)" />
         <Property Name="isCompliant" Type="Edm.Boolean" />
         <Property Name="isManaged" Type="Edm.Boolean" />
         <Property Name="isRooted" Type="Edm.Boolean" />
@@ -6844,7 +6798,6 @@
         <Property Name="name" Type="Edm.String" />
         <Property Name="platform" Type="Edm.String" />
         <Property Name="status" Type="Edm.String" />
-        <NavigationProperty Name="usageRights" Type="Collection(graph.usageRight)" ContainsTarget="true" />
         <NavigationProperty Name="memberOf" Type="Collection(graph.directoryObject)" />
         <NavigationProperty Name="registeredOwners" Type="Collection(graph.directoryObject)" />
         <NavigationProperty Name="registeredUsers" Type="Collection(graph.directoryObject)" />
@@ -6882,7 +6835,6 @@
       <EntityType Name="presence" BaseType="graph.entity">
         <Property Name="activity" Type="Edm.String" />
         <Property Name="availability" Type="Edm.String" />
-        <Property Name="outOfOfficeSettings" Type="graph.outOfOfficeSettings" />
       </EntityType>
       <EntityType Name="authentication" BaseType="graph.entity">
         <NavigationProperty Name="emailMethods" Type="Collection(graph.emailAuthenticationMethod)" ContainsTarget="true" />
@@ -6928,7 +6880,6 @@
         <NavigationProperty Name="owners" Type="Collection(graph.user)" />
         <NavigationProperty Name="photo" Type="graph.profilePhoto" ContainsTarget="true" />
         <NavigationProperty Name="primaryChannel" Type="graph.channel" ContainsTarget="true" />
-        <NavigationProperty Name="tags" Type="Collection(graph.teamworkTag)" ContainsTarget="true" />
         <NavigationProperty Name="template" Type="graph.teamsTemplate" />
       </EntityType>
       <EntityType Name="userTeamwork" BaseType="graph.entity">
@@ -7002,7 +6953,6 @@
         <Property Name="appId" Type="Edm.String" />
         <Property Name="appRoles" Type="Collection(graph.appRole)" Nullable="false" />
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="defaultRedirectUri" Type="Edm.String" />
         <Property Name="description" Type="Edm.String" />
         <Property Name="displayName" Type="Edm.String" />
         <Property Name="groupMembershipClaims" Type="Edm.String" />
@@ -7313,6 +7263,16 @@
         <Property Name="aaGuids" Type="Collection(Edm.String)" />
         <Property Name="enforcementType" Type="graph.fido2RestrictionEnforcementType" />
         <Property Name="isEnforced" Type="Edm.Boolean" />
+      </ComplexType>
+      <ComplexType Name="registrationAndResetTarget">
+        <Property Name="id" Type="Edm.String" />
+        <Property Name="minAuthMethodsToRegister" Type="Edm.Int32" />
+        <Property Name="minAuthMethodsToReset" Type="Edm.Int32" />
+        <Property Name="targetType" Type="graph.authenticationMethodTargetType" />
+      </ComplexType>
+      <ComplexType Name="registrationEnforcement">
+        <Property Name="isAllowedToSkipRegistration" Type="Edm.Boolean" />
+        <Property Name="registrationSkipDurationInDays" Type="Edm.Int32" />
       </ComplexType>
       <EntityType Name="authenticationMethodTarget" BaseType="graph.entity" />
       <EntityType Name="microsoftAuthenticatorAuthenticationMethodTarget" BaseType="graph.authenticationMethodTarget">
@@ -9068,22 +9028,6 @@
         <Property Name="thumbprint" Type="Edm.String" />
         <Property Name="userPrincipalName" Type="Edm.String" />
       </EntityType>
-      <ComplexType Name="alternativeSecurityId">
-        <Property Name="identityProvider" Type="Edm.String" />
-        <Property Name="key" Type="Edm.Binary" />
-        <Property Name="type" Type="Edm.Int32" />
-      </ComplexType>
-      <EntityType Name="command" BaseType="graph.entity">
-        <Property Name="appServiceName" Type="Edm.String" />
-        <Property Name="error" Type="Edm.String" />
-        <Property Name="packageFamilyName" Type="Edm.String" />
-        <Property Name="payload" Type="graph.payloadRequest" />
-        <Property Name="permissionTicket" Type="Edm.String" />
-        <Property Name="postBackUri" Type="Edm.String" />
-        <Property Name="status" Type="Edm.String" />
-        <Property Name="type" Type="Edm.String" />
-        <NavigationProperty Name="responsepayload" Type="graph.payloadResponse" />
-      </EntityType>
       <ComplexType Name="identitySet" OpenType="true">
         <Property Name="application" Type="graph.identity" />
         <Property Name="device" Type="graph.identity" />
@@ -9094,11 +9038,97 @@
         <Property Name="message" Type="Edm.String" />
         <Property Name="subcode" Type="Edm.Int32" Nullable="false" />
       </ComplexType>
+      <EntityType Name="case" BaseType="graph.entity">
+        <Property Name="closedBy" Type="graph.identitySet" />
+        <Property Name="closedDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="description" Type="Edm.String" />
+        <Property Name="displayName" Type="Edm.String" />
+        <Property Name="externalId" Type="Edm.String" />
+        <Property Name="lastModifiedBy" Type="graph.identitySet" />
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="status" Type="graph.caseStatus" />
+        <NavigationProperty Name="custodians" Type="Collection(graph.custodian)" ContainsTarget="true" />
+        <NavigationProperty Name="legalholds" Type="Collection(graph.legalhold)" ContainsTarget="true" />
+        <NavigationProperty Name="operations" Type="Collection(graph.caseOperation)" ContainsTarget="true" />
+        <NavigationProperty Name="reviewSets" Type="Collection(graph.reviewSet)" ContainsTarget="true" />
+      </EntityType>
+      <EntityType Name="custodian" BaseType="graph.entity">
+        <Property Name="acknowledgedDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="applyHoldToSources" Type="Edm.Boolean" />
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="displayName" Type="Edm.String" />
+        <Property Name="email" Type="Edm.String" Nullable="false" />
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="releasedDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="status" Type="graph.custodianStatus" />
+        <NavigationProperty Name="lastIndexOperation" Type="graph.caseIndexOperation" />
+        <NavigationProperty Name="siteSources" Type="Collection(graph.siteSource)" ContainsTarget="true" />
+        <NavigationProperty Name="unifiedGroupSources" Type="Collection(graph.unifiedGroupSource)" ContainsTarget="true" />
+        <NavigationProperty Name="userSources" Type="Collection(graph.userSource)" ContainsTarget="true" />
+      </EntityType>
+      <EntityType Name="legalhold" BaseType="graph.entity">
+        <Property Name="contentQuery" Type="Edm.String" />
+        <Property Name="createdBy" Type="graph.identitySet" />
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="description" Type="Edm.String" />
+        <Property Name="displayName" Type="Edm.String" />
+        <Property Name="errors" Type="Collection(Edm.String)" />
+        <Property Name="isEnabled" Type="Edm.Boolean" />
+        <Property Name="lastModifiedBy" Type="graph.identitySet" />
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="status" Type="graph.legalHoldStatus" />
+        <NavigationProperty Name="siteSources" Type="Collection(graph.siteSource)" ContainsTarget="true" />
+        <NavigationProperty Name="unifiedGroupSources" Type="Collection(graph.unifiedGroupSource)" ContainsTarget="true" />
+        <NavigationProperty Name="userSources" Type="Collection(graph.userSource)" ContainsTarget="true" />
+      </EntityType>
+      <EntityType Name="caseOperation" BaseType="graph.entity">
+        <Property Name="action" Type="graph.caseAction" />
+        <Property Name="completedDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="createdBy" Type="graph.identitySet" />
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="percentProgress" Type="Edm.Int32" />
+        <Property Name="resultInfo" Type="graph.resultInfo" />
+        <Property Name="status" Type="graph.caseOperationStatus" />
+      </EntityType>
+      <EntityType Name="reviewSet" BaseType="graph.entity">
+        <Property Name="createdBy" Type="graph.identitySet" />
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="displayName" Type="Edm.String" />
+        <NavigationProperty Name="queries" Type="Collection(graph.reviewSetQuery)" ContainsTarget="true" />
+      </EntityType>
+      <EntityType Name="caseExportOperation" BaseType="graph.caseOperation">
+        <Property Name="azureBlobContainer" Type="Edm.String" />
+        <Property Name="azureBlobToken" Type="Edm.String" />
+        <Property Name="description" Type="Edm.String" />
+        <Property Name="exportOptions" Type="graph.exportOptions" />
+        <Property Name="exportStructure" Type="graph.exportFileStructure" />
+        <Property Name="outputFolderId" Type="Edm.String" />
+        <Property Name="outputName" Type="Edm.String" />
+        <NavigationProperty Name="reviewSet" Type="graph.reviewSet" />
+      </EntityType>
+      <EntityType Name="caseIndexOperation" BaseType="graph.caseOperation" />
       <EntityType Name="compliance">
         <NavigationProperty Name="ediscovery" Type="graph.ediscovery" ContainsTarget="true" />
       </EntityType>
       <EntityType Name="ediscovery" BaseType="graph.entity">
-        <NavigationProperty Name="cases" Type="Collection(microsoft.graph.ediscovery.case)" ContainsTarget="true" />
+        <NavigationProperty Name="cases" Type="Collection(graph.case)" ContainsTarget="true" />
+      </EntityType>
+      <EntityType Name="dataSource" BaseType="graph.entity" Abstract="true">
+        <Property Name="createdBy" Type="graph.identitySet" />
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="displayName" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="siteSource" BaseType="graph.dataSource">
+        <NavigationProperty Name="site" Type="graph.site" Nullable="false" />
+      </EntityType>
+      <EntityType Name="unifiedGroupSource" BaseType="graph.dataSource">
+        <Property Name="includedSources" Type="graph.sourceType" />
+        <NavigationProperty Name="group" Type="graph.group" Nullable="false" />
+      </EntityType>
+      <EntityType Name="userSource" BaseType="graph.dataSource">
+        <Property Name="email" Type="Edm.String" Nullable="false" />
+        <Property Name="includedSources" Type="graph.sourceType" />
       </EntityType>
       <ComplexType Name="assignedLabel">
         <Property Name="displayName" Type="Edm.String" />
@@ -9150,6 +9180,14 @@
       </EntityType>
       <EntityType Name="plannerGroup" BaseType="graph.entity">
         <NavigationProperty Name="plans" Type="Collection(graph.plannerPlan)" />
+      </EntityType>
+      <EntityType Name="reviewSetQuery" BaseType="graph.entity">
+        <Property Name="createdBy" Type="graph.identitySet" />
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="displayName" Type="Edm.String" />
+        <Property Name="lastModifiedBy" Type="graph.identitySet" />
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="query" Type="Edm.String" />
       </EntityType>
       <ComplexType Name="deleted">
         <Property Name="state" Type="Edm.String" />
@@ -9227,13 +9265,8 @@
         <Property Name="title" Type="Edm.String" />
         <Property Name="webParts" Type="Collection(graph.webPart)" />
       </EntityType>
-      <ComplexType Name="apiAuthenticationConfigurationBase" Abstract="true" />
       <ComplexType Name="assignmentOrder">
         <Property Name="order" Type="Collection(Edm.String)" />
-      </ComplexType>
-      <ComplexType Name="basicAuthentication" BaseType="graph.apiAuthenticationConfigurationBase">
-        <Property Name="password" Type="Edm.String" />
-        <Property Name="username" Type="Edm.String" />
       </ComplexType>
       <ComplexType Name="claimsMapping" OpenType="true">
         <Property Name="displayName" Type="Edm.String" />
@@ -9268,25 +9301,12 @@
         <Property Name="name" Type="Edm.String" />
         <Property Name="value" Type="Edm.String" />
       </ComplexType>
-      <ComplexType Name="userFlowApiConnectorConfiguration">
-        <NavigationProperty Name="postAttributeCollection" Type="graph.identityApiConnector" ContainsTarget="true" />
-        <NavigationProperty Name="postFederationSignup" Type="graph.identityApiConnector" ContainsTarget="true" />
-      </ComplexType>
-      <EntityType Name="identityApiConnector" BaseType="graph.entity">
-        <Property Name="authenticationConfiguration" Type="graph.apiAuthenticationConfigurationBase" />
-        <Property Name="displayName" Type="Edm.String" />
-        <Property Name="targetUrl" Type="Edm.String" />
-      </EntityType>
       <EntityType Name="identityUserFlow" BaseType="graph.entity">
         <Property Name="userFlowType" Type="graph.userFlowType" Nullable="false" />
         <Property Name="userFlowTypeVersion" Type="Edm.Single" Nullable="false" />
       </EntityType>
       <EntityType Name="b2cIdentityUserFlow" BaseType="graph.identityUserFlow">
-        <Property Name="apiConnectorConfiguration" Type="graph.userFlowApiConnectorConfiguration" />
-        <Property Name="defaultLanguageTag" Type="Edm.String" />
-        <Property Name="isLanguageCustomizationEnabled" Type="Edm.Boolean" Nullable="false" />
         <NavigationProperty Name="identityProviders" Type="Collection(graph.identityProvider)" />
-        <NavigationProperty Name="languages" Type="Collection(graph.userFlowLanguageConfiguration)" ContainsTarget="true" />
         <NavigationProperty Name="userAttributeAssignments" Type="Collection(graph.identityUserFlowAttributeAssignment)" ContainsTarget="true" />
       </EntityType>
       <EntityType Name="identityProvider" BaseType="graph.entity">
@@ -9294,12 +9314,6 @@
         <Property Name="clientSecret" Type="Edm.String" />
         <Property Name="name" Type="Edm.String" />
         <Property Name="type" Type="Edm.String" />
-      </EntityType>
-      <EntityType Name="userFlowLanguageConfiguration" BaseType="graph.entity">
-        <Property Name="displayName" Type="Edm.String" />
-        <Property Name="isEnabled" Type="Edm.Boolean" Nullable="false" />
-        <NavigationProperty Name="defaultPages" Type="Collection(graph.userFlowLanguagePage)" ContainsTarget="true" />
-        <NavigationProperty Name="overridesPages" Type="Collection(graph.userFlowLanguagePage)" ContainsTarget="true" />
       </EntityType>
       <EntityType Name="identityUserFlowAttributeAssignment" BaseType="graph.entity">
         <Property Name="displayName" Type="Edm.String" />
@@ -9310,9 +9324,7 @@
         <NavigationProperty Name="userAttribute" Type="graph.identityUserFlowAttribute" />
       </EntityType>
       <EntityType Name="b2xIdentityUserFlow" BaseType="graph.identityUserFlow">
-        <Property Name="apiConnectorConfiguration" Type="graph.userFlowApiConnectorConfiguration" />
         <NavigationProperty Name="identityProviders" Type="Collection(graph.identityProvider)" />
-        <NavigationProperty Name="languages" Type="Collection(graph.userFlowLanguageConfiguration)" ContainsTarget="true" />
         <NavigationProperty Name="userAttributeAssignments" Type="Collection(graph.identityUserFlowAttributeAssignment)" ContainsTarget="true" />
       </EntityType>
       <EntityType Name="identityUserFlowAttribute" BaseType="graph.entity">
@@ -9324,7 +9336,6 @@
       <EntityType Name="identityBuiltInUserFlowAttribute" BaseType="graph.identityUserFlowAttribute" />
       <EntityType Name="identityContainer">
         <NavigationProperty Name="conditionalAccess" Type="graph.conditionalAccessRoot" ContainsTarget="true" />
-        <NavigationProperty Name="apiConnectors" Type="Collection(graph.identityApiConnector)" ContainsTarget="true" />
         <NavigationProperty Name="b2cUserFlows" Type="Collection(graph.b2cIdentityUserFlow)" ContainsTarget="true" />
         <NavigationProperty Name="b2xUserFlows" Type="Collection(graph.b2xIdentityUserFlow)" ContainsTarget="true" />
         <NavigationProperty Name="userFlowAttributes" Type="Collection(graph.identityUserFlowAttribute)" ContainsTarget="true" />
@@ -9360,7 +9371,6 @@
         <Property Name="keys" Type="Collection(graph.trustFrameworkKey)" />
       </EntityType>
       <EntityType Name="trustFrameworkPolicy" BaseType="graph.entity" HasStream="true" />
-      <EntityType Name="userFlowLanguagePage" BaseType="graph.entity" HasStream="true" />
       <ComplexType Name="labelActionBase" Abstract="true">
         <Property Name="name" Type="Edm.String" />
       </ComplexType>
@@ -9552,10 +9562,6 @@
         <Property Name="id" Type="Edm.String" Nullable="false" />
         <Property Name="name" Type="Edm.String" />
       </ComplexType>
-      <ComplexType Name="lobbyBypassSettings">
-        <Property Name="isDialInBypassEnabled" Type="Edm.Boolean" />
-        <Property Name="scope" Type="graph.lobbyBypassScope" />
-      </ComplexType>
       <ComplexType Name="machineLearningDetectedSensitiveContent" BaseType="graph.detectedSensitiveContent">
         <Property Name="matchTolerance" Type="graph.mlClassificationMatchTolerance" />
         <Property Name="modelVersion" Type="Edm.String" />
@@ -9571,13 +9577,6 @@
         <Property Name="allowEmailFromGuestUsers" Type="Edm.Boolean" />
         <Property Name="allowGuestUsers" Type="Edm.Boolean" />
         <Property Name="privacy" Type="graph.groupPrivacy" />
-      </ComplexType>
-      <ComplexType Name="protectOnlineMeetingAction" BaseType="graph.labelActionBase">
-        <Property Name="allowedForwarders" Type="graph.onlineMeetingForwarders" />
-        <Property Name="allowedPresenters" Type="graph.onlineMeetingPresenters" />
-        <Property Name="isCopyToClipboardEnabled" Type="Edm.Boolean" />
-        <Property Name="isLobbyEnabled" Type="Edm.Boolean" />
-        <Property Name="lobbyBypassSettings" Type="graph.lobbyBypassSettings" />
       </ComplexType>
       <ComplexType Name="protectSite" BaseType="graph.labelActionBase">
         <Property Name="accessType" Type="graph.siteAccessType" />
@@ -9652,6 +9651,11 @@
         <Property Name="result" Type="graph.evaluateLabelsAndPoliciesResult" />
       </EntityType>
       <ComplexType Name="allowedDataLocationInfo" OpenType="true" />
+      <ComplexType Name="alternativeSecurityId">
+        <Property Name="identityProvider" Type="Edm.String" />
+        <Property Name="key" Type="Edm.Binary" />
+        <Property Name="type" Type="Edm.Int32" />
+      </ComplexType>
       <ComplexType Name="apiServicePrincipal">
         <Property Name="resourceSpecificApplicationPermissions" Type="Collection(graph.resourceSpecificPermission)" Nullable="false" />
       </ComplexType>
@@ -9768,6 +9772,17 @@
         <Property Name="customerId" Type="Edm.Guid" />
         <Property Name="defaultDomainName" Type="Edm.String" />
         <Property Name="displayName" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="command" BaseType="graph.entity">
+        <Property Name="appServiceName" Type="Edm.String" />
+        <Property Name="error" Type="Edm.String" />
+        <Property Name="packageFamilyName" Type="Edm.String" />
+        <Property Name="payload" Type="graph.payloadRequest" />
+        <Property Name="permissionTicket" Type="Edm.String" />
+        <Property Name="postBackUri" Type="Edm.String" />
+        <Property Name="status" Type="Edm.String" />
+        <Property Name="type" Type="Edm.String" />
+        <NavigationProperty Name="responsepayload" Type="graph.payloadResponse" />
       </EntityType>
       <EntityType Name="directory">
         <NavigationProperty Name="administrativeUnits" Type="Collection(graph.administrativeUnit)" ContainsTarget="true" />
@@ -10095,7 +10110,6 @@
         <Property Name="qualityId" Type="Edm.String" />
       </ComplexType>
       <EntityType Name="educationAssignment" BaseType="graph.entity">
-        <Property Name="addedStudentAction" Type="graph.educationAddedStudentAction" />
         <Property Name="allowLateSubmissions" Type="Edm.Boolean" />
         <Property Name="allowStudentsToAddResourcesToSubmission" Type="Edm.Boolean" />
         <Property Name="assignDateTime" Type="Edm.DateTimeOffset" />
@@ -10111,7 +10125,6 @@
         <Property Name="instructions" Type="graph.educationItemBody" />
         <Property Name="lastModifiedBy" Type="graph.identitySet" />
         <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="notificationChannelUrl" Type="Edm.String" />
         <Property Name="status" Type="graph.educationAssignmentStatus" />
         <NavigationProperty Name="categories" Type="Collection(graph.educationCategory)" ContainsTarget="true" />
         <NavigationProperty Name="resources" Type="Collection(graph.educationAssignmentResource)" ContainsTarget="true" />
@@ -10390,7 +10403,6 @@
         <Property Name="reportableIdentifier" Type="Edm.String" />
       </EntityType>
       <EntityType Name="educationSynchronizationProfileStatus" BaseType="graph.entity">
-        <Property Name="lastActivityDateTime" Type="Edm.DateTimeOffset" />
         <Property Name="lastSynchronizationDateTime" Type="Edm.DateTimeOffset" />
         <Property Name="status" Type="graph.educationSynchronizationStatus" />
       </EntityType>
@@ -10754,10 +10766,10 @@
         <Property Name="encryptionCertificate" Type="Edm.String" />
         <Property Name="encryptionCertificateId" Type="Edm.String" />
         <Property Name="expirationDateTime" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="includeProperties" Type="Edm.Boolean" />
         <Property Name="includeResourceData" Type="Edm.Boolean" />
         <Property Name="latestSupportedTlsVersion" Type="Edm.String" />
         <Property Name="lifecycleNotificationUrl" Type="Edm.String" />
-        <Property Name="notificationContentType" Type="Edm.String" />
         <Property Name="notificationQueryOptions" Type="Edm.String" />
         <Property Name="notificationUrl" Type="Edm.String" Nullable="false" />
         <Property Name="resource" Type="Edm.String" Nullable="false" />
@@ -11105,9 +11117,7 @@
       <EntityType Name="roomList" BaseType="graph.place">
         <Property Name="emailAddress" Type="Edm.String" />
         <NavigationProperty Name="rooms" Type="Collection(graph.room)" ContainsTarget="true" />
-        <NavigationProperty Name="spaces" Type="Collection(graph.space)" ContainsTarget="true" />
       </EntityType>
-      <EntityType Name="space" BaseType="graph.place" />
       <ComplexType Name="attachmentItem">
         <Property Name="attachmentType" Type="graph.attachmentType" />
         <Property Name="contentType" Type="Edm.String" />
@@ -12328,9 +12338,7 @@
         <Property Name="users" Type="graph.conditionalAccessUsers" />
       </ComplexType>
       <ComplexType Name="conditionalAccessDevices">
-        <Property Name="excludeDevices" Type="Collection(Edm.String)" Nullable="false" />
         <Property Name="excludeDeviceStates" Type="Collection(Edm.String)" Nullable="false" />
-        <Property Name="includeDevices" Type="Collection(Edm.String)" Nullable="false" />
         <Property Name="includeDeviceStates" Type="Collection(Edm.String)" Nullable="false" />
       </ComplexType>
       <ComplexType Name="conditionalAccessDeviceStates">
@@ -12529,9 +12537,7 @@
         <Property Name="id" Type="Edm.String" />
       </ComplexType>
       <ComplexType Name="internalSponsors" BaseType="graph.userSet" />
-      <ComplexType Name="requestorManager" BaseType="graph.userSet">
-        <Property Name="managerLevel" Type="Edm.Int32" />
-      </ComplexType>
+      <ComplexType Name="requestorManager" BaseType="graph.userSet" />
       <ComplexType Name="requestorSettings">
         <Property Name="acceptRequests" Type="Edm.Boolean" />
         <Property Name="allowedRequestors" Type="Collection(graph.userSet)" />
@@ -20570,11 +20576,6 @@
       </ComplexType>
       <ComplexType Name="plannerFavoritePlanReferenceCollection" OpenType="true" />
       <ComplexType Name="plannerOrderHintsByAssignee" OpenType="true" />
-      <ComplexType Name="plannerPlanContainer">
-        <Property Name="containerId" Type="Edm.String" Nullable="false" />
-        <Property Name="type" Type="graph.plannerContainerType" Nullable="false" />
-        <Property Name="url" Type="Edm.String" Nullable="false" />
-      </ComplexType>
       <ComplexType Name="plannerPlanContext">
         <Property Name="associationType" Type="Edm.String" />
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
@@ -20591,16 +20592,6 @@
         <Property Name="planTitle" Type="Edm.String" />
       </ComplexType>
       <ComplexType Name="plannerRecentPlanReferenceCollection" OpenType="true" />
-      <ComplexType Name="plannerTaskCreation">
-        <Property Name="teamsPublicationInfo" Type="graph.plannerTeamsPublicationInfo" />
-      </ComplexType>
-      <ComplexType Name="plannerTeamsPublicationInfo">
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="publicationId" Type="Edm.String" />
-        <Property Name="publishedToPlanId" Type="Edm.String" />
-        <Property Name="publishingTeamId" Type="Edm.String" />
-        <Property Name="publishingTeamName" Type="Edm.String" />
-      </ComplexType>
       <ComplexType Name="plannerUserIds" OpenType="true" />
       <EntityType Name="planner">
         <NavigationProperty Name="buckets" Type="Collection(graph.plannerBucket)" ContainsTarget="true" />
@@ -20614,7 +20605,6 @@
         <NavigationProperty Name="tasks" Type="Collection(graph.plannerTask)" />
       </EntityType>
       <EntityType Name="plannerPlan" BaseType="graph.plannerDelta">
-        <Property Name="container" Type="graph.plannerPlanContainer" />
         <Property Name="contexts" Type="graph.plannerPlanContextCollection" />
         <Property Name="createdBy" Type="graph.identitySet" />
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
@@ -20636,7 +20626,6 @@
         <Property Name="conversationThreadId" Type="Edm.String" />
         <Property Name="createdBy" Type="graph.identitySet" />
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="creationSource" Type="graph.plannerTaskCreation" />
         <Property Name="dueDateTime" Type="Edm.DateTimeOffset" />
         <Property Name="hasDescription" Type="Edm.Boolean" />
         <Property Name="orderHint" Type="Edm.String" />
@@ -20732,7 +20721,6 @@
         <Property Name="defaultSpeechInputLanguage" Type="graph.localeInfo" />
         <Property Name="defaultTranslationLanguage" Type="graph.localeInfo" />
         <Property Name="regionalFormatOverrides" Type="graph.regionalFormatOverrides" />
-        <Property Name="translationPreferences" Type="graph.translationPreferences" />
       </EntityType>
       <EntityType Name="changeTrackedEntity" BaseType="graph.entity" Abstract="true">
         <Property Name="createdBy" Type="graph.identitySet" />
@@ -20938,15 +20926,6 @@
       <ComplexType Name="serviceInformation">
         <Property Name="name" Type="Edm.String" Nullable="false" />
         <Property Name="webUrl" Type="Edm.String" Nullable="false" />
-      </ComplexType>
-      <ComplexType Name="translationLanguageOverride">
-        <Property Name="languageTag" Type="Edm.String" Nullable="false" />
-        <Property Name="translationBehavior" Type="graph.translationBehavior" />
-      </ComplexType>
-      <ComplexType Name="translationPreferences">
-        <Property Name="languageOverrides" Type="Collection(graph.translationLanguageOverride)" Nullable="false" />
-        <Property Name="translationBehavior" Type="graph.translationBehavior" />
-        <Property Name="untranslatedLanguages" Type="Collection(Edm.String)" />
       </ComplexType>
       <ComplexType Name="yomiPersonName">
         <Property Name="displayName" Type="Edm.String" />
@@ -21489,15 +21468,13 @@
         <Property Name="building" Type="Edm.String" />
         <Property Name="city" Type="Edm.String" />
         <Property Name="countryOrRegion" Type="Edm.String" />
-        <Property Name="floor" Type="Edm.String" />
         <Property Name="floorDescription" Type="Edm.String" />
         <Property Name="floorNumber" Type="Edm.Int32" />
-        <Property Name="latitude" Type="Edm.Double" />
-        <Property Name="longitude" Type="Edm.Double" />
+        <Property Name="latitude" Type="Edm.Single" />
+        <Property Name="longitude" Type="Edm.Single" />
         <Property Name="organization" Type="Collection(Edm.String)" />
         <Property Name="postalCode" Type="Edm.String" />
         <Property Name="roomDescription" Type="Edm.String" />
-        <Property Name="roomName" Type="Edm.String" />
         <Property Name="roomNumber" Type="Edm.Int32" />
         <Property Name="site" Type="Edm.String" />
         <Property Name="stateOrProvince" Type="Edm.String" />
@@ -21620,7 +21597,7 @@
         <Property Name="displayName" Type="Edm.String" Nullable="false" />
         <NavigationProperty Name="tasks" Type="Collection(graph.printTask)" ContainsTarget="true" />
       </EntityType>
-      <EntityType Name="printDocument" BaseType="graph.entity" HasStream="true">
+      <EntityType Name="printDocument" BaseType="graph.entity">
         <Property Name="configuration" Type="graph.printerDocumentConfiguration" Nullable="false" />
         <Property Name="contentType" Type="Edm.String" />
         <Property Name="displayName" Type="Edm.String" />
@@ -22266,6 +22243,10 @@
       <ComplexType Name="inviteNewBotResponse" BaseType="graph.participantJoiningResponse">
         <Property Name="inviteUri" Type="Edm.String" />
       </ComplexType>
+      <ComplexType Name="lobbyBypassSettings">
+        <Property Name="isDialInBypassEnabled" Type="Edm.Boolean" />
+        <Property Name="scope" Type="graph.lobbyBypassScope" />
+      </ComplexType>
       <ComplexType Name="mediaInfo">
         <Property Name="resourceId" Type="Edm.String" />
         <Property Name="uri" Type="Edm.String" Nullable="false" />
@@ -22305,10 +22286,6 @@
         <Property Name="organizer" Type="graph.identitySet" Nullable="false" />
       </ComplexType>
       <ComplexType Name="outgoingCallOptions" BaseType="graph.callOptions" />
-      <ComplexType Name="outOfOfficeSettings">
-        <Property Name="isOutOfOffice" Type="Edm.Boolean" />
-        <Property Name="message" Type="Edm.String" />
-      </ComplexType>
       <ComplexType Name="participantInfo">
         <Property Name="countryCode" Type="Edm.String" />
         <Property Name="endpointType" Type="graph.endpointType" />
@@ -22657,11 +22634,9 @@
       <EntityType Name="conversationMember" BaseType="graph.entity" Abstract="true">
         <Property Name="displayName" Type="Edm.String" />
         <Property Name="roles" Type="Collection(Edm.String)" />
-        <Property Name="visibleHistoryStartDateTime" Type="Edm.DateTimeOffset" />
       </EntityType>
       <EntityType Name="aadUserConversationMember" BaseType="graph.conversationMember">
         <Property Name="email" Type="Edm.String" />
-        <Property Name="tenantId" Type="Edm.String" />
         <Property Name="userId" Type="Edm.String" />
         <NavigationProperty Name="user" Type="graph.user" />
       </EntityType>
@@ -22762,14 +22737,6 @@
         <Property Name="targetResourceId" Type="Edm.String" />
         <Property Name="targetResourceLocation" Type="Edm.String" />
       </EntityType>
-      <EntityType Name="teamworkTag" BaseType="graph.entity">
-        <Property Name="description" Type="Edm.String" />
-        <Property Name="displayName" Type="Edm.String" />
-        <Property Name="memberCount" Type="Edm.Int32" />
-        <Property Name="tagType" Type="graph.teamworkTagType" />
-        <Property Name="teamId" Type="Edm.String" />
-        <NavigationProperty Name="members" Type="Collection(graph.teamworkTagMember)" ContainsTarget="true" />
-      </EntityType>
       <EntityType Name="teamsTemplate" BaseType="graph.entity" />
       <EntityType Name="teamsAppDefinition" BaseType="graph.entity">
         <Property Name="azureADAppId" Type="Edm.String" />
@@ -22781,9 +22748,7 @@
         <Property Name="shortdescription" Type="Edm.String" />
         <Property Name="teamsAppId" Type="Edm.String" />
         <Property Name="version" Type="Edm.String" />
-        <NavigationProperty Name="bot" Type="graph.teamworkBot" ContainsTarget="true" />
       </EntityType>
-      <EntityType Name="teamworkBot" BaseType="graph.entity" />
       <EntityType Name="teamwork" BaseType="graph.entity">
         <NavigationProperty Name="workforceIntegrations" Type="Collection(graph.workforceIntegration)" ContainsTarget="true" />
       </EntityType>
@@ -22796,11 +22761,6 @@
         <Property Name="supportedEntities" Type="graph.workforceIntegrationSupportedEntities" />
         <Property Name="supports" Type="graph.workforceIntegrationSupportedEntities" />
         <Property Name="url" Type="Edm.String" />
-      </EntityType>
-      <EntityType Name="teamworkTagMember" BaseType="graph.entity">
-        <Property Name="displayName" Type="Edm.String" />
-        <Property Name="tenantId" Type="Edm.String" />
-        <Property Name="userId" Type="Edm.String" />
       </EntityType>
       <EntityType Name="userScopeTeamsAppInstallation" BaseType="graph.teamsAppInstallation">
         <NavigationProperty Name="chat" Type="graph.chat" />
@@ -23514,26 +23474,6 @@
         <Parameter Name="period" Type="Edm.Int32" Nullable="false" />
         <ReturnType Type="graph.report" />
       </Function>
-      <Function Name="usersRegisteredByFeature" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.authenticationMethodsRoot" />
-        <ReturnType Type="graph.userRegistrationFeatureSummary" Nullable="false" />
-      </Function>
-      <Function Name="usersRegisteredByFeature" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.authenticationMethodsRoot" />
-        <Parameter Name="includedUserTypes" Type="graph.includedUserTypes" />
-        <Parameter Name="includedUserRoles" Type="graph.includedUserRoles" />
-        <ReturnType Type="graph.userRegistrationFeatureSummary" Nullable="false" />
-      </Function>
-      <Function Name="usersRegisteredByMethod" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.authenticationMethodsRoot" />
-        <ReturnType Type="graph.userRegistrationMethodSummary" Nullable="false" />
-      </Function>
-      <Function Name="usersRegisteredByMethod" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.authenticationMethodsRoot" />
-        <Parameter Name="includedUserTypes" Type="graph.includedUserTypes" />
-        <Parameter Name="includedUserRoles" Type="graph.includedUserRoles" />
-        <ReturnType Type="graph.userRegistrationMethodSummary" Nullable="false" />
-      </Function>
       <Action Name="createPasswordSingleSignOnCredentials" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.servicePrincipal" />
         <Parameter Name="id" Type="Edm.String" Nullable="false" Unicode="false" />
@@ -23744,10 +23684,6 @@
       <Action Name="runHealthChecks" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.cloudPcOnPremisesConnection" />
       </Action>
-      <Action Name="updateAdDomainPassword" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.cloudPcOnPremisesConnection" />
-        <Parameter Name="adDomainPassword" Type="Edm.String" Unicode="false" />
-      </Action>
       <Function Name="getEffectivePermissions" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.virtualEndpoint" />
         <ReturnType Type="Collection(Edm.String)" Unicode="false" />
@@ -23764,6 +23700,38 @@
       <Function Name="getSourceImages" IsBound="true">
         <Parameter Name="bindingParameter" Type="Collection(graph.cloudPcDeviceImage)" />
         <ReturnType Type="Collection(graph.cloudPcSourceDeviceImage)" />
+      </Function>
+      <Action Name="activate" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.custodian" />
+      </Action>
+      <Action Name="release" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.custodian" />
+      </Action>
+      <Action Name="updateIndex" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.custodian" />
+      </Action>
+      <Action Name="close" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.case" />
+      </Action>
+      <Action Name="reopen" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.case" />
+      </Action>
+      <Action Name="export" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.reviewSet" />
+        <Parameter Name="outputName" Type="Edm.String" Unicode="false" />
+        <Parameter Name="description" Type="Edm.String" Unicode="false" />
+        <Parameter Name="azureBlobContainer" Type="Edm.String" Unicode="false" />
+        <Parameter Name="azureBlobToken" Type="Edm.String" Unicode="false" />
+        <Parameter Name="exportOptions" Type="graph.exportOptions" />
+        <Parameter Name="exportStructure" Type="graph.exportFileStructure" Nullable="false" />
+      </Action>
+      <Function Name="export" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.governanceRoleAssignment)" />
+        <ReturnType Type="Collection(Edm.String)" Unicode="false" />
+      </Function>
+      <Function Name="getDownloadUrl" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.caseExportOperation" />
+        <ReturnType Type="Edm.String" Unicode="false" />
       </Function>
       <Action Name="generateKey" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.trustFrameworkKeySet" />
@@ -28627,10 +28595,6 @@
         <Parameter Name="bindingParameter" Type="Collection(graph.governanceResource)" />
         <Parameter Name="externalId" Type="Edm.String" Unicode="false" />
       </Action>
-      <Function Name="export" IsBound="true">
-        <Parameter Name="bindingParameter" Type="Collection(graph.governanceRoleAssignment)" />
-        <ReturnType Type="Collection(Edm.String)" Unicode="false" />
-      </Function>
       <Action Name="completeSetup" IsBound="true">
         <Parameter Name="bindingParameter" Type="Collection(graph.privilegedSignupStatus)" />
         <Parameter Name="tenantSetupInfo" Type="graph.tenantSetupInfo" />
@@ -29102,12 +29066,6 @@
         </EntitySet>
         <EntitySet Name="bookingBusinesses" EntityType="microsoft.graph.bookingBusiness" />
         <EntitySet Name="bookingCurrencies" EntityType="microsoft.graph.bookingCurrency" />
-        <EntitySet Name="devices" EntityType="microsoft.graph.device">
-          <NavigationPropertyBinding Path="memberOf" Target="directoryObjects" />
-          <NavigationPropertyBinding Path="registeredOwners" Target="directoryObjects" />
-          <NavigationPropertyBinding Path="registeredUsers" Target="directoryObjects" />
-          <NavigationPropertyBinding Path="transitiveMemberOf" Target="directoryObjects" />
-        </EntitySet>
         <EntitySet Name="identityProviders" EntityType="microsoft.graph.identityProvider" />
         <EntitySet Name="administrativeUnits" EntityType="microsoft.graph.administrativeUnit">
           <NavigationPropertyBinding Path="members" Target="directoryObjects" />
@@ -29126,6 +29084,12 @@
           <NavigationPropertyBinding Path="transitiveMemberOf" Target="directoryObjects" />
         </EntitySet>
         <EntitySet Name="contracts" EntityType="microsoft.graph.contract" />
+        <EntitySet Name="devices" EntityType="microsoft.graph.device">
+          <NavigationPropertyBinding Path="memberOf" Target="directoryObjects" />
+          <NavigationPropertyBinding Path="registeredOwners" Target="directoryObjects" />
+          <NavigationPropertyBinding Path="registeredUsers" Target="directoryObjects" />
+          <NavigationPropertyBinding Path="transitiveMemberOf" Target="directoryObjects" />
+        </EntitySet>
         <EntitySet Name="directoryObjects" EntityType="microsoft.graph.directoryObject" />
         <EntitySet Name="directoryRoles" EntityType="microsoft.graph.directoryRole">
           <NavigationPropertyBinding Path="members" Target="directoryObjects" />
@@ -30370,7 +30334,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The list of assignment filters" />
       </Annotations>
       <Annotations Target="microsoft.graph.termsAndConditions">
-        <Annotation Term="Org.OData.Core.V1.Description" String="A termsAndConditions entity represents the metadata and contents of a given Terms and Conditions (T&amp;C) policy. T&amp;C policies’ contents are presented to users upon their first attempt to enroll into Intune and subsequently upon edits where an administrator has required re-acceptance. They enable administrators to communicate the provisions to which a user must agree in order to have devices enrolled into Intune." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="A termsAndConditions entity represents the metadata and contents of a given Terms and Conditions (T&amp;C) policy. T&amp;C policiesâ€™ contents are presented to users upon their first attempt to enroll into Intune and subsequently upon edits where an administrator has required re-acceptance. They enable administrators to communicate the provisions to which a user must agree in order to have devices enrolled into Intune." />
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagement/termsAndConditions">
         <Annotation Term="Org.OData.Core.V1.Description" String="The terms and conditions associated with device management of the company." />
@@ -30570,10 +30534,10 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The custom privacy message used to explain what the organization can see and do on managed devices." />
       </Annotations>
       <Annotations Target="microsoft.graph.intuneBrand/customCantSeePrivacyMessage">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The custom privacy message used to explain what the organization can’t see or do on managed devices." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="The custom privacy message used to explain what the organization canâ€™t see or do on managed devices." />
       </Annotations>
       <Annotations Target="microsoft.graph.intuneBrand/customPrivacyMessage">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The custom privacy message used to explain what the organization can’t see or do on managed devices." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="The custom privacy message used to explain what the organization canâ€™t see or do on managed devices." />
       </Annotations>
       <Annotations Target="microsoft.graph.mimeContent">
         <Annotation Term="Org.OData.Core.V1.Description" String="Contains properties for a generic mime content." />
@@ -30609,13 +30573,13 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Logo image displayed in Company Portal apps which have a light background behind the logo." />
       </Annotations>
       <Annotations Target="microsoft.graph.intuneBrand/onlineSupportSiteName">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Display name of the company/organization’s IT helpdesk site." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Display name of the company/organizationâ€™s IT helpdesk site." />
       </Annotations>
       <Annotations Target="microsoft.graph.intuneBrand/onlineSupportSiteUrl">
-        <Annotation Term="Org.OData.Core.V1.Description" String="URL to the company/organization’s IT helpdesk site." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="URL to the company/organizationâ€™s IT helpdesk site." />
       </Annotations>
       <Annotations Target="microsoft.graph.intuneBrand/privacyUrl">
-        <Annotation Term="Org.OData.Core.V1.Description" String="URL to the company/organization’s privacy policy." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="URL to the company/organizationâ€™s privacy policy." />
       </Annotations>
       <Annotations Target="microsoft.graph.intuneBrand/roleScopeTagIds">
         <Annotation Term="Org.OData.Core.V1.Description" String="List of scope tags assigned to the default branding profile" />
@@ -31236,7 +31200,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Collection of MicrosoftTunnelSite settings associated with account." />
       </Annotations>
       <Annotations Target="microsoft.graph.notificationMessageTemplate">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Notification messages are messages that are sent to end users who are determined to be not-compliant with the compliance policies defined by the administrator. Administrators choose notifications and configure them in the Intune Admin Console using the compliance policy creation page under the “Actions for non-compliance” section. Use the notificationMessageTemplate object to create your own custom notifications for administrators to choose while configuring actions for non-compliance." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Notification messages are messages that are sent to end users who are determined to be not-compliant with the compliance policies defined by the administrator. Administrators choose notifications and configure them in the Intune Admin Console using the compliance policy creation page under the â€œActions for non-complianceâ€ section. Use the notificationMessageTemplate object to create your own custom notifications for administrators to choose while configuring actions for non-compliance." />
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagement/notificationMessageTemplates">
         <Annotation Term="Org.OData.Core.V1.Description" String="The Notification Message Templates." />
@@ -36592,7 +36556,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Start time of the time window" />
       </Annotations>
       <Annotations Target="microsoft.graph.defenderDetectedMalwareActions">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Specify Defender’s actions to take on detected Malware per threat level." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Specify Defenderâ€™s actions to take on detected Malware per threat level." />
       </Annotations>
       <Annotations Target="microsoft.graph.defenderDetectedMalwareActions/highSeverity">
         <Annotation Term="Org.OData.Core.V1.Description" String="Indicates a Defender action to take for high severity Malware threat detected." />
@@ -36831,7 +36795,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Represents information for a local user or group used for user rights setting." />
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementUserRightsLocalUserOrGroup/description">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Admin’s description of this local user or group." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Adminâ€™s description of this local user or group." />
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementUserRightsLocalUserOrGroup/name">
         <Annotation Term="Org.OData.Core.V1.Description" String="The name of this local user or group." />
@@ -37476,13 +37440,13 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Allow or block access to event information managed by Calendar." />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSPrivacyAccessControlItem/codeRequirement">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Enter the code requirement, which can be obtained with the command 'codesign –display -r –' in the Terminal app. Include everything after '=&gt;'." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Enter the code requirement, which can be obtained with the command 'codesign â€“display -r â€“' in the Terminal app. Include everything after '=&gt;'." />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSPrivacyAccessControlItem/displayName">
         <Annotation Term="Org.OData.Core.V1.Description" String="The display name of the app, process, or executable." />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSPrivacyAccessControlItem/fileProviderPresence">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Allow the app or process to access files managed by another app’s file provider extension. Requires macOS 10.15 or later. " />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Allow the app or process to access files managed by another appâ€™s file provider extension. Requires macOS 10.15 or later. " />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSPrivacyAccessControlItem/identifier">
         <Annotation Term="Org.OData.Core.V1.Description" String="The bundle ID or path of the app, process, or executable." />
@@ -37971,7 +37935,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Network Proxy Server Policy." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10NetworkProxyServer/address">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Address to the proxy server. Specify an address in the format &lt;server&gt;[“:”&lt;port&gt;]" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Address to the proxy server. Specify an address in the format &lt;server&gt;[â€œ:â€&lt;port&gt;]" />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10NetworkProxyServer/exceptions">
         <Annotation Term="Org.OData.Core.V1.Description" String="Addresses that should not use the proxy server. The system will not use the proxy server for addresses beginning with what is specified in this node." />
@@ -42003,13 +41967,13 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Require Mobile Threat Protection minimum risk level to report noncompliance." />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSCompliancePolicy/firewallBlockAllIncoming">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Corresponds to the “Block all incoming connections” option." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Corresponds to the â€œBlock all incoming connectionsâ€ option." />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSCompliancePolicy/firewallEnabled">
         <Annotation Term="Org.OData.Core.V1.Description" String="Whether the firewall should be enabled or not." />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSCompliancePolicy/firewallEnableStealthMode">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Corresponds to “Enable stealth mode.”" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Corresponds to â€œEnable stealth mode.â€" />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSCompliancePolicy/gatekeeperAllowedAppSource">
         <Annotation Term="Org.OData.Core.V1.Description" String="System and Privacy setting that determines which download locations apps can be run from on a macOS device." />
@@ -42270,13 +42234,13 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="List of applications with firewall settings. Firewall settings for applications not on this list are determined by the user. This collection can contain a maximum of 500 elements." />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSEndpointProtectionConfiguration/firewallBlockAllIncoming">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Corresponds to the “Block all incoming connections” option." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Corresponds to the â€œBlock all incoming connectionsâ€ option." />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSEndpointProtectionConfiguration/firewallEnabled">
         <Annotation Term="Org.OData.Core.V1.Description" String="Whether the firewall should be enabled or not." />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSEndpointProtectionConfiguration/firewallEnableStealthMode">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Corresponds to “Enable stealth mode.”" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Corresponds to â€œEnable stealth mode.â€" />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSEndpointProtectionConfiguration/gatekeeperAllowedAppSource">
         <Annotation Term="Org.OData.Core.V1.Description" String="System and Privacy setting that determines which download locations apps can be run from on a macOS device." />
@@ -43177,13 +43141,13 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Hardware information of a given device." />
       </Annotations>
       <Annotations Target="microsoft.graph.hardwareInformation/batteryChargeCycles">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The number of charge cycles the device’s current battery has gone through. Valid values 0 to 2147483647" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="The number of charge cycles the deviceâ€™s current battery has gone through. Valid values 0 to 2147483647" />
       </Annotations>
       <Annotations Target="microsoft.graph.hardwareInformation/batteryHealthPercentage">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The device’s current battery’s health percentage. Valid values 0 to 100" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="The deviceâ€™s current batteryâ€™s health percentage. Valid values 0 to 100" />
       </Annotations>
       <Annotations Target="microsoft.graph.hardwareInformation/batterySerialNumber">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The serial number of the device’s current battery" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="The serial number of the deviceâ€™s current battery" />
       </Annotations>
       <Annotations Target="microsoft.graph.hardwareInformation/cellularTechnology">
         <Annotation Term="Org.OData.Core.V1.Description" String="Cellular technology of the device" />
@@ -44496,7 +44460,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="If enabled,the SMB client will allow insecure guest logons. If not configured, the SMB client will reject insecure guest logons." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10EndpointProtectionConfiguration/localSecurityOptionsAdministratorAccountName">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Define a different account name to be associated with the security identifier (SID) for the account “Administrator”." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Define a different account name to be associated with the security identifier (SID) for the account â€œAdministratorâ€." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10EndpointProtectionConfiguration/localSecurityOptionsAdministratorElevationPromptBehavior">
         <Annotation Term="Org.OData.Core.V1.Description" String="Define the behavior of the elevation prompt for admins in Admin Approval Mode." />
@@ -44571,19 +44535,19 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Require CTRL+ALT+DEL to be pressed before a user can log on." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10EndpointProtectionConfiguration/localSecurityOptionsDoNotStoreLANManagerHashValueOnNextPasswordChange">
-        <Annotation Term="Org.OData.Core.V1.Description" String="This security setting determines if, at the next password change, the LAN Manager (LM) hash value for the new password is stored. It’s not stored by default." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="This security setting determines if, at the next password change, the LAN Manager (LM) hash value for the new password is stored. Itâ€™s not stored by default." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10EndpointProtectionConfiguration/localSecurityOptionsFormatAndEjectOfRemovableMediaAllowedUser">
         <Annotation Term="Org.OData.Core.V1.Description" String="Define who is allowed to format and eject removable NTFS media." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10EndpointProtectionConfiguration/localSecurityOptionsGuestAccountName">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Define a different account name to be associated with the security identifier (SID) for the account “Guest”." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Define a different account name to be associated with the security identifier (SID) for the account â€œGuestâ€." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10EndpointProtectionConfiguration/localSecurityOptionsHideLastSignedInUser">
         <Annotation Term="Org.OData.Core.V1.Description" String="Do not display the username of the last person who signed in on this device." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10EndpointProtectionConfiguration/localSecurityOptionsHideUsernameAtSignIn">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Do not display the username of the person signing in to this device after credentials are entered and before the device’s desktop is shown." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Do not display the username of the person signing in to this device after credentials are entered and before the deviceâ€™s desktop is shown." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10EndpointProtectionConfiguration/localSecurityOptionsInformationDisplayedOnLockScreen">
         <Annotation Term="Org.OData.Core.V1.Description" String="Configure the user information that is displayed when the session is locked. If not configured, user display name, domain and username are shown" />
@@ -44598,10 +44562,10 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Set message title for users attempting to log in." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10EndpointProtectionConfiguration/localSecurityOptionsMachineInactivityLimit">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Define maximum minutes of inactivity on the interactive desktop’s login screen until the screen saver runs. Valid values 0 to 9999" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Define maximum minutes of inactivity on the interactive desktopâ€™s login screen until the screen saver runs. Valid values 0 to 9999" />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10EndpointProtectionConfiguration/localSecurityOptionsMachineInactivityLimitInMinutes">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Define maximum minutes of inactivity on the interactive desktop’s login screen until the screen saver runs. Valid values 0 to 9999" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Define maximum minutes of inactivity on the interactive desktopâ€™s login screen until the screen saver runs. Valid values 0 to 9999" />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10EndpointProtectionConfiguration/localSecurityOptionsMinimumSessionSecurityForNtlmSspBasedClients">
         <Annotation Term="Org.OData.Core.V1.Description" String="This security setting allows a client to require the negotiation of 128-bit encryption and/or NTLMv2 session security." />
@@ -44769,7 +44733,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="This policy setting directs Windows Installer to use elevated permissions when it installs any program on the system." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/appManagementPackageFamilyNamesToLaunchAfterLogOn">
-        <Annotation Term="Org.OData.Core.V1.Description" String="List of semi-colon delimited Package Family Names of Windows apps. Listed Windows apps are to be launched after logon.​" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="List of semi-colon delimited Package Family Names of Windows apps. Listed Windows apps are to be launched after logon.â€‹" />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/appsAllowTrustedAppsSideloading">
         <Annotation Term="Org.OData.Core.V1.Description" String="Indicates whether apps from AppX packages signed with a trusted certificate can be side loaded." />
@@ -44859,7 +44823,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Number of days before deleting quarantined malware. Valid values 0 to 90" />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/defenderDetectedMalwareActions">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Gets or sets Defender’s actions to take on detected Malware per threat level." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Gets or sets Defenderâ€™s actions to take on detected Malware per threat level." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/defenderDisableCatchupFullScan">
         <Annotation Term="Org.OData.Core.V1.Description" String="When blocked, catch-up scans for scheduled full scans will be turned off." />
@@ -44877,10 +44841,10 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Value for monitoring file activity." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/defenderPotentiallyUnwantedAppAction">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Gets or sets Defender’s action to take on Potentially Unwanted Application (PUA), which includes software with behaviors of ad-injection, software bundling, persistent solicitation for payment or subscription, etc. Defender alerts user when PUA is being downloaded or attempts to install itself. Added in Windows 10 for desktop." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Gets or sets Defenderâ€™s action to take on Potentially Unwanted Application (PUA), which includes software with behaviors of ad-injection, software bundling, persistent solicitation for payment or subscription, etc. Defender alerts user when PUA is being downloaded or attempts to install itself. Added in Windows 10 for desktop." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/defenderPotentiallyUnwantedAppActionSetting">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Gets or sets Defender’s action to take on Potentially Unwanted Application (PUA), which includes software with behaviors of ad-injection, software bundling, persistent solicitation for payment or subscription, etc. Defender alerts user when PUA is being downloaded or attempts to install itself. Added in Windows 10 for desktop." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Gets or sets Defenderâ€™s action to take on Potentially Unwanted Application (PUA), which includes software with behaviors of ad-injection, software bundling, persistent solicitation for payment or subscription, etc. Defender alerts user when PUA is being downloaded or attempts to install itself. Added in Windows 10 for desktop." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/defenderProcessesToExclude">
         <Annotation Term="Org.OData.Core.V1.Description" String="Processes to exclude from scans and real time protection." />
@@ -45204,7 +45168,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Controls the Microsoft Account Sign-In Assistant (wlidsvc) NT service." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/networkProxyApplySettingsDeviceWide">
-        <Annotation Term="Org.OData.Core.V1.Description" String="If set, proxy settings will be applied to all processes and accounts in the device. Otherwise, it will be applied to the user account that’s enrolled into MDM." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="If set, proxy settings will be applied to all processes and accounts in the device. Otherwise, it will be applied to the user account thatâ€™s enrolled into MDM." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/networkProxyAutomaticConfigurationUrl">
         <Annotation Term="Org.OData.Core.V1.Description" String="Address to the proxy auto-config (PAC) script you want to use." />
@@ -45309,7 +45273,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Blocks the shared experiences/discovery of recently used resources in task switcher etc." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/privacyDisableLaunchExperience">
-        <Annotation Term="Org.OData.Core.V1.Description" String="This policy prevents the privacy experience from launching during user logon for new and upgraded users.​" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="This policy prevents the privacy experience from launching during user logon for new and upgraded users.â€‹" />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/resetProtectionModeBlocked">
         <Annotation Term="Org.OData.Core.V1.Description" String="Indicates whether or not to Block the user from reset protection mode." />
@@ -45348,7 +45312,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Specifies minimum amount of hard drive space on the same drive as the index location before indexing stops." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/searchEnableRemoteQueries">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates whether or not to block remote queries of this computer’s index." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates whether or not to block remote queries of this computerâ€™s index." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/securityBlockAzureADJoinedDevicesAutoEncryption">
         <Annotation Term="Org.OData.Core.V1.Description" String="Specify whether to allow automatic device encryption during OOBE when the device is Azure AD joined (desktop only)." />
@@ -45453,7 +45417,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Enabling this policy hides recently added apps from appearing on the start menu and disables the corresponding toggle in the Settings app." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/startMenuHideRestartOptions">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Enabling this policy hides “Restart/Update and Restart” from appearing in the power button in the start menu." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Enabling this policy hides â€œRestart/Update and Restartâ€ from appearing in the power button in the start menu." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/startMenuHideShutDown">
         <Annotation Term="Org.OData.Core.V1.Description" String="Enabling this policy hides shut down/update and shut down from appearing in the power button in the start menu." />
@@ -45567,7 +45531,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Block suggestions from Microsoft that show after each OS clean install, upgrade or in an on-going basis to introduce users to what is new or changed" />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/windowsSpotlightBlockTailoredExperiences">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Block personalized content in Windows spotlight based on user’s device usage." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Block personalized content in Windows spotlight based on userâ€™s device usage." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/windowsSpotlightBlockThirdPartyNotifications">
         <Annotation Term="Org.OData.Core.V1.Description" String="Block third party content delivered via Windows Spotlight" />
@@ -46187,7 +46151,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Specifies number of seconds to delay a fall back from cache servers to an HTTP source for a background download. Valid values 0 to 2592000." />
       </Annotations>
       <Annotations Target="microsoft.graph.windowsDeliveryOptimizationConfiguration/cacheServerForegroundDownloadFallbackToHttpDelayInSeconds">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Specifies number of seconds to delay a fall back from cache servers to an HTTP source for a foreground download. Valid values 0 to 2592000.​" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Specifies number of seconds to delay a fall back from cache servers to an HTTP source for a foreground download. Valid values 0 to 2592000.â€‹" />
       </Annotations>
       <Annotations Target="microsoft.graph.windowsDeliveryOptimizationConfiguration/cacheServerHostNames">
         <Annotation Term="Org.OData.Core.V1.Description" String="Specifies cache servers host names." />
@@ -46728,10 +46692,10 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Scheduled the update installation on the weeks of the month" />
       </Annotations>
       <Annotations Target="microsoft.graph.windowsUpdateForBusinessConfiguration/userPauseAccess">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Specifies whether to enable end user’s access to pause software updates." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Specifies whether to enable end userâ€™s access to pause software updates." />
       </Annotations>
       <Annotations Target="microsoft.graph.windowsUpdateForBusinessConfiguration/userWindowsUpdateScanAccess">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Specifies whether to disable user’s access to scan Windows Update." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Specifies whether to disable userâ€™s access to scan Windows Update." />
       </Annotations>
       <Annotations Target="microsoft.graph.windowsUpdateForBusinessConfiguration/deviceUpdateStates">
         <Annotation Term="Org.OData.Core.V1.Description" String="Windows update for business configuration device states." />
@@ -46827,10 +46791,10 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Specify the number of seconds between a failed authentication and the next authentication attempt. Valid range 1-3600." />
       </Annotations>
       <Annotations Target="microsoft.graph.windowsWifiEnterpriseEAPConfiguration/authenticationType">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Specify whether to authenticate the user, the device, either, or to use guest authentication (none). If you’re using certificate authentication, make sure the certificate type matches the authentication type." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Specify whether to authenticate the user, the device, either, or to use guest authentication (none). If youâ€™re using certificate authentication, make sure the certificate type matches the authentication type." />
       </Annotations>
       <Annotations Target="microsoft.graph.windowsWifiEnterpriseEAPConfiguration/cacheCredentials">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Specify whether to cache user credentials on the device so that users don’t need to keep entering them each time they connect." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Specify whether to cache user credentials on the device so that users donâ€™t need to keep entering them each time they connect." />
       </Annotations>
       <Annotations Target="microsoft.graph.windowsWifiEnterpriseEAPConfiguration/disableUserPromptForServerValidation">
         <Annotation Term="Org.OData.Core.V1.Description" String="Specify whether to prevent the user from being prompted to authorize new servers for trusted certification authorities when EAP type is selected as PEAP." />
@@ -46887,7 +46851,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Specify trusted server certificate names." />
       </Annotations>
       <Annotations Target="microsoft.graph.windowsWifiEnterpriseEAPConfiguration/userBasedVirtualLan">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Specifiy whether to change the virtual LAN used by the device based on the user’s credentials. Cannot be used when NetworkSingleSignOnType is set to ​Disabled." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Specifiy whether to change the virtual LAN used by the device based on the userâ€™s credentials. Cannot be used when NetworkSingleSignOnType is set to â€‹Disabled." />
       </Annotations>
       <Annotations Target="microsoft.graph.windowsWifiEnterpriseEAPConfiguration/identityCertificateForClientAuthentication">
         <Annotation Term="Org.OData.Core.V1.Description" String="Specify identity certificate for client authentication." />
@@ -52826,13 +52790,13 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Logo image displayed in Company Portal apps which have a light background behind the logo" />
       </Annotations>
       <Annotations Target="microsoft.graph.intuneBrandingProfile/onlineSupportSiteName">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Display name of the company/organization’s IT helpdesk site" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Display name of the company/organizationâ€™s IT helpdesk site" />
       </Annotations>
       <Annotations Target="microsoft.graph.intuneBrandingProfile/onlineSupportSiteUrl">
-        <Annotation Term="Org.OData.Core.V1.Description" String="URL to the company/organization’s IT helpdesk site" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="URL to the company/organizationâ€™s IT helpdesk site" />
       </Annotations>
       <Annotations Target="microsoft.graph.intuneBrandingProfile/privacyUrl">
-        <Annotation Term="Org.OData.Core.V1.Description" String="URL to the company/organization’s privacy policy" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="URL to the company/organizationâ€™s privacy policy" />
       </Annotations>
       <Annotations Target="microsoft.graph.intuneBrandingProfile/profileDescription">
         <Annotation Term="Org.OData.Core.V1.Description" String="Description of the profile" />
@@ -53539,21 +53503,6 @@
         <Annotation Term="Org.OData.Capabilities.V1.BatchContinueOnErrorSupported" Bool="false" />
         <Annotation Term="Org.OData.Capabilities.V1.BatchSupported" Bool="false" />
       </Annotations>
-      <Annotations Target="microsoft.graph.plannerPlan/owner">
-        <Annotation Term="Org.OData.Core.V1.Revisions">
-          <Collection>
-            <Record>
-              <PropertyValue Property="Date" Date="2021-01-18" />
-              <PropertyValue Property="Description" String="Owner property is deprecated and will be removed in January 2023. Please use the container property instead." />
-              <PropertyValue Property="Kind">
-                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
-              </PropertyValue>
-              <PropertyValue Property="RemovalDate" Date="2023-01-18" />
-              <PropertyValue Property="Version" String="2021-01/Tasks_And_Plans" />
-            </Record>
-          </Collection>
-        </Annotation>
-      </Annotations>
       <Annotations Target="microsoft.graph.plannerUser/all">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
           <Record>
@@ -53962,13 +53911,6 @@
           </Collection>
         </Annotation>
       </Annotations>
-      <Annotations Target="microsoft.graph.externalItem">
-        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
-          <Record>
-            <PropertyValue Property="Upsertable" Bool="true" />
-          </Record>
-        </Annotation>
-      </Annotations>
       <Annotations Target="microsoft.graph.channel/messages">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
           <Record>
@@ -54058,254 +54000,6 @@
           </Record>
         </Annotation>
       </Annotations>
-    </Schema>
-    <Schema Namespace="microsoft.graph.ediscovery" xmlns="http://docs.oasis-open.org/odata/ns/edm">
-      <EnumType Name="caseAction">
-        <Member Name="contentExport" Value="0" />
-        <Member Name="applyTags" Value="1" />
-        <Member Name="convertToPdf" Value="2" />
-        <Member Name="index" Value="3" />
-        <Member Name="estimateStatistics" Value="4" />
-        <Member Name="addToReviewSet" Value="5" />
-        <Member Name="unknownFutureValue" Value="6" />
-      </EnumType>
-      <EnumType Name="caseOperationStatus">
-        <Member Name="notStarted" Value="0" />
-        <Member Name="submissionFailed" Value="1" />
-        <Member Name="running" Value="2" />
-        <Member Name="succeeded" Value="3" />
-        <Member Name="partiallySucceeded" Value="4" />
-        <Member Name="failed" Value="5" />
-      </EnumType>
-      <EnumType Name="caseStatus" UnderlyingType="Edm.Byte">
-        <Member Name="unknown" Value="0" />
-        <Member Name="active" Value="1" />
-        <Member Name="pendingDelete" Value="2" />
-        <Member Name="closing" Value="3" />
-        <Member Name="closed" Value="4" />
-        <Member Name="closedWithError" Value="5" />
-      </EnumType>
-      <EnumType Name="childSelectability">
-        <Member Name="One" Value="0" />
-        <Member Name="Many" Value="1" />
-      </EnumType>
-      <EnumType Name="custodianStatus">
-        <Member Name="active" Value="1" />
-        <Member Name="released" Value="2" />
-      </EnumType>
-      <EnumType Name="dataCollectionScope" IsFlags="true">
-        <Member Name="allVersions" Value="1" />
-        <Member Name="conversations" Value="2" />
-        <Member Name="linkedFiles" Value="4" />
-        <Member Name="unknownFutureValue" Value="8" />
-      </EnumType>
-      <EnumType Name="exportFileStructure">
-        <Member Name="none" Value="0" />
-        <Member Name="directory" Value="1" />
-        <Member Name="pst" Value="2" />
-        <Member Name="unknownFutureValue" Value="3" />
-      </EnumType>
-      <EnumType Name="exportOptions" IsFlags="true">
-        <Member Name="originalFiles" Value="1" />
-        <Member Name="text" Value="2" />
-        <Member Name="pdfReplacement" Value="4" />
-        <Member Name="fileInfo" Value="8" />
-        <Member Name="tags" Value="16" />
-        <Member Name="unknownFutureValue" Value="32" />
-      </EnumType>
-      <EnumType Name="legalHoldStatus">
-        <Member Name="Pending" Value="0" />
-        <Member Name="Error" Value="1" />
-        <Member Name="Success" Value="2" />
-        <Member Name="UnknownFutureValue" Value="3" />
-      </EnumType>
-      <EnumType Name="sourceType" IsFlags="true">
-        <Member Name="mailbox" Value="1" />
-        <Member Name="site" Value="2" />
-      </EnumType>
-      <EnumType Name="tenantSources" IsFlags="true">
-        <Member Name="allMailboxes" Value="1" />
-        <Member Name="allSites" Value="2" />
-        <Member Name="unknownFutureValue" Value="4" />
-      </EnumType>
-      <EntityType Name="case" BaseType="graph.entity">
-        <Property Name="closedBy" Type="graph.identitySet" />
-        <Property Name="closedDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="description" Type="Edm.String" />
-        <Property Name="displayName" Type="Edm.String" />
-        <Property Name="externalId" Type="Edm.String" />
-        <Property Name="lastModifiedBy" Type="graph.identitySet" />
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="status" Type="microsoft.graph.ediscovery.caseStatus" />
-        <NavigationProperty Name="custodians" Type="Collection(microsoft.graph.ediscovery.custodian)" ContainsTarget="true" />
-        <NavigationProperty Name="legalholds" Type="Collection(microsoft.graph.ediscovery.legalhold)" ContainsTarget="true" />
-        <NavigationProperty Name="operations" Type="Collection(microsoft.graph.ediscovery.caseOperation)" ContainsTarget="true" />
-        <NavigationProperty Name="reviewSets" Type="Collection(microsoft.graph.ediscovery.reviewSet)" ContainsTarget="true" />
-        <NavigationProperty Name="sourceCollections" Type="Collection(microsoft.graph.ediscovery.sourceCollection)" ContainsTarget="true" />
-        <NavigationProperty Name="tags" Type="Collection(microsoft.graph.ediscovery.tag)" ContainsTarget="true" />
-      </EntityType>
-      <EntityType Name="caseOperation" BaseType="graph.entity">
-        <Property Name="action" Type="microsoft.graph.ediscovery.caseAction" />
-        <Property Name="completedDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="createdBy" Type="graph.identitySet" />
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="percentProgress" Type="Edm.Int32" />
-        <Property Name="resultInfo" Type="graph.resultInfo" />
-        <Property Name="status" Type="microsoft.graph.ediscovery.caseOperationStatus" />
-      </EntityType>
-      <EntityType Name="addToReviewSetOperation" BaseType="microsoft.graph.ediscovery.caseOperation">
-        <NavigationProperty Name="reviewSet" Type="microsoft.graph.ediscovery.reviewSet" />
-        <NavigationProperty Name="sourceCollection" Type="microsoft.graph.ediscovery.sourceCollection" />
-      </EntityType>
-      <EntityType Name="reviewSet" BaseType="graph.entity">
-        <Property Name="createdBy" Type="graph.identitySet" />
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="displayName" Type="Edm.String" />
-        <NavigationProperty Name="queries" Type="Collection(microsoft.graph.ediscovery.reviewSetQuery)" ContainsTarget="true" />
-      </EntityType>
-      <EntityType Name="sourceCollection" BaseType="graph.entity">
-        <Property Name="contentQuery" Type="Edm.String" />
-        <Property Name="createdBy" Type="graph.identitySet" />
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="description" Type="Edm.String" />
-        <Property Name="displayName" Type="Edm.String" />
-        <Property Name="lastModifiedBy" Type="graph.identitySet" />
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="tenantSources" Type="microsoft.graph.ediscovery.tenantSources" />
-        <NavigationProperty Name="additionalSources" Type="Collection(microsoft.graph.ediscovery.dataSource)" ContainsTarget="true" />
-        <NavigationProperty Name="addToReviewSetOperation" Type="microsoft.graph.ediscovery.addToReviewSetOperation" />
-        <NavigationProperty Name="custodianSources" Type="Collection(microsoft.graph.ediscovery.dataSource)" />
-        <NavigationProperty Name="lastEstimateStatisticsOperation" Type="microsoft.graph.ediscovery.estimateStatisticsOperation" />
-      </EntityType>
-      <EntityType Name="custodian" BaseType="graph.entity">
-        <Property Name="acknowledgedDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="applyHoldToSources" Type="Edm.Boolean" />
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="displayName" Type="Edm.String" />
-        <Property Name="email" Type="Edm.String" Nullable="false" />
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="releasedDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="status" Type="microsoft.graph.ediscovery.custodianStatus" />
-        <NavigationProperty Name="lastIndexOperation" Type="microsoft.graph.ediscovery.caseIndexOperation" />
-        <NavigationProperty Name="siteSources" Type="Collection(microsoft.graph.ediscovery.siteSource)" ContainsTarget="true" />
-        <NavigationProperty Name="unifiedGroupSources" Type="Collection(microsoft.graph.ediscovery.unifiedGroupSource)" ContainsTarget="true" />
-        <NavigationProperty Name="userSources" Type="Collection(microsoft.graph.ediscovery.userSource)" ContainsTarget="true" />
-      </EntityType>
-      <EntityType Name="legalhold" BaseType="graph.entity">
-        <Property Name="contentQuery" Type="Edm.String" />
-        <Property Name="createdBy" Type="graph.identitySet" />
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="description" Type="Edm.String" />
-        <Property Name="displayName" Type="Edm.String" />
-        <Property Name="errors" Type="Collection(Edm.String)" />
-        <Property Name="isEnabled" Type="Edm.Boolean" />
-        <Property Name="lastModifiedBy" Type="graph.identitySet" />
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="status" Type="microsoft.graph.ediscovery.legalHoldStatus" />
-        <NavigationProperty Name="siteSources" Type="Collection(microsoft.graph.ediscovery.siteSource)" ContainsTarget="true" />
-        <NavigationProperty Name="unifiedGroupSources" Type="Collection(microsoft.graph.ediscovery.unifiedGroupSource)" ContainsTarget="true" />
-        <NavigationProperty Name="userSources" Type="Collection(microsoft.graph.ediscovery.userSource)" ContainsTarget="true" />
-      </EntityType>
-      <EntityType Name="tag" BaseType="graph.entity">
-        <Property Name="childSelectability" Type="microsoft.graph.ediscovery.childSelectability" />
-        <Property Name="createdBy" Type="graph.identitySet" />
-        <Property Name="description" Type="Edm.String" />
-        <Property Name="displayName" Type="Edm.String" />
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" />
-        <NavigationProperty Name="childTags" Type="Collection(microsoft.graph.ediscovery.tag)" />
-        <NavigationProperty Name="parent" Type="microsoft.graph.ediscovery.tag" />
-      </EntityType>
-      <EntityType Name="caseExportOperation" BaseType="microsoft.graph.ediscovery.caseOperation">
-        <Property Name="azureBlobContainer" Type="Edm.String" />
-        <Property Name="azureBlobToken" Type="Edm.String" />
-        <Property Name="description" Type="Edm.String" />
-        <Property Name="exportOptions" Type="microsoft.graph.ediscovery.exportOptions" />
-        <Property Name="exportStructure" Type="microsoft.graph.ediscovery.exportFileStructure" />
-        <Property Name="outputFolderId" Type="Edm.String" />
-        <Property Name="outputName" Type="Edm.String" />
-        <NavigationProperty Name="reviewSet" Type="microsoft.graph.ediscovery.reviewSet" />
-      </EntityType>
-      <EntityType Name="caseIndexOperation" BaseType="microsoft.graph.ediscovery.caseOperation" />
-      <EntityType Name="dataSource" BaseType="graph.entity" Abstract="true">
-        <Property Name="createdBy" Type="graph.identitySet" />
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="displayName" Type="Edm.String" />
-      </EntityType>
-      <EntityType Name="siteSource" BaseType="microsoft.graph.ediscovery.dataSource">
-        <NavigationProperty Name="site" Type="graph.site" Nullable="false" />
-      </EntityType>
-      <EntityType Name="unifiedGroupSource" BaseType="microsoft.graph.ediscovery.dataSource">
-        <Property Name="includedSources" Type="microsoft.graph.ediscovery.sourceType" />
-        <NavigationProperty Name="group" Type="graph.group" Nullable="false" />
-      </EntityType>
-      <EntityType Name="userSource" BaseType="microsoft.graph.ediscovery.dataSource">
-        <Property Name="email" Type="Edm.String" Nullable="false" />
-        <Property Name="includedSources" Type="microsoft.graph.ediscovery.sourceType" />
-      </EntityType>
-      <EntityType Name="estimateStatisticsOperation" BaseType="microsoft.graph.ediscovery.caseOperation">
-        <Property Name="indexedItemCount" Type="Edm.Int64" />
-        <Property Name="indexedItemsSize" Type="Edm.Int64" />
-        <Property Name="mailboxCount" Type="Edm.Int32" />
-        <Property Name="siteCount" Type="Edm.Int32" />
-        <Property Name="unindexedItemCount" Type="Edm.Int64" />
-        <Property Name="unindexedItemsSize" Type="Edm.Int64" />
-        <NavigationProperty Name="sourceCollection" Type="microsoft.graph.ediscovery.sourceCollection" />
-      </EntityType>
-      <EntityType Name="reviewSetQuery" BaseType="graph.entity">
-        <Property Name="createdBy" Type="graph.identitySet" />
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="displayName" Type="Edm.String" />
-        <Property Name="lastModifiedBy" Type="graph.identitySet" />
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" />
-        <Property Name="query" Type="Edm.String" />
-      </EntityType>
-      <EntityType Name="tagOperation" BaseType="microsoft.graph.ediscovery.caseOperation" />
-      <Action Name="activate" IsBound="true">
-        <Parameter Name="bindingParameter" Type="microsoft.graph.ediscovery.custodian" />
-      </Action>
-      <Action Name="release" IsBound="true">
-        <Parameter Name="bindingParameter" Type="microsoft.graph.ediscovery.custodian" />
-      </Action>
-      <Action Name="updateIndex" IsBound="true">
-        <Parameter Name="bindingParameter" Type="microsoft.graph.ediscovery.custodian" />
-      </Action>
-      <Action Name="addToReviewSet" IsBound="true">
-        <Parameter Name="bindingParameter" Type="microsoft.graph.ediscovery.reviewSet" />
-        <Parameter Name="sourceCollection" Type="microsoft.graph.ediscovery.sourceCollection" />
-        <Parameter Name="additionalData" Type="microsoft.graph.ediscovery.dataCollectionScope" />
-      </Action>
-      <Action Name="export" IsBound="true">
-        <Parameter Name="bindingParameter" Type="microsoft.graph.ediscovery.reviewSet" />
-        <Parameter Name="outputName" Type="Edm.String" Unicode="false" />
-        <Parameter Name="description" Type="Edm.String" Unicode="false" />
-        <Parameter Name="azureBlobContainer" Type="Edm.String" Unicode="false" />
-        <Parameter Name="azureBlobToken" Type="Edm.String" Unicode="false" />
-        <Parameter Name="exportOptions" Type="microsoft.graph.ediscovery.exportOptions" />
-        <Parameter Name="exportStructure" Type="microsoft.graph.ediscovery.exportFileStructure" Nullable="false" />
-      </Action>
-      <Action Name="applyTags" IsBound="true">
-        <Parameter Name="bindingParameter" Type="microsoft.graph.ediscovery.reviewSetQuery" />
-        <Parameter Name="tagsToAdd" Type="Collection(microsoft.graph.ediscovery.tag)" />
-        <Parameter Name="tagsToRemove" Type="Collection(microsoft.graph.ediscovery.tag)" />
-      </Action>
-      <Action Name="close" IsBound="true">
-        <Parameter Name="bindingParameter" Type="microsoft.graph.ediscovery.case" />
-      </Action>
-      <Action Name="reopen" IsBound="true">
-        <Parameter Name="bindingParameter" Type="microsoft.graph.ediscovery.case" />
-      </Action>
-      <Action Name="estimateStatistics" IsBound="true">
-        <Parameter Name="bindingParameter" Type="microsoft.graph.ediscovery.sourceCollection" />
-      </Action>
-      <Function Name="asHierarchy" IsBound="true">
-        <Parameter Name="bindingParameter" Type="Collection(microsoft.graph.ediscovery.tag)" />
-        <ReturnType Type="Collection(microsoft.graph.ediscovery.tag)" />
-      </Function>
-      <Function Name="getDownloadUrl" IsBound="true">
-        <Parameter Name="bindingParameter" Type="microsoft.graph.ediscovery.caseExportOperation" />
-        <ReturnType Type="Edm.String" Unicode="false" />
-      </Function>
     </Schema>
     <Schema Namespace="microsoft.graph.termStore" xmlns="http://docs.oasis-open.org/odata/ns/edm">
       <EnumType Name="relationType">

--- a/v1.0_metadata.xml
+++ b/v1.0_metadata.xml
@@ -436,8 +436,7 @@
         <Member Name="domainJoinedDevice" Value="3" />
         <Member Name="approvedApplication" Value="4" />
         <Member Name="compliantApplication" Value="5" />
-        <Member Name="passwordChange" Value="6" />
-        <Member Name="unknownFutureValue" Value="7" />
+        <Member Name="unknownFutureValue" Value="6" />
       </EnumType>
       <EnumType Name="conditionalAccessPolicyState">
         <Member Name="enabled" Value="0" />
@@ -2688,7 +2687,6 @@
         <Property Name="publisherDomain" Type="Edm.String" />
         <Property Name="requiredResourceAccess" Type="Collection(graph.requiredResourceAccess)" Nullable="false" />
         <Property Name="signInAudience" Type="Edm.String" />
-        <Property Name="spa" Type="graph.spaApplication" />
         <Property Name="tags" Type="Collection(Edm.String)" Nullable="false" />
         <Property Name="tokenEncryptionKeyId" Type="Edm.Guid" />
         <Property Name="web" Type="graph.webApplication" />
@@ -2786,9 +2784,6 @@
       <ComplexType Name="resourceAccess">
         <Property Name="id" Type="Edm.Guid" Nullable="false" />
         <Property Name="type" Type="Edm.String" />
-      </ComplexType>
-      <ComplexType Name="spaApplication">
-        <Property Name="redirectUris" Type="Collection(Edm.String)" Nullable="false" />
       </ComplexType>
       <ComplexType Name="webApplication">
         <Property Name="homePageUrl" Type="Edm.String" />
@@ -4635,7 +4630,6 @@
         <Property Name="locations" Type="graph.conditionalAccessLocations" />
         <Property Name="platforms" Type="graph.conditionalAccessPlatforms" />
         <Property Name="signInRiskLevels" Type="Collection(graph.riskLevel)" Nullable="false" />
-        <Property Name="userRiskLevels" Type="Collection(graph.riskLevel)" Nullable="false" />
         <Property Name="users" Type="graph.conditionalAccessUsers" Nullable="false" />
       </ComplexType>
       <ComplexType Name="conditionalAccessLocations">
@@ -14941,7 +14935,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Intune Account Id for given tenant" />
       </Annotations>
       <Annotations Target="microsoft.graph.termsAndConditions">
-        <Annotation Term="Org.OData.Core.V1.Description" String="A termsAndConditions entity represents the metadata and contents of a given Terms and Conditions (T&amp;C) policy. T&amp;C policies’ contents are presented to users upon their first attempt to enroll into Intune and subsequently upon edits where an administrator has required re-acceptance. They enable administrators to communicate the provisions to which a user must agree in order to have devices enrolled into Intune." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="A termsAndConditions entity represents the metadata and contents of a given Terms and Conditions (T&amp;C) policy. T&amp;C policiesâ€™ contents are presented to users upon their first attempt to enroll into Intune and subsequently upon edits where an administrator has required re-acceptance. They enable administrators to communicate the provisions to which a user must agree in order to have devices enrolled into Intune." />
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagement/termsAndConditions">
         <Annotation Term="Org.OData.Core.V1.Description" String="The terms and conditions associated with device management of the company." />
@@ -15013,13 +15007,13 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Logo image displayed in Company Portal apps which have a light background behind the logo." />
       </Annotations>
       <Annotations Target="microsoft.graph.intuneBrand/onlineSupportSiteName">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Display name of the company/organization’s IT helpdesk site." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Display name of the company/organizationâ€™s IT helpdesk site." />
       </Annotations>
       <Annotations Target="microsoft.graph.intuneBrand/onlineSupportSiteUrl">
-        <Annotation Term="Org.OData.Core.V1.Description" String="URL to the company/organization’s IT helpdesk site." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="URL to the company/organizationâ€™s IT helpdesk site." />
       </Annotations>
       <Annotations Target="microsoft.graph.intuneBrand/privacyUrl">
-        <Annotation Term="Org.OData.Core.V1.Description" String="URL to the company/organization’s privacy policy." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="URL to the company/organizationâ€™s privacy policy." />
       </Annotations>
       <Annotations Target="microsoft.graph.intuneBrand/showDisplayNameNextToLogo">
         <Annotation Term="Org.OData.Core.V1.Description" String="Boolean that represents whether the administrator-supplied display name will be shown next to the logo image." />
@@ -15115,7 +15109,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The list of managed devices." />
       </Annotations>
       <Annotations Target="microsoft.graph.notificationMessageTemplate">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Notification messages are messages that are sent to end users who are determined to be not-compliant with the compliance policies defined by the administrator. Administrators choose notifications and configure them in the Intune Admin Console using the compliance policy creation page under the “Actions for non-compliance” section. Use the notificationMessageTemplate object to create your own custom notifications for administrators to choose while configuring actions for non-compliance." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Notification messages are messages that are sent to end users who are determined to be not-compliant with the compliance policies defined by the administrator. Administrators choose notifications and configure them in the Intune Admin Console using the compliance policy creation page under the â€œActions for non-complianceâ€ section. Use the notificationMessageTemplate object to create your own custom notifications for administrators to choose while configuring actions for non-compliance." />
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagement/notificationMessageTemplates">
         <Annotation Term="Org.OData.Core.V1.Description" String="The Notification Message Templates." />
@@ -15250,7 +15244,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Indicates whether to block write access to devices configured in another organization.  If requireEncryptionForWriteAccess is false, this value does not affect." />
       </Annotations>
       <Annotations Target="microsoft.graph.defenderDetectedMalwareActions">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Specify Defender’s actions to take on detected Malware per threat level." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Specify Defenderâ€™s actions to take on detected Malware per threat level." />
       </Annotations>
       <Annotations Target="microsoft.graph.defenderDetectedMalwareActions/highSeverity">
         <Annotation Term="Org.OData.Core.V1.Description" String="Indicates a Defender action to take for high severity Malware threat detected." />
@@ -15571,7 +15565,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Network Proxy Server Policy." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10NetworkProxyServer/address">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Address to the proxy server. Specify an address in the format &lt;server&gt;[“:”&lt;port&gt;]" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Address to the proxy server. Specify an address in the format &lt;server&gt;[â€œ:â€&lt;port&gt;]" />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10NetworkProxyServer/exceptions">
         <Annotation Term="Org.OData.Core.V1.Description" String="Addresses that should not use the proxy server. The system will not use the proxy server for addresses beginning with what is specified in this node." />
@@ -16990,13 +16984,13 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Require Mobile Threat Protection minimum risk level to report noncompliance." />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSCompliancePolicy/firewallBlockAllIncoming">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Corresponds to the “Block all incoming connections” option." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Corresponds to the â€œBlock all incoming connectionsâ€ option." />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSCompliancePolicy/firewallEnabled">
         <Annotation Term="Org.OData.Core.V1.Description" String="Whether the firewall should be enabled or not." />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSCompliancePolicy/firewallEnableStealthMode">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Corresponds to “Enable stealth mode.”" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Corresponds to â€œEnable stealth mode.â€" />
       </Annotations>
       <Annotations Target="microsoft.graph.macOSCompliancePolicy/osMaximumVersion">
         <Annotation Term="Org.OData.Core.V1.Description" String="Maximum MacOS version." />
@@ -17905,7 +17899,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Number of days before deleting quarantined malware. Valid values 0 to 90" />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/defenderDetectedMalwareActions">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Gets or sets Defender’s actions to take on detected Malware per threat level." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Gets or sets Defenderâ€™s actions to take on detected Malware per threat level." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/defenderFileExtensionsToExclude">
         <Annotation Term="Org.OData.Core.V1.Description" String="File extensions to exclude from scans and real time protection." />
@@ -18124,7 +18118,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Indicates whether or not to Block Microsoft account settings sync." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/networkProxyApplySettingsDeviceWide">
-        <Annotation Term="Org.OData.Core.V1.Description" String="If set, proxy settings will be applied to all processes and accounts in the device. Otherwise, it will be applied to the user account that’s enrolled into MDM." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="If set, proxy settings will be applied to all processes and accounts in the device. Otherwise, it will be applied to the user account thatâ€™s enrolled into MDM." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/networkProxyAutomaticConfigurationUrl">
         <Annotation Term="Org.OData.Core.V1.Description" String="Address to the proxy auto-config (PAC) script you want to use." />
@@ -18214,7 +18208,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Specifies minimum amount of hard drive space on the same drive as the index location before indexing stops." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/searchEnableRemoteQueries">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates whether or not to block remote queries of this computer’s index." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates whether or not to block remote queries of this computerâ€™s index." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/settingsBlockAccountsPage">
         <Annotation Term="Org.OData.Core.V1.Description" String="Indicates whether or not to block access to Accounts in Settings app." />
@@ -18313,7 +18307,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Enabling this policy hides recently added apps from appearing on the start menu and disables the corresponding toggle in the Settings app." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/startMenuHideRestartOptions">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Enabling this policy hides “Restart/Update and Restart” from appearing in the power button in the start menu." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Enabling this policy hides â€œRestart/Update and Restartâ€ from appearing in the power button in the start menu." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/startMenuHideShutDown">
         <Annotation Term="Org.OData.Core.V1.Description" String="Enabling this policy hides shut down/update and shut down from appearing in the power button in the start menu." />
@@ -18415,7 +18409,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Block suggestions from Microsoft that show after each OS clean install, upgrade or in an on-going basis to introduce users to what is new or changed" />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/windowsSpotlightBlockTailoredExperiences">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Block personalized content in Windows spotlight based on user’s device usage." />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Block personalized content in Windows spotlight based on userâ€™s device usage." />
       </Annotations>
       <Annotations Target="microsoft.graph.windows10GeneralConfiguration/windowsSpotlightBlockThirdPartyNotifications">
         <Annotation Term="Org.OData.Core.V1.Description" String="Block third party content delivered via Windows Spotlight" />


### PR DESCRIPTION
Non-fatal typewriter error in generation pipeline pushed changes to the metadata snapshots without validating with a smoke test in .NET SDK. Reverting to last known good state from Dec 8.