### PR TITLE
Remove reordering rule for event actions

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -464,30 +464,6 @@
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='delta'][edm:Parameter[@Name='token']][edm:Parameter[@Type='Collection(graph.site)']]"/>
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='additionalAccess'][edm:Parameter[@Name='accessPackageId']][edm:Parameter[@Type='Collection(graph.accessPackageAssignment)']][1]"/>
 
-    <!-- Reorder action parameters -->
-
-    <!-- These actions have the same parameters that need reordering. Will need to create a new template
-         for each reordering. -->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='accept'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]">
-        <xsl:copy>
-            <xsl:apply-templates select="@*"/>
-            <xsl:apply-templates select="edm:Parameter[@Name='bindingParameter'][@Type='graph.event']" />
-            <xsl:apply-templates select="edm:Parameter[@Name='Comment']" />
-            <xsl:apply-templates select="edm:Parameter[@Name='SendResponse']" />
-        </xsl:copy>
-    </xsl:template>
-
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='decline'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='tentativelyAccept'][.//edm:Parameter[@Name='bindingParameter'][@Type='graph.event']]">
-        <xsl:copy>
-            <xsl:apply-templates select="@*"/>
-            <xsl:apply-templates select="edm:Parameter[@Name='bindingParameter'][@Type='graph.event']" />
-            <xsl:apply-templates select="edm:Parameter[@Name='Comment']" />
-            <xsl:apply-templates select="edm:Parameter[@Name='SendResponse']" />
-            <xsl:apply-templates select="edm:Parameter[@Name='ProposedNewTime']" />
-        </xsl:copy>
-    </xsl:template>
-
     <!-- Remove action parameters -->
     <!-- This should be a temp fix, tracking: https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/261 -->
     <!-- <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='createUploadSession']/edm:Parameter[@Name='deferCommit']"/> -->

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -586,8 +586,8 @@
       </EntityContainer>
       <Action Name="accept" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event" />
-        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
         <Parameter Name="SendResponse" Type="Edm.Boolean" />
+        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>
       <Action Name="accept" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.eventMessage" />
@@ -596,15 +596,13 @@
       </Action>
       <Action Name="decline" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event" />
-        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
         <Parameter Name="SendResponse" Type="Edm.Boolean" />
-        <Parameter Name="ProposedNewTime" Type="graph.timeSlot" />
+        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>
       <Action Name="tentativelyAccept" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event" />
-        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
         <Parameter Name="SendResponse" Type="Edm.Boolean" />
-        <Parameter Name="ProposedNewTime" Type="graph.timeSlot" />
+        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>
       <Action Name="createUploadSession" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.driveItem" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='preprocess_csdl.xsl'?>
 <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
   <edmx:DataServices>
@@ -596,11 +596,13 @@
       </Action>
       <Action Name="decline" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event" />
+        <Parameter Name="ProposedNewTime" Type="graph.timeSlot" />
         <Parameter Name="SendResponse" Type="Edm.Boolean" />
         <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>
       <Action Name="tentativelyAccept" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event" />
+        <Parameter Name="ProposedNewTime" Type="graph.timeSlot" />
         <Parameter Name="SendResponse" Type="Edm.Boolean" />
         <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>
@@ -718,6 +720,7 @@
             <PropertyValue Property="UpdateMethod">
               <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
             </PropertyValue>
+            <PropertyValue Property="Updatable" Bool="true" />
           </Record>
         </Annotation>
       </Annotations>
@@ -769,18 +772,6 @@
         <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
           <Record>
             <PropertyValue Property="Insertable" Bool="false" />
-          </Record>
-        </Annotation>
-      </Annotations>
-      <Annotations Target="microsoft.graph.GraphService/teams">
-        <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
-          <Record>
-            <PropertyValue Property="Readable" Bool="false" />
-            <PropertyValue Property="ReadByKeyRestrictions">
-              <Record>
-                <PropertyValue Property="Readable" Bool="true" />
-              </Record>
-            </PropertyValue>
           </Record>
         </Annotation>
       </Annotations>


### PR DESCRIPTION
XLST rules were for backwards compatibility (i.e. to prevent breaking changes). Removing it will propagate what is in the original metadata.

This will cause a breaking change in C# and Java SDKs, so it is planned to be applied for Java V3 and C# V4 major releases.
Related #21 