### PR TITLE
Replaces `graph.report` return type with `Edm.Stream` return type for matching Functions

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -432,6 +432,10 @@
     <!-- <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='createUploadSession']/edm:Parameter[@Name='deferCommit']"/> -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='createUploadSession']/edm:Parameter[@Name='deferCommit']"/>
 
+    <!-- Replace graph.report return type with Edm.Stream return type -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[edm:ReturnType[@Type='graph.report']]/edm:ReturnType/@Type">
+       <xsl:attribute name="Type">Edm.Stream</xsl:attribute>
+    </xsl:template>
 
     <!-- Add custom query options to calendarView navigation property -->
     <xsl:template name="CalendarViewRestrictedPopertyTemplate">

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -237,7 +237,23 @@
                 <Parameter Name="accessPackageId" Type="Edm.String" Unicode="false" />
                 <Parameter Name="incompatibleAccessPackageId" Type="Edm.String" Unicode="false" />
                 <ReturnType Type="Collection(graph.accessPackageAssignment)" />
-            </Function>            
+            </Function>
+            <Function Name="deviceConfigurationDeviceActivity" IsBound="true" IsComposable="true">
+                <Parameter Name="bindingParameter" Type="graph.reportRoot" />
+                <ReturnType Type="graph.report" />
+            </Function>
+            <Function Name="deviceConfigurationUserActivity" IsBound="true" IsComposable="true">
+                <Parameter Name="bindingParameter" Type="graph.reportRoot" />
+                <ReturnType Type="graph.report" />
+            </Function>
+            <Function Name="getOffice365ActivationsUserCounts" IsBound="true" IsComposable="true">
+                <Parameter Name="bindingParameter" Type="graph.reportRoot" />
+                <ReturnType Type="graph.report" Nullable="false" />
+            </Function>
+            <Function Name="getOffice365ActivationsUserDetail" IsBound="true" IsComposable="true">
+                <Parameter Name="bindingParameter" Type="graph.reportRoot" />
+                <ReturnType Type="graph.report" Nullable="false" />
+            </Function>
         </Schema>
         <Schema Namespace="microsoft.graph.callRecords" xmlns="http://docs.oasis-open.org/odata/ns/edm">
             <EnumType Name="callType">

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -519,6 +519,22 @@
         <Parameter Name="incompatibleAccessPackageId" Type="Edm.String" Unicode="false" />
         <ReturnType Type="Collection(graph.accessPackageAssignment)" />
       </Function>
+      <Function Name="deviceConfigurationDeviceActivity" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot" />
+        <ReturnType Type="Edm.Stream" />
+      </Function>
+      <Function Name="deviceConfigurationUserActivity" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot" />
+        <ReturnType Type="Edm.Stream" />
+      </Function>
+      <Function Name="getOffice365ActivationsUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot" />
+        <ReturnType Type="Edm.Stream" Nullable="false" />
+      </Function>
+      <Function Name="getOffice365ActivationsUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot" />
+        <ReturnType Type="Edm.Stream" Nullable="false" />
+      </Function>
       <Annotations Target="microsoft.graph.driveItem/workbook">
         <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
           <Record>


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/140

- Replaces `graph.report` return type with `Edm.Stream` return type for functions with a return type of `graph.report`.