### PR TITLE
Member Of administrative unit

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -200,6 +200,7 @@
             <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
                 <Collection>
                     <String>microsoft.graph.group</String>
+                    <String>microsoft.graph.administrativeUnit</String>
                 </Collection>
             </Annotation>
             <xsl:element name="Annotation">


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1730

Users,groups,devices can also be members of adminstrative units so adding the derived type constraint should fix the path.

https://learn.microsoft.com/en-us/graph/api/administrativeunit-post-members?view=graph-rest-1.0&tabs=http