### PR TITLE
Fix template matching clause for `places` EntitySet

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -283,7 +283,7 @@
             </Annotation>
         </xsl:copy>
     </xsl:template>
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntitySet[@Name='places']">
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='places']">
         <xsl:copy>
             <xsl:copy-of select="@* | node()" />
             <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -152,6 +152,10 @@
             <EntityType Name="message" BaseType="graph.entity">
                 <Property Name="conversationId" Type="Edm.String"/>
             </EntityType>
+            <EntityType Name="place" BaseType="graph.entity" Abstract="true">
+                <Property Name="displayName" Type="Edm.String" Nullable="false" />
+                <Property Name="phone" Type="Edm.String" />
+            </EntityType>
             <ComplexType Name="timeSlot">
                 <Property Name="end" Type="graph.dateTimeTimeZone" Nullable="false" />
                 <Property Name="start" Type="graph.dateTimeTimeZone" Nullable="false" />
@@ -166,6 +170,7 @@
               <EntitySet Name="groups" EntityType="microsoft.graph.group" />
               <EntitySet Name="servicePrincipals" EntityType="microsoft.graph.servicePrincipal" />
               <EntitySet Name="directoryObjects" EntityType="microsoft.graph.directoryObject" />
+              <EntitySet Name="places" EntityType="microsoft.graph.place" />
             </EntityContainer>
             <Action Name="accept" IsBound="true">
                 <Parameter Name="bindingParameter" Type="graph.event" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -209,6 +209,10 @@
       <EntityType HasStream="true" Name="message" BaseType="graph.entity">
         <Property Name="conversationId" Type="Edm.String" />
       </EntityType>
+      <EntityType Name="place" BaseType="graph.entity" Abstract="true">
+        <Property Name="displayName" Type="Edm.String" Nullable="false" />
+        <Property Name="phone" Type="Edm.String" />
+      </EntityType>
       <ComplexType Name="timeSlot">
         <Property Name="end" Type="graph.dateTimeTimeZone" Nullable="false" />
         <Property Name="start" Type="graph.dateTimeTimeZone" Nullable="false" />
@@ -399,6 +403,14 @@
                 </Collection>
               </PropertyValue>
             </Record>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="places" EntityType="microsoft.graph.place">
+          <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
+            <Collection>
+              <String>microsoft.graph.room</String>
+              <String>microsoft.graph.roomlist</String>
+            </Collection>
           </Annotation>
         </EntitySet>
       </EntityContainer>


### PR DESCRIPTION
This PR is part of https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/141

It addressed a bug in the XSLT transform that would incorrectly match the `places` EntitySet so as to add the relevant `DerivedTypeConstraint` annotation to the metadata as it failed to cater for the fact that the `EntitySet` is held within an `EntityContainer`.

The test input has been updated to validate that the fix works. 