### PR TITLE
Adds annotation to remove `$skip` support for the `users` entity set

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1133,7 +1133,7 @@
     <!-- Update UpdateRestrictions for synchronization/secrets complex property -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.synchronization/secrets']/edm:Annotation[@Term='Org.OData.Capabilities.V1.UpdateRestrictions']">
         <xsl:copy>
-        <xsl:copy-of select="@*"/>        
+        <xsl:copy-of select="@*"/>
             <xsl:element name="Record" namespace="{namespace-uri()}">
             <xsl:copy-of select="edm:Record/edm:PropertyValue"/>
                 <xsl:call-template name="UpdateMethodTemplate">

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -671,6 +671,13 @@
     </xsl:template>
 
     <!-- Capability Annotations Templates -->
+    <xsl:template name="SkipSupportTemplate">
+        <xsl:param name="skipSupported" />
+        <xsl:element name="Annotation">
+            <xsl:attribute name="Term">Org.OData.Capabilities.V1.SkipSupported</xsl:attribute>
+            <xsl:attribute name="Bool"><xsl:value-of select="$skipSupported"/></xsl:attribute>
+        </xsl:element>           
+    </xsl:template>
     <xsl:template name="DeleteRestrictionsTemplate">
         <xsl:param name = "deletable" />
         <xsl:element name="Annotation">
@@ -904,6 +911,7 @@
             <!-- Add UpdateRestrictions for synchronization/secrets complex property -->
             <!-- Add Insertability for driveItem/children navigation property -->
             <!-- Remove Insertability, Updatability and Deletability for applicationTemplates entity set -->
+            <!-- Remove skip support for users entity set -->            
             <xsl:choose>
                 <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.team/schedule'])">
                     <xsl:element name="Annotations">
@@ -980,6 +988,16 @@
                         <xsl:call-template name="DeleteRestrictionsTemplate">
                             <xsl:with-param name="deletable">false</xsl:with-param>
                         </xsl:call-template>                        
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.GraphService/users'])">
+                    <xsl:element name="Annotations">
+                       <xsl:attribute name="Target">microsoft.graph.GraphService/users</xsl:attribute>                       
+                       <xsl:call-template name="SkipSupportTemplate">
+                           <xsl:with-param name="skipSupported">false</xsl:with-param>
+                       </xsl:call-template>
                     </xsl:element>
                 </xsl:when>
             </xsl:choose>
@@ -1092,7 +1110,7 @@
 
     <!-- If only the grand-parent "Annotations" tag exists, modify it -->
     <!-- Add UpdateRestrictions for synchronization/secrets complex property -->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.synchronization/secrets']">     
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.synchronization/secrets']">
         <xsl:choose>
             <xsl:when test="not(edm:Annotation[@Term='Org.OData.Capabilities.V1.UpdateRestrictions'])">
                 <xsl:copy>
@@ -1108,14 +1126,14 @@
                     <xsl:apply-templates select="@* | node()"/>
                 </xsl:copy>    
             </xsl:otherwise>
-        </xsl:choose> 
+        </xsl:choose>        
     </xsl:template>
     
     <!-- If the parent "Annotation" tag already exists, modify it --> 
     <!-- Update UpdateRestrictions for synchronization/secrets complex property -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.synchronization/secrets']/edm:Annotation[@Term='Org.OData.Capabilities.V1.UpdateRestrictions']">
         <xsl:copy>
-        <xsl:copy-of select="@*"/>
+        <xsl:copy-of select="@* | node()"/>        
             <xsl:element name="Record" namespace="{namespace-uri()}">
             <xsl:copy-of select="edm:Record/edm:PropertyValue"/>
                 <xsl:call-template name="UpdateMethodTemplate">
@@ -1127,6 +1145,28 @@
             </xsl:element>
         </xsl:copy>
     </xsl:template>
+    
+     <!-- If only the grand-parent "Annotations" tag exists, modify it -->
+     <!-- Remove skip support for users entity set -->    
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.GraphService/users']">     
+        <xsl:choose>
+            <xsl:when test="not(edm:Annotation[@Term='Org.OData.Capabilities.V1.SkipSupported'])">
+                <xsl:copy>
+                    <xsl:copy-of select="@*|node()"/>
+                    <xsl:call-template name="SkipSupportTemplate">
+                        <xsl:with-param name="skipSupported">false</xsl:with-param>
+                    </xsl:call-template>
+                </xsl:copy>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy>
+                    <!--<xsl:apply-templates select="@* | node()"/>-->
+                    <xsl:copy-of select="@*|node()"/>
+                </xsl:copy>    
+            </xsl:otherwise>
+        </xsl:choose> 
+    </xsl:template>
+    
     
     <!-- Remove directoryObject Capability Annotations -->
     <xsl:template match="edm:Schema[starts-with(@Namespace, 'microsoft.graph')]/edm:Annotations[@Target='microsoft.graph.directoryObject']/*[starts-with(@Term, 'Org.OData.Capabilities')]"/>

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -911,7 +911,7 @@
             <!-- Add UpdateRestrictions for synchronization/secrets complex property -->
             <!-- Add Insertability for driveItem/children navigation property -->
             <!-- Remove Insertability, Updatability and Deletability for applicationTemplates entity set -->
-            <!-- Remove skip support for users entity set -->            
+            <!-- Remove $skip support for users entity set -->            
             <xsl:choose>
                 <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.team/schedule'])">
                     <xsl:element name="Annotations">
@@ -1126,14 +1126,14 @@
                     <xsl:apply-templates select="@* | node()"/>
                 </xsl:copy>    
             </xsl:otherwise>
-        </xsl:choose>        
+        </xsl:choose>
     </xsl:template>
     
     <!-- If the parent "Annotation" tag already exists, modify it --> 
     <!-- Update UpdateRestrictions for synchronization/secrets complex property -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.synchronization/secrets']/edm:Annotation[@Term='Org.OData.Capabilities.V1.UpdateRestrictions']">
         <xsl:copy>
-        <xsl:copy-of select="@* | node()"/>        
+        <xsl:copy-of select="@*"/>        
             <xsl:element name="Record" namespace="{namespace-uri()}">
             <xsl:copy-of select="edm:Record/edm:PropertyValue"/>
                 <xsl:call-template name="UpdateMethodTemplate">
@@ -1160,13 +1160,11 @@
             </xsl:when>
             <xsl:otherwise>
                 <xsl:copy>
-                    <!--<xsl:apply-templates select="@* | node()"/>-->
-                    <xsl:copy-of select="@*|node()"/>
+                    <xsl:copy-of select="@* | node()"/>
                 </xsl:copy>    
             </xsl:otherwise>
         </xsl:choose> 
     </xsl:template>
-    
     
     <!-- Remove directoryObject Capability Annotations -->
     <xsl:template match="edm:Schema[starts-with(@Namespace, 'microsoft.graph')]/edm:Annotations[@Target='microsoft.graph.directoryObject']/*[starts-with(@Term, 'Org.OData.Capabilities')]"/>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -679,6 +679,9 @@
           </Record>
         </Annotation>
       </Annotations>
+      <Annotations Target="microsoft.graph.GraphService/users">
+        <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false" />
+      </Annotations>
       <Annotations Target="microsoft.graph.directorySetting">
         <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
           <Record>


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/135

This PR:
- Adds `Org.OData.Capabilities.V1.SkipSupported` annotation for the `users` entity set.
- Updates output test file.