### PR TITLE
Add restrictions annotations for `applicationTemplates` entity set

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -881,9 +881,26 @@
                        </xsl:call-template>
                     </xsl:element>
                 </xsl:when>
-            </xsl:choose>       
+            </xsl:choose>
+
+            <!-- Remove Insertability, Updatability and Deletability for applicationTemplates entity set -->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.GraphService/applicationTemplates'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.GraphService/applicationTemplates</xsl:attribute>
+                        <xsl:call-template name="InsertRestrictionsTemplate">
+                            <xsl:with-param name="insertable">false</xsl:with-param>
+                        </xsl:call-template><xsl:call-template name="UpdateRestrictionsTemplate">
+                            <xsl:with-param name="updatable">false</xsl:with-param>
+                        </xsl:call-template>
+                        <xsl:call-template name="DeleteRestrictionsTemplate">
+                            <xsl:with-param name="deletable">false</xsl:with-param>
+                        </xsl:call-template>                        
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
             
-           <!-- Add FilterRestrictions to directorySetting entity type -->
+            <!-- Add FilterRestrictions to directorySetting entity type -->
             <xsl:choose>
                 <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.directorySetting'])">
                     <xsl:element name="Annotations">
@@ -926,6 +943,23 @@
           </xsl:call-template>
        </xsl:copy>
     </xsl:template>
+
+    <!-- If the parent "Annotations" tag already exists modify it -->
+    <!-- Remove Insertability, Updatability and Deletability for applicationTemplates entity set -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.GraphService/applicationTemplates']">
+      <xsl:copy>
+        <xsl:copy-of select="@*|node()"/>
+          <xsl:call-template name="InsertRestrictionsTemplate">
+            <xsl:with-param name="insertable">false</xsl:with-param>
+          </xsl:call-template>
+          <xsl:call-template name="UpdateRestrictionsTemplate">
+            <xsl:with-param name="updatable">false</xsl:with-param>
+          </xsl:call-template>
+          <xsl:call-template name="DeleteRestrictionsTemplate">
+            <xsl:with-param name="deletable">false</xsl:with-param>
+          </xsl:call-template>
+      </xsl:copy>
+    </xsl:template>    
     
     <!-- Add FilterRestrictions to directorySetting entity type -->
      <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.directorySetting']">

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -611,6 +611,23 @@
           </Record>
         </Annotation>
       </Annotations>
+      <Annotations Target="microsoft.graph.GraphService/applicationTemplates">
+        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false" />
+          </Record>
+        </Annotation>
+      </Annotations>
       <Annotations Target="microsoft.graph.directorySetting">
         <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
           <Record>


### PR DESCRIPTION
This PR:
- Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/236
- Removes insertability, updatability and deletability for the `applicationTemplates` entity set.