### PR TITLE
Removes countability using `CountRestrictions`

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -788,7 +788,7 @@
             </xsl:element>
         </xsl:copy>
     </xsl:template>
-    
+
     <!-- Capability Annotations Templates -->
     <xsl:template name="CountRestrictionsTemplate">
         <xsl:param name="countable" />

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -788,8 +788,22 @@
             </xsl:element>
         </xsl:copy>
     </xsl:template>
-
+    
     <!-- Capability Annotations Templates -->
+    <xsl:template name="CountRestrictionsTemplate">
+        <xsl:param name="countable" />
+        <xsl:element name="Annotation">
+            <xsl:attribute name="Term">Org.OData.Capabilities.V1.CountRestrictions</xsl:attribute>
+            <xsl:element name="Record" namespace="{namespace-uri()}">
+                <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">Countable</xsl:attribute>
+                    <xsl:attribute name="Bool">
+                        <xsl:value-of select="$countable" />
+                    </xsl:attribute>
+                </xsl:element>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
     <xsl:template name="SkipSupportTemplate">
         <xsl:param name="skipSupported" />
         <xsl:element name="Annotation">
@@ -1277,6 +1291,30 @@
                     </xsl:element>
                 </xsl:when>
             </xsl:choose>
+            
+            <!-- Remove countability for drives entity set -->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.GraphService/drives'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.GraphService/drives</xsl:attribute>
+                        <xsl:call-template name="CountRestrictionsTemplate">
+                            <xsl:with-param name="countable">false</xsl:with-param>
+                        </xsl:call-template>                        
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
+            
+            <!-- Remove countability for list/items navigation property -->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.list/items'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.list/items</xsl:attribute>
+                        <xsl:call-template name="CountRestrictionsTemplate">
+                            <xsl:with-param name="countable">false</xsl:with-param>
+                        </xsl:call-template>                        
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
 
             <!-- Remove readability only for teams entity set v1.0 -->
             <xsl:choose>
@@ -1382,6 +1420,17 @@
                 </xsl:copy>            
             </xsl:otherwise>        
         </xsl:choose>     
+    </xsl:template>
+    
+    <!-- If the parent "Annotations" tag already exists, modify it -->
+    <!-- Remove countability for list/items navigation property -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.list/items']">
+       <xsl:copy>
+         <xsl:copy-of select="@*|node()"/>
+         <xsl:call-template name="CountRestrictionsTemplate">
+            <xsl:with-param name="countable">false</xsl:with-param>
+          </xsl:call-template>
+       </xsl:copy>
     </xsl:template>
     
     <!-- If only the grand-parent "Annotations" tag exists, modify it -->
@@ -1587,6 +1636,27 @@
         </xsl:choose>        
     </xsl:template>   
     
+    <!-- Remove countability -->    
+    <!-- If the grand-parent "Annotations" tag already exists, modify it -->
+    <!-- Add CountRestrictions annotation and remove countability for drives entity set -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.GraphService/drives']">     
+        <xsl:choose>
+            <xsl:when test="not(edm:Annotation[@Term='Org.OData.Capabilities.V1.CountRestrictions'])">
+                <xsl:copy>
+                    <xsl:copy-of select="@*|node()"/>
+                    <xsl:call-template name="CountRestrictionsTemplate">
+                        <xsl:with-param name="countable">false</xsl:with-param>
+                    </xsl:call-template>
+                </xsl:copy>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy>
+                    <xsl:copy-of select="@* | node()"/>
+                </xsl:copy>    
+            </xsl:otherwise>
+        </xsl:choose> 
+    </xsl:template>    
+        
     <!-- Remove directoryObject Capability Annotations -->
     <xsl:template match="edm:Schema[starts-with(@Namespace, 'microsoft.graph')]/edm:Annotations[@Target='microsoft.graph.directoryObject']/*[starts-with(@Term, 'Org.OData.Capabilities')]"/>
 

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -138,6 +138,13 @@
                     </Record>
                 </Annotation>
             </Annotations>
+            <Annotations Target="microsoft.graph.list/items">
+                <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+                    <Record>
+                        <PropertyValue Property="Filterable" Bool="true" />
+                    </Record>
+                </Annotation>
+            </Annotations>
             <ComplexType Name="searchQuery">
                 <Property Name="queryString" Type="Edm.String" />
                 <Property Name="queryTemplate" Type="Edm.String" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -361,6 +361,18 @@
           </Record>
         </Annotation>
       </Annotations>
+      <Annotations Target="microsoft.graph.list/items">
+        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+          <Record>
+            <PropertyValue Property="Filterable" Bool="true" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
+          <Record>
+            <PropertyValue Property="Countable" Bool="false" />
+          </Record>
+        </Annotation>
+      </Annotations>
       <ComplexType Name="searchQuery">
         <Property Name="queryString" Type="Edm.String" />
         <Property Name="queryTemplate" Type="Edm.String" />
@@ -853,6 +865,13 @@
         <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
           <Record>
             <PropertyValue Property="Insertable" Bool="false" />
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.GraphService/drives">
+        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
+          <Record>
+            <PropertyValue Property="Countable" Bool="false" />
           </Record>
         </Annotation>
       </Annotations>


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/328

This PR:
- Removes countability for `drives` entity set and `list/items` navigation property using `Org.OData.Capabilities.V1.CountRestrictions` annotation.