### PR TITLE
Restricts the expansion of select containment navigation properties

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -285,10 +285,7 @@
         <xsl:apply-templates select="@* | node()"/>
     </xsl:template>
 
-    <!-- Remove ContainsTarget
-         For microsoft.graph.sharedDriveItem/site this is a temp. fix
-         so as to help further reduce the size of the converted OpenAPI
-         Files module for AutoREST cmdlet generation for PowerShell -->
+    <!-- Remove ContainsTarget -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='acceptedSenders']/@ContainsTarget|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='rejectedSenders']/@ContainsTarget|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='channel']/edm:NavigationProperty[@Name='filesFolder']/@ContainsTarget|
@@ -304,8 +301,7 @@
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='sectionGroup']/edm:NavigationProperty[@Name='parentNotebook']/@ContainsTarget|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='itemActivityOLD']/edm:NavigationProperty[@Name='driveItem']/@ContainsTarget|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='itemActivity']/edm:NavigationProperty[@Name='driveItem']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='accessPackage']/edm:NavigationProperty[@Name='incompatibleGroups']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='sharedDriveItem']/edm:NavigationProperty[@Name='site']/@ContainsTarget">
+                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='accessPackage']/edm:NavigationProperty[@Name='incompatibleGroups']/@ContainsTarget">
         <xsl:apply-templates select="@* | node()"/>
     </xsl:template>
 
@@ -575,11 +571,13 @@
           </xsl:element>
         </xsl:element>
       </xsl:element>
-      <!-- Remove indexability for drives navigation property for user entity type.
+      <!-- Set false indexabilities for:
+           microsoft.graph.user/drive | microsoft.graph.group/drive | microsoft.graph.sharedDriveItem/site
+           These will restrict expanding these containment navigation properties.
            This is a temp. fix so as to reduce the size of the converted OpenAPI
-           Files module (~10MB to ~5MB for beta) for AutoREST cmdlet generation for PowerShell -->
+           Files module (~10MB to ~5.5MB for beta) for PowerShell AutoREST cmdlet generation -->
       <xsl:element name="Annotations">
-        <xsl:attribute name="Target">microsoft.graph.user/drives</xsl:attribute>
+        <xsl:attribute name="Target">microsoft.graph.user/drive</xsl:attribute>
         <xsl:element name="Annotation">
           <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
           <xsl:element name="Record" namespace="{namespace-uri()}">
@@ -597,11 +595,27 @@
           </xsl:element>
         </xsl:element>
       </xsl:element>
-      <!-- Remove indexability for drives navigation property for group entity type.
-           This is a temp. fix so as to reduce the size of the converted OpenAPI
-           Files module (~10MB to ~5MB for beta) for AutoREST cmdlet generation for PowerShell -->
       <xsl:element name="Annotations">
-        <xsl:attribute name="Target">microsoft.graph.group/drives</xsl:attribute>
+        <xsl:attribute name="Target">microsoft.graph.group/drive</xsl:attribute>
+        <xsl:element name="Annotation">
+          <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
+          <xsl:element name="Record" namespace="{namespace-uri()}">
+            <xsl:element name="PropertyValue">
+              <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
+              <xsl:element name="Collection">
+                <xsl:element name="Record">
+                  <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">IndexableByKey</xsl:attribute>
+                    <xsl:attribute name="Bool">false</xsl:attribute>
+                  </xsl:element>
+                </xsl:element>
+              </xsl:element>
+            </xsl:element>
+          </xsl:element>
+        </xsl:element>
+      </xsl:element>
+      <xsl:element name="Annotations">
+        <xsl:attribute name="Target">microsoft.graph.sharedDriveItem/site</xsl:attribute>
         <xsl:element name="Annotation">
           <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
           <xsl:element name="Record" namespace="{namespace-uri()}">

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -285,7 +285,10 @@
         <xsl:apply-templates select="@* | node()"/>
     </xsl:template>
 
