### PR TITLE
OpenAPI conversion validation as a PR gate

### DIFF
--- a/.github/workflows/metadata-parser-validation.yml
+++ b/.github/workflows/metadata-parser-validation.yml
@@ -1,4 +1,4 @@
-name: Metadata Parser Validation for Preprocessor output
+name: Metadata Parser Validation for latest XSLT rules
 
 on:
   push:
@@ -20,4 +20,5 @@ jobs:
       with:
         dotnet-version: 5.0.x
     - name: Parse preprocessor test output
-      run: dotnet run -p ./tools/MetadataParser/MetadataParser.csproj $GITHUB_WORKSPACE/transforms/csdl/preprocess_csdl_test_output.xml
+      run: ./run-metadata-validation.ps1 -repoDirectory $GITHUB_WORKSPACE
+      shell: pwsh

--- a/.github/workflows/metadata-parser-validation.yml
+++ b/.github/workflows/metadata-parser-validation.yml
@@ -19,6 +19,6 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 5.0.x
-    - name: Parse preprocessor test output
+    - name: Validate latest XSLT rules
       run: ./run-metadata-validation.ps1 -repoDirectory $GITHUB_WORKSPACE
       shell: pwsh

--- a/.github/workflows/metadata-parser-validation.yml
+++ b/.github/workflows/metadata-parser-validation.yml
@@ -20,5 +20,5 @@ jobs:
       with:
         dotnet-version: 5.0.x
     - name: Validate latest XSLT rules
-      run: ./run-metadata-validation.ps1 -repoDirectory $GITHUB_WORKSPACE
+      run: ./scripts/run-metadata-validation.ps1 -repoDirectory $GITHUB_WORKSPACE
       shell: pwsh

--- a/.github/workflows/metadata-parser-validation.yml
+++ b/.github/workflows/metadata-parser-validation.yml
@@ -20,5 +20,5 @@ jobs:
       with:
         dotnet-version: 5.0.x
     - name: Validate latest XSLT rules
-      run: ./scripts/run-metadata-validation.ps1 -repoDirectory $GITHUB_WORKSPACE
+      run: ./scripts/run-metadata-validation.ps1 -repoDirectory "${{ github.workspace }}"
       shell: pwsh

