### PR TITLE
Adds additional derived types for deletedItems DerivedTypeConstraint 

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -321,6 +321,7 @@
                     <String>microsoft.graph.application</String>
                     <String>microsoft.graph.servicePrincipal</String>
                     <String>microsoft.graph.administrativeUnit</String>
+                    <String>microsoft.graph.device</String>
                 </Collection>
             </Annotation>
         </xsl:copy>

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -319,6 +319,8 @@
                     <String>microsoft.graph.user</String>
                     <String>microsoft.graph.group</String>
                     <String>microsoft.graph.application</String>
+                    <String>microsoft.graph.servicePrincipal</String>
+                    <String>microsoft.graph.administrativeUnit</String>
                 </Collection>
             </Annotation>
         </xsl:copy>

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -70,6 +70,9 @@
                     <Annotation Term="Org.OData.Core.V1.Description" String="The collection of single-value extended properties defined for the contact. Read-only. Nullable." />
                 </NavigationProperty>
             </EntityType>
+            <EntityType Name="directory" BaseType="graph.entity">
+                <NavigationProperty Name="deletedItems" Type="Collection(graph.directoryObject)" ContainsTarget="true" />
+            </EntityType>
             <Annotations Target="microsoft.graph.user/joinedGroups">
                 <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
                     <Record>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='preprocess_csdl.xsl'?>
 <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
   <edmx:DataServices>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -271,6 +271,7 @@
               <String>microsoft.graph.application</String>
               <String>microsoft.graph.servicePrincipal</String>
               <String>microsoft.graph.administrativeUnit</String>
+              <String>microsoft.graph.device</String>
             </Collection>
           </Annotation>
         </NavigationProperty>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -262,6 +262,19 @@
           </Annotation>
         </NavigationProperty>
       </EntityType>
+      <EntityType Name="directory" BaseType="graph.entity">
+        <NavigationProperty Name="deletedItems" Type="Collection(graph.directoryObject)" ContainsTarget="true">
+          <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
+            <Collection>
+              <String>microsoft.graph.user</String>
+              <String>microsoft.graph.group</String>
+              <String>microsoft.graph.application</String>
+              <String>microsoft.graph.servicePrincipal</String>
+              <String>microsoft.graph.administrativeUnit</String>
+            </Collection>
+          </Annotation>
+        </NavigationProperty>
+      </EntityType>
       <Annotations Target="microsoft.graph.user/joinedGroups">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
           <Record>


### PR DESCRIPTION
This PR fixes #336 by adding addional derived types for `DeletedItems` DerivedTypeConstraint as shown in the docs -https://learn.microsoft.com/en-us/graph/api/directory-deleteditems-list?view=graph-rest-beta&tabs=http#http-request.
