### PR TITLE
Removes delta function for the derived type `administrativeUnit`

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -435,7 +435,7 @@
     <!--Remove functions that are blocking beta generation-->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='delta'][edm:Parameter[@Name='token']][edm:Parameter[@Type='Collection(graph.site)']]"/>
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='additionalAccess'][edm:Parameter[@Name='accessPackageId']][edm:Parameter[@Type='Collection(graph.accessPackageAssignment)']][1]"/>
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='delta'][edm:Parameter[@Name='bindingParameter']][edm:Parameter[@Type='Collection(graph.directoryObject)']]"/>
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='delta'][edm:Parameter[@Name='bindingParameter']][edm:Parameter[@Type='Collection(graph.administrativeUnit)']]"/>
 
     <!-- Reorder action parameters -->
 

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -435,6 +435,7 @@
     <!--Remove functions that are blocking beta generation-->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='delta'][edm:Parameter[@Name='token']][edm:Parameter[@Type='Collection(graph.site)']]"/>
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='additionalAccess'][edm:Parameter[@Name='accessPackageId']][edm:Parameter[@Type='Collection(graph.accessPackageAssignment)']][1]"/>
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='delta'][edm:Parameter[@Name='bindingParameter']][edm:Parameter[@Type='Collection(graph.directoryObject)']]"/>
 
     <!-- Reorder action parameters -->
 

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -279,6 +279,10 @@
                 <Parameter Name="bindingParameter" Type="graph.reportRoot" />
                 <ReturnType Type="graph.report" Nullable="false" />
             </Function>
+            <Function Name="delta" IsBound="true">
+                <Parameter Name="bindingParameter" Type="Collection(graph.directoryObject)" />
+                <ReturnType Type="Collection(graph.directoryObject)" />
+            </Function>
         </Schema>
         <Schema Namespace="microsoft.graph.callRecords" xmlns="http://docs.oasis-open.org/odata/ns/edm">
             <EnumType Name="callType">

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -280,8 +280,8 @@
                 <ReturnType Type="graph.report" Nullable="false" />
             </Function>
             <Function Name="delta" IsBound="true">
-                <Parameter Name="bindingParameter" Type="Collection(graph.directoryObject)" />
-                <ReturnType Type="Collection(graph.directoryObject)" />
+                <Parameter Name="bindingParameter" Type="Collection(graph.administrativeUnit)" />
+                <ReturnType Type="Collection(graph.administrativeUnit)" />
             </Function>
         </Schema>
         <Schema Namespace="microsoft.graph.callRecords" xmlns="http://docs.oasis-open.org/odata/ns/edm">


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/276

This PR:
- Removes the `delta` function of type `Collection(graph.administrativeUnit)`.
- Adds a test to validate this.