### PR TITLE
Remove containment for `deletedItems` navigation property

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -332,9 +332,11 @@
             </Annotation>
         </xsl:copy>
     </xsl:template>
+    
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='directory']/edm:NavigationProperty[@Name='deletedItems']">
         <xsl:copy>
-            <xsl:copy-of select="@* | node()" />
+            <xsl:copy-of select="@*[not(name()='ContainsTarget')]" />
+            <xsl:copy-of select="node()" />
             <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
                 <Collection>
                     <String>microsoft.graph.user</String>

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -332,7 +332,6 @@
             </Annotation>
         </xsl:copy>
     </xsl:template>
-    
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='directory']/edm:NavigationProperty[@Name='deletedItems']">
         <xsl:copy>
             <xsl:copy-of select="@*[not(name()='ContainsTarget')]" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -324,7 +324,7 @@
         </NavigationProperty>
       </EntityType>
       <EntityType Name="directory" BaseType="graph.entity">
-        <NavigationProperty Name="deletedItems" Type="Collection(graph.directoryObject)" ContainsTarget="true">
+        <NavigationProperty Name="deletedItems" Type="Collection(graph.directoryObject)">
           <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
             <Collection>
               <String>microsoft.graph.user</String>


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/434

Removes containment for `deletedItems` navigation property. This will help stop expanding into the type cast segments of its indexer.