### PR TITLE
Add custom query options for includeHiddenFolders and includeHiddenMessages

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -531,6 +531,42 @@
         </xsl:element>
     </xsl:template>
 
+    <!-- Add custom query options to given navigation property -->
+    <xsl:template name="CustomQueryOptionsTemplate">
+        <xsl:param name = "customQueryOptionName" />
+        <xsl:param name = "description" />
+        <xsl:element name="Record">
+            <xsl:element name="PropertyValue">
+                <xsl:attribute name="Property">ReadRestrictions</xsl:attribute>
+                <xsl:element name="Record">
+                    <xsl:element name="PropertyValue">
+                        <xsl:attribute name="Property">CustomQueryOptions</xsl:attribute>
+                        <xsl:element name="Collection">
+                            <xsl:element name="Record">
+                                <xsl:element name="PropertyValue">
+                                    <xsl:attribute name="Property">Name</xsl:attribute>
+                                    <xsl:attribute name="String">
+                                        <xsl:value-of select = "$customQueryOptionName" />
+                                    </xsl:attribute>
+                                </xsl:element>
+                                <xsl:element name="PropertyValue">
+                                    <xsl:attribute name="Property">Description</xsl:attribute>
+                                    <xsl:attribute name="String">
+                                        <xsl:value-of select = "$description" />
+                                    </xsl:attribute>
+                                </xsl:element>
+                                <xsl:element name="PropertyValue">
+                                    <xsl:attribute name="Property">Required</xsl:attribute>
+                                    <xsl:attribute name="Bool">false</xsl:attribute>
+                                </xsl:element>
+                            </xsl:element>
+                        </xsl:element>
+                    </xsl:element>
+                </xsl:element>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
+
     <!-- Header templates -->
     <xsl:template name="ConsistencyLevelHeaderTemplate">
         <xsl:element name="Record" namespace="{namespace-uri()}">
@@ -651,6 +687,48 @@
                                 <xsl:with-param name="propertyPath">instances</xsl:with-param>
                                 <xsl:with-param name="startDateTimeName">startDateTime</xsl:with-param>
                                 <xsl:with-param name="endDateTimeName">endDateTime</xsl:with-param>
+                            </xsl:call-template>
+                        </xsl:element>
+                    </xsl:element>
+                </xsl:element>
+            </xsl:element>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Add custom query options - includeHiddenFolders to mailFolders -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='user']/edm:NavigationProperty[@Name='mailFolders']">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+            <xsl:element name="Annotation">
+                <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
+                <xsl:element name="Record" namespace="{namespace-uri()}">
+                    <xsl:element name="PropertyValue">
+                        <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
+                        <xsl:element name="Collection">
+                            <xsl:call-template name="CustomQueryOptionsTemplate">
+                                <xsl:with-param name="customQueryOptionName">includeHiddenFolders</xsl:with-param>
+                                <xsl:with-param name="description">Include Hidden Folders</xsl:with-param>
+                            </xsl:call-template>
+                        </xsl:element>
+                    </xsl:element>
+                </xsl:element>
+            </xsl:element>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Add custom query options - includeHiddenMessages to messages -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='user']/edm:NavigationProperty[@Name='messages']">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+            <xsl:element name="Annotation">
+                <xsl:attribute name="Term">Org.OData.Capabilities.V1.NavigationRestrictions</xsl:attribute>
+                <xsl:element name="Record" namespace="{namespace-uri()}">
+                    <xsl:element name="PropertyValue">
+                        <xsl:attribute name="Property">RestrictedProperties</xsl:attribute>
+                        <xsl:element name="Collection">
+                            <xsl:call-template name="CustomQueryOptionsTemplate">
+                                <xsl:with-param name="customQueryOptionName">includeHiddenMessages</xsl:with-param>
+                                <xsl:with-param name="description">Include Hidden Messages</xsl:with-param>
                             </xsl:call-template>
                         </xsl:element>
                     </xsl:element>

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -49,6 +49,7 @@
             <EntityType Name="user" BaseType="graph.directoryObject" OpenType="true">
                 <Property Name="displayName" Type="Edm.String" />
                 <NavigationProperty Name="planner" Type="graph.plannerUser" ContainsTarget="true" />
+                <NavigationProperty Name="messages" Type="Collection(graph.message)" ContainsTarget="true" />
             </EntityType>
             <Annotations Target="microsoft.graph.user/joinedGroups">
                 <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -192,6 +192,31 @@
             </Record>
           </Annotation>
         </NavigationProperty>
+        <NavigationProperty Name="messages" Type="Collection(graph.message)" ContainsTarget="true">
+          <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+            <Record>
+              <PropertyValue Property="RestrictedProperties">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="ReadRestrictions">
+                      <Record>
+                        <PropertyValue Property="CustomQueryOptions">
+                          <Collection>
+                            <Record>
+                              <PropertyValue Property="Name" String="includeHiddenMessages" />
+                              <PropertyValue Property="Description" String="Include Hidden Messages" />
+                              <PropertyValue Property="Required" Bool="false" />
+                            </Record>
+                          </Collection>
+                        </PropertyValue>
+                      </Record>
+                    </PropertyValue>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </NavigationProperty>
       </EntityType>
       <Annotations Target="microsoft.graph.user/joinedGroups">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1814
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1680

Adds a `CustomQueryOptionsTemplate` to enable adding custom query option to various navigation properties as needed and adds `includeHiddenFolders` and  `includeHiddenMessages` query options for relevant endpoints

Ref - https://learn.microsoft.com/en-us/graph/api/user-list-mailfolders?view=graph-rest-1.0&tabs=csharp