-    <!-- Remove ContainsTarget -->
+    <!-- Remove ContainsTarget
+         For microsoft.graph.sharedDriveItem/site this is a temp. fix
+         so as to help further reduce the size of the converted OpenAPI
+         Files module for AutoREST cmdlet generation for PowerShell -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='acceptedSenders']/@ContainsTarget|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='rejectedSenders']/@ContainsTarget|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='channel']/edm:NavigationProperty[@Name='filesFolder']/@ContainsTarget|
@@ -301,7 +304,8 @@
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='sectionGroup']/edm:NavigationProperty[@Name='parentNotebook']/@ContainsTarget|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='itemActivityOLD']/edm:NavigationProperty[@Name='driveItem']/@ContainsTarget|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='itemActivity']/edm:NavigationProperty[@Name='driveItem']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='accessPackage']/edm:NavigationProperty[@Name='incompatibleGroups']/@ContainsTarget">
+                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='accessPackage']/edm:NavigationProperty[@Name='incompatibleGroups']/@ContainsTarget|
+                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='sharedDriveItem']/edm:NavigationProperty[@Name='site']/@ContainsTarget">
         <xsl:apply-templates select="@* | node()"/>
     </xsl:template>
 
@@ -554,6 +558,50 @@
       <!-- Remove indexability for users navigation property -->
       <xsl:element name="Annotations">
         <xsl:attribute name="Target">microsoft.graph.managedDevice/users</xsl:attribute>
+        <xsl:element name="Annotation">
+          <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
+          <xsl:element name="Record" namespace="{namespace-uri()}">
+            <xsl:element name="PropertyValue">
+              <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
+              <xsl:element name="Collection">
+                <xsl:element name="Record">
+                  <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">IndexableByKey</xsl:attribute>
+                    <xsl:attribute name="Bool">false</xsl:attribute>
+                  </xsl:element>
+                </xsl:element>
+              </xsl:element>
+            </xsl:element>
+          </xsl:element>
+        </xsl:element>
+      </xsl:element>
+      <!-- Remove indexability for drives navigation property for user entity type.
+           This is a temp. fix so as to reduce the size of the converted OpenAPI
+           Files module (~10MB to ~5MB for beta) for AutoREST cmdlet generation for PowerShell -->
+      <xsl:element name="Annotations">
+        <xsl:attribute name="Target">microsoft.graph.user/drives</xsl:attribute>
+        <xsl:element name="Annotation">
+          <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
+          <xsl:element name="Record" namespace="{namespace-uri()}">
+            <xsl:element name="PropertyValue">
+              <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
+              <xsl:element name="Collection">
+                <xsl:element name="Record">
+                  <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">IndexableByKey</xsl:attribute>
+                    <xsl:attribute name="Bool">false</xsl:attribute>
+                  </xsl:element>
+                </xsl:element>
+              </xsl:element>
+            </xsl:element>
+          </xsl:element>
+        </xsl:element>
+      </xsl:element>
+      <!-- Remove indexability for drives navigation property for group entity type.
+           This is a temp. fix so as to reduce the size of the converted OpenAPI
+           Files module (~10MB to ~5MB for beta) for AutoREST cmdlet generation for PowerShell -->
+      <xsl:element name="Annotations">
+        <xsl:attribute name="Target">microsoft.graph.group/drives</xsl:attribute>
         <xsl:element name="Annotation">
           <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
           <xsl:element name="Record" namespace="{namespace-uri()}">

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -38,9 +38,6 @@
             <EntityType Name="directoryObject" BaseType="graph.entity" OpenType="true">
                 <Property Name="deletedDateTime" Type="Edm.DateTimeOffset" />
             </EntityType>
