### PR TITLE
- adds andrew and irvine to code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @baywet @ddyett @MichaelMainer @nikithauc @zengin @peombwa @finsharp
+* @baywet @ddyett @MichaelMainer @nikithauc @zengin @peombwa @finsharp @andrueastman @irvinesunday

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @baywet @ddyett @MichaelMainer @nikithauc @zengin @peombwa @finsharp @andrueastman @irvinesunday
+* @baywet @ddyett @MichaelMainer @nikithauc @zengin @peombwa @andrueastman @irvinesunday


### PR DESCRIPTION
all the current code owners are in north america, which reduces our resiliency to holidays