### PR TITLE
Add PowerShell v2 convert settings

### DIFF
--- a/conversion-settings/powershell_v2.json
+++ b/conversion-settings/powershell_v2.json
@@ -1,0 +1,21 @@
+{
+  "OpenApiConvertSettings": {
+    "AddSingleQuotesForStringParameters": true,
+    "AddEnumDescriptionExtension": true,
+    "EnableKeyAsSegment": true,
+    "EnableOperationId": true,
+    "PrefixEntityTypeNameBeforeKey": true,
+    "TagDepth": 2,
+    "EnablePagination": true,
+    "EnableDiscriminatorValue": false,
+    "EnableDerivedTypesReferencesForRequestBody": false,
+    "EnableDerivedTypesReferencesForResponses": false,
+    "ShowRootPath": false,
+    "ExpandDerivedTypesNavigationProperties": false,
+    "ShowLinks": false,
+    "DeclarePathParametersOnPathItem": false,
+    "EnableODataAnnotationReferencesForResponses": false,
+    "EnableODataTypeCast": false,
+    "UseSuccessStatusCodeRange": true
+  }
+}


### PR DESCRIPTION
PowerShell v2 uses different convert settings than PowerShell v1, namely:
- DeclarePathParametersOnPathItem --> false
 - UseSuccessStatusCodeRange --> true