### PR TITLE
Revert "Removes ContainsTarget for select navigation properties"

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -287,21 +287,7 @@
 
     <!-- Remove ContainsTarget -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='acceptedSenders']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='rejectedSenders']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='channel']/edm:NavigationProperty[@Name='filesFolder']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='listItem']/edm:NavigationProperty[@Name='driveItem']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='sharedDriveItem']/edm:NavigationProperty[@Name='driveItem']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='sharedDriveItem']/edm:NavigationProperty[@Name='root']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='sharedDriveItem']/edm:NavigationProperty[@Name='items']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='site']/edm:NavigationProperty[@Name='drive']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='site']/edm:NavigationProperty[@Name='drives']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='list']/edm:NavigationProperty[@Name='drive']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='onenotePage']/edm:NavigationProperty[@Name='parentNotebook']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='onenoteSection']/edm:NavigationProperty[@Name='parentNotebook']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='sectionGroup']/edm:NavigationProperty[@Name='parentNotebook']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='itemActivityOLD']/edm:NavigationProperty[@Name='driveItem']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='itemActivity']/edm:NavigationProperty[@Name='driveItem']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='accessPackage']/edm:NavigationProperty[@Name='incompatibleGroups']/@ContainsTarget">
+                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='rejectedSenders']/@ContainsTarget">
         <xsl:apply-templates select="@* | node()"/>
     </xsl:template>
 

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -76,7 +76,7 @@
       </EntityType>
       <EntityType Name="onenotePage" BaseType="graph.onenoteEntitySchemaObjectModel">
         <Property Name="title" Type="Edm.String" />
-        <NavigationProperty Name="parentNotebook" Type="graph.notebook" />
+        <NavigationProperty Name="parentNotebook" Type="graph.notebook" ContainsTarget="true" />
       </EntityType>
       <EntityType Name="itemActivityStat" BaseType="graph.entity" OpenType="true">
         <Property Name="incompleteData" Type="graph.incompleteData" />

--- a/transforms/csdl/readme.md
+++ b/transforms/csdl/readme.md
@@ -34,6 +34,6 @@ Please use fully qualified and precise template match statements so as not to pe
 1. Clone this repo.
 2. Open Visual Studio without a project.
 3. Open a metadata file from your local repo: `beta_metadata.xml` or `v1.0_metadata.xml`.
-4. Add `<?xml-stylesheet type='text/xsl' href='.\transforms\csdl\preprocess_csdl.xsl'?>` under the first XML declaration in the metadata file. If the XML declaration is missing, add it to the top of the file first: `<?xml version="1.0" encoding="utf-8"?>`
+4. Add `<?xml-stylesheet type='text/xsl' href='..\transforms\csdl\preprocess_csdl.xsl'?>` under the first XML declaration in the metadata file. If the XML declaration is missing, add it to the top of the file first: `<?xml version="1.0" encoding="utf-8"?>`
 5. From the top menu in Visual Studio, select XML > Start XSLT Without Debugging or Alt + F5. This will result in a transformed metadata file which will be created in your %AppData%. It will be opened in Visual Studio.
 6. Inspect the transformed file output file for the expected changes.


### PR DESCRIPTION
Reverts microsoftgraph/msgraph-metadata#91 to unblock SDK generation for now.

To resolve this, we can probably add another parameter to the transform to isolate changes that are intended to only support the generation of OpenAPI spec