### PR TITLE
- removes ghost workbooks root path

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -941,20 +941,6 @@
     <!-- Remove directoryObject Capability Annotations -->
     <xsl:template match="edm:Schema[starts-with(@Namespace, 'microsoft.graph')]/edm:Annotations[@Target='microsoft.graph.directoryObject']/*[starts-with(@Term, 'Org.OData.Capabilities')]"/>
 
-    <!-- Add workbooks entity set if missing -->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']">
-        <xsl:copy>
-            <xsl:apply-templates select="@*"/>
-            <xsl:if test="not(edm:EntitySet[@Name='workbooks'])">
-                <xsl:element name="EntitySet">
-                    <xsl:attribute name="Name">workbooks</xsl:attribute>
-                    <xsl:attribute name="EntityType">microsoft.graph.driveItem</xsl:attribute>
-                </xsl:element>
-            </xsl:if>
-            <xsl:apply-templates select="node()"/>
-        </xsl:copy>
-    </xsl:template>
-
     <!-- Add Referenceable Annotations (for /$ref paths) -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='connectorGroup']/edm:NavigationProperty[@Name='members']|
                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='educationClass']/edm:NavigationProperty[@Name='members']|

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -286,7 +286,6 @@
         <Property Name="timeZone" Type="Edm.String" />
       </ComplexType>
       <EntityContainer Name="GraphService">
-        <EntitySet Name="workbooks" EntityType="microsoft.graph.driveItem" />
         <EntitySet Name="bookingBusinesses" EntityType="microsoft.graph.bookingBusiness">
           <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
             <Record>


### PR DESCRIPTION
related #86 #84. Adding the workbooks root node was already contreversial at the time. It's leading people to confusion and causing issues with over expansion on all OpenAPI based generation. @peombwa I understand this might be problematic for PS somehow, would you mind providing more context here? I'd support shipping a breaking change fix to remove something that never worked rather than maintaining the illusion it does work.