### PR TITLE
Remove insertability and deletability from site resources.

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -544,6 +544,7 @@
         </xsl:copy>
     </xsl:template>
 
+    <!-- Capability Annotations Templates -->
     <xsl:template name="DeleteRestrictionsTemplate">
         <xsl:param name = "deletable" />
         <xsl:element name="Annotation">
@@ -552,6 +553,18 @@
                 <xsl:element name="PropertyValue">
                     <xsl:attribute name="Property">Deletable</xsl:attribute>
                     <xsl:attribute name="Bool"><xsl:value-of select = "$deletable" /></xsl:attribute>
+                </xsl:element>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
+    <xsl:template name="InsertRestrictionsTemplate">
+        <xsl:param name = "insertable" />
+        <xsl:element name="Annotation">
+            <xsl:attribute name="Term">Org.OData.Capabilities.V1.InsertRestrictions</xsl:attribute>
+            <xsl:element name="Record" namespace="{namespace-uri()}">
+                <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">Insertable</xsl:attribute>
+                    <xsl:attribute name="Bool"><xsl:value-of select = "$insertable" /></xsl:attribute>
                 </xsl:element>
             </xsl:element>
         </xsl:element>
@@ -666,7 +679,7 @@
                     </xsl:element>
                 </xsl:element>
             </xsl:element>
-            <!-- Remove deletability from navigation properties -->
+            <!-- Remove deletability -->
             <xsl:element name="Annotations">
                 <xsl:attribute name="Target">microsoft.graph.security/alerts</xsl:attribute>
                 <xsl:call-template name="DeleteRestrictionsTemplate">
@@ -677,6 +690,19 @@
                 <xsl:attribute name="Target">microsoft.graph.authentication/methods</xsl:attribute>
                 <xsl:call-template name="DeleteRestrictionsTemplate">
                     <xsl:with-param name="deletable">false</xsl:with-param>
+                </xsl:call-template>
+            </xsl:element>
+            <xsl:element name="Annotations">
+                <xsl:attribute name="Target">microsoft.graph.site</xsl:attribute>
+                <xsl:call-template name="DeleteRestrictionsTemplate">
+                    <xsl:with-param name="deletable">false</xsl:with-param>
+                </xsl:call-template>
+            </xsl:element>
+            <!-- Remove insertability -->
+            <xsl:element name="Annotations">
+                <xsl:attribute name="Target">microsoft.graph.site</xsl:attribute>
+                <xsl:call-template name="InsertRestrictionsTemplate">
+                    <xsl:with-param name="insertable">false</xsl:with-param>
                 </xsl:call-template>
             </xsl:element>
         </xsl:copy>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -404,6 +404,20 @@
                 </Record>
               </Annotation>
             </Annotations>
+            <Annotations Target="microsoft.graph.site">
+              <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+                <Record>
+                  <PropertyValue Property="Deletable" Bool="false" />
+                </Record>
+              </Annotation>
+            </Annotations>
+            <Annotations Target="microsoft.graph.site">
+              <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+                <Record>
+                  <PropertyValue Property="Insertable" Bool="false" />
+                </Record>
+              </Annotation>
+            </Annotations>
         </Schema>
         <Schema Namespace="microsoft.graph.callRecords" xmlns="http://docs.oasis-open.org/odata/ns/edm">
             <EnumType Name="callType">


### PR DESCRIPTION
This PR removes insertability and deletability from site resources as described in https://docs.microsoft.com/en-us/graph/api/resources/sharepoint?view=graph-rest-beta:
> The SharePoint API in Microsoft Graph supports the following core scenarios:
> - Access to Read-only support for site resources (no ability to create new sites)
> ...

This is done to avoid confusion as we currently generate create and delete commands for a site that are not supported by the API.