### PR TITLE
Set expand conditions for mailFolders,messages,events and calendarView to true.

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1273,7 +1273,8 @@
     <!-- Add ExpandRestrictions to events,mailfolders and messages entity type -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/events']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
                         edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/mailFolders']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
-                        edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/calendarView']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']| 
+                        edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/calendarView']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
+                        edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.calendar/events']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']| 
                         edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/messages']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']">
         <xsl:copy>
         <xsl:copy-of select="@*"/>

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -848,6 +848,16 @@
             </xsl:element>
         </xsl:element>
     </xsl:template>
+    <xsl:template name="ExpandRestrictionsTemplate">
+        <xsl:param name = "expandable" />
+            <xsl:attribute name="Term">Org.OData.Capabilities.V1.ExpandRestrictions</xsl:attribute>
+            <xsl:element name="Record" namespace="{namespace-uri()}">
+                <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">Expandable</xsl:attribute>
+                    <xsl:attribute name="Bool"><xsl:value-of select="$expandable"/></xsl:attribute>
+                </xsl:element>
+        </xsl:element>
+    </xsl:template>
 
     <!-- Add Navigation Restrictions Annotations -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']">
@@ -1258,6 +1268,19 @@
                <xsl:with-param name="filterable">false</xsl:with-param>
              </xsl:call-template>
        </xsl:copy>
+    </xsl:template>
+
+    <!-- Add ExpandRestrictions to events,mailfolders and messages entity type -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/events']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
+                        edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/mailFolders']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
+                        edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/calendarView']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']| 
+                        edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/messages']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']">
+        <xsl:copy>
+        <xsl:copy-of select="@*"/>
+                <xsl:call-template name="ExpandRestrictionsTemplate">
+                    <xsl:with-param name="expandable">true</xsl:with-param>            
+                </xsl:call-template>       
+        </xsl:copy>
     </xsl:template>
 
     <!-- If only the grand-parent "Annotations" tag exists, modify it -->

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -64,6 +64,13 @@
                     </Record>
                 </Annotation>
             </Annotations>
+            <Annotations Target="microsoft.graph.user/messages">
+                <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+                    <Record>
+                        <PropertyValue Property="Expandable" Bool="false" />
+                    </Record>
+                </Annotation>
+            </Annotations>
             <Annotations Target="microsoft.graph.managedDevice/users">
                 <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
                     <Record>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -182,6 +182,13 @@
           </Record>
         </Annotation>
       </Annotations>
+      <Annotations Target="microsoft.graph.user/messages">
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="true" />
+          </Record>
+        </Annotation>
+      </Annotations>
       <Annotations Target="microsoft.graph.managedDevice/users">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
           <Record>
@@ -665,6 +672,13 @@
             <PropertyValue Property="Updatable" Bool="true" />
           </Record>
         </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true" />
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.drive/bundles">
         <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
           <Record>
             <PropertyValue Property="Insertable" Bool="true" />


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1581
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1672
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1744
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1735

Mailfolders can have the `messages` property expanded.
Events/Calendarview can have the `singleValueExtendedProperties` property expanded.
Messages can have the `attachements` property expanded