### PR TITLE
Add `UpdateRestrictions` to change the update `HttpMethod` to `PUT`

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -805,12 +805,34 @@
                 </xsl:call-template>
             </xsl:element>
 
-            <!-- Add UpdateRestrictions for team/schedule navigation property -->
             <!-- Add the parent "Annotations" tag if it doesn't exists -->
+            <!-- Add UpdateRestrictions for team/schedule navigation property -->
+            <!-- Add UpdateRestrictions for entitlementManagement/accessPackageAssignmentPolicies navigation property -->
+            <!-- Add UpdateRestrictions for entitlementManagement/assignmentPolicies navigation property -->
             <xsl:choose>
                 <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.team/schedule'])">
                     <xsl:element name="Annotations">
                         <xsl:attribute name="Target">microsoft.graph.team/schedule</xsl:attribute>
+                        <xsl:call-template name="UpdateRestrictionsTemplate">
+                            <xsl:with-param name="httpMethod">PUT</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.entitlementManagement/accessPackageAssignmentPolicies'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.entitlementManagement/accessPackageAssignmentPolicies</xsl:attribute>
+                        <xsl:call-template name="UpdateRestrictionsTemplate">
+                            <xsl:with-param name="httpMethod">PUT</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.entitlementManagement/assignmentPolicies'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.entitlementManagement/assignmentPolicies</xsl:attribute>
                         <xsl:call-template name="UpdateRestrictionsTemplate">
                             <xsl:with-param name="httpMethod">PUT</xsl:with-param>
                         </xsl:call-template>

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -634,6 +634,18 @@
             </xsl:element>
         </xsl:element>
     </xsl:template>
+    <xsl:template name="UpdateRestrictionsTemplate">
+        <xsl:param name = "httpMethod" />
+        <xsl:element name="Annotation">
+            <xsl:attribute name="Term">Org.OData.Capabilities.V1.UpdateRestrictions</xsl:attribute>
+            <xsl:element name="Record" namespace="{namespace-uri()}">
+                <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">UpdateMethod</xsl:attribute>
+                        <xsl:element name="EnumMember">Org.OData.Capabilities.V1.HttpMethod/<xsl:value-of select="$httpMethod"/></xsl:element>
+                </xsl:element>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
     <xsl:template name="NavigationRestrictionsTemplate">
         <xsl:param name = "navigable" />
         <xsl:element name="Annotation">
@@ -792,6 +804,19 @@
                     <xsl:with-param name="referenceable">true</xsl:with-param>
                 </xsl:call-template>
             </xsl:element>
+
+            <!-- Add UpdateRestrictions for team/schedule navigation property -->
+            <!-- Add the parent "Annotations" tag if it doesn't exists -->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.team/schedule'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.team/schedule</xsl:attribute>
+                        <xsl:call-template name="UpdateRestrictionsTemplate">
+                            <xsl:with-param name="httpMethod">PUT</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
         </xsl:copy>
     </xsl:template>
 

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -163,6 +163,13 @@
             <EntityType Name="teamTemplate" BaseType="graph.entity">
                 <NavigationProperty Name="definitions" Type="Collection(graph.teamTemplateDefinition)" />
             </EntityType>
+            <EntityType Name="team" BaseType="graph.entity" OpenType="true">
+                <NavigationProperty Name="schedule" Type="graph.schedule" ContainsTarget="true" />
+            </EntityType>
+            <EntityType Name="schedule" BaseType="graph.entity">
+                <Property Name="openShiftsEnabled" Type="Edm.Boolean" />
+                <Property Name="timeZone" Type="Edm.String" />
+            </EntityType>
             <ComplexType Name="timeSlot">
                 <Property Name="end" Type="graph.dateTimeTimeZone" Nullable="false" />
                 <Property Name="start" Type="graph.dateTimeTimeZone" Nullable="false" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -565,6 +565,24 @@
           </Record>
         </Annotation>
       </Annotations>
+      <Annotations Target="microsoft.graph.entitlementManagement/accessPackageAssignmentPolicies">
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="UpdateMethod">
+              <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.entitlementManagement/assignmentPolicies">
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="UpdateMethod">
+              <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
     </Schema>
     <Schema Namespace="microsoft.graph.callRecords" xmlns="http://docs.oasis-open.org/odata/ns/edm">
       <EnumType Name="callType">

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -270,6 +270,13 @@
       <EntityType Name="teamTemplate" BaseType="graph.entity">
         <NavigationProperty Name="definitions" Type="Collection(graph.teamTemplateDefinition)" ContainsTarget="true" />
       </EntityType>
+      <EntityType Name="team" BaseType="graph.entity" OpenType="true">
+        <NavigationProperty Name="schedule" Type="graph.schedule" ContainsTarget="true" />
+      </EntityType>
+      <EntityType Name="schedule" BaseType="graph.entity">
+        <Property Name="openShiftsEnabled" Type="Edm.Boolean" />
+        <Property Name="timeZone" Type="Edm.String" />
+      </EntityType>
       <ComplexType Name="timeSlot">
         <Property Name="end" Type="graph.dateTimeTimeZone" Nullable="false" />
         <Property Name="start" Type="graph.dateTimeTimeZone" Nullable="false" />
@@ -546,6 +553,15 @@
         <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
           <Record>
             <PropertyValue Property="Referenceable" Bool="true" />
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.team/schedule">
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="UpdateMethod">
+              <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+            </PropertyValue>
           </Record>
         </Annotation>
       </Annotations>


### PR DESCRIPTION
This PR closes #180 and closes https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/870 by adding `UpdateRestrictions` for:
- `team/schedule`. [API doc](https://learn.microsoft.com/en-us/graph/api/team-put-schedule?view=graph-rest-1.0&tabs=http)
- `entitlementManagement/accessPackageAssignmentPolicies`. [API doc](https://learn.microsoft.com/en-us/graph/api/accesspackageassignmentpolicy-update?view=graph-rest-beta&tabs=http)
- `entitlementManagement/assignmentPolicies`. [API doc](https://learn.microsoft.com/en-us/graph/api/accesspackageassignmentpolicy-update?view=graph-rest-1.0&tabs=http)

The `UpdateRestrictions` changes the `HttpMethod` of the update operations to `PUT` as supported by the workloads.