### PR TITLE
Add `Explode` attribute to specific nav properties

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -634,4 +634,16 @@
       <xsl:apply-templates select="node()"/>
     </xsl:copy>
   </xsl:template>
+
+  <!-- Add custom 'explode' attribute -->
+  <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='drive']/edm:NavigationProperty[@Name='bundles']|
+                       edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='drive']/edm:NavigationProperty[@Name='following']|
+                       edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='drive']/edm:NavigationProperty[@Name='special']">
+    <xsl:copy>
+      <!-- Select all attributes, add Explode="false" attribute, apply to the current node. -->
+      <xsl:apply-templates select="@*"/>
+      <xsl:attribute name="Explode">false</xsl:attribute>
+      <xsl:apply-templates select="node()"/>
+    </xsl:copy>
+  </xsl:template>
 </xsl:stylesheet>

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -42,6 +42,13 @@
             <EntityType Name="directoryObject" BaseType="graph.entity" OpenType="true">
                 <Property Name="deletedDateTime" Type="Edm.DateTimeOffset" />
             </EntityType>
+            <EntityType Name="drive" BaseType="graph.baseItem">
+                <Property Name="driveType" Type="Edm.String" />
+                <NavigationProperty Name="bundles" Type="Collection(graph.driveItem)" ContainsTarget="true" />
+                <NavigationProperty Name="items" Type="Collection(graph.driveItem)" ContainsTarget="true" />
+                <NavigationProperty Name="root" Type="graph.driveItem" ContainsTarget="true" />
+                <NavigationProperty Name="special" Type="Collection(graph.driveItem)" ContainsTarget="true" />
+            </EntityType>
             <Annotations Target="graph.activityHistoryItem">
                 <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
                     <Record>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -51,6 +51,13 @@
       <EntityType Name="directoryObject" BaseType="graph.entity" OpenType="true">
         <Property Name="deletedDateTime" Type="Edm.DateTimeOffset" />
       </EntityType>
+      <EntityType Name="drive" BaseType="graph.baseItem">
+        <Property Name="driveType" Type="Edm.String" />
+        <NavigationProperty Name="bundles" Type="Collection(graph.driveItem)" ContainsTarget="true" Explode="false" />
+        <NavigationProperty Name="items" Type="Collection(graph.driveItem)" ContainsTarget="true" />
+        <NavigationProperty Name="root" Type="graph.driveItem" ContainsTarget="true" />
+        <NavigationProperty Name="special" Type="Collection(graph.driveItem)" ContainsTarget="true" Explode="false" />
+      </EntityType>
       <Annotations Target="graph.activityHistoryItem">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
       </Annotations>

--- a/transforms/csdl/transform.ps1
+++ b/transforms/csdl/transform.ps1
@@ -17,7 +17,7 @@ function Get-PathWithPrefix([string]$requestedPath) {
     if([System.IO.Path]::IsPathRooted($requestedPath)) {
         return $requestedPath
     } else {
-        return Join-Path $PWD $requestedPath
+        return Join-Path $PSScriptRoot $requestedPath
     }
 }
 $xslFullPath = Get-PathWithPrefix -requestedPath $xslPath
@@ -42,7 +42,7 @@ $xmlWriterSettings.Indent = $true
 
 $xmlWriter = [System.Xml.XmlWriter]::Create($outputFullPath, $xmlWriterSettings)
 
-$xslt = [System.Xml.Xsl.XslCompiledTransform]::new($dbg) 
+$xslt = [System.Xml.Xsl.XslCompiledTransform]::new($dbg)
 $xslt.Load($xslFullPath)
 try {
     $xslt.Transform($inputFullPath, $xsltargs, $xmlWriter)
@@ -50,3 +50,4 @@ try {
 catch {
     Write-Error $_.Exception
 }
+$xmlWriter.Dispose()


### PR DESCRIPTION
This PR implements https://github.com/microsoftgraph/msgraph-metadata/issues/104 by adding an `Explode` attribute to targeted navigation properties that we don't want OpenAPI.Net.OData lib to expand.

Discussion on this attribute can be found in the `OpenAPI expanded paths` channel.

This change shouldn't affect typewriter since this is a custom attribute.