### PR TITLE
Adds UpdateRestrictions annotation for the `synchronization/secrets` complex property

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -653,7 +653,7 @@
               </xsl:choose>
               <xsl:choose>
                  <xsl:when test="$updatable">
-                    <xsl:call-template name="updatableTemplate">
+                    <xsl:call-template name="UpdatableTemplate">
                       <xsl:with-param name="updatable"><xsl:value-of select="$updatable"/></xsl:with-param>
                     </xsl:call-template>                                                        
                 </xsl:when>
@@ -668,7 +668,7 @@
               <xsl:element name="EnumMember">Org.OData.Capabilities.V1.HttpMethod/<xsl:value-of select="$httpMethod"/></xsl:element>
         </xsl:element>
     </xsl:template>
-    <xsl:template name ="updatableTemplate">
+    <xsl:template name ="UpdatableTemplate">
        <xsl:param name = "updatable" />
        <xsl:element name="PropertyValue">
          <xsl:attribute name="Property">Updatable</xsl:attribute>
@@ -967,41 +967,39 @@
     <!-- If only the grand-parent "Annotations" tag exists, modify it -->
     <!-- Add UpdateRestrictions for synchronization/secrets complex property -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.synchronization/secrets']">     
-      <xsl:choose>
-        <xsl:when test="not(edm:Annotation[@Term='Org.OData.Capabilities.V1.UpdateRestrictions'])">
-          <xsl:copy>
-            <xsl:copy-of select="@*|node()"/>
-              <xsl:call-template name="UpdateRestrictionsTemplate">
-                <xsl:with-param name="httpMethod">PUT</xsl:with-param>
-                <xsl:with-param name="updatable">true</xsl:with-param>
-              </xsl:call-template>
-          </xsl:copy>
-        </xsl:when>
-      <xsl:otherwise>
-        <xsl:copy>
-          <xsl:apply-templates select="@* | node()"/>
-        </xsl:copy>    
-      </xsl:otherwise>
-     </xsl:choose> 
+        <xsl:choose>
+            <xsl:when test="not(edm:Annotation[@Term='Org.OData.Capabilities.V1.UpdateRestrictions'])">
+                <xsl:copy>
+                    <xsl:copy-of select="@*|node()"/>
+                    <xsl:call-template name="UpdateRestrictionsTemplate">
+                        <xsl:with-param name="httpMethod">PUT</xsl:with-param>
+                        <xsl:with-param name="updatable">true</xsl:with-param>
+                    </xsl:call-template>
+                </xsl:copy>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy>
+                    <xsl:apply-templates select="@* | node()"/>
+                </xsl:copy>    
+            </xsl:otherwise>
+        </xsl:choose> 
     </xsl:template>
     
     <!-- If the parent "Annotation" tag already exists, modify it --> 
     <!-- Update UpdateRestrictions for synchronization/secrets complex property -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.synchronization/secrets']/edm:Annotation[@Term='Org.OData.Capabilities.V1.UpdateRestrictions']">
-      <xsl:copy>
-       <xsl:copy-of select="@*"/>   
-        <xsl:element name="Record" namespace="{namespace-uri()}">
-          <xsl:copy-of select="edm:Record/edm:PropertyValue"/>
-            <xsl:element name="PropertyValue">
-              <xsl:attribute name="Property">UpdateMethod</xsl:attribute>
-                <xsl:element name="EnumMember">Org.OData.Capabilities.V1.HttpMethod/PUT</xsl:element>
+        <xsl:copy>
+        <xsl:copy-of select="@*"/>
+            <xsl:element name="Record" namespace="{namespace-uri()}">
+            <xsl:copy-of select="edm:Record/edm:PropertyValue"/>
+                <xsl:call-template name="UpdateMethodTemplate">
+                    <xsl:with-param name="httpMethod">PUT</xsl:with-param>            
+                </xsl:call-template>
+                <xsl:call-template name="UpdatableTemplate">
+                    <xsl:with-param name="updatable">true</xsl:with-param>            
+                </xsl:call-template>       
             </xsl:element>
-            <xsl:element name="PropertyValue">
-              <xsl:attribute name="Property">Updatable</xsl:attribute>
-              <xsl:attribute name="Bool">true</xsl:attribute>
-            </xsl:element>
-        </xsl:element>
-      </xsl:copy>
+        </xsl:copy>
     </xsl:template>
     
     <!-- Remove directoryObject Capability Annotations -->

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -964,10 +964,32 @@
        </xsl:copy>
     </xsl:template>
 
