### PR TITLE
Task: Add optional parameter to support validation

### DIFF
--- a/.github/workflows/metadata-parser-validation.yml
+++ b/.github/workflows/metadata-parser-validation.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: set-conversion-settings
-        run: echo "::set-output name=matrix::$(ls conversion-settings/*.json | jq -R -f -s -c 'split("\n")[:-1]')"
+        run: echo "::set-output name=matrix::$(ls conversion-settings/*.json | sed 's/.*\///' | sed 's/\.[^.]*$//' | jq -R -s -c 'split("\n")[:-1]')"
 
   build:
     needs: list-conversion-settings

--- a/.github/workflows/metadata-parser-validation.yml
+++ b/.github/workflows/metadata-parser-validation.yml
@@ -40,6 +40,7 @@ jobs:
       shell: pwsh
 
     - uses: actions/upload-artifact@v3
+      if: always()
       with:
         name: openapi
         path: openapi/*

--- a/.github/workflows/metadata-parser-validation.yml
+++ b/.github/workflows/metadata-parser-validation.yml
@@ -7,10 +7,21 @@ on:
     branches: [ master ]
 
 jobs:
+  list-conversion-settings:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-conversion-settings.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: set-conversion-settings
+        run: echo "::set-output name=matrix::$(ls conversion-settings/*.json | jq -R -f -s -c 'split("\n")[:-1]')"
+
   build:
+    needs: list-conversion-settings
     strategy:
       matrix:
         version: ["v1.0", "beta"]
+        settings: ${{ fromJson(needs.list-conversion-settings.outputs.matrix) }}
 
     runs-on: ubuntu-latest
 
@@ -18,10 +29,17 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 7.0.x
+
     - name: Validate latest XSLT rules
-      run: ./scripts/run-metadata-validation.ps1 -repoDirectory "${{ github.workspace }}" -version "${{ matrix.version }}"
+      run: ./scripts/run-metadata-validation.ps1 -repoDirectory "${{ github.workspace }}" -version "${{ matrix.version }}" -platformName "${{ matrix.settings }}"
       shell: pwsh
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: openapi
+        path: openapi/*

--- a/.github/workflows/openapi-parser-validation.yml
+++ b/.github/workflows/openapi-parser-validation.yml
@@ -7,10 +7,22 @@ on:
     branches: [ master ]
 
 jobs:
+
+  list-conversion-settings:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-conversion-settings.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: set-conversion-settings
+        run: echo "::set-output name=matrix::$(ls conversion-settings/*.json | jq -R -f -s -c 'split("\n")[:-1]')"
+
   build:
+    needs: list-conversion-settings
     strategy:
       matrix:
         version: ["v1.0", "beta"]
+        settings: ${{ fromJson(needs.list-conversion-settings.outputs.matrix) }}
 
     runs-on: ubuntu-latest
 
@@ -23,5 +35,5 @@ jobs:
       with:
         dotnet-version: 7.0.x
     - name: Validate latest OpenAPI docs
-      run: ./scripts/run-openapi-validation.ps1 -repoDirectory "${{ github.workspace }}" -version "${{ matrix.version }}"
+      run: ./scripts/run-openapi-validation.ps1 -repoDirectory "${{ github.workspace }}" -version "${{ matrix.version }}" -platformName "${{ matrix.settings }}"
       shell: pwsh

--- a/.github/workflows/openapi-parser-validation.yml
+++ b/.github/workflows/openapi-parser-validation.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: set-conversion-settings
-        run: echo "::set-output name=matrix::$(ls conversion-settings/*.json | jq -R -f -s -c 'split("\n")[:-1]')"
+        run: echo "::set-output name=matrix::$(ls conversion-settings/*.json | sed 's/.*\///' | sed 's/\.[^.]*$//' | jq -R -s -c 'split("\n")[:-1]')"
 
   build:
     needs: list-conversion-settings

--- a/conversion-settings/graphexplorer.json
+++ b/conversion-settings/graphexplorer.json
@@ -1,0 +1,22 @@
+{
+  "OpenApiConvertSettings": {
+    "AddEnumDescriptionExtension": true,
+    "AddSingleQuotesForStringParameters": true,
+    "DeclarePathParametersOnPathItem": true,
+    "EnableCount": true,
+    "EnableDiscriminatorValue": false,
+    "EnableDerivedTypesReferencesForRequestBody": false,
+    "EnableDerivedTypesReferencesForResponses": false,
+    "EnableKeyAsSegment": true,
+    "EnableOperationId": true,
+    "EnablePagination": true,
+    "EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty": true,
+    "ErrorResponsesAsDefault": false,
+    "ExpandDerivedTypesNavigationProperties": false,
+    "PrefixEntityTypeNameBeforeKey": true,
+    "ShowLinks": true,
+    "ShowRootPath": true,
+    "TagDepth": 2,
+    "UseSuccessStatusCodeRange": false
+  }
+}

--- a/conversion-settings/openapi.json
+++ b/conversion-settings/openapi.json
@@ -1,0 +1,22 @@
+{
+  "OpenApiConvertSettings": {
+    "AddEnumDescriptionExtension": true,
+    "AddSingleQuotesForStringParameters": true,
+    "DeclarePathParametersOnPathItem": true,
+    "EnableCount": true,
+    "EnableDerivedTypesReferencesForRequestBody": false,
+    "EnableDerivedTypesReferencesForResponses": false,
+    "EnableDiscriminatorValue": true,
+    "EnableKeyAsSegment": true,
+    "EnableOperationId": true,
+    "EnablePagination": true,
+    "EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty": true,
+    "ErrorResponsesAsDefault": false,
+    "ExpandDerivedTypesNavigationProperties": false,
+    "PrefixEntityTypeNameBeforeKey": true,
+    "ShowLinks": false,
+    "ShowRootPath": false,
+    "TagDepth": 2,
+    "UseSuccessStatusCodeRange": true
+  }
+}

--- a/conversion-settings/powershell.json
+++ b/conversion-settings/powershell.json
@@ -1,0 +1,23 @@
+{
+  "OpenApiConvertSettings": {
+    "AddEnumDescriptionExtension": true,
+    "AddSingleQuotesForStringParameters": true,
+    "DeclarePathParametersOnPathItem": true,
+    "EnableCount": true,
+    "EnableDiscriminatorValue": false,
+    "EnableDerivedTypesReferencesForRequestBody": false,
+    "EnableDerivedTypesReferencesForResponses": false,
+    "EnableKeyAsSegment": true,
+    "EnableODataAnnotationReferencesForResponses": false,
+    "EnableOperationId": true,
+    "EnablePagination": true,
+    "EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty": true,
+    "ErrorResponsesAsDefault": false,
+    "ExpandDerivedTypesNavigationProperties": false,
+    "PrefixEntityTypeNameBeforeKey": true,
+    "ShowLinks": false,
+    "ShowRootPath": true,
+    "TagDepth": 2,
+    "UseSuccessStatusCodeRange": false
+  }
+}

--- a/scripts/run-openapi-validation.ps1
+++ b/scripts/run-openapi-validation.ps1
@@ -16,13 +16,23 @@
 
 .Parameter repoDirectory
     Full path the the root directory of msgraph-metadata checkout.
+
+.Parameter platformName
+    Name of the platform to be tested.
 #>
 
 param(
     [Parameter(Mandatory=$true)][string]$repoDirectory,
-    [Parameter(Mandatory=$true)][string]$version
+    [Parameter(Mandatory=$true)][string]$version,
+    [Parameter(Mandatory=$false)][string]$platformName
 )
-$yaml = Join-Path $repoDirectory "openapi" $version "openapi.yaml"
+
+if([string]::IsNullOrWhiteSpace($aString))
+{
+   $platformName = "openapi"
+}
+
+$yaml = Join-Path $repoDirectory "openapi" $version "$platformName.yaml"
 
 Write-Host "Validating $yaml OpenAPI doc..." -ForegroundColor Green
 

--- a/scripts/run-openapi-validation.ps1
+++ b/scripts/run-openapi-validation.ps1
@@ -27,7 +27,7 @@ param(
     [Parameter(Mandatory=$false)][string]$platformName
 )
 
-if([string]::IsNullOrWhiteSpace($aString))
+if([string]::IsNullOrWhiteSpace($platformName))
 {
    $platformName = "openapi"
 }


### PR DESCRIPTION
Depends on the merging of [this PR](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/944) .

The new generator will need to validate the individual "platform" yaml files generated. It passes a new parameter "platformName" that tells the validation script which file to validate.


### Changes
This script will change from:
> ./scripts/run-openapi-validation.ps1 -repoDirectory C:/github/msgraph-metadata -version "v1.0" 

To
> ./scripts/run-openapi-validation.ps1 -repoDirectory C:/github/msgraph-metadata -version "v1.0" -platformName "openapi"


### Notes
To make sure things do not break, the `platformName` parameter is optional and set to the known available platform -> `openapi` to make sure things do not break 