### PR TITLE
ContainsTarget fix for group's acceptedSenders and rejectedSenders

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -274,6 +274,12 @@
         <xsl:apply-templates select="@* | node()"/>
     </xsl:template>
 
+    <!-- Remove ContainsTarget -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='acceptedSenders']/@ContainsTarget|
+                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='rejectedSenders']/@ContainsTarget">
+        <xsl:apply-templates select="@* | node()"/>
+    </xsl:template>
+
     <!--Remove functions that are blocking beta generation-->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']/edm:Function[@Name='getPstnCalls']"/>
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']/edm:Function[@Name='getDirectRoutingCalls']"/>

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -29,6 +29,8 @@
                 <NavigationProperty Name="members" Type="Collection(graph.directoryObject)">
                   <Annotation Term="Org.OData.Core.V1.Description" String="Users and groups that are members of this group. HTTP Methods: GET (supported for all groups), POST (supported for Microsoft 365 groups, security groups and mail-enabled security groups), DELETE (supported for Microsoft 365 groups and security groups) Nullable." />
                 </NavigationProperty>
+                <NavigationProperty Name="acceptedSenders" Type="Collection(graph.directoryObject)" ContainsTarget="true"/>
+                <NavigationProperty Name="rejectedSenders" Type="Collection(graph.directoryObject)" ContainsTarget="true"/>
             </EntityType>
             <EntityType Name="servicePrincipal" BaseType="graph.directoryObject" OpenType="true">
                 <Property Name="appId" Type="Edm.String"/>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -38,6 +38,8 @@
             </Collection>
           </Annotation>
         </NavigationProperty>
+        <NavigationProperty Name="acceptedSenders" Type="Collection(graph.directoryObject)" />
+        <NavigationProperty Name="rejectedSenders" Type="Collection(graph.directoryObject)" />
       </EntityType>
       <EntityType Name="servicePrincipal" BaseType="graph.directoryObject" OpenType="true">
         <Property Name="appId" Type="Edm.String" />


### PR DESCRIPTION
Service team has confirmed that these need to be references. They haven't fixed the actual metadata though. Until it is fixed, removing the `ContainsTarget=true` using XSLT.

Fixes couple of Raptor tests in both V1 and Beta.