### PR TITLE
Removes `$skip` and `$top` support for `message/attachments` navigation property

### DIFF
--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -76,6 +76,9 @@
             <EntityType Name="accessPackageCatalog" BaseType="graph.entity">                
                 <NavigationProperty Name="accessPackages" Type="Collection(graph.accessPackage)" ContainsTarget="true"/>
             </EntityType>
+            <EntityType Name="message" BaseType="graph.outlookItem" OpenType="true">                
+                <NavigationProperty Name="attachments" Type="Collection(graph.attachment)" ContainsTarget="true" />                
+            </EntityType>
             <Annotations Target="microsoft.graph.user/joinedGroups">
                 <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
                     <Record>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -279,6 +279,9 @@
       <EntityType Name="accessPackageCatalog" BaseType="graph.entity">
         <NavigationProperty Name="accessPackages" Type="Collection(graph.accessPackage)" />
       </EntityType>
+      <EntityType HasStream="true" Name="message" BaseType="graph.outlookItem" OpenType="true">
+        <NavigationProperty Name="attachments" Type="Collection(graph.attachment)" ContainsTarget="true" />
+      </EntityType>
       <Annotations Target="microsoft.graph.user/joinedGroups">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
           <Record>
@@ -930,6 +933,10 @@
             <PropertyValue Property="Updatable" Bool="false" />
           </Record>
         </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.message/attachments">
+        <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false" />
+        <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="false" />
       </Annotations>
     </Schema>
     <Schema Namespace="microsoft.graph.callRecords" xmlns="http://docs.oasis-open.org/odata/ns/edm">


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/321

This PR:
- Removes `$skip` and `$top` support for `message/attachments` navigation property.
- Updates test files