### PR TITLE
chore: capture initial branch policy settings

### DIFF
--- a/.github/policies/msgraph-metadata-branch-protection.yml
+++ b/.github/policies/msgraph-metadata-branch-protection.yml
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# File initially created using https://github.com/MIchaelMainer/policyservicetoolkit/blob/main/branch_protection_export.ps1.
+
+name: msgraph-metadata-branch-protection
+description: Branch protection policy for the msgraph-metadata repository
+resource: repository
+configuration:
+  branchProtectionRules:
+


### PR DESCRIPTION
Capture current policy state so that we can make versioned changes to branch protection policies. This will enable policy history, auditing, review, standardization, and templatization. We will update policy in later PR.

This branch protection policy will not take effect until https://github.com/microsoftgraph/.github/blob/main/policies/branch-protection-sdks.yml has been removed.

The yaml validation is new as we've checked in policy files without branch protection rules in them.