### PR TITLE
adds inner error description

### DIFF
--- a/.github/workflows/metadata-parser-validation.yml
+++ b/.github/workflows/metadata-parser-validation.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Validate latest XSLT rules
       run: ./scripts/run-metadata-validation.ps1 -repoDirectory "${{ github.workspace }}"
       shell: pwsh

--- a/scripts/run-metadata-validation.ps1
+++ b/scripts/run-metadata-validation.ps1
@@ -39,10 +39,10 @@ Write-Host "Tranforming beta metadata using xslt..." -ForegroundColor Green
 & $transformScript -xslPath $xsltPath -inputPath $betaSnapshot -outputPath $transformedBeta
 
 Write-Host "Validating beta metadata after the transform..." -ForegroundColor Green
-& dotnet run -p $metadataParserTool $transformedBeta
+& dotnet run --project $metadataParserTool $transformedBeta
 
 Write-Host "Tranforming v1.0 metadata using xslt..." -ForegroundColor Green
 & $transformScript -xslPath $xsltPath -inputPath $v1Snapshot -outputPath $transformedV1
 
 Write-Host "Validating v1.0 metadata after the transform..." -ForegroundColor Green
-& dotnet run -p $metadataParserTool $transformedV1
+& dotnet run --project $metadataParserTool $transformedV1

