### PR TITLE
Add the `microsoft.graph.user/joinedGroups` annotations otherwise modify it if exists

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -570,6 +570,25 @@
             </xsl:element>
         </xsl:element>
     </xsl:template>
+    <xsl:template name="NavigationRestrictionsTemplate">
+        <xsl:param name = "navigable" />
+        <xsl:element name="Annotation">
+            <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
+            <xsl:element name="Record" namespace="{namespace-uri()}">
+                <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
+                    <xsl:element name="Collection">
+                        <xsl:element name="Record">
+                            <xsl:element name="PropertyValue">
+                                <xsl:attribute name="Property">IndexableByKey</xsl:attribute>
+                                <xsl:attribute name="Bool"><xsl:value-of select = "$navigable" /></xsl:attribute>
+                            </xsl:element>
+                        </xsl:element>
+                    </xsl:element>
+                </xsl:element>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
 
     <!-- Add Navigation Restrictions Annotations -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
@@ -620,66 +639,43 @@
                     </xsl:element>
                 </xsl:element>
             </xsl:element>
+            
             <!-- Remove indexability for joinedGroups navigation property -->
-            <xsl:element name="Annotations">
-                <xsl:attribute name="Target">microsoft.graph.user/joinedGroups</xsl:attribute>
-                <xsl:element name="Annotation">
-                    <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
-                    <xsl:element name="Record" namespace="{namespace-uri()}">
-                        <xsl:element name="PropertyValue">
-                            <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
-                            <xsl:element name="Collection">
-                                <xsl:element name="Record">
-                                    <xsl:element name="PropertyValue">
-                                        <xsl:attribute name="Property">IndexableByKey</xsl:attribute>
-                                        <xsl:attribute name="Bool">false</xsl:attribute>
-                                    </xsl:element>
-                                </xsl:element>
-                            </xsl:element>
-                        </xsl:element>
+            <!-- Add the parent "Annotations" tag if it doesn't exists -->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.user/joinedGroups'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.user/joinedGroups</xsl:attribute>
+                        <xsl:call-template name="NavigationRestrictionsTemplate">
+                            <xsl:with-param name="navigable">false</xsl:with-param>
+                        </xsl:call-template>
                     </xsl:element>
-                </xsl:element>
-            </xsl:element>
+                </xsl:when>
+            </xsl:choose>
             <!-- Remove indexability for users navigation property -->
-            <xsl:element name="Annotations">
-                <xsl:attribute name="Target">microsoft.graph.managedDevice/users</xsl:attribute>
-                <xsl:element name="Annotation">
-                    <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
-                    <xsl:element name="Record" namespace="{namespace-uri()}">
-                        <xsl:element name="PropertyValue">
-                            <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
-                            <xsl:element name="Collection">
-                                <xsl:element name="Record">
-                                    <xsl:element name="PropertyValue">
-                                        <xsl:attribute name="Property">IndexableByKey</xsl:attribute>
-                                        <xsl:attribute name="Bool">false</xsl:attribute>
-                                    </xsl:element>
-                                </xsl:element>
-                            </xsl:element>
-                        </xsl:element>
+            <!-- Add the parent "Annotations" tag if it doesn't exists -->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.managedDevice/users'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.managedDevice/users</xsl:attribute>
+                        <xsl:call-template name="NavigationRestrictionsTemplate">
+                            <xsl:with-param name="navigable">false</xsl:with-param>
+                        </xsl:call-template>
                     </xsl:element>
-                </xsl:element>
-            </xsl:element>
+                </xsl:when>
+            </xsl:choose>
             <!-- Remove indexability for activities navigation property -->
-            <xsl:element name="Annotations">
-                <xsl:attribute name="Target">microsoft.graph.list/activities</xsl:attribute>
-                <xsl:element name="Annotation">
-                    <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
-                    <xsl:element name="Record" namespace="{namespace-uri()}">
-                        <xsl:element name="PropertyValue">
-                            <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
-                            <xsl:element name="Collection">
-                                <xsl:element name="Record">
-                                    <xsl:element name="PropertyValue">
-                                        <xsl:attribute name="Property">IndexableByKey</xsl:attribute>
-                                        <xsl:attribute name="Bool">false</xsl:attribute>
-                                    </xsl:element>
-                                </xsl:element>
-                            </xsl:element>
-                        </xsl:element>
+            <!-- Add the parent "Annotations" tag if it doesn't exists -->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.list/activities'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.list/activities</xsl:attribute>
+                        <xsl:call-template name="NavigationRestrictionsTemplate">
+                            <xsl:with-param name="navigable">false</xsl:with-param>
+                        </xsl:call-template>
                     </xsl:element>
