### PR TITLE
Extend required If-Match header support for Planner APIs

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1164,7 +1164,16 @@
     </xsl:template>
 
     <!-- Add IfMatch header for these paths-->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='user']/edm:NavigationProperty[@Name='planner']">
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='user']/edm:NavigationProperty[@Name='planner'] |
+                    edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='planner'] |
+                    edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='planner']/edm:NavigationPrssoperty[@Name='plans'] |
+                    edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='planner']/edm:NavigationProperty[@Name='tasks'] |
+                    edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='planner']/edm:NavigationProperty[@Name='buckets'] |
+                    edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='plannerPlan']/edm:NavigationProperty[@Name='details'] |
+                    edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='plannerTask']/edm:NavigationProperty[@Name='details'] |
+                    edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='plannerTask']/edm:NavigationProperty[@Name='assignedToTaskBoardFormat'] |
+                    edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='plannerTask']/edm:NavigationProperty[@Name='progressTaskBoardFormat'] |
+                    edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='plannerTask']/edm:NavigationProperty[@Name='bucketTaskBoardFormat']">
         <xsl:copy>
             <xsl:copy-of select="@* | node()" />
             <xsl:element name="Annotation">

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -22,7 +22,21 @@
         <Property Name="title" Type="Edm.String" Nullable="false" />
         <NavigationProperty Name="tasks" Type="Collection(graph.plannerTask)" ContainsTarget="true" />
         <NavigationProperty Name="buckets" Type="Collection(graph.plannerBucket)" ContainsTarget="true" />
-        <NavigationProperty Name="details" Type="graph.plannerPlanDetails" ContainsTarget="true" />
+        <NavigationProperty Name="details" Type="graph.plannerPlanDetails" ContainsTarget="true">
+          <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+            <Record>
+              <PropertyValue Property="CustomHeaders">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="Name" String="If-Match" />
+                    <PropertyValue Property="Description" String="ETag value." />
+                    <PropertyValue Property="Required" Bool="true" />
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </NavigationProperty>
       </EntityType>
       <EntityType Name="plannerBucket" BaseType="graph.entity">
         <Property Name="name" Type="Edm.String" Nullable="false" />


### PR DESCRIPTION
This PR extends #259 by adding required `If-Match` header support when updating:
- group/planner
- planner/tasks
- planner/plans
- planner/buckets
- plannerTask/details
- plannerTask/assignedToTaskBoardFormat
- plannerTask/progressTaskBoardFormat
- plannerTask/bucketTaskBoardFormat
- plannerPlan/details

See https://learn.microsoft.com/en-us/graph/api/resources/planner-overview?view=graph-rest-beta for additional details.