### PR TITLE
Cleanup Transform Rules

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -32,7 +32,6 @@
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='androidWorkProfileScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='appVulnerabilityTask']/edm:NavigationProperty[@Name='managedDevices']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='appVulnerabilityTask']/edm:NavigationProperty[@Name='mobileApps']|
-                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='cloudPcProvisioningPolicy']/edm:NavigationProperty[@Name='assignments']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='connector']/edm:NavigationProperty[@Name='memberOf']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='connectorGroup']/edm:NavigationProperty[@Name='members']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='deviceManagementAbstractComplexSettingInstance']/edm:NavigationProperty[@Name='value']|
@@ -52,7 +51,6 @@
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='onPremisesAgent']/edm:NavigationProperty[@Name='agentGroups']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='onPremisesAgentGroup']/edm:NavigationProperty[@Name='agents']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='onPremisesAgentGroup']/edm:NavigationProperty[@Name='publishedResources']|
-                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='onPremisesPublishingProfile']/edm:NavigationProperty[@Name='agents']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='plannerBucket']/edm:NavigationProperty[@Name='tasks']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='plannerGroup']/edm:NavigationProperty[@Name='plans']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='plannerPlan']/edm:NavigationProperty[@Name='buckets']|
@@ -60,15 +58,9 @@
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='plannerUser']/edm:NavigationProperty[@Name='all']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='plannerUser']/edm:NavigationProperty[@Name='plans']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='plannerUser']/edm:NavigationProperty[@Name='tasks']|
-                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='printJob']/edm:NavigationProperty[@Name='documents']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='printJob']/edm:NavigationProperty[@Name='tasks']|
-                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='printService']/edm:NavigationProperty[@Name='endpoints']|
-                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='printer']/edm:NavigationProperty[@Name='allowedGroups']|
-                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='printer']/edm:NavigationProperty[@Name='allowedUsers']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='publishedResource']/edm:NavigationProperty[@Name='agentGroups']|
-                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='teamsApp']/edm:NavigationProperty[@Name='appDefinitions']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='securityConfigurationTask']/edm:NavigationProperty[@Name='managedDevices']|
-                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windows10CertificateProfileBase']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windows10ImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windows10PkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windows81SCEPCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -48,6 +48,7 @@
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSPkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
+                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='managementTemplateStepVersion']/edm:NavigationProperty[@Name='deployments']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='onPremisesAgent']/edm:NavigationProperty[@Name='agentGroups']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='onPremisesAgentGroup']/edm:NavigationProperty[@Name='agents']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='onPremisesAgentGroup']/edm:NavigationProperty[@Name='publishedResources']|

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -25,6 +25,13 @@
                 <NavigationProperty Name="buckets" Type="Collection(graph.plannerBucket)" />
                 <NavigationProperty Name="details" Type="graph.plannerPlanDetails" ContainsTarget="true" />
             </EntityType>
+            <EntityType Name="managementTemplateStepVersion" BaseType="graph.entity">
+                <Property Name="configurationAction" Type="microsoft.graph.managedTenants.templateAction" />
+                <Property Name="validationAction" Type="microsoft.graph.managedTenants.templateAction" />
+                <Property Name="version" Type="Edm.Int32" />
+                <NavigationProperty Name="deployments" Type="Collection(microsoft.graph.managedTenants.managementTemplateStepDeployment)" />
+                <NavigationProperty Name="templateStep" Type="microsoft.graph.managedTenants.managementTemplateStep" />
+            </EntityType>
             <EntityType Name="plannerBucket" BaseType="graph.entity">
                 <Property Name="name" Type="Edm.String" Nullable="false" />
                 <NavigationProperty Name="tasks" Type="Collection(graph.plannerTask)" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -24,6 +24,13 @@
         <NavigationProperty Name="buckets" Type="Collection(graph.plannerBucket)" ContainsTarget="true" />
         <NavigationProperty Name="details" Type="graph.plannerPlanDetails" ContainsTarget="true" />
       </EntityType>
+      <EntityType Name="managementTemplateStepVersion" BaseType="graph.entity">
+        <Property Name="configurationAction" Type="microsoft.graph.managedTenants.templateAction" />
+        <Property Name="validationAction" Type="microsoft.graph.managedTenants.templateAction" />
+        <Property Name="version" Type="Edm.Int32" />
+        <NavigationProperty Name="deployments" Type="Collection(microsoft.graph.managedTenants.managementTemplateStepDeployment)" ContainsTarget="true" />
+        <NavigationProperty Name="templateStep" Type="microsoft.graph.managedTenants.managementTemplateStep" />
+      </EntityType>
       <EntityType Name="plannerBucket" BaseType="graph.entity">
         <Property Name="name" Type="Edm.String" Nullable="false" />
         <NavigationProperty Name="tasks" Type="Collection(graph.plannerTask)" ContainsTarget="true" />
@@ -73,7 +80,7 @@
         <Property Name="resourceData" Type="graph.resourceData" />
       </ComplexType>
       <EntityType Name="cloudPcProvisioningPolicy" BaseType="graph.entity">
-        <NavigationProperty Name="assignments" Type="Collection(graph.cloudPcProvisioningPolicyAssignment)" ContainsTarget="true" />
+        <NavigationProperty Name="assignments" Type="Collection(graph.cloudPcProvisioningPolicyAssignment)" />
       </EntityType>
       <EntityType Name="onenoteResource" BaseType="graph.onenoteEntityBaseModel">
         <Property Name="content" Type="Edm.Stream" />
@@ -101,7 +108,7 @@
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false" />
         <Property Name="status" Type="graph.printJobStatus" />
         <Property Name="createdBy" Type="graph.userIdentity" />
-        <NavigationProperty Name="documents" Type="Collection(graph.printDocument)" ContainsTarget="true" />
+        <NavigationProperty Name="documents" Type="Collection(graph.printDocument)" />
       </EntityType>
       <EntityType Name="publishedResource" BaseType="graph.entity">
         <Property Name="displayName" Type="Edm.String" />


### PR DESCRIPTION
The transform rules in this PR are no longer useful as the ContainTarget has since been updated on these entities. We can dismiss these rules without affecting out metadata.

Also including transformation rule for entity currently causing a build failure in the latest Beta Generation: https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/200 