### PR TITLE
Adds `DerivedTypeConstraint` annotation for caseExportOperation

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -319,6 +319,16 @@
             </Annotation>
         </xsl:copy>
     </xsl:template>
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph.ediscovery']/edm:EntityType[@Name='case']/edm:NavigationProperty[@Name='operations']">
+        <xsl:copy>
+            <xsl:copy-of select="@* | node()" />
+            <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
+                <Collection>
+                    <String>microsoft.graph.ediscovery.caseExportOperation</String>
+                </Collection>
+            </Annotation>
+        </xsl:copy>
+    </xsl:template>
 
     <!-- Remove attribute -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='onenotePage']/@HasStream|


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/338

Reference
- https://docs.microsoft.com/en-us/graph/api/ediscovery-caseexportoperation-getdownloadurl?view=graph-rest-beta&tabs=csharp#http-request