### PR TITLE
Set `EnableDollarCountPath` to `false` for PowerShell v1

### DIFF
--- a/conversion-settings/powershell.json
+++ b/conversion-settings/powershell.json
@@ -14,6 +14,7 @@
     "ExpandDerivedTypesNavigationProperties": false,
     "ShowLinks": false,
     "DeclarePathParametersOnPathItem": false,
-    "EnableODataAnnotationReferencesForResponses": false
+    "EnableODataAnnotationReferencesForResponses": false,
+    "EnableCount": false
   }
 }

--- a/conversion-settings/powershell.json
+++ b/conversion-settings/powershell.json
@@ -15,6 +15,6 @@
     "ShowLinks": false,
     "DeclarePathParametersOnPathItem": false,
     "EnableODataAnnotationReferencesForResponses": false,
-    "EnableCount": false
+    "EnableDollarCountPath": false
   }
 }


### PR DESCRIPTION
This PR unblocks PowerShell v1 releases by setting `EnableDollarCountPath` to `false`. `\$count` is not supported in PowerShell v1 due to AutoREST.PowerShell v2 size limitation.

Also, the operationIds for `/$count` operations have an invalid hash prefix that will be fixed by https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1480.

Unblocks https://github.com/microsoftgraph/msgraph-sdk-powershell/pull/1924.