### PR TITLE
Adds workbooks entity set transform

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -559,4 +559,17 @@
       </xsl:element>
     </xsl:copy>
   </xsl:template>
+  <!-- Add workbooks entity set if missing -->
+  <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']">
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:if test="not(edm:EntitySet[@Name='workbooks'])">
+        <xsl:element name="EntitySet">
+          <xsl:attribute name="Name">workbooks</xsl:attribute>
+          <xsl:attribute name="EntityType">microsoft.graph.driveItem</xsl:attribute>
+        </xsl:element>
+      </xsl:if>
+      <xsl:apply-templates select="node()"/>
+    </xsl:copy>
+  </xsl:template>
 </xsl:stylesheet>

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -501,6 +501,8 @@
       </xsl:element>
     </xsl:copy>
   </xsl:template>
+
+  <!-- Add Navigation Restrictions Annotations -->
   <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
     <xsl:copy>
       <xsl:apply-templates select="@* | node()"/>
@@ -559,6 +561,7 @@
       </xsl:element>
     </xsl:copy>
   </xsl:template>
+
   <!-- Add workbooks entity set if missing -->
   <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']">
     <xsl:copy>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -123,6 +123,7 @@
         <Property Name="timeZone" Type="Edm.String" />
       </ComplexType>
       <EntityContainer Name="GraphService">
+        <EntitySet Name="workbooks" EntityType="microsoft.graph.driveItem" />
         <EntitySet Name="bookingBusinesses" EntityType="microsoft.graph.bookingBusiness">
           <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
             <Record>


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/84

This PR: 
- Updates the transform file by:
  - Adding the `workbooks` entity set if it's missing from the `EntityContainer`.

**NB**: This is a temporary workaround to add in the _workbooks_ entity set so as to unblock the metadata refreshes for DevX API.