### PR TITLE
Fixes java beta generation by adding `customExtensionStageSettings` containsTarget

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -39,6 +39,7 @@
 
     <xsl:template match="
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='accessPackageAssignmentPolicy']/edm:NavigationProperty[@Name='customExtensionHandlers']|
+                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='accessPackageAssignmentPolicy']/edm:NavigationProperty[@Name='customExtensionStageSettings']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='androidDeviceOwnerImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='androidDeviceOwnerScepCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='androidForWorkImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/538

The current default value causes the generated build to fail. This is because it fails to generate a collectionPage for the nav property as there is no other path that currently exists where the collection can be retrieved from (i.e. has a containsTarget for the model collection)

This is similar to the transform for `customExtensionHandlers` just above it. 

