### PR TITLE
Set expand conditions for contacts to true

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1273,10 +1273,17 @@
 
     <!-- Add ExpandRestrictions to events,mailfolders and messages entity type -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/events']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
+                        edm:Schema[@Namespace='microsoft.graph.identityGovernance']/edm:Annotations[@Target='microsoft.graph.user/events']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
                         edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/mailFolders']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
+                        edm:Schema[@Namespace='microsoft.graph.identityGovernance']/edm:Annotations[@Target='microsoft.graph.user/mailFolders']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
                         edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/calendarView']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
-                        edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.calendar/events']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']| 
-                        edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/messages']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']">
+                        edm:Schema[@Namespace='microsoft.graph.identityGovernance']/edm:Annotations[@Target='microsoft.graph.user/calendarView']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
+                        edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.calendar/events']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
+                        edm:Schema[@Namespace='microsoft.graph.identityGovernance']/edm:Annotations[@Target='microsoft.graph.calendar/events']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
+                        edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/contacts']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']| 
+                        edm:Schema[@Namespace='microsoft.graph.identityGovernance']/edm:Annotations[@Target='microsoft.graph.user/contacts']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
+                        edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/messages']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']|
+                        edm:Schema[@Namespace='microsoft.graph.identityGovernance']/edm:Annotations[@Target='microsoft.graph.user/messages']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ExpandRestrictions']">
         <xsl:copy>
         <xsl:copy-of select="@*"/>
                 <xsl:call-template name="ExpandRestrictionsTemplate">


### PR DESCRIPTION
Follow up to https://github.com/microsoftgraph/msgraph-metadata/pull/299

Fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1761


Contacts are also expandable according to 
https://learn.microsoft.com/en-us/graph/api/singlevaluelegacyextendedproperty-get?view=graph-rest-1.0&tabs=http

As the annotations in the beta metadata are nested in a different namespace(`microsoft.graph.identityGovernance`), the match conditions have also been updated to capture these.