-    <!-- If the parent "Annotation" tag already exists, modify it -->
+    <!-- If only the grand-parent "Annotations" tag exists, modify it -->
     <!-- Add UpdateRestrictions for synchronization/secrets complex property -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.synchronization/secrets']">     
+      <xsl:choose>
+        <xsl:when test="not(edm:Annotation[@Term='Org.OData.Capabilities.V1.UpdateRestrictions'])">
+          <xsl:copy>
+            <xsl:copy-of select="@*|node()"/>
+              <xsl:call-template name="UpdateRestrictionsTemplate">
+                <xsl:with-param name="httpMethod">PUT</xsl:with-param>
+                <xsl:with-param name="updatable">true</xsl:with-param>
+              </xsl:call-template>
+          </xsl:copy>
+        </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>    
+      </xsl:otherwise>
+     </xsl:choose> 
+    </xsl:template>
+    
+    <!-- If the parent "Annotation" tag already exists, modify it --> 
+    <!-- Update UpdateRestrictions for synchronization/secrets complex property -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.synchronization/secrets']/edm:Annotation[@Term='Org.OData.Capabilities.V1.UpdateRestrictions']">
       <xsl:copy>
+       <xsl:copy-of select="@*"/>   
         <xsl:element name="Record" namespace="{namespace-uri()}">
           <xsl:copy-of select="edm:Record/edm:PropertyValue"/>
             <xsl:element name="PropertyValue">
@@ -978,21 +1000,6 @@
               <xsl:attribute name="Property">Updatable</xsl:attribute>
               <xsl:attribute name="Bool">true</xsl:attribute>
             </xsl:element>
-        </xsl:element>
-      </xsl:copy>
-    </xsl:template>
-    
-    <!-- If the grand-parent "Annotation" tag already exists, modify it -->
-    <!-- Add UpdateRestrictions for synchronization/secrets complex property -->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.synchronization/secrets']">
-      <xsl:copy>
-        <xsl:copy-of select="@*|node()"/>            
-        <xsl:element name="Annotations">
-          <xsl:attribute name="Target">microsoft.graph.synchronization/secrets</xsl:attribute>
-          <xsl:call-template name="UpdateRestrictionsTemplate">
-            <xsl:with-param name="httpMethod">PUT</xsl:with-param>
-            <xsl:with-param name="updatable">true</xsl:with-param>
-           </xsl:call-template>
         </xsl:element>
       </xsl:copy>
     </xsl:template>

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -88,6 +88,14 @@
                 <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false" />
                 <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
             </Annotations>
+            <Annotations Target="microsoft.graph.synchronization/secrets">
+                <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Property="Description" String="synchronization: secrets" />
+                        <PropertyValue Property="LongDescription" String="Provide credentials for establishing connectivity with the target system." />
+                    </Record>
+                </Annotation>
+            </Annotations>
             <ComplexType Name="thumbnail">
                 <Property Name="content" Type="Edm.Stream" />
                 <Property Name="height" Type="Edm.Int32" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -189,6 +189,18 @@
       <Annotations Target="graph.activityHistoryItem">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
       </Annotations>
+      <Annotations Target="microsoft.graph.synchronization/secrets">
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Description" String="synchronization: secrets" />
+            <PropertyValue Property="LongDescription" String="Provide credentials for establishing connectivity with the target system." />
+            <PropertyValue Property="UpdateMethod">
+              <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+            </PropertyValue>
+            <PropertyValue Property="Updatable" Bool="true" />
+          </Record>
+        </Annotation>
+      </Annotations>
       <ComplexType Name="thumbnail">
         <Property Name="content" Type="Edm.Stream" />
         <Property Name="height" Type="Edm.Int32" />


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/127

This PR:
- Adds/update `PUT` UpdateRestrictions for `synchronization/secrets` complex property depending on whether the `Annotations` target _microsoft.graph.synchronization/secret_ is present or not,  or whether the `Annotation` term _Org.OData.Capabilities.V1.UpdateRestrictions_ is also present or not.
- Refactors the `UpdateRestrictionsTemplate` by splitting out two other templates that can be reused within and outside the former: `UpdatableTemplate` & `UpdateMethodTemplate`
- Updates the test files appropriately.