### PR TITLE
Remove deletability for select nav properties.

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -653,6 +653,19 @@
                     </xsl:element>
                 </xsl:element>
             </xsl:element>
+            <!-- Remove deletable for alerts navigation property -->
+            <xsl:element name="Annotations">
+                <xsl:attribute name="Target">microsoft.graph.security/alerts</xsl:attribute>
+                <xsl:element name="Annotation">
+                    <xsl:attribute name="Term">Org.OData.Capabilities.V1.DeleteRestrictions</xsl:attribute>
+                    <xsl:element name="Record" namespace="{namespace-uri()}">
+                        <xsl:element name="PropertyValue">
+                            <xsl:attribute name="Property">Deletable</xsl:attribute>
+                            <xsl:attribute name="Bool">false</xsl:attribute>
+                        </xsl:element>
+                    </xsl:element>
+                </xsl:element>
+            </xsl:element>
         </xsl:copy>
     </xsl:template>
 

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -666,7 +666,7 @@
                     </xsl:element>
                 </xsl:element>
             </xsl:element>
-            <!-- Remove deletable from navigation properties -->
+            <!-- Remove deletability from navigation properties -->
             <xsl:element name="Annotations">
                 <xsl:attribute name="Target">microsoft.graph.security/alerts</xsl:attribute>
                 <xsl:call-template name="DeleteRestrictionsTemplate">

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -544,6 +544,19 @@
         </xsl:copy>
     </xsl:template>
 
+    <xsl:template name="DeleteRestrictionsTemplate">
+        <xsl:param name = "deletable" />
+        <xsl:element name="Annotation">
+            <xsl:attribute name="Term">Org.OData.Capabilities.V1.DeleteRestrictions</xsl:attribute>
+            <xsl:element name="Record" namespace="{namespace-uri()}">
+                <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">Deletable</xsl:attribute>
+                    <xsl:attribute name="Bool"><xsl:value-of select = "$deletable" /></xsl:attribute>
+                </xsl:element>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
+
     <!-- Add Navigation Restrictions Annotations -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
         <xsl:copy>
@@ -653,18 +666,18 @@
                     </xsl:element>
                 </xsl:element>
             </xsl:element>
-            <!-- Remove deletable for alerts navigation property -->
+            <!-- Remove deletable from navigation properties -->
             <xsl:element name="Annotations">
                 <xsl:attribute name="Target">microsoft.graph.security/alerts</xsl:attribute>
-                <xsl:element name="Annotation">
-                    <xsl:attribute name="Term">Org.OData.Capabilities.V1.DeleteRestrictions</xsl:attribute>
-                    <xsl:element name="Record" namespace="{namespace-uri()}">
-                        <xsl:element name="PropertyValue">
-                            <xsl:attribute name="Property">Deletable</xsl:attribute>
-                            <xsl:attribute name="Bool">false</xsl:attribute>
-                        </xsl:element>
-                    </xsl:element>
-                </xsl:element>
+                <xsl:call-template name="DeleteRestrictionsTemplate">
+                    <xsl:with-param name="deletable">false</xsl:with-param>
+                </xsl:call-template>
+            </xsl:element>
+            <xsl:element name="Annotations">
+                <xsl:attribute name="Target">microsoft.graph.authentication/methods</xsl:attribute>
+                <xsl:call-template name="DeleteRestrictionsTemplate">
+                    <xsl:with-param name="deletable">false</xsl:with-param>
+                </xsl:call-template>
             </xsl:element>
         </xsl:copy>
     </xsl:template>

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -120,6 +120,9 @@
             <EntityType Name="message" BaseType="graph.entity">
                 <Property Name="conversationId" Type="Edm.String"/>
             </EntityType>
+            <EntityType Name="security" BaseType="graph.entity">
+                <NavigationProperty Name="alerts" Type="Collection(graph.alert)" ContainsTarget="true" />
+            </EntityType>
             <ComplexType Name="timeSlot">
                 <Property Name="end" Type="graph.dateTimeTimeZone" Nullable="false" />
                 <Property Name="start" Type="graph.dateTimeTimeZone" Nullable="false" />

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -120,9 +120,6 @@
             <EntityType Name="message" BaseType="graph.entity">
                 <Property Name="conversationId" Type="Edm.String"/>
             </EntityType>
