### PR TITLE
ExternalConnection schema

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1314,6 +1314,21 @@
                 </xsl:when>
             </xsl:choose>
             
+            <!-- Add Insertability and remove Deletability for enternalConnection/schema navigation property-->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.externalConnectors.externalConnection/schema'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.externalConnectors.externalConnection/schema</xsl:attribute>
+                        <xsl:call-template name="InsertRestrictionsTemplate">
+                            <xsl:with-param name="insertable">true</xsl:with-param>
+                        </xsl:call-template>
+                        <xsl:call-template name="DeleteRestrictionsTemplate">
+                            <xsl:with-param name="deletable">false</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
+            
             <!-- Add Insertability and Updatability for educationSchool/administrativeUnit non-containment navigation property -->
             <xsl:choose>
                 <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.educationSchool/administrativeUnit'])">

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -1079,6 +1079,18 @@
           </Record>
         </Annotation>
       </Annotations>
+      <Annotations Target="microsoft.graph.externalConnectors.externalConnection/schema">
+        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false" />
+          </Record>
+        </Annotation>
+      </Annotations>
       <Annotations Target="microsoft.graph.educationSchool/administrativeUnit">
         <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
           <Record>


### PR DESCRIPTION
Add `POST` method for `/external/connections/{externalConnection-id}/schema`
Remove `DELETE` method for `/external/connections/{externalConnection-id}/schema`

Fix for #438

I believe that schema cannot be deleted once it has been registered.

The `PATCH` method is only documented for [beta](https://learn.microsoft.com/en-us/graph/api/resources/externalconnectors-schema?view=graph-rest-beta), but should be supported for [v1.0](https://learn.microsoft.com/en-us/graph/api/resources/externalconnectors-schema?view=graph-rest-1.0) event though it is not documented.