### PR TITLE
Adds `model` custom header to getAllMessages

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -457,6 +457,26 @@
         </xsl:if>
     </xsl:template>
 
+    <!--Delta function for events need the start and end date parameters-->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='getAllMessages']">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+            <Annotation Term="Org.OData.Capabilities.V1.OperationRestrictions">
+                <Record>
+                    <PropertyValue Property="CustomQueryOptions">
+                        <Collection>
+                        <Record>
+                            <PropertyValue Property="Name" String="model" />
+                            <PropertyValue Property="Description" String="The payment model for the API" />
+                            <PropertyValue Property="Required" Bool="false" />
+                        </Record>
+                        </Collection>
+                    </PropertyValue>
+                </Record>
+            </Annotation>
+        </xsl:copy>
+    </xsl:template>
+
     <!--Remove functions that are blocking beta generation only for CSDL based generation -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph.callRecords']/edm:Function[@Name='getPstnCalls'] |
                          edm:Schema[@Namespace='microsoft.graph.callRecords']/edm:Function[@Name='getDirectRoutingCalls']">

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -356,6 +356,14 @@
                 <Parameter Name="bindingParameter" Type="graph.reportRoot" />
                 <ReturnType Type="graph.report" Nullable="false" />
             </Function>
+            <Function Name="getAllMessages" IsBound="true" EntitySetPath="bindingParameter/channels/messages">
+                <Parameter Name="bindingParameter" Type="Collection(graph.team)" />
+                <ReturnType Type="Collection(graph.chatMessage)" />
+            </Function>
+            <Function Name="getAllMessages" IsBound="true" EntitySetPath="bindingParameter/messages">
+                <Parameter Name="bindingParameter" Type="Collection(graph.channel)" />
+                <ReturnType Type="Collection(graph.chatMessage)" />
+            </Function>
         </Schema>
         <Schema Namespace="microsoft.graph.callRecords" xmlns="http://docs.oasis-open.org/odata/ns/edm">
             <EnumType Name="callType">

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -773,6 +773,40 @@
         <Parameter Name="bindingParameter" Type="graph.reportRoot" />
         <ReturnType Type="Edm.Stream" Nullable="false" />
       </Function>
+      <Function Name="getAllMessages" IsBound="true" EntitySetPath="bindingParameter/channels/messages">
+        <Parameter Name="bindingParameter" Type="Collection(graph.team)" />
+        <ReturnType Type="Collection(graph.chatMessage)" />
+        <Annotation Term="Org.OData.Capabilities.V1.OperationRestrictions" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
+          <Record>
+            <PropertyValue Property="CustomQueryOptions">
+              <Collection>
+                <Record>
+                  <PropertyValue Property="Name" String="model" />
+                  <PropertyValue Property="Description" String="The payment model for the API" />
+                  <PropertyValue Property="Required" Bool="false" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Function>
+      <Function Name="getAllMessages" IsBound="true" EntitySetPath="bindingParameter/messages">
+        <Parameter Name="bindingParameter" Type="Collection(graph.channel)" />
+        <ReturnType Type="Collection(graph.chatMessage)" />
+        <Annotation Term="Org.OData.Capabilities.V1.OperationRestrictions" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
+          <Record>
+            <PropertyValue Property="CustomQueryOptions">
+              <Collection>
+                <Record>
+                  <PropertyValue Property="Name" String="model" />
+                  <PropertyValue Property="Description" String="The payment model for the API" />
+                  <PropertyValue Property="Required" Bool="false" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Function>
       <Annotations Target="microsoft.graph.driveItem/workbook">
         <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
           <Record>


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-metadata/issues/314
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1979

Uses the `Org.OData.Capabilities.V1.OperationRestrictions` to add the custom query parameters to the odata function. 