### PR TITLE
Removes containment for `accessPackageCatalog/accessPackages` nav. prop.

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -379,9 +379,10 @@
         <xsl:apply-templates select="@* | node()"/>
     </xsl:template>
 
-    <!-- Remove ContainsTarget attribute. -->
+    <!-- Remove ContainsTarget attribute for both Kiota-based and PowerShell based CSDL  -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='acceptedSenders']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='rejectedSenders']/@ContainsTarget">
+                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='rejectedSenders']/@ContainsTarget|
+                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='accessPackageCatalog']/edm:NavigationProperty[@Name='accessPackages']/@ContainsTarget">
         <xsl:apply-templates select="@* | node()"/>
     </xsl:template>
 

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -379,7 +379,7 @@
         <xsl:apply-templates select="@* | node()"/>
     </xsl:template>
 
-    <!-- Remove ContainsTarget attribute for both Kiota-based and PowerShell based CSDL  -->
+    <!-- Remove ContainsTarget attribute for both Kiota-based and PowerShell-based CSDL  -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='acceptedSenders']/@ContainsTarget|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='rejectedSenders']/@ContainsTarget|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='accessPackageCatalog']/edm:NavigationProperty[@Name='accessPackages']/@ContainsTarget">

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -70,6 +70,9 @@
                     <Annotation Term="Org.OData.Core.V1.Description" String="The collection of single-value extended properties defined for the contact. Read-only. Nullable." />
                 </NavigationProperty>
             </EntityType>
+            <EntityType Name="accessPackageCatalog" BaseType="graph.entity">                
+                <NavigationProperty Name="accessPackages" Type="Collection(graph.accessPackage)" ContainsTarget="true"/>
+            </EntityType>
             <Annotations Target="microsoft.graph.user/joinedGroups">
                 <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
                     <Record>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -262,6 +262,9 @@
           </Annotation>
         </NavigationProperty>
       </EntityType>
+      <EntityType Name="accessPackageCatalog" BaseType="graph.entity">
+        <NavigationProperty Name="accessPackages" Type="Collection(graph.accessPackage)" />
+      </EntityType>
       <Annotations Target="microsoft.graph.user/joinedGroups">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
           <Record>


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/338

This PR:
- Removes the containment for `accessPackageCatalog/accessPackages` navigation property for both Kiota-based and PowerShell based CSDLs. 