### PR TITLE
Make remove directoryObject capability annotations sub namespace agnostic

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -858,7 +858,7 @@
     </xsl:template>
 
     <!-- Remove directoryObject Capability Annotations -->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.directoryObject']/*[starts-with(@Term, 'Org.OData.Capabilities')]"/>
+    <xsl:template match="edm:Schema[starts-with(@Namespace, 'microsoft.graph')]/edm:Annotations[@Target='microsoft.graph.directoryObject']/*[starts-with(@Term, 'Org.OData.Capabilities')]"/>
 
     <!-- Add workbooks entity set if missing -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']">

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -268,5 +268,25 @@
                 <NavigationProperty Name="templateStep" Type="microsoft.graph.managedTenants.managementTemplateStep" />
             </EntityType>
         </Schema>
+        <Schema Namespace="microsoft.graph.identityGovernance" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+            <EntityType Name="task" BaseType="graph.entity">
+                <Property Name="description" Type="Edm.String" />
+                <Property Name="displayName" Type="Edm.String" Nullable="false" />
+            </EntityType>
+            <Annotations Target="microsoft.graph.directoryObject">
+                <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+                    <Record>
+                        <PropertyValue Property="Filterable" Bool="true" />
+                    </Record>
+                </Annotation>
+                <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true" />
+                <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+                    <Record>
+                        <PropertyValue Property="Filterable" Bool="false" />
+                    </Record>
+                </Annotation>
+                <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false" />
+            </Annotations>
+        </Schema>
     </edmx:DataServices>
 </edmx:Edmx>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -601,5 +601,12 @@
         <NavigationProperty Name="templateStep" Type="microsoft.graph.managedTenants.managementTemplateStep" />
       </EntityType>
     </Schema>
+    <Schema Namespace="microsoft.graph.identityGovernance" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="task" BaseType="graph.entity">
+        <Property Name="description" Type="Edm.String" />
+        <Property Name="displayName" Type="Edm.String" Nullable="false" />
+      </EntityType>
+      <Annotations Target="microsoft.graph.directoryObject" />
+    </Schema>
   </edmx:DataServices>
 </edmx:Edmx>


### PR DESCRIPTION
This PR closes #208 by making `remove directoryObject capability annotations` sub namespace agnostic.

This is needed because annotations targeting `microsoft.graph.directoryObject` were moved to `microsoft.graph.identityGovernance` sub namespace in `beta`. This move led to the bug described in #208.

In `v1.0`, the annotations targeting `microsoft.graph.directoryObject` are still under the root namespace (`microsoft.graph`).