### PR TITLE
Enable OData type cast for PowerShell v2

### DIFF
--- a/conversion-settings/powershell_v2.json
+++ b/conversion-settings/powershell_v2.json
@@ -15,7 +15,7 @@
     "ShowLinks": false,
     "DeclarePathParametersOnPathItem": false,
     "EnableODataAnnotationReferencesForResponses": false,
-    "EnableODataTypeCast": false,
+    "EnableODataTypeCast": true,
     "UseSuccessStatusCodeRange": true
   }
 }


### PR DESCRIPTION
This PR enables OData type cast paths in PowerShell v2 by setting `EnableODataTypeCast` to `true`. PowerShell can now support  OData type cast paths thanks to the recent operationId and tag names fix for OData cast paths in the conversion library - https://github.com/microsoft/OpenAPI.NET.OData/pull/338.

This PR is a partial fix for https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1228.