--- a/tools/MetadataParser/MetadataParser.csproj
+++ b/tools/MetadataParser/MetadataParser.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/MetadataParser/Program.cs
+++ b/tools/MetadataParser/Program.cs
@@ -11,7 +11,8 @@ using Microsoft.OpenApi.Models;
 IEdmModel edmModel;
 try
 {
-    edmModel = CsdlReader.Parse(XmlReader.Create(args[0]));
+    using var reader = XmlReader.Create(args[0]);
+    edmModel = CsdlReader.Parse(reader);
     Console.WriteLine("Parsing the metadata as an edm model was successful!");
 
     var settings = new OpenApiConvertSettings()

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -501,6 +501,38 @@
   <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
     <xsl:copy>
       <xsl:apply-templates select="@* | node()"/>
+      <xsl:choose>
+        <!-- Add inner error description -->
+        <xsl:when test="$add-innererror-description='True'">
+          <xsl:element name="ComplexType">
+            <xsl:attribute name="Name">InnerError</xsl:attribute>
+            <xsl:element name="Property">
+              <xsl:attribute name="Name">request-id</xsl:attribute>
+              <xsl:attribute name="Type">Edm.String</xsl:attribute>
+              <xsl:element name="Annotation">
+                <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
+                <xsl:attribute name="String">Request Id as tracked internally by the service</xsl:attribute>
+              </xsl:element>
+            </xsl:element>
+            <xsl:element name="Property">
+              <xsl:attribute name="Name">client-request-id</xsl:attribute>
+              <xsl:attribute name="Type">Edm.String</xsl:attribute>
+              <xsl:element name="Annotation">
+                <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
+                <xsl:attribute name="String">Client request Id as sent by the client application.</xsl:attribute>
+              </xsl:element>
+            </xsl:element>
+            <xsl:element name="Property">
+              <xsl:attribute name="Name">Date</xsl:attribute>
+              <xsl:attribute name="Type">Edm.DateTimeOffset</xsl:attribute>
+              <xsl:element name="Annotation">
+                <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
+                <xsl:attribute name="String">Date when the error occured.</xsl:attribute>
+              </xsl:element>
+            </xsl:element>
+          </xsl:element>
+        </xsl:when>
+      </xsl:choose>
       <!-- Remove navigability for workbook navigation property -->
       <xsl:element name="Annotations">
         <xsl:attribute name="Target">microsoft.graph.driveItem/workbook</xsl:attribute>
@@ -636,41 +668,4 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- Add inner error description -->
-  <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
-    <xsl:choose>
-      <xsl:when test="$add-innererror-description='True'">
-        <xsl:copy>
-          <xsl:apply-templates select="@* | node()"/>
-          <xsl:element name="ComplexType">
-            <xsl:attribute name="Name">InnerError</xsl:attribute>
-            <xsl:element name="Property">
-              <xsl:attribute name="Name">request-id</xsl:attribute>
-              <xsl:attribute name="Type">Edm.String</xsl:attribute>
-              <xsl:element name="Annotation">
-                <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
-                <xsl:attribute name="String">Request Id as tracked internally by the service</xsl:attribute>
-              </xsl:element>
-            </xsl:element>
-            <xsl:element name="Property">
-              <xsl:attribute name="Name">client-request-id</xsl:attribute>
-              <xsl:attribute name="Type">Edm.String</xsl:attribute>
-              <xsl:element name="Annotation">
-                <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
-                <xsl:attribute name="String">Client request Id as sent by the client application.</xsl:attribute>
-              </xsl:element>
-            </xsl:element>
-            <xsl:element name="Property">
-              <xsl:attribute name="Name">Date</xsl:attribute>
-              <xsl:attribute name="Type">Edm.DateTimeOffset</xsl:attribute>
-              <xsl:element name="Annotation">
-                <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
-                <xsl:attribute name="String">Date when the error occured.</xsl:attribute>
-              </xsl:element>
-            </xsl:element>
-          </xsl:element>
-        </xsl:copy>
-      </xsl:when>
-    </xsl:choose>
-  </xsl:template>
 </xsl:stylesheet>

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -5,6 +5,7 @@
     <xsl:output method="xml" indent="yes"/>
     <xsl:strip-space elements="*"/> <!-- Remove empty space after deletions. -->
     <xsl:param name="remove-capability-annotations">True</xsl:param>
+    <xsl:param name="remove-innererror-description">True</xsl:param>
 
     <!-- DO NOT FORMAT ON SAVE or else the match templates will become unreadable. -->
     <!-- All element references should include schema namespace as we need to support multiple namespaces. -->
@@ -637,35 +638,39 @@
 
   <!-- Add inner error description -->
   <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
-    <xsl:copy>
-      <xsl:apply-templates select="@* | node()"/>
-      <xsl:element name="ComplexType">
-        <xsl:attribute name="Name">InnerError</xsl:attribute>
-        <xsl:element name="Property">
-          <xsl:attribute name="Name">request-id</xsl:attribute>
-          <xsl:attribute name="Type">Edm.String</xsl:attribute>
-          <xsl:element name="Annotation">
-            <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
-            <xsl:attribute name="String">Request Id as tracked internally by the service</xsl:attribute>
+    <xsl:choose>
+      <xsl:when test="$remove-innererror-description='False'">
+        <xsl:copy>
+          <xsl:apply-templates select="@* | node()"/>
+          <xsl:element name="ComplexType">
+            <xsl:attribute name="Name">InnerError</xsl:attribute>
+            <xsl:element name="Property">
+              <xsl:attribute name="Name">request-id</xsl:attribute>
+              <xsl:attribute name="Type">Edm.String</xsl:attribute>
+              <xsl:element name="Annotation">
+                <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
+                <xsl:attribute name="String">Request Id as tracked internally by the service</xsl:attribute>
+              </xsl:element>
+            </xsl:element>
+            <xsl:element name="Property">
+              <xsl:attribute name="Name">client-request-id</xsl:attribute>
+              <xsl:attribute name="Type">Edm.String</xsl:attribute>
+              <xsl:element name="Annotation">
+                <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
+                <xsl:attribute name="String">Client request Id as sent by the client application.</xsl:attribute>
+              </xsl:element>
+            </xsl:element>
+            <xsl:element name="Property">
+              <xsl:attribute name="Name">Date</xsl:attribute>
+              <xsl:attribute name="Type">Edm.DateTimeOffset</xsl:attribute>
+              <xsl:element name="Annotation">
+                <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
+                <xsl:attribute name="String">Date when the error occured.</xsl:attribute>
+              </xsl:element>
+            </xsl:element>
           </xsl:element>
-        </xsl:element>
-        <xsl:element name="Property">
-          <xsl:attribute name="Name">client-request-id</xsl:attribute>
-          <xsl:attribute name="Type">Edm.String</xsl:attribute>
-          <xsl:element name="Annotation">
-            <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
-            <xsl:attribute name="String">Client request Id as sent by the client application.</xsl:attribute>
-          </xsl:element>
-        </xsl:element>
-        <xsl:element name="Property">
-          <xsl:attribute name="Name">Date</xsl:attribute>
-          <xsl:attribute name="Type">Edm.DateTimeOffset</xsl:attribute>
-          <xsl:element name="Annotation">
-            <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
-            <xsl:attribute name="String">Date when the error occured.</xsl:attribute>
-          </xsl:element>
-        </xsl:element>
-      </xsl:element>
-    </xsl:copy>
+        </xsl:copy>
+      </xsl:when>
+    </xsl:choose>
   </xsl:template>
 </xsl:stylesheet>

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -634,4 +634,22 @@
       <xsl:apply-templates select="node()"/>
     </xsl:copy>
   </xsl:template>
+
+  <!-- Add inner error description -->
+  <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
+    <xsl:copy>
+      <xsl:apply-templates select="node()"/>
+      <ComplexType Name="InnerError">
+        <Property Name="request-id" Type="Edm.String">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Request Id as tracked internally by the service" />
+        </Property>
+        <Property Name="client-request-id" Type="Edm.String">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Client request Id as sent by the client application." />
+        </Property>
+        <Property Name="Date" Type="Edm.DateTimeOffset">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Date when the error occured." />
+        </Property>
+      </ComplexType>
+    </xsl:copy>
+  </xsl:template>
 </xsl:stylesheet>

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -5,7 +5,7 @@
     <xsl:output method="xml" indent="yes"/>
     <xsl:strip-space elements="*"/> <!-- Remove empty space after deletions. -->
     <xsl:param name="remove-capability-annotations">True</xsl:param>
-    <xsl:param name="remove-innererror-description">True</xsl:param>
+    <xsl:param name="add-innererror-description">False</xsl:param>
 
     <!-- DO NOT FORMAT ON SAVE or else the match templates will become unreadable. -->
     <!-- All element references should include schema namespace as we need to support multiple namespaces. -->
@@ -639,7 +639,7 @@
   <!-- Add inner error description -->
   <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
     <xsl:choose>
-      <xsl:when test="$remove-innererror-description='False'">
+      <xsl:when test="$add-innererror-description='True'">
         <xsl:copy>
           <xsl:apply-templates select="@* | node()"/>
           <xsl:element name="ComplexType">

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -638,18 +638,34 @@
   <!-- Add inner error description -->
   <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
     <xsl:copy>
-      <xsl:apply-templates select="node()"/>
-      <ComplexType Name="InnerError">
-        <Property Name="request-id" Type="Edm.String">
-          <Annotation Term="Org.OData.Core.V1.Description" String="Request Id as tracked internally by the service" />
-        </Property>
-        <Property Name="client-request-id" Type="Edm.String">
-          <Annotation Term="Org.OData.Core.V1.Description" String="Client request Id as sent by the client application." />
-        </Property>
-        <Property Name="Date" Type="Edm.DateTimeOffset">
-          <Annotation Term="Org.OData.Core.V1.Description" String="Date when the error occured." />
-        </Property>
-      </ComplexType>
+      <xsl:apply-templates select="@* | node()"/>
+      <xsl:element name="ComplexType">
+        <xsl:attribute name="Name">InnerError</xsl:attribute>
+        <xsl:element name="Property">
+          <xsl:attribute name="Name">request-id</xsl:attribute>
+          <xsl:attribute name="Type">Edm.String</xsl:attribute>
+          <xsl:element name="Annotation">
+            <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
+            <xsl:attribute name="String">Request Id as tracked internally by the service</xsl:attribute>
+          </xsl:element>
+        </xsl:element>
+        <xsl:element name="Property">
+          <xsl:attribute name="Name">client-request-id</xsl:attribute>
+          <xsl:attribute name="Type">Edm.String</xsl:attribute>
+          <xsl:element name="Annotation">
+            <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
+            <xsl:attribute name="String">Client request Id as sent by the client application.</xsl:attribute>
+          </xsl:element>
+        </xsl:element>
+        <xsl:element name="Property">
+          <xsl:attribute name="Name">Date</xsl:attribute>
+          <xsl:attribute name="Type">Edm.DateTimeOffset</xsl:attribute>
+          <xsl:element name="Annotation">
+            <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>
+            <xsl:attribute name="String">Date when the error occured.</xsl:attribute>
+          </xsl:element>
+        </xsl:element>
+      </xsl:element>
     </xsl:copy>
   </xsl:template>
 </xsl:stylesheet>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -342,6 +342,17 @@
         <Parameter Name="bindingParameter" Type="Collection(graph.site)" />
         <ReturnType Type="Collection(graph.site)" />
       </Function>
+      <ComplexType Name="InnerError">
+        <Property Name="request-id" Type="Edm.String">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Request Id as tracked internally by the service" />
+        </Property>
+        <Property Name="client-request-id" Type="Edm.String">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Client request Id as sent by the client application." />
+        </Property>
+        <Property Name="Date" Type="Edm.DateTimeOffset">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Date when the error occured." />
+        </Property>
+      </ComplexType>
       <Annotations Target="microsoft.graph.driveItem/workbook">
         <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
           <Record>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -342,17 +342,6 @@
         <Parameter Name="bindingParameter" Type="Collection(graph.site)" />
         <ReturnType Type="Collection(graph.site)" />
       </Function>
-      <ComplexType Name="InnerError">
-        <Property Name="request-id" Type="Edm.String">
-          <Annotation Term="Org.OData.Core.V1.Description" String="Request Id as tracked internally by the service" />
-        </Property>
-        <Property Name="client-request-id" Type="Edm.String">
-          <Annotation Term="Org.OData.Core.V1.Description" String="Client request Id as sent by the client application." />
-        </Property>
-        <Property Name="Date" Type="Edm.DateTimeOffset">
-          <Annotation Term="Org.OData.Core.V1.Description" String="Date when the error occured." />
-        </Property>
-      </ComplexType>
       <Annotations Target="microsoft.graph.driveItem/workbook">
         <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
           <Record>

--- a/transforms/csdl/readme.md
+++ b/transforms/csdl/readme.md
@@ -24,10 +24,12 @@ Please use fully qualified and precise template match statements so as not to pe
     > NB: The build job in the pipeline currently errors out on PRs coming in from personal forked repos.  
 
 ## Command line instructions for running the transform
+
 1. Start PowerShell
 2. `cd` into `transforms\csdl` folder
-3. Run `transform.ps1 <xsl_file> <input_file> <output_file>`. If files are not specified, the script will apply transformations from  *preprocess_csdl.xsl* on  *preprocess_csdl_test_input.xml* and override *preprocess_csdl_test_output.xml* file. 
+3. Run `transform.ps1 <xsl_file> <input_file> <output_file>`. If files are not specified, the script will apply transformations from  *preprocess_csdl.xsl* on  *preprocess_csdl_test_input.xml* and override *preprocess_csdl_test_output.xml* file.
 4. You can optionally run the transform without removing capability annotations by setting the `-removeCapabilityAnnotations` flag to `$false`. The default behavior is to remove capability annotations.
+5. You can additional run the transform without injecting the inner error description by setting the `-removeInnererrorDescription` false to `$true` (default, false to include it).
 
 ## Instructions for running transform against Microsoft Graph metadata
 

--- a/transforms/csdl/readme.md
+++ b/transforms/csdl/readme.md
@@ -29,7 +29,7 @@ Please use fully qualified and precise template match statements so as not to pe
 2. `cd` into `transforms\csdl` folder
 3. Run `transform.ps1 <xsl_file> <input_file> <output_file>`. If files are not specified, the script will apply transformations from  *preprocess_csdl.xsl* on  *preprocess_csdl_test_input.xml* and override *preprocess_csdl_test_output.xml* file.
 4. You can optionally run the transform without removing capability annotations by setting the `-removeCapabilityAnnotations` flag to `$false`. The default behavior is to remove capability annotations.
-5. You can additional run the transform without injecting the inner error description by setting the `-removeInnererrorDescription` false to `$true` (default, false to include it).
+5. You can optionally run the transform to inject the OData inner error description by setting the `addInnerErrorDescription` flag to `$true`. The default value is `$false`.
 
 ## Instructions for running transform against Microsoft Graph metadata
 

--- a/transforms/csdl/transform.ps1
+++ b/transforms/csdl/transform.ps1
@@ -13,7 +13,7 @@ param (
     [bool]
     $removeCapabilityAnnotations = $true,
     [bool]
-    $removeInnererrorDescription = $true
+    $addInnerErrorDescription = $false
 )
 function Get-PathWithPrefix([string]$requestedPath) {
     if([System.IO.Path]::IsPathRooted($requestedPath)) {
@@ -38,7 +38,7 @@ $outputFullPath = Get-PathWithPrefix -requestedPath $outputPath
 
 $xsltargs = [System.Xml.Xsl.XsltArgumentList]::new()
 $xsltargs.AddParam("remove-capability-annotations", "", $removeCapabilityAnnotations.ToString())
-$xsltargs.AddParam("remove-innererror-description", "", $removeInnererrorDescription.ToString())
+$xsltargs.AddParam("add-innererror-description", "", $removeInnererrorDescription.ToString())
 
 $xmlWriterSettings = [System.Xml.XmlWriterSettings]::new()
 $xmlWriterSettings.Indent = $true

--- a/transforms/csdl/transform.ps1
+++ b/transforms/csdl/transform.ps1
@@ -42,11 +42,14 @@ $xmlWriterSettings.Indent = $true
 
 $xmlWriter = [System.Xml.XmlWriter]::Create($outputFullPath, $xmlWriterSettings)
 
-$xslt = [System.Xml.Xsl.XslCompiledTransform]::new($dbg) 
-$xslt.Load($xslFullPath)
 try {
+    $xslt = [System.Xml.Xsl.XslCompiledTransform]::new($dbg) 
+    $xslt.Load($xslFullPath)
     $xslt.Transform($inputFullPath, $xsltargs, $xmlWriter)
 }
 catch {
     Write-Error $_.Exception
+}
+finally {
+    $xmlWriter.Close()
 }

--- a/transforms/csdl/transform.ps1
+++ b/transforms/csdl/transform.ps1
@@ -38,7 +38,7 @@ $outputFullPath = Get-PathWithPrefix -requestedPath $outputPath
 
 $xsltargs = [System.Xml.Xsl.XsltArgumentList]::new()
 $xsltargs.AddParam("remove-capability-annotations", "", $removeCapabilityAnnotations.ToString())
-$xsltargs.AddParam("add-innererror-description", "", $removeInnererrorDescription.ToString())
+$xsltargs.AddParam("add-innererror-description", "", $addInnerErrorDescription.ToString())
 
 $xmlWriterSettings = [System.Xml.XmlWriterSettings]::new()
 $xmlWriterSettings.Indent = $true

--- a/transforms/csdl/transform.ps1
+++ b/transforms/csdl/transform.ps1
@@ -11,7 +11,9 @@ param (
     [bool]
     $dbg = $false,
     [bool]
-    $removeCapabilityAnnotations = $true
+    $removeCapabilityAnnotations = $true,
+    [bool]
+    $removeInnererrorDescription = $true
 )
 function Get-PathWithPrefix([string]$requestedPath) {
     if([System.IO.Path]::IsPathRooted($requestedPath)) {
@@ -36,6 +38,7 @@ $outputFullPath = Get-PathWithPrefix -requestedPath $outputPath
 
 $xsltargs = [System.Xml.Xsl.XsltArgumentList]::new()
 $xsltargs.AddParam("remove-capability-annotations", "", $removeCapabilityAnnotations.ToString())
+$xsltargs.AddParam("remove-innererror-description", "", $removeInnererrorDescription.ToString())
 
 $xmlWriterSettings = [System.Xml.XmlWriterSettings]::new()
 $xmlWriterSettings.Indent = $true


### PR DESCRIPTION
inserts a description for the inner error type as prepration work for Kiota.

We're not describing the error itself as it's brought in the conversion process by OData conventions.

related https://github.com/microsoft/kiota/issues/411
related https://github.com/microsoft/OpenAPI.NET.OData/pull/167

More reading https://docs.microsoft.com/en-us/graph/errors

(I believe the inner error description is partly wrong, as it doesn't inherit from error according to the odata spec)