### PR TITLE
Removes invalid property `query_string` from complex property `searchQuery`

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -97,6 +97,7 @@
     <!-- Remove Property -->
 
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:ComplexType[@Name='changeNotification']/edm:Property[@Name='sequenceNumber']"/>
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:ComplexType[@Name='searchQuery']/edm:Property[@Name='query_string']"/>
 
     <!-- Remove NavigationProperty -->
 

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -108,6 +108,11 @@
                     </Record>
                 </Annotation>
             </Annotations>
+            <ComplexType Name="searchQuery">
+                <Property Name="queryString" Type="Edm.String" />
+                <Property Name="queryTemplate" Type="Edm.String" />
+                <Property Name="query_string" Type="graph.searchQueryString" />
+            </ComplexType>
             <ComplexType Name="thumbnail">
                 <Property Name="content" Type="Edm.Stream" />
                 <Property Name="height" Type="Edm.Int32" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -246,6 +246,10 @@
           </Record>
         </Annotation>
       </Annotations>
+      <ComplexType Name="searchQuery">
+        <Property Name="queryString" Type="Edm.String" />
+        <Property Name="queryTemplate" Type="Edm.String" />
+      </ComplexType>
       <ComplexType Name="thumbnail">
         <Property Name="content" Type="Edm.Stream" />
         <Property Name="height" Type="Edm.Int32" />


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/262

This PR:
- Removes the property `query_string` from the ComplexProperty `searchQuery`
- Updates the integration test files.