### PR TITLE
Adds ContainsTarget attribute to certificateBasedAuthConfiguration navigation property

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -92,7 +92,8 @@
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windowsWifiEnterpriseEAPConfiguration']/edm:NavigationProperty[@Name='rootCertificatesForServerValidation']|
                   edm:Schema[@Namespace='microsoft.graph.managedTenants']/edm:EntityType[@Name='managementTemplateStepVersion']/edm:NavigationProperty[@Name='deployments']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='driveItem']/edm:NavigationProperty[@Name='analytics']|
-                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='site']/edm:NavigationProperty[@Name='analytics']
+                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='site']/edm:NavigationProperty[@Name='analytics']|
+                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='organization']/edm:NavigationProperty[@Name='certificateBasedAuthConfiguration']
                          ">
         <!-- Didn't add the rule for teamsAppDefinition and unifiedRoleDefinition since it doesn't
            look like we applied it, and I don't see any issues because of it.
@@ -1269,7 +1270,18 @@
                     </xsl:element>
                 </xsl:when>
             </xsl:choose>
-    
+
+            <!-- Remove Updatability for organization/certificateBasedAuthConfiguration containment navigation property -->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.organization/certificateBasedAuthConfiguration'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.organization/certificateBasedAuthConfiguration</xsl:attribute>
+                        <xsl:call-template name="UpdateRestrictionsTemplate">
+                            <xsl:with-param name="updatable">false</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
         </xsl:copy>
     </xsl:template>
 

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -217,6 +217,18 @@
                 <Property Name="openShiftsEnabled" Type="Edm.Boolean" />
                 <Property Name="timeZone" Type="Edm.String" />
             </EntityType>
+            <EntityType Name="organization" BaseType="graph.directoryObject" OpenType="true">
+                <Property Name="city" Type="Edm.String" />
+                <NavigationProperty Name="certificateBasedAuthConfiguration" Type="Collection(graph.certificateBasedAuthConfiguration)" />
+            </EntityType>
+            <EntityType Name="certificateBasedAuthConfiguration" BaseType="graph.entity">
+                <Property Name="certificateAuthorities" Type="Collection(graph.certificateAuthority)" Nullable="false" />
+            </EntityType>
+            <ComplexType Name="certificateAuthority">
+                <Property Name="certificate" Type="Edm.Binary" Nullable="false" />
+                <Property Name="isRootAuthority" Type="Edm.Boolean" Nullable="false" />
+                <Property Name="issuer" Type="Edm.String" Nullable="false" />
+            </ComplexType>
             <ComplexType Name="timeSlot">
                 <Property Name="end" Type="graph.dateTimeTimeZone" Nullable="false" />
                 <Property Name="start" Type="graph.dateTimeTimeZone" Nullable="false" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -431,6 +431,18 @@
         <Property Name="openShiftsEnabled" Type="Edm.Boolean" />
         <Property Name="timeZone" Type="Edm.String" />
       </EntityType>
+      <EntityType Name="organization" BaseType="graph.directoryObject" OpenType="true">
+        <Property Name="city" Type="Edm.String" />
+        <NavigationProperty Name="certificateBasedAuthConfiguration" Type="Collection(graph.certificateBasedAuthConfiguration)" ContainsTarget="true" />
+      </EntityType>
+      <EntityType Name="certificateBasedAuthConfiguration" BaseType="graph.entity">
+        <Property Name="certificateAuthorities" Type="Collection(graph.certificateAuthority)" Nullable="false" />
+      </EntityType>
+      <ComplexType Name="certificateAuthority">
+        <Property Name="certificate" Type="Edm.Binary" Nullable="false" />
+        <Property Name="isRootAuthority" Type="Edm.Boolean" Nullable="false" />
+        <Property Name="issuer" Type="Edm.String" Nullable="false" />
+      </ComplexType>
       <ComplexType Name="timeSlot">
         <Property Name="end" Type="graph.dateTimeTimeZone" Nullable="false" />
         <Property Name="start" Type="graph.dateTimeTimeZone" Nullable="false" />
@@ -838,6 +850,13 @@
         <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
           <Record>
             <PropertyValue Property="Filterable" Bool="false" />
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.organization/certificateBasedAuthConfiguration">
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false" />
           </Record>
         </Annotation>
       </Annotations>


### PR DESCRIPTION
This PR fixes #206 by:
- Adds `ContainsTarget="true"` attribute to `certificateBasedAuthConfiguration` navigation property.
- Removes updatability for `organization/certificateBasedAuthConfiguration` navigation property to match what's supported by API.

See supported methods at https://learn.microsoft.com/en-us/graph/api/resources/certificatebasedauthconfiguration?view=graph-rest-1.0#methods for more details.