### PR TITLE
virutalEventRegistration navProperties contain target

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -83,6 +83,8 @@
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='publishedResource']/edm:NavigationProperty[@Name='agentGroups']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='securityConfigurationTask']/edm:NavigationProperty[@Name='managedDevices']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='teamTemplate']/edm:NavigationProperty[@Name='definitions']|
+                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='virtualEventRegistration']/edm:NavigationProperty[@Name='questions']|
+                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='virtualEventRegistration']/edm:NavigationProperty[@Name='registrants']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windows10ImportedPFXCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windows10PkcsCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windows81SCEPCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
@@ -90,10 +92,10 @@
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windowsPhone81SCEPCertificateProfile']/edm:NavigationProperty[@Name='managedDeviceCertificateStates']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windowsUniversalAppX']/edm:NavigationProperty[@Name='committedContainedApps']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='windowsWifiEnterpriseEAPConfiguration']/edm:NavigationProperty[@Name='rootCertificatesForServerValidation']|
-                  edm:Schema[@Namespace='microsoft.graph.managedTenants']/edm:EntityType[@Name='managementTemplateStepVersion']/edm:NavigationProperty[@Name='deployments']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='driveItem']/edm:NavigationProperty[@Name='analytics']|
                   edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='site']/edm:NavigationProperty[@Name='analytics']|
-                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='organization']/edm:NavigationProperty[@Name='certificateBasedAuthConfiguration']
+                  edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='organization']/edm:NavigationProperty[@Name='certificateBasedAuthConfiguration']|
+                  edm:Schema[@Namespace='microsoft.graph.managedTenants']/edm:EntityType[@Name='managementTemplateStepVersion']/edm:NavigationProperty[@Name='deployments']
                          ">
         <!-- Didn't add the rule for teamsAppDefinition and unifiedRoleDefinition since it doesn't
            look like we applied it, and I don't see any issues because of it.

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -261,6 +261,12 @@
             <EntityType Name="certificateBasedAuthConfiguration" BaseType="graph.entity">
                 <Property Name="certificateAuthorities" Type="Collection(graph.certificateAuthority)" Nullable="false" />
             </EntityType>
+            <EntityType Name="virtualEventRegistration" BaseType="graph.entity">
+                <Property Name="capacity" Type="Edm.Int32" />
+                <Property Name="registrationWebUrl" Type="Edm.String" />
+                <NavigationProperty Name="questions" Type="Collection(graph.virtualEventRegistrationQuestion)" />
+                <NavigationProperty Name="registrants" Type="Collection(graph.virtualEventRegistrant)" />
+            </EntityType>
             <ComplexType Name="certificateAuthority">
                 <Property Name="certificate" Type="Edm.Binary" Nullable="false" />
                 <Property Name="isRootAuthority" Type="Edm.Boolean" Nullable="false" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -505,6 +505,12 @@
       <EntityType Name="certificateBasedAuthConfiguration" BaseType="graph.entity">
         <Property Name="certificateAuthorities" Type="Collection(graph.certificateAuthority)" Nullable="false" />
       </EntityType>
+      <EntityType Name="virtualEventRegistration" BaseType="graph.entity">
+        <Property Name="capacity" Type="Edm.Int32" />
+        <Property Name="registrationWebUrl" Type="Edm.String" />
+        <NavigationProperty Name="questions" Type="Collection(graph.virtualEventRegistrationQuestion)" ContainsTarget="true" />
+        <NavigationProperty Name="registrants" Type="Collection(graph.virtualEventRegistrant)" ContainsTarget="true" />
+      </EntityType>
       <ComplexType Name="certificateAuthority">
         <Property Name="certificate" Type="Edm.Binary" Nullable="false" />
         <Property Name="isRootAuthority" Type="Edm.Boolean" Nullable="false" />


### PR DESCRIPTION
Adds contains target to VirtualEventRegistration navigation properties that are missing this, fixes java-beta compile issue. 
https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/601
