### PR TITLE
Fixes response types for properties in complex type `appliedConditionalAccessPolicy`

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -483,6 +483,11 @@
        <xsl:attribute name="Type">Edm.Stream</xsl:attribute>
     </xsl:template>
 
+    <!--Replace single-valued with collection-valued return types for complex type appliedConditionalAccessPolicy-->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:ComplexType[@Name='appliedConditionalAccessPolicy']/edm:Property[@Name='conditionsNotSatisfied' or @Name='conditionsSatisfied']/@Type">
+        <xsl:attribute name="Type">Collection(graph.conditionalAccessConditions)</xsl:attribute>
+    </xsl:template>
+    
     <!-- Add custom query options to calendarView navigation property -->
     <xsl:template name="CalendarViewRestrictedPopertyTemplate">
         <xsl:param name = "propertyPath" />

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -131,6 +131,19 @@
                 <Property Name="tenantId" Type="Edm.Guid" Nullable="false" />
                 <Property Name="resourceData" Type="graph.resourceData" />
             </ComplexType>
+            <ComplexType Name="appliedConditionalAccessPolicy">
+                <Property Name="authenticationStrength" Type="graph.authenticationStrength" />
+                <Property Name="conditionsNotSatisfied" Type="graph.conditionalAccessConditions" />
+                <Property Name="conditionsSatisfied" Type="graph.conditionalAccessConditions" />
+                <Property Name="displayName" Type="Edm.String" />
+                <Property Name="enforcedGrantControls" Type="Collection(Edm.String)" />
+                <Property Name="enforcedSessionControls" Type="Collection(Edm.String)" />
+                <Property Name="excludeRulesSatisfied" Type="Collection(graph.conditionalAccessRuleSatisfied)" />
+                <Property Name="id" Type="Edm.String" />
+                <Property Name="includeRulesSatisfied" Type="Collection(graph.conditionalAccessRuleSatisfied)" />
+                <Property Name="result" Type="graph.appliedConditionalAccessPolicyResult" />
+                <Property Name="sessionControlsNotSatisfied" Type="Collection(Edm.String)" />
+            </ComplexType>            
             <EntityType Name="cloudPcProvisioningPolicy" BaseType="graph.entity">
                 <NavigationProperty Name="assignments" Type="Collection(graph.cloudPcProvisioningPolicyAssignment)" />
             </EntityType>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -268,6 +268,19 @@
         <Property Name="tenantId" Type="Edm.Guid" Nullable="false" />
         <Property Name="resourceData" Type="graph.resourceData" />
       </ComplexType>
+      <ComplexType Name="appliedConditionalAccessPolicy">
+        <Property Name="authenticationStrength" Type="graph.authenticationStrength" />
+        <Property Name="conditionsNotSatisfied" Type="Collection(graph.conditionalAccessConditions)" />
+        <Property Name="conditionsSatisfied" Type="Collection(graph.conditionalAccessConditions)" />
+        <Property Name="displayName" Type="Edm.String" />
+        <Property Name="enforcedGrantControls" Type="Collection(Edm.String)" />
+        <Property Name="enforcedSessionControls" Type="Collection(Edm.String)" />
+        <Property Name="excludeRulesSatisfied" Type="Collection(graph.conditionalAccessRuleSatisfied)" />
+        <Property Name="id" Type="Edm.String" />
+        <Property Name="includeRulesSatisfied" Type="Collection(graph.conditionalAccessRuleSatisfied)" />
+        <Property Name="result" Type="graph.appliedConditionalAccessPolicyResult" />
+        <Property Name="sessionControlsNotSatisfied" Type="Collection(Edm.String)" />
+      </ComplexType>
       <EntityType Name="cloudPcProvisioningPolicy" BaseType="graph.entity">
         <NavigationProperty Name="assignments" Type="Collection(graph.cloudPcProvisioningPolicyAssignment)" />
       </EntityType>


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/263

- Replaces single-valued with collection-valued return types for complex type `appliedConditionalAccessPolicy` for the properties:
  - conditionsNotSatisfied
  - conditionsSatisfied