### PR TITLE
Updates conversion setting for Kiota-based OpenAPI files

### DIFF
--- a/conversion-settings/openapi.json
+++ b/conversion-settings/openapi.json
@@ -12,7 +12,7 @@
     "EnablePagination": true,
     "EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty": true,
     "ErrorResponsesAsDefault": false,
-    "ExpandDerivedTypesNavigationProperties": false,
+    "ExpandDerivedTypesNavigationProperties": true,
     "PrefixEntityTypeNameBeforeKey": true,
     "ShowLinks": false,
     "ShowRootPath": false,


### PR DESCRIPTION
Related to issue: https://github.com/microsoftgraph/msgraph-metadata/issues/434 and PR: https://github.com/microsoftgraph/msgraph-metadata/pull/442

- We can now expand derived types navigation properties.
- We are doing this for Kiota-based OpenAPI files first, and observe the change of paths then roll out for the other OpenAPI files later