### PR TITLE
Remove `ReadRestrictions` annotation for `/teams`

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1325,19 +1325,6 @@
                 </xsl:when>
             </xsl:choose>
 
-            <!-- Remove readability only for teams entity set v1.0 -->
-            <xsl:choose>
-                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.GraphService/teams']) and $is-version-v1='True'">
-                    <xsl:element name="Annotations">
-                        <xsl:attribute name="Target">microsoft.graph.GraphService/teams</xsl:attribute>
-                        <xsl:call-template name="ReadRestrictionsTemplate">
-                            <xsl:with-param name="readable">false</xsl:with-param>
-                            <xsl:with-param name="readableByKey">true</xsl:with-param>
-                        </xsl:call-template>                        
-                    </xsl:element>
-                </xsl:when>
-            </xsl:choose>
-
             <!-- Add FilterRestrictions to directorySetting entity type -->
             <xsl:choose>
                 <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.directorySetting'])">
@@ -1409,27 +1396,6 @@
           </xsl:call-template>
       </xsl:copy>
     </xsl:template>    
-
-    <!-- If the parent "Annotations" tag already exists modify it -->
-    <!-- Remove readability only for teams entity set for v1.0 -->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.GraphService/teams']">
-        <xsl:choose>
-            <xsl:when test="is-version-v1='True'">
-                 <xsl:copy>
-                    <xsl:copy-of select="@*|node()"/>
-                       <xsl:call-template name="ReadRestrictionsTemplate">
-                          <xsl:with-param name="readable">false</xsl:with-param>
-                          <xsl:with-param name="readableByKey">true</xsl:with-param>
-                       </xsl:call-template>
-                  </xsl:copy>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:copy>
-                    <xsl:apply-templates select="@* | node()"/>
-                </xsl:copy>            
-            </xsl:otherwise>        
-        </xsl:choose>     
-    </xsl:template>
     
     <!-- If the parent "Annotations" tag already exists, modify it -->
     <!-- Remove countability for list/items navigation property -->

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -905,18 +905,6 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="microsoft.graph.GraphService/teams">
-        <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
-          <Record>
-            <PropertyValue Property="Readable" Bool="false" />
-            <PropertyValue Property="ReadByKeyRestrictions">
-              <Record>
-                <PropertyValue Property="Readable" Bool="true" />
-              </Record>
-            </PropertyValue>
-          </Record>
-        </Annotation>
-      </Annotations>
       <Annotations Target="microsoft.graph.directorySetting">
         <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
           <Record>


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/356

GET `/teams` is now supported in v1.0.