-          <EntityType Name="sharedDriveItem" BaseType="graph.baseItem">
-            <NavigationProperty Name="site" Type="graph.site" ContainsTarget="true" />
-          </EntityType>
             <Annotations Target="graph.activityHistoryItem">
                 <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
                     <Record>

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -38,6 +38,9 @@
             <EntityType Name="directoryObject" BaseType="graph.entity" OpenType="true">
                 <Property Name="deletedDateTime" Type="Edm.DateTimeOffset" />
             </EntityType>
+          <EntityType Name="sharedDriveItem" BaseType="graph.baseItem">
+            <NavigationProperty Name="site" Type="graph.site" ContainsTarget="true" />
+          </EntityType>
             <Annotations Target="graph.activityHistoryItem">
                 <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
                     <Record>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -47,6 +47,9 @@
       <EntityType Name="directoryObject" BaseType="graph.entity" OpenType="true">
         <Property Name="deletedDateTime" Type="Edm.DateTimeOffset" />
       </EntityType>
+      <EntityType Name="sharedDriveItem" BaseType="graph.baseItem">
+        <NavigationProperty Name="site" Type="graph.site" />
+      </EntityType>
       <Annotations Target="graph.activityHistoryItem">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
       </Annotations>
@@ -360,6 +363,32 @@
         </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.managedDevice/users">
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="RestrictedProperties">
+              <Collection>
+                <Record>
+                  <PropertyValue Property="IndexableByKey" Bool="false" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.user/drives">
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="RestrictedProperties">
+              <Collection>
+                <Record>
+                  <PropertyValue Property="IndexableByKey" Bool="false" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.group/drives">
         <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
           <Record>
             <PropertyValue Property="RestrictedProperties">

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -47,9 +47,6 @@
       <EntityType Name="directoryObject" BaseType="graph.entity" OpenType="true">
         <Property Name="deletedDateTime" Type="Edm.DateTimeOffset" />
       </EntityType>
-      <EntityType Name="sharedDriveItem" BaseType="graph.baseItem">
-        <NavigationProperty Name="site" Type="graph.site" />
-      </EntityType>
       <Annotations Target="graph.activityHistoryItem">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
       </Annotations>
@@ -375,7 +372,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="microsoft.graph.user/drives">
+      <Annotations Target="microsoft.graph.user/drive">
         <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
           <Record>
             <PropertyValue Property="RestrictedProperties">
@@ -388,7 +385,20 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="microsoft.graph.group/drives">
+      <Annotations Target="microsoft.graph.group/drive">
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="RestrictedProperties">
+              <Collection>
+                <Record>
+                  <PropertyValue Property="IndexableByKey" Bool="false" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.sharedDriveItem/site">
         <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
           <Record>
             <PropertyValue Property="RestrictedProperties">


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-metadata/issues/95

This PR:
- Removes the indexability of the below navigation properties:
    - microsoft.graph.user/drive
    - microsoft.graph.group/drive
    - microsoft.graph.sharedDriveItem/site

Technically, these are not collection navigation properties, and as such they really have no indexability values, but adding these annotations will prevent these properties from being expanded by the [OpenAPI.NET.OData](https://github.com/microsoft/OpenAPI.NET.OData) converter lib. in the output OpenAPI doc.
The resulting generated OpenAPI doc. is ~5.5MB, slightly under the 6MB threshold for AutoREST.

![image](https://user-images.githubusercontent.com/40403681/136115797-0effb862-5645-4450-acbc-715c525e5615.png)
https://devxapitest.azurewebsites.net/openapi?tags=^drives\.|^shares\.|^users.drive$|^groups.drive$&openApiVersion=3&graphVersion=beta&format=yaml&style=PowerShell


**NB**: This is a temp. fix restricting only the expansion of the above containment navigation properties, so as to reduce the size of the [Files](https://github.com/microsoftgraph/msgraph-sdk-powershell/blob/da8d94b44181722094c3a5d0ec5985247286d56d/config/ModulesMapping.jsonc#L18) module for PowerShell and to fast track the release of the expanded and refreshed weekly versions of the metadata. All other containment navigation properties still get expanded.