### PR TITLE
Fixes custom query parameters for bookingBusinesses.

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -662,7 +662,29 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='bookingBusinesses']">
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='event']/edm:NavigationProperty[@Name='instances']">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+            <xsl:element name="Annotation">
+                <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
+                <xsl:element name="Record" namespace="{namespace-uri()}">
+                    <xsl:element name="PropertyValue">
+                        <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
+                        <xsl:element name="Collection">
+                            <xsl:call-template name="CalendarViewRestrictedPopertyTemplate">
+                                <xsl:with-param name="propertyPath">instances</xsl:with-param>
+                                <xsl:with-param name="startDateTimeName">startDateTime</xsl:with-param>
+                                <xsl:with-param name="endDateTimeName">endDateTime</xsl:with-param>
+                            </xsl:call-template>
+                        </xsl:element>
+                    </xsl:element>
+                </xsl:element>
+            </xsl:element>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='bookingBusinesses'] |
+                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='bookingBusiness']/edm:NavigationProperty[@Name='calendarView']">
         <xsl:copy>
             <xsl:apply-templates select="@* | node()"/>
             <xsl:element name="Annotation">


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1791
as bookingBusinesses uses a different path in V1 metadata
Reference at https://learn.microsoft.com/en-us/graph/api/bookingbusiness-list-calendarview?view=graph-rest-1.0

Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1706
as `instances` also uses the custom queryparameters for `startDateTime` and `endDateTime`

Reference at https://learn.microsoft.com/en-us/graph/api/event-list-instances?view=graph-rest-1.0&tabs=http

Closes https://github.com/microsoftgraph/msgraph-sdk-go/issues/454