-                </xsl:element>
-            </xsl:element>
+                </xsl:when>
+            </xsl:choose>
             <!-- Remove deletability -->
             <xsl:element name="Annotations">
                 <xsl:attribute name="Target">microsoft.graph.security/alerts</xsl:attribute>
@@ -705,6 +701,21 @@
                     </xsl:call-template>
                 </xsl:element>
             </xsl:if>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- If the parent "Annotations" tag already exists modify it -->
+    <!-- Remove indexability for joinedGroups navigation property -->
+    <!-- Remove indexability for activities navigation property -->
+    <!-- Remove indexability for users navigation property -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/joinedGroups'] |
+                        edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.managedDevice/users'] |
+                        edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.list/activities'] ">
+        <xsl:copy>
+            <xsl:copy-of select="@*|node()"/>
+            <xsl:call-template name="NavigationRestrictionsTemplate">
+                <xsl:with-param name="navigable">false</xsl:with-param>
+            </xsl:call-template>            
         </xsl:copy>
     </xsl:template>
 

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -42,6 +42,37 @@
             <EntityType Name="directoryObject" BaseType="graph.entity" OpenType="true">
                 <Property Name="deletedDateTime" Type="Edm.DateTimeOffset" />
             </EntityType>
+            <Annotations Target="microsoft.graph.user/joinedGroups">
+                <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+                    <Record>
+                        <PropertyValue Property="Supported" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+                    <Record>
+                        <PropertyValue Property="Deletable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+                    <Record>
+                        <PropertyValue Property="Expandable" Bool="false"/>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="microsoft.graph.managedDevice/users">
+                <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+                    <Record>
+                        <PropertyValue Property="Supported" Bool="false"/>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="microsoft.graph.list/activities">
+                <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+                    <Record>
+                        <PropertyValue Property="Supported" Bool="false"/>
+                    </Record>
+                </Annotation>
+            </Annotations>
             <Annotations Target="graph.activityHistoryItem">
                 <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
                     <Record>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -51,6 +51,70 @@
       <EntityType Name="directoryObject" BaseType="graph.entity" OpenType="true">
         <Property Name="deletedDateTime" Type="Edm.DateTimeOffset" />
       </EntityType>
+      <Annotations Target="microsoft.graph.user/joinedGroups">
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="false" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="false" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="RestrictedProperties">
+              <Collection>
+                <Record>
+                  <PropertyValue Property="IndexableByKey" Bool="false" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.managedDevice/users">
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="false" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="RestrictedProperties">
+              <Collection>
+                <Record>
+                  <PropertyValue Property="IndexableByKey" Bool="false" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.list/activities">
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="false" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="RestrictedProperties">
+              <Collection>
+                <Record>
+                  <PropertyValue Property="IndexableByKey" Bool="false" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
       <Annotations Target="graph.activityHistoryItem">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
       </Annotations>
@@ -357,45 +421,6 @@
           <Record>
             <PropertyValue Property="Navigability">
               <EnumMember>Org.OData.Capabilities.V1.NavigationType/None</EnumMember>
-            </PropertyValue>
-          </Record>
-        </Annotation>
-      </Annotations>
-      <Annotations Target="microsoft.graph.user/joinedGroups">
-        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
-          <Record>
-            <PropertyValue Property="RestrictedProperties">
-              <Collection>
-                <Record>
-                  <PropertyValue Property="IndexableByKey" Bool="false" />
-                </Record>
-              </Collection>
-            </PropertyValue>
-          </Record>
-        </Annotation>
-      </Annotations>
-      <Annotations Target="microsoft.graph.managedDevice/users">
-        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
-          <Record>
-            <PropertyValue Property="RestrictedProperties">
-              <Collection>
-                <Record>
-                  <PropertyValue Property="IndexableByKey" Bool="false" />
-                </Record>
-              </Collection>
-            </PropertyValue>
-          </Record>
-        </Annotation>
-      </Annotations>
-      <Annotations Target="microsoft.graph.list/activities">
-        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
-          <Record>
-            <PropertyValue Property="RestrictedProperties">
-              <Collection>
-                <Record>
-                  <PropertyValue Property="IndexableByKey" Bool="false" />
-                </Record>
-              </Collection>
             </PropertyValue>
           </Record>
         </Annotation>


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-metadata/issues/150

Related to #145 

It makes changes to the CSDL transform to add the `microsoft.graph.user/joinedGroups` annotations to cater for the v1.0 metadata. 

However, if the annotation already exists, we simply modify it by appending the subset of annotations.

This is done to prevent issues observed after work done through https://github.com/OneDrive/apidoctor/pull/116 where annotations targets should ideally be unique, and an XML document shouldn't have multiple annotation tags with the same target in the same doc.