### PR TITLE
Adds back `NavigationRestrictions` that removes navigability for `driveItem/workbook` navigation property

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -7,7 +7,7 @@
     <xsl:param name="remove-capability-annotations">True</xsl:param>
     <xsl:param name="add-innererror-description">False</xsl:param>
 
-    <!-- Flag to signal if we are generating a document for open api generation. -->
+    <!-- Flag to signal if we are generating a document for Kiota-based open api generation. -->
     <xsl:variable name="open-api-generation">
         <xsl:choose>
             <!-- Open API document generation is done with capability annotations and error descriptions -->
@@ -789,7 +789,7 @@
             
             <!-- Remove navigability for driveItem/workbook navigation property for DevX API-specific CSDL-->
             <xsl:choose>
-                <xsl:when test="$remove-capability-annotations='False'">
+                <xsl:when test="$open-api-generation='False'">
                     <xsl:element name="Annotations">
                         <xsl:attribute name="Target">microsoft.graph.driveItem/workbook</xsl:attribute>
                         <xsl:element name="Annotation">

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -786,6 +786,25 @@
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
         <xsl:copy>
             <xsl:apply-templates select="@* | node()"/>
+            
+            <!-- Remove navigability for driveItem/workbook navigation property for DevX API-specific CSDL-->
+            <xsl:choose>
+                <xsl:when test="$remove-capability-annotations='False'">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.driveItem/workbook</xsl:attribute>
+                        <xsl:element name="Annotation">
+                            <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
+                            <xsl:element name="Record" namespace="{namespace-uri()}">
+                                <xsl:element name="PropertyValue">
+                                    <xsl:attribute name="Property">Navigability</xsl:attribute>
+                                        <xsl:element name="EnumMember">Org.OData.Capabilities.V1.NavigationType/None</xsl:element>
+                                </xsl:element>
+                            </xsl:element>
+                        </xsl:element>
+                      </xsl:element>                
+                </xsl:when>            
+            </xsl:choose>
+            
             <xsl:choose>
                 <!-- Add inner error description -->
                 <xsl:when test="$add-innererror-description='True'">

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -595,6 +595,15 @@
         <Parameter Name="bindingParameter" Type="graph.reportRoot" />
         <ReturnType Type="Edm.Stream" Nullable="false" />
       </Function>
+      <Annotations Target="microsoft.graph.driveItem/workbook">
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="Navigability">
+              <EnumMember>Org.OData.Capabilities.V1.NavigationType/None</EnumMember>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
       <Annotations Target="microsoft.graph.security/alerts">
         <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
           <Record>


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/270

This PR:
- Removes the navigability for `driveItem/workbook` navigation property for the target CSDL file - `cleanMetadataWithDescriptionsAndAnnotations` (v1.0 and beta)