### PR TITLE
Adds query parameter for childfolders

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -786,7 +786,8 @@
     </xsl:template>
 
     <!-- Add custom query options - includeHiddenFolders to mailFolders -->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='user']/edm:NavigationProperty[@Name='mailFolders']">
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='user']/edm:NavigationProperty[@Name='mailFolders'] |
+                        edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='mailFolder']/edm:NavigationProperty[@Name='childFolders']">
         <xsl:copy>
             <xsl:apply-templates select="@* | node()"/>
             <xsl:element name="Annotation">


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2031

ChildFolders are still mailFolders and support the custom parameter. 

https://learn.microsoft.com/en-us/graph/api/mailfolder-list-childfolders?view=graph-rest-1.0&tabs=http#example-2-include-hidden-child-folders-under-a-specified-mail-folder