### PR TITLE
Adds required `If-Match` header to planner.

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -506,7 +506,7 @@
         </xsl:element>
     </xsl:template>
 
-    <!-- Add custom headers (ConsistencyLevel) to AAD objects -->
+    <!-- Header templates -->
     <xsl:template name="ConsistencyLevelHeaderTemplate">
         <xsl:element name="Record" namespace="{namespace-uri()}">
             <xsl:element name="PropertyValue">
@@ -543,6 +543,30 @@
                                     </xsl:element>
                                 </xsl:element>
                             </xsl:element>
+                        </xsl:element>
+                    </xsl:element>
+                </xsl:element>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template name="IfMatchHeaderTemplate">
+        <xsl:element name="Record" namespace="{namespace-uri()}">
+            <xsl:element name="PropertyValue">
+                <xsl:attribute name="Property">CustomHeaders</xsl:attribute>
+                <xsl:element name="Collection">
+                    <xsl:element name="Record">
+                        <xsl:element name="PropertyValue">
+                            <xsl:attribute name="Property">Name</xsl:attribute>
+                            <xsl:attribute name="String">If-Match</xsl:attribute>
+                        </xsl:element>
+                        <xsl:element name="PropertyValue">
+                            <xsl:attribute name="Property">Description</xsl:attribute>
+                            <xsl:attribute name="String">ETag value.</xsl:attribute>
+                        </xsl:element>
+                        <xsl:element name="PropertyValue">
+                            <xsl:attribute name="Property">Required</xsl:attribute>
+                            <xsl:attribute name="Bool">true</xsl:attribute>
                         </xsl:element>
                     </xsl:element>
                 </xsl:element>
@@ -1135,6 +1159,17 @@
             <xsl:element name="Annotation">
                 <xsl:attribute name="Term">Org.OData.Capabilities.V1.ReadRestrictions</xsl:attribute>
                 <xsl:call-template name="ConsistencyLevelHeaderTemplate"/>
+            </xsl:element>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Add IfMatch header for these paths-->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='user']/edm:NavigationProperty[@Name='planner']">
+        <xsl:copy>
+            <xsl:copy-of select="@* | node()" />
+            <xsl:element name="Annotation">
+                <xsl:attribute name="Term">Org.OData.Capabilities.V1.UpdateRestrictions</xsl:attribute>
+                <xsl:call-template name="IfMatchHeaderTemplate"/>
             </xsl:element>
         </xsl:copy>
     </xsl:template>

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -43,6 +43,10 @@
             <EntityType Name="directoryObject" BaseType="graph.entity" OpenType="true">
                 <Property Name="deletedDateTime" Type="Edm.DateTimeOffset" />
             </EntityType>
+            <EntityType Name="user" BaseType="graph.directoryObject" OpenType="true">
+                <Property Name="displayName" Type="Edm.String" />
+                <NavigationProperty Name="planner" Type="graph.plannerUser" ContainsTarget="true" />
+            </EntityType>
             <Annotations Target="microsoft.graph.user/joinedGroups">
                 <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
                     <Record>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='preprocess_csdl.xsl'?>
 <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
   <edmx:DataServices>
@@ -121,6 +121,24 @@
       </EntityType>
       <EntityType Name="directoryObject" BaseType="graph.entity" OpenType="true">
         <Property Name="deletedDateTime" Type="Edm.DateTimeOffset" />
+      </EntityType>
+      <EntityType Name="user" BaseType="graph.directoryObject" OpenType="true">
+        <Property Name="displayName" Type="Edm.String" />
+        <NavigationProperty Name="planner" Type="graph.plannerUser" ContainsTarget="true">
+          <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+            <Record>
+              <PropertyValue Property="CustomHeaders">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="Name" String="If-Match" />
+                    <PropertyValue Property="Description" String="ETag value." />
+                    <PropertyValue Property="Required" Bool="true" />
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </NavigationProperty>
       </EntityType>
       <Annotations Target="microsoft.graph.user/joinedGroups">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">


### PR DESCRIPTION
This PR fixes #89 by applying a required `If-match` header to `planner` nav property on a `user`. The header is required when updating `plannerUser`. Requests will fail if the header is not included - https://docs.microsoft.com/en-us/graph/api/planneruser-update?view=graph-rest-beta&tabs=http.