### PR TITLE
Add referenceable annotation to `internalSponsors` nav property

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -803,6 +803,7 @@
                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='b2cIdentityUserFlow']/edm:NavigationProperty[@Name='identityProviders']|
                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='b2xIdentityUserFlow']/edm:NavigationProperty[@Name='userFlowIdentityProviders']|
                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='connectedOrganization']/edm:NavigationProperty[@Name='externalSponsors']|
+                        edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='connectedOrganization']/edm:NavigationProperty[@Name='internalSponsors']|
                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='connector']/edm:NavigationProperty[@Name='memberOf']|
                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='application']/edm:NavigationProperty[@Name='connectorGroup']|
                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='connector']/edm:NavigationProperty[@Name='registeredUsers']|

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -156,6 +156,10 @@
                 <Property Name="displayName" Type="Edm.String" Nullable="false" />
                 <Property Name="phone" Type="Edm.String" />
             </EntityType>
+            <EntityType Name="connectedOrganization" BaseType="graph.entity">
+                <Property Name="description" Type="Edm.String" />
+                <NavigationProperty Name="internalSponsors" Type="Collection(graph.directoryObject)" ContainsTarget="true" />
+            </EntityType>
             <ComplexType Name="timeSlot">
                 <Property Name="end" Type="graph.dateTimeTimeZone" Nullable="false" />
                 <Property Name="start" Type="graph.dateTimeTimeZone" Nullable="false" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -213,6 +213,16 @@
         <Property Name="displayName" Type="Edm.String" Nullable="false" />
         <Property Name="phone" Type="Edm.String" />
       </EntityType>
+      <EntityType Name="connectedOrganization" BaseType="graph.entity">
+        <Property Name="description" Type="Edm.String" />
+        <NavigationProperty Name="internalSponsors" Type="Collection(graph.directoryObject)" ContainsTarget="true">
+          <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+            <Record>
+              <PropertyValue Property="Referenceable" Bool="true" />
+            </Record>
+          </Annotation>
+        </NavigationProperty>
+      </EntityType>
       <ComplexType Name="timeSlot">
         <Property Name="end" Type="graph.dateTimeTimeZone" Nullable="false" />
         <Property Name="start" Type="graph.dateTimeTimeZone" Nullable="false" />


### PR DESCRIPTION
This PR closes #156 by adding referenceable annotation to `internalSponsors` navigation property. See https://docs.microsoft.com/en-us/graph/api/connectedorganization-post-internalsponsors?view=graph-rest-1.0&tabs=http for more details.