--- a/.github/workflows/openapi-update.yml
+++ b/.github/workflows/openapi-update.yml
@@ -25,8 +25,16 @@ jobs:
       shell: pwsh
     - name: Commit and push
       run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git add openapi/*
-        git commit --allow-empty -m "Auto-updates OpenAPI descriptions"
-        git push origin HEAD:${{ github.head_ref }}
+        try {
+          iex "git config user.name github-actions"
+          iex "git config user.email github-actions@github.com"
+          iex "git add openapi/*"
+          iex "git commit -m 'Auto-updates OpenAPI descriptions'"
+          iex "git push origin HEAD:${{ github.head_ref }}"
+        }
+        catch
+        {
+          Write-Warning "error with pushing updated OpenAPI descriptions $_"
+          Write-Warning "This is most likely due to the fact that there are no changes to push."
+        }
+      shell: pwsh

--- a/.github/workflows/openapi-update.yml
+++ b/.github/workflows/openapi-update.yml
@@ -1,8 +1,6 @@
 name: Open API descriptions update
 
 on:
-  push:
-    branches: [ master, dev ]
   pull_request:
     branches: [ master, dev ]
 
@@ -15,20 +13,20 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+    - name: Checkout head branch
+      run: |
+        git fetch origin ${{ github.head_ref }}
+        git switch ${{ github.head_ref }}
     - name: Update v1.0 OpenAPI description
       run: ./scripts/GenerateOpenApi.ps1 -endpointVersion "v1.0"
       shell: pwsh
     - name: Update beta OpenAPI description
       run: ./scripts/GenerateOpenApi.ps1 -endpointVersion "beta"
       shell: pwsh
-    - name: Extract branch name
-      shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      id: extract_branch
-    - name: Commit & Push changes
-      uses: actions-js/push@v1.2
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        directory: openapi
-        message: 'Auto-updates OpenAPI descriptions'
-        branch: ${{ steps.extract_branch.outputs.branch }}
+    - name: Commit and push
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add openapi/*
+        git commit -m "Auto-updates OpenAPI descriptions"
+        git push origin HEAD:${{ github.head_ref }}

--- a/.github/workflows/openapi-update.yml
+++ b/.github/workflows/openapi-update.yml
@@ -28,5 +28,5 @@ jobs:
         git config user.name github-actions
         git config user.email github-actions@github.com
         git add openapi/*
-        git commit -m "Auto-updates OpenAPI descriptions"
+        git commit --allow-empty -m "Auto-updates OpenAPI descriptions"
         git push origin HEAD:${{ github.head_ref }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/OpenAPI.NET.OData"]
+	path = submodules/OpenAPI.NET.OData
+	url = https://github.com/microsoftgraph/OpenAPI.NET.OData

--- a/scripts/run-metadata-validation.ps1
+++ b/scripts/run-metadata-validation.ps1
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+.Synopsis
+    Runs MetadataParser tool to validate latest XSLT rules don't break downstream parsing of the metadata
+
+.Description
+    1. tranforms latests snapshots of beta and v1 metadata
+    2. validates that the transformed metadata is parsable as OData EDM model and conversion to OpenAPI document is possible
+
+.Example
+    ./scripts/run-metadata-validation.ps1 -repoDirectory C:/github/msgraph-metadata
+
+.Example
+    ./scripts/run-metadata-validation.ps1 -repoDirectory $GITHUB_WORKSPACE
+
+.Parameter repoDirectory
+    Full path the the root directory of msgraph-metadata checkout.
+#>
+
+param(
+    [Parameter(Mandatory=$true)][string]$repoDirectory
+)
+
+$transformCsdlDirectory = Join-Path $repoDirectory "transforms/csdl"
+$transformScript = Join-Path $transformCsdlDirectory "transform.ps1"
+$xsltPath = Join-Path $transformCsdlDirectory "preprocess_csdl.xsl"
+
+$betaSnapshot = Join-Path $repoDirectory "beta_metadata.xml"
+$v1Snapshot = Join-Path $repoDirectory "v1.0_metadata.xml"
+
+$metadataParserTool = Join-Path $repoDirectory "tools/MetadataParser/MetadataParser.csproj"
+
+$transformedBeta = Join-Path $repoDirectory "transformed_beta_metadata.xml"
+$transformedV1 = Join-Path $repoDirectory "transformed_v1.0_metadata.xml"
+
+Write-Host "Tranforming beta metadata using xslt..."
+& $transformScript -xslPath $xsltPath -inputPath $betaSnapshot -outputPath $transformedBeta
+
+Write-Host "Validating beta metadata after the transform..."
+& dotnet run -p $metadataParserTool $transformedBeta
+
+Write-Host "Tranforming v1.0 metadata using xslt..."
+& $transformScript -xslPath $xsltPath -inputPath $v1Snapshot -outputPath $transformedV1
+
+Write-Host "Validating v1.0 metadata after the transform..."
+& dotnet run -p $metadataParserTool $transformedBeta

--- a/scripts/run-metadata-validation.ps1
+++ b/scripts/run-metadata-validation.ps1
@@ -35,14 +35,14 @@ $metadataParserTool = Join-Path $repoDirectory "tools/MetadataParser/MetadataPar
 $transformedBeta = Join-Path $repoDirectory "transformed_beta_metadata.xml"
 $transformedV1 = Join-Path $repoDirectory "transformed_v1.0_metadata.xml"
 
-Write-Host "Tranforming beta metadata using xslt..."
+Write-Host "Tranforming beta metadata using xslt..." -ForegroundColor Green
 & $transformScript -xslPath $xsltPath -inputPath $betaSnapshot -outputPath $transformedBeta
 
-Write-Host "Validating beta metadata after the transform..."
+Write-Host "Validating beta metadata after the transform..." -ForegroundColor Green
 & dotnet run -p $metadataParserTool $transformedBeta
 
-Write-Host "Tranforming v1.0 metadata using xslt..."
+Write-Host "Tranforming v1.0 metadata using xslt..." -ForegroundColor Green
 & $transformScript -xslPath $xsltPath -inputPath $v1Snapshot -outputPath $transformedV1
 
-Write-Host "Validating v1.0 metadata after the transform..."
+Write-Host "Validating v1.0 metadata after the transform..." -ForegroundColor Green
 & dotnet run -p $metadataParserTool $transformedV1

--- a/scripts/run-metadata-validation.ps1
+++ b/scripts/run-metadata-validation.ps1
@@ -45,4 +45,4 @@ Write-Host "Tranforming v1.0 metadata using xslt..."
 & $transformScript -xslPath $xsltPath -inputPath $v1Snapshot -outputPath $transformedV1
 
 Write-Host "Validating v1.0 metadata after the transform..."
-& dotnet run -p $metadataParserTool $transformedBeta
+& dotnet run -p $metadataParserTool $transformedV1

--- a/tools/MetadataParser/MetadataParser.csproj
+++ b/tools/MetadataParser/MetadataParser.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\submodules\OpenAPI.NET.OData\src\Microsoft.OpenApi.OData.Reader\Microsoft.OpenAPI.OData.Reader.csproj" />
     <PackageReference Include="Microsoft.OData.Core" Version="7.8.1" />
   </ItemGroup>
 

--- a/tools/MetadataParser/Program.cs
+++ b/tools/MetadataParser/Program.cs
@@ -1,12 +1,35 @@
 ﻿using Microsoft.OData.Edm.Csdl;
 using System.Xml;
 using System;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.OData;
+using Microsoft.OpenApi.Models;
 
+IEdmModel edmModel;
 try
 {
-    CsdlReader.Parse(XmlReader.Create(args[0]));
+    edmModel = CsdlReader.Parse(XmlReader.Create(args[0]));
+    Console.WriteLine("Parsing the metadata as an edm model was successful!");
+
+    var settings = new OpenApiConvertSettings()
+    {
+        EnableKeyAsSegment = true,
+        EnableOperationId = true,
+        PrefixEntityTypeNameBeforeKey = true,
+        TagDepth = 2,
+        EnablePagination = true,
+        EnableDiscriminatorValue = false,
+        EnableDerivedTypesReferencesForRequestBody = false,
+        EnableDerivedTypesReferencesForResponses = false,
+        ShowRootPath = true,
+        ShowLinks = true
+    };
+
+    OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
+
+    Console.WriteLine("Conversion to OpenAPI was successful!");
 }
-catch(Exception e)
+catch (Exception e)
 {
     Console.Error.WriteLine(e.Message);
     Environment.Exit(-1);

--- a/tools/MetadataParser/Program.cs
+++ b/tools/MetadataParser/Program.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.OData.Edm.Csdl;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.OData.Edm.Csdl;
 using System.Xml;
 using System;
 using Microsoft.OData.Edm;

--- a/tools/MetadataParser/README.md
+++ b/tools/MetadataParser/README.md
@@ -1,0 +1,9 @@
+Validates that a given metadata file is
+1. Parsable as an EDM model
+2. OpenAPI.NET.OData can read this model to create an OpenAPI model
+
+Run the tool with:
+
+```
+dotnet run -p ./MetadataParser.csproj <path_to_metadata>
+```

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -285,41 +285,18 @@
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']/edm:Function[@Name='getDirectRoutingCalls']"/>
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='delta'][edm:Parameter[@Name='token']][edm:Parameter[@Type='Collection(graph.site)']]"/>
 
-    <!-- accept, decline and tentativelyAccept action signatures have changed. Following rule set keeps the old signaure in the clean metadata.
-    New signatures are copied as is, so we have redundant implmenetations to avoid breaking change for existing client applications. -->
-    <xsl:template name="BackwardsCompatibleEventAction">
-      <xsl:param name="actionName" />
-      <xsl:element name="Action">
-        <xsl:attribute name="Name"><xsl:value-of select = "$actionName" /></xsl:attribute>
-        <xsl:attribute name="IsBound">true</xsl:attribute>
-        <xsl:element name="Parameter">
-          <xsl:attribute name="Name">bindingParameter</xsl:attribute>
-          <xsl:attribute name="Type">graph.event</xsl:attribute>
-        </xsl:element>
-        <xsl:element name="Parameter">
-          <xsl:attribute name="Name">Comment</xsl:attribute>
-          <xsl:attribute name="Type">Edm.String</xsl:attribute>
-          <xsl:attribute name="Unicode">false</xsl:attribute>
-        </xsl:element>
-        <xsl:element name="Parameter">
-          <xsl:attribute name="Name">SendResponse</xsl:attribute>
-          <xsl:attribute name="Type">Edm.Boolean</xsl:attribute>
-        </xsl:element>
-      </xsl:element>
-    </xsl:template>
+    <!-- Reorder action parameters -->
 
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
-      <xsl:copy>
-        <xsl:apply-templates select="@* | node()"/>
-        <xsl:call-template name="BackwardsCompatibleEventAction">
-          <xsl:with-param name="actionName">accept</xsl:with-param>
-        </xsl:call-template>
-        <xsl:call-template name="BackwardsCompatibleEventAction">
-          <xsl:with-param name="actionName">decline</xsl:with-param>
-        </xsl:call-template>
-        <xsl:call-template name="BackwardsCompatibleEventAction">
-          <xsl:with-param name="actionName">tentativelyAccept</xsl:with-param>
-        </xsl:call-template>
+    <!-- These actions have the same parameters that need reordering. Will need to create a new template
+         for each reordering. -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='accept'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]|
+                         edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='decline'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]|
+                         edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='tentativelyAccept'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]">
+        <xsl:copy>
+            <xsl:apply-templates select="@*"/>
+            <xsl:apply-templates select="edm:Parameter[@Name='bindingParameter'][@Type='graph.event']" />
+            <xsl:apply-templates select="edm:Parameter[@Name='Comment']" />
+            <xsl:apply-templates select="edm:Parameter[@Name='SendResponse']" />
         </xsl:copy>
     </xsl:template>
 

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -285,18 +285,41 @@
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']/edm:Function[@Name='getDirectRoutingCalls']"/>
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='delta'][edm:Parameter[@Name='token']][edm:Parameter[@Type='Collection(graph.site)']]"/>
 
-    <!-- Reorder action parameters -->
+    <!-- accept, decline and tentativelyAccept action signatures have changed. Following rule set keeps the old signaure in the clean metadata.
+    New signatures are copied as is, so we have redundant implmenetations to avoid breaking change for existing client applications. -->
+    <xsl:template name="BackwardsCompatibleEventAction">
+      <xsl:param name="actionName" />
+      <xsl:element name="Action">
+        <xsl:attribute name="Name"><xsl:value-of select = "$actionName" /></xsl:attribute>
+        <xsl:attribute name="IsBound">true</xsl:attribute>
+        <xsl:element name="Parameter">
+          <xsl:attribute name="Name">bindingParameter</xsl:attribute>
+          <xsl:attribute name="Type">graph.event</xsl:attribute>
+        </xsl:element>
+        <xsl:element name="Parameter">
+          <xsl:attribute name="Name">Comment</xsl:attribute>
+          <xsl:attribute name="Type">Edm.String</xsl:attribute>
+          <xsl:attribute name="Unicode">false</xsl:attribute>
+        </xsl:element>
+        <xsl:element name="Parameter">
+          <xsl:attribute name="Name">SendResponse</xsl:attribute>
+          <xsl:attribute name="Type">Edm.Boolean</xsl:attribute>
+        </xsl:element>
+      </xsl:element>
+    </xsl:template>
 
-    <!-- These actions have the same parameters that need reordering. Will need to create a new template
-         for each reordering. -->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='accept'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='decline'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='tentativelyAccept'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]">
-        <xsl:copy>
-            <xsl:apply-templates select="@*"/>
-            <xsl:apply-templates select="edm:Parameter[@Name='bindingParameter'][@Type='graph.event']" />
-            <xsl:apply-templates select="edm:Parameter[@Name='Comment']" />
-            <xsl:apply-templates select="edm:Parameter[@Name='SendResponse']" />
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
+      <xsl:copy>
+        <xsl:apply-templates select="@* | node()"/>
+        <xsl:call-template name="BackwardsCompatibleEventAction">
+          <xsl:with-param name="actionName">accept</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="BackwardsCompatibleEventAction">
+          <xsl:with-param name="actionName">decline</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="BackwardsCompatibleEventAction">
+          <xsl:with-param name="actionName">tentativelyAccept</xsl:with-param>
+        </xsl:call-template>
         </xsl:copy>
     </xsl:template>
 


### PR DESCRIPTION
- adds OpenAPI reader as a submodule
- adds a step to MetadataParser tool to convert to OpenAPI
- adds a Github Action which will
  - apply the latest XSLT rules on the latest v1 and beta metadata
  - validate those transformed metadata is parsable

Fixes #62 