-            <EntityType Name="security" BaseType="graph.entity">
-                <NavigationProperty Name="alerts" Type="Collection(graph.alert)" ContainsTarget="true" />
-            </EntityType>
             <ComplexType Name="timeSlot">
                 <Property Name="end" Type="graph.dateTimeTimeZone" Nullable="false" />
                 <Property Name="start" Type="graph.dateTimeTimeZone" Nullable="false" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -118,9 +118,6 @@
             <EntityType HasStream="true" Name="message" BaseType="graph.entity">
                 <Property Name="conversationId" Type="Edm.String" />
             </EntityType>
-            <EntityType Name="security" BaseType="graph.entity">
-              <NavigationProperty Name="alerts" Type="Collection(graph.alert)" ContainsTarget="true" />
-            </EntityType>
             <ComplexType Name="timeSlot">
                 <Property Name="end" Type="graph.dateTimeTimeZone" Nullable="false" />
                 <Property Name="start" Type="graph.dateTimeTimeZone" Nullable="false" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -118,6 +118,9 @@
             <EntityType HasStream="true" Name="message" BaseType="graph.entity">
                 <Property Name="conversationId" Type="Edm.String" />
             </EntityType>
+            <EntityType Name="security" BaseType="graph.entity">
+              <NavigationProperty Name="alerts" Type="Collection(graph.alert)" ContainsTarget="true" />
+            </EntityType>
             <ComplexType Name="timeSlot">
                 <Property Name="end" Type="graph.dateTimeTimeZone" Nullable="false" />
                 <Property Name="start" Type="graph.dateTimeTimeZone" Nullable="false" />
@@ -389,6 +392,13 @@
                         </PropertyValue>
                     </Record>
                 </Annotation>
+            </Annotations>
+            <Annotations Target="microsoft.graph.security/alerts">
+              <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+                <Record>
+                  <PropertyValue Property="Deletable" Bool="false" />
+                </Record>
+              </Annotation>
             </Annotations>
         </Schema>
         <Schema Namespace="microsoft.graph.callRecords" xmlns="http://docs.oasis-open.org/odata/ns/edm">

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -400,6 +400,13 @@
                 </Record>
               </Annotation>
             </Annotations>
+            <Annotations Target="microsoft.graph.authentication/methods">
+              <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+                <Record>
+                  <PropertyValue Property="Deletable" Bool="false" />
+                </Record>
+              </Annotation>
+            </Annotations>
         </Schema>
         <Schema Namespace="microsoft.graph.callRecords" xmlns="http://docs.oasis-open.org/odata/ns/edm">
             <EnumType Name="callType">

--- a/transforms/csdl/transform.ps1
+++ b/transforms/csdl/transform.ps1
@@ -16,10 +16,11 @@ param (
     $addInnerErrorDescription = $false
 )
 function Get-PathWithPrefix([string]$requestedPath) {
-    if([System.IO.Path]::IsPathRooted($requestedPath)) {
+    if ([System.IO.Path]::IsPathRooted($requestedPath)) {
         return $requestedPath
-    } else {
-        return Join-Path $PWD $requestedPath
+    }
+    else {
+        return Join-Path $PSScriptRoot $requestedPath
     }
 }
 $xslFullPath = Get-PathWithPrefix -requestedPath $xslPath
@@ -46,7 +47,7 @@ $xmlWriterSettings.Indent = $true
 $xmlWriter = [System.Xml.XmlWriter]::Create($outputFullPath, $xmlWriterSettings)
 
 try {
-    $xslt = [System.Xml.Xsl.XslCompiledTransform]::new($dbg) 
+    $xslt = [System.Xml.Xsl.XslCompiledTransform]::new($dbg)
     $xslt.Load($xslFullPath)
     $xslt.Transform($inputFullPath, $xsltargs, $xmlWriter)
 }


### PR DESCRIPTION
This PR closes #137 and closes #138 by reamoving deletability for `security/alerts` and `authentication/methods` as they do not support `DELETE`.