### PR TITLE
Fixes java beta generation by adding `deviceHealthScriptStates` containsTarget

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -59,6 +59,7 @@
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSPkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='macOSScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
+                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='managedDevice']/edm:NavigationProperty[@Name='deviceHealthScriptStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='onPremisesAgent']/edm:NavigationProperty[@Name='agentGroups']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='onPremisesAgentGroup']/edm:NavigationProperty[@Name='agents']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='onPremisesAgentGroup']/edm:NavigationProperty[@Name='publishedResources']|


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/526

The `deviceHealthScriptStates` property should have a `containsTarget` as true. 

The current default value causes the generated build to fail. This is because it fails to generate a collectionPage for the nav property as there is no other path that currently exists where the collection can be retrieved from (i.e. has a containsTarget for the model collection)

Reference documentation points to the collection retrieval from the nav property 
https://learn.microsoft.com/en-us/graph/api/intune-devices-devicehealthscriptpolicystate-list?view=graph-rest-beta