### PR TITLE
Fix event delta function parameters to include start and end dates

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -487,6 +487,31 @@
         <xsl:attribute name="Type">Collection(graph.conditionalAccessConditions)</xsl:attribute>
     </xsl:template>
     
+    <!--Delta function for events need the start and end date parameters-->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='delta'][edm:Parameter[@Name='bindingparameter']][edm:Parameter[@Type='Collection(graph.event)']]">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+            <Annotation Term="Org.OData.Capabilities.V1.OperationRestrictions">
+            <Record>
+                <PropertyValue Property="CustomQueryOptions">
+                    <Collection>
+                        <Record>
+                            <PropertyValue Property="Name" String="startDateTime" />
+                            <PropertyValue Property="Description" String="The start date and time of the time range in the function, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
+                            <PropertyValue Property="Required" Bool="true" />
+                        </Record>
+                        <Record>
+                            <PropertyValue Property="Name" String="endDateTime" />
+                            <PropertyValue Property="Description" String="The end date and time of the time range in the function, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
+                            <PropertyValue Property="Required" Bool="true" />
+                        </Record>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+            </Annotation>
+        </xsl:copy>
+    </xsl:template>
+
     <!-- Add custom query options to calendarView navigation property -->
     <xsl:template name="CalendarViewRestrictedPopertyTemplate">
         <xsl:param name = "propertyPath" />

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -288,6 +288,10 @@
               <EntitySet Name="directoryObjects" EntityType="microsoft.graph.directoryObject" />
               <EntitySet Name="places" EntityType="microsoft.graph.place" />
             </EntityContainer>
+            <Function Name="delta" IsBound="true">
+                <Parameter Name="bindingparameter" Type="Collection(graph.event)" Nullable="false" />
+                <ReturnType Type="Collection(graph.event)" Nullable="false" />
+            </Function>
             <Action Name="accept" IsBound="true">
                 <Parameter Name="bindingParameter" Type="graph.event" />
                 <Parameter Name="SendResponse" Type="Edm.Boolean" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -716,6 +716,28 @@
           </Annotation>
         </EntitySet>
       </EntityContainer>
+      <Function Name="delta" IsBound="true">
+        <Parameter Name="bindingparameter" Type="Collection(graph.event)" Nullable="false" />
+        <ReturnType Type="Collection(graph.event)" Nullable="false" />
+        <Annotation Term="Org.OData.Capabilities.V1.OperationRestrictions" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
+          <Record>
+            <PropertyValue Property="CustomQueryOptions">
+              <Collection>
+                <Record>
+                  <PropertyValue Property="Name" String="startDateTime" />
+                  <PropertyValue Property="Description" String="The start date and time of the time range in the function, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
+                  <PropertyValue Property="Required" Bool="true" />
+                </Record>
+                <Record>
+                  <PropertyValue Property="Name" String="endDateTime" />
+                  <PropertyValue Property="Description" String="The end date and time of the time range in the function, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
+                  <PropertyValue Property="Required" Bool="true" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Function>
       <Action Name="accept" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event" />
         <Parameter Name="SendResponse" Type="Edm.Boolean" />


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-metadata/issues/329
Closes https://github.com/microsoftgraph/msgraph-sdk-go/issues/318
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1860
Closes https://github.com/microsoftgraph/msgraph-sdk-php/issues/1152

Uses the `Org.OData.Capabilities.V1.OperationRestrictions` to add the custom query parameters to the odata function. 