### PR TITLE
Fixes typo in `roomList` type name

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -362,7 +362,7 @@
             <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
                 <Collection>
                     <String>microsoft.graph.room</String>
-                    <String>microsoft.graph.roomlist</String>
+                    <String>microsoft.graph.roomList</String>
                 </Collection>
             </Annotation>
         </xsl:copy>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -711,7 +711,7 @@
           <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
             <Collection>
               <String>microsoft.graph.room</String>
-              <String>microsoft.graph.roomlist</String>
+              <String>microsoft.graph.roomList</String>
             </Collection>
           </Annotation>
         </EntitySet>
@@ -925,6 +925,13 @@
         </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.drive/bundles">
+        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true" />
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.administrativeUnit/members">
         <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
           <Record>
             <PropertyValue Property="Insertable" Bool="true" />


### PR DESCRIPTION
Odata cast path is not being generated in openApi path due to typo in transform.

Closes https://github.com/microsoftgraph/microsoft-graph-docs/issues/21503