### PR TITLE
Adds `csdlVersion` param

### DIFF
--- a/scripts/run-metadata-validation.ps1
+++ b/scripts/run-metadata-validation.ps1
@@ -36,7 +36,7 @@ $snapshot = Join-Path $repoDirectory "$($version)_metadata.xml"
 $transformed = Join-Path $repoDirectory "transformed_$($version)_metadata.xml"
 
 Write-Host "Tranforming $snapshot metadata using xslt with parameters used in the OpenAPI flow..." -ForegroundColor Green
-& $transformScript -xslPath $xsltPath -inputPath $snapshot -outputPath $transformed -addInnerErrorDescription $true -removeCapabilityAnnotations $false
+& $transformScript -xslPath $xsltPath -inputPath $snapshot -outputPath $transformed -addInnerErrorDescription $true -removeCapabilityAnnotations $false -csdlVersion $version
 
 Write-Host "Validating $transformed metadata after the transform..." -ForegroundColor Green
 & dotnet tool install Microsoft.OpenApi.Hidi -g --prerelease

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -6,6 +6,7 @@
     <xsl:strip-space elements="*"/> <!-- Remove empty space after deletions. -->
     <xsl:param name="remove-capability-annotations">True</xsl:param>
     <xsl:param name="add-innererror-description">False</xsl:param>
+    <xsl:param name="csdlVersion">v1_0</xsl:param>
 
     <!-- Flag to signal if we are generating a document for Kiota-based open api generation. -->
     <xsl:variable name="open-api-generation">

--- a/transforms/csdl/transform.ps1
+++ b/transforms/csdl/transform.ps1
@@ -13,7 +13,7 @@ param (
     [bool]
     $removeCapabilityAnnotations = $true,
     [bool]
-    $addInnerErrorDescription = $false
+    $addInnerErrorDescription = $false,
     [string]
     $csdlVersion = $v1_0
 )

--- a/transforms/csdl/transform.ps1
+++ b/transforms/csdl/transform.ps1
@@ -14,6 +14,8 @@ param (
     $removeCapabilityAnnotations = $true,
     [bool]
     $addInnerErrorDescription = $false
+    [string]
+    $csdlVersion = $v1_0
 )
 function Get-PathWithPrefix([string]$requestedPath) {
     if ([System.IO.Path]::IsPathRooted($requestedPath)) {
@@ -40,6 +42,7 @@ $outputFullPath = Get-PathWithPrefix -requestedPath $outputPath
 $xsltargs = [System.Xml.Xsl.XsltArgumentList]::new()
 $xsltargs.AddParam("remove-capability-annotations", "", $removeCapabilityAnnotations.ToString())
 $xsltargs.AddParam("add-innererror-description", "", $addInnerErrorDescription.ToString())
+$xsltargs.AddParam("csdlVersion", "", csdlVersion)
 
 $xmlWriterSettings = [System.Xml.XmlWriterSettings]::new()
 $xmlWriterSettings.Indent = $true

--- a/transforms/csdl/transform.ps1
+++ b/transforms/csdl/transform.ps1
@@ -42,7 +42,7 @@ $outputFullPath = Get-PathWithPrefix -requestedPath $outputPath
 $xsltargs = [System.Xml.Xsl.XsltArgumentList]::new()
 $xsltargs.AddParam("remove-capability-annotations", "", $removeCapabilityAnnotations.ToString())
 $xsltargs.AddParam("add-innererror-description", "", $addInnerErrorDescription.ToString())
-$xsltargs.AddParam("csdlVersion", "", csdlVersion)
+$xsltargs.AddParam("csdlVersion", "", $csdlVersion)
 
 $xmlWriterSettings = [System.Xml.XmlWriterSettings]::new()
 $xmlWriterSettings.Indent = $true


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/282

This PR:
- Adds a new param: `csdlVersion` to be used in performing version-specific transforms. Default is set to v1.0: `v1_0` 