### PR TITLE
Adds mailboxsettings path to openApi document

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -695,6 +695,31 @@
         </xsl:copy>
     </xsl:template>
 
+    <!-- Add paths for user mailboxSettings by adding annotations to read and update the complex property-->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='user']/edm:Property[@Name='mailboxSettings']">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+            <xsl:element name="Annotation">
+                <xsl:attribute name="Term">Org.OData.Capabilities.V1.ReadRestrictions</xsl:attribute>
+                <xsl:element name="Record" namespace="{namespace-uri()}">
+                    <xsl:element name="PropertyValue">
+                        <xsl:attribute name="Property">Readable</xsl:attribute>
+                        <xsl:attribute name="Bool">true</xsl:attribute>
+                    </xsl:element>
+                </xsl:element>
+            </xsl:element>
+            <xsl:element name="Annotation">
+                <xsl:attribute name="Term">Org.OData.Capabilities.V1.UpdateRestrictions</xsl:attribute>
+                <xsl:element name="Record" namespace="{namespace-uri()}">
+                    <xsl:element name="PropertyValue">
+                        <xsl:attribute name="Property">Updatable</xsl:attribute>
+                        <xsl:attribute name="Bool">true</xsl:attribute>
+                    </xsl:element>
+                </xsl:element>
+            </xsl:element>
+        </xsl:copy>
+    </xsl:template>
+
     <!-- Add custom query options - includeHiddenFolders to mailFolders -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='user']/edm:NavigationProperty[@Name='mailFolders']">
         <xsl:copy>

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -699,24 +699,12 @@
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='user']/edm:Property[@Name='mailboxSettings']">
         <xsl:copy>
             <xsl:apply-templates select="@* | node()"/>
-            <xsl:element name="Annotation">
-                <xsl:attribute name="Term">Org.OData.Capabilities.V1.ReadRestrictions</xsl:attribute>
-                <xsl:element name="Record" namespace="{namespace-uri()}">
-                    <xsl:element name="PropertyValue">
-                        <xsl:attribute name="Property">Readable</xsl:attribute>
-                        <xsl:attribute name="Bool">true</xsl:attribute>
-                    </xsl:element>
-                </xsl:element>
-            </xsl:element>
-            <xsl:element name="Annotation">
-                <xsl:attribute name="Term">Org.OData.Capabilities.V1.UpdateRestrictions</xsl:attribute>
-                <xsl:element name="Record" namespace="{namespace-uri()}">
-                    <xsl:element name="PropertyValue">
-                        <xsl:attribute name="Property">Updatable</xsl:attribute>
-                        <xsl:attribute name="Bool">true</xsl:attribute>
-                    </xsl:element>
-                </xsl:element>
-            </xsl:element>
+            <xsl:call-template name="ReadRestrictionsTemplate">
+                <xsl:with-param name="readable">true</xsl:with-param>
+            </xsl:call-template>
+            <xsl:call-template name="UpdateRestrictionsTemplate">
+                <xsl:with-param name="updatable">true</xsl:with-param>
+            </xsl:call-template>
         </xsl:copy>
     </xsl:template>
 

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -48,6 +48,7 @@
             </EntityType>
             <EntityType Name="user" BaseType="graph.directoryObject" OpenType="true">
                 <Property Name="displayName" Type="Edm.String" />
+                <Property Name="mailboxSettings" Type="graph.mailboxSettings"/>
                 <NavigationProperty Name="planner" Type="graph.plannerUser" ContainsTarget="true" />
                 <NavigationProperty Name="messages" Type="Collection(graph.message)" ContainsTarget="true" />
             </EntityType>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -177,6 +177,18 @@
       </EntityType>
       <EntityType Name="user" BaseType="graph.directoryObject" OpenType="true">
         <Property Name="displayName" Type="Edm.String" />
+        <Property Name="mailboxSettings" Type="graph.mailboxSettings">
+          <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+            <Record>
+              <PropertyValue Property="Readable" Bool="true" />
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+            <Record>
+              <PropertyValue Property="Updatable" Bool="true" />
+            </Record>
+          </Annotation>
+        </Property>
         <NavigationProperty Name="planner" Type="graph.plannerUser" ContainsTarget="true">
           <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
             <Record>


### PR DESCRIPTION
This PR

- Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1712
- Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/258
- Closes https://github.com/microsoftgraph/msgraph-sdk-go/issues/464

Using the conversion mechanisms suggested at https://github.com/microsoft/OpenAPI.NET.OData/issues/176 the mailBoxSettings path is added to allow accessing the structural property from the path.

References
- https://learn.microsoft.com/en-us/graph/api/user-get-mailboxsettings?view=graph-rest-1.0&tabs=http (ReadRestrictions)
- https://learn.microsoft.com/en-us/graph/api/user-update-mailboxsettings?view=graph-rest-1.0&tabs=http (UpdateRestrictions)
