### PR TITLE
athmangude/permissionspec

### DIFF
--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -61,7 +61,7 @@ The "pathSets" member is a REQUIRED JSON Array. Each element of the array is a [
 
 The owner info object contains information related to the ownership of the permission. This object should only contain information that is not required by a consumer of the API and can safely be removed in any public projection of the permissions information.
 ### ownerSecurityGroup
-The "ownerSecurityGroup" member is a string that provides a contact mechanism for communicating with the owners of the permission. It is important that owners of permissions are aware when new paths are added to an existing permission. This member is only required when `ownerInfo` is present.
+The "ownerSecurityGroup" member is a string that provides a contact mechanism for communicating with the owners of the permission. It is important that owners of permissions are aware when new paths are added to an existing permission. This member is REQUIRED when `ownerInfo` is present.
 
 ## <a name="pathSetObject"></a>PathSet Object
 A pathSet object identifies a set of paths that are accessible and have a common set of security characteristics, such as HTTP methods and schemes. Ideally, a permission object contains a single pathSet object. This indicates that all paths protected by the permission support the same characteristics. In practice there are cases where support is not uniform. Distinct pathSet objects can be created to separate the paths with varying characteristics.  


### PR DESCRIPTION
### Changes

- Moved `alsoRequires` and `implicit` properties into path object from the permissions object
- Added usage for `alsoRequires` for simple and complex expressions of additional permissions
- Changed the value of `path` object to string
- Update model diagram