### PR TITLE
Replaces `graph.report` return type with `Edm.Stream` return type only for report functions that start with `get`

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -432,8 +432,8 @@
     <!-- <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='createUploadSession']/edm:Parameter[@Name='deferCommit']"/> -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='createUploadSession']/edm:Parameter[@Name='deferCommit']"/>
 
-    <!-- Replace graph.report return type with Edm.Stream return type -->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[edm:ReturnType[@Type='graph.report']]/edm:ReturnType/@Type">
+    <!-- Replace graph.report return type with Edm.Stream return type for report functions that start with 'get' -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[starts-with(@Name, 'get')][edm:ReturnType[@Type='graph.report']]/edm:ReturnType/@Type">
        <xsl:attribute name="Type">Edm.Stream</xsl:attribute>
     </xsl:template>
 

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -521,11 +521,11 @@
       </Function>
       <Function Name="deviceConfigurationDeviceActivity" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot" />
-        <ReturnType Type="Edm.Stream" />
+        <ReturnType Type="graph.report" />
       </Function>
       <Function Name="deviceConfigurationUserActivity" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot" />
-        <ReturnType Type="Edm.Stream" />
+        <ReturnType Type="graph.report" />
       </Function>
       <Function Name="getOffice365ActivationsUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot" />


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/216

This PR: 
- Replaces `graph.report` return type with `Edm.Stream` return type only for report functions that start with `get`.