### PR TITLE
Adds missing PUT methods for `team/group` and `externalConnection/items`

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1030,6 +1030,31 @@
                     </xsl:element>
                 </xsl:when>
             </xsl:choose>
+
+            <!-- Add UpdateRestrictions for group/team navigation property -->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.group/team'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.group/team</xsl:attribute>
+                        <xsl:call-template name="UpdateRestrictionsTemplate">
+                            <xsl:with-param name="httpMethod">PUT</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
+
+            <!-- Add UpdateRestrictions for externalConnection/items navigation property -->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.externalConnectors.externalConnection/items'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.externalConnectors.externalConnection/items</xsl:attribute>
+                        <xsl:call-template name="UpdateRestrictionsTemplate">
+                            <xsl:with-param name="httpMethod">PUT</xsl:with-param>
+                            <xsl:with-param name="updatable">true</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
             
             <!-- Add Insertability and Updatability for educationSchool/administrativeUnit non-containment navigation property -->
             <xsl:choose>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -666,6 +666,24 @@
           </Record>
         </Annotation>
       </Annotations>
+      <Annotations Target="microsoft.graph.group/team">
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="UpdateMethod">
+              <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.externalConnectors.externalConnection/items">
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="UpdateMethod">
+              <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
       <Annotations Target="microsoft.graph.educationSchool/administrativeUnit">
         <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
           <Record>


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1742

Creating team from group is done via PUT
Reference at https://learn.microsoft.com/en-us/graph/api/team-put-teams?view=graph-rest-1.0&tabs=csharp

Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1736

Creating externalItem is done via PUT
Reference at https://learn.microsoft.com/en-us/graph/api/externalconnectors-externalitem-create?view=graph-rest-1.0&tabs=http



