### PR TITLE
Fix for operations bound to `directoryObjects/deletedItems`

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -438,6 +438,8 @@
     <!-- Remove ContainsTarget attribute for both Kiota-based and PowerShell-based CSDL  -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='acceptedSenders']/@ContainsTarget|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='rejectedSenders']/@ContainsTarget|
+                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='connectedOrganization']/edm:NavigationProperty[@Name='externalSponsors']/@ContainsTarget|
+                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='connectedOrganization']/edm:NavigationProperty[@Name='internalSponsors']/@ContainsTarget|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='accessPackageCatalog']/edm:NavigationProperty[@Name='accessPackages']/@ContainsTarget">
         <xsl:apply-templates select="@* | node()"/>
     </xsl:template>

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1986,7 +1986,8 @@
     <xsl:template match="edm:Schema[starts-with(@Namespace, 'microsoft.graph')]/edm:Annotations[@Target='microsoft.graph.directoryObject']/*[starts-with(@Term, 'Org.OData.Capabilities')]"/>
 
     <xsl:template match="edm:Schema[starts-with(@Namespace, 'microsoft.graph')]/edm:Annotations[@Target='microsoft.graph.directoryObject']">
-        <xsl:element name="Annotation">
+        <xsl:element name="Annotations">
+          <xsl:attribute name="Target">microsoft.graph.directoryObject</xsl:attribute>    
           <Annotation Term="Org.OData.Core.V1.ExplicitOperationBindings">
             <Collection>
                 <String>microsoft.graph.getByIds</String>

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -346,6 +346,18 @@
                     <String>microsoft.graph.device</String>
                 </Collection>
             </Annotation>
+            <Annotation Term="Org.OData.Core.V1.ExplicitOperationBindings">
+                <Collection>
+                    <String>microsoft.graph.getByIds</String>
+                    <String>microsoft.graph.getAvailableExtensionProperties</String>
+                    <String>microsoft.graph.validateProperties</String>
+                    <String>microsoft.graph.restore</String>
+                    <String>microsoft.graph.getMemberObjects</String>
+                    <String>microsoft.graph.getMemberGroups</String>
+                    <String>microsoft.graph.checkMemberObjects</String>
+                    <String>microsoft.graph.checkMemberGroups</String>
+                </Collection>
+          </Annotation>
         </xsl:copy>
     </xsl:template>
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='user']/edm:NavigationProperty[@Name='ownedDevices']|
@@ -539,6 +551,17 @@
     <!-- Replace graph.report return type with Edm.Stream return type for report functions that start with 'get' -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[starts-with(@Name, 'get')][edm:ReturnType[@Type='graph.report']]/edm:ReturnType/@Type">
        <xsl:attribute name="Type">Edm.Stream</xsl:attribute>
+    </xsl:template>
+
+    <!-- Actions/Functions bound to  directoryObject should have the 'RequiresExplicitBinding' annotation-->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@IsBound='true'][edm:Parameter[@Type='graph.directoryObject']] |
+                         edm:Schema[@Namespace='microsoft.graph']/edm:Action[@IsBound='true'][edm:Parameter[@Type='Collection(graph.directoryObject)']] |
+                         edm:Schema[@Namespace='microsoft.graph']/edm:Function[@IsBound='true'][edm:Parameter[@Type='graph.directoryObject']] |
+                         edm:Schema[@Namespace='microsoft.graph']/edm:Function[@IsBound='true'][edm:Parameter[@Type='Collection(graph.directoryObject)']]">
+        <xsl:copy>
+            <xsl:copy-of select="@* | node()" />
+            <Annotation Term="Org.OData.Core.V1.RequiresExplicitBinding"/>
+        </xsl:copy>
     </xsl:template>
 
     <!--Replace single-valued with collection-valued return types for complex type appliedConditionalAccessPolicy-->
@@ -1961,6 +1984,24 @@
 
     <!-- Remove directoryObject Capability Annotations -->
     <xsl:template match="edm:Schema[starts-with(@Namespace, 'microsoft.graph')]/edm:Annotations[@Target='microsoft.graph.directoryObject']/*[starts-with(@Term, 'Org.OData.Capabilities')]"/>
+
+    <xsl:template match="edm:Schema[starts-with(@Namespace, 'microsoft.graph')]/edm:Annotations[@Target='microsoft.graph.directoryObject']">
+        <xsl:element name="Annotation">
+          <Annotation Term="Org.OData.Core.V1.ExplicitOperationBindings">
+            <Collection>
+                <String>microsoft.graph.getByIds</String>
+                <String>microsoft.graph.delta</String>
+                <String>microsoft.graph.getAvailableExtensionProperties</String>
+                <String>microsoft.graph.validateProperties</String>
+                <String>microsoft.graph.restore</String>
+                <String>microsoft.graph.getMemberObjects</String>
+                <String>microsoft.graph.getMemberGroups</String>
+                <String>microsoft.graph.checkMemberObjects</String>
+                <String>microsoft.graph.checkMemberGroups</String>
+            </Collection>
+          </Annotation>
+        </xsl:element>
+    </xsl:template>
 
     <!-- Add Referenceable Annotations (for /$ref paths) -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='connectorGroup']/edm:NavigationProperty[@Name='members']|

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -350,6 +350,10 @@
                 <Parameter Name="bindingparameter" Type="Collection(graph.event)" Nullable="false" />
                 <ReturnType Type="Collection(graph.event)" Nullable="false" />
             </Function>
+            <Function Name="delta" IsBound="true">
+                <Parameter Name="bindingparameter" Type="Collection(graph.directoryObject)" Nullable="false" />
+                <ReturnType Type="Collection(graph.directoryObject)" Nullable="false" />
+            </Function>
             <Action Name="accept" IsBound="true">
                 <Parameter Name="bindingParameter" Type="graph.event" />
                 <Parameter Name="SendResponse" Type="Edm.Boolean" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -641,7 +641,7 @@
       </EntityType>
       <EntityType Name="connectedOrganization" BaseType="graph.entity">
         <Property Name="description" Type="Edm.String" />
-        <NavigationProperty Name="internalSponsors" Type="Collection(graph.directoryObject)" ContainsTarget="true">
+        <NavigationProperty Name="internalSponsors" Type="Collection(graph.directoryObject)">
           <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
             <Record>
               <PropertyValue Property="Referenceable" Bool="true" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='preprocess_csdl.xsl'?>
 <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
   <edmx:DataServices>
@@ -356,6 +356,18 @@
               <String>microsoft.graph.servicePrincipal</String>
               <String>microsoft.graph.administrativeUnit</String>
               <String>microsoft.graph.device</String>
+            </Collection>
+          </Annotation>
+          <Annotation Term="Org.OData.Core.V1.ExplicitOperationBindings" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
+            <Collection>
+              <String>microsoft.graph.getByIds</String>
+              <String>microsoft.graph.getAvailableExtensionProperties</String>
+              <String>microsoft.graph.validateProperties</String>
+              <String>microsoft.graph.restore</String>
+              <String>microsoft.graph.getMemberObjects</String>
+              <String>microsoft.graph.getMemberGroups</String>
+              <String>microsoft.graph.checkMemberObjects</String>
+              <String>microsoft.graph.checkMemberGroups</String>
             </Collection>
           </Annotation>
         </NavigationProperty>
@@ -905,6 +917,11 @@
           </Record>
         </Annotation>
       </Function>
+      <Function Name="delta" IsBound="true">
+        <Parameter Name="bindingparameter" Type="Collection(graph.directoryObject)" Nullable="false" />
+        <ReturnType Type="Collection(graph.directoryObject)" Nullable="false" />
+        <Annotation Term="Org.OData.Core.V1.RequiresExplicitBinding" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm" />
+      </Function>
       <Action Name="accept" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event" />
         <Parameter Name="SendResponse" Type="Edm.Boolean" />
@@ -1225,7 +1242,21 @@
         <Property Name="description" Type="Edm.String" />
         <Property Name="displayName" Type="Edm.String" Nullable="false" />
       </EntityType>
-      <Annotations Target="microsoft.graph.directoryObject" />
+      <Annotation>
+        <Annotation Term="Org.OData.Core.V1.ExplicitOperationBindings" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
+          <Collection>
+            <String>microsoft.graph.getByIds</String>
+            <String>microsoft.graph.delta</String>
+            <String>microsoft.graph.getAvailableExtensionProperties</String>
+            <String>microsoft.graph.validateProperties</String>
+            <String>microsoft.graph.restore</String>
+            <String>microsoft.graph.getMemberObjects</String>
+            <String>microsoft.graph.getMemberGroups</String>
+            <String>microsoft.graph.checkMemberObjects</String>
+            <String>microsoft.graph.checkMemberGroups</String>
+          </Collection>
+        </Annotation>
+      </Annotation>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -1242,7 +1242,7 @@
         <Property Name="description" Type="Edm.String" />
         <Property Name="displayName" Type="Edm.String" Nullable="false" />
       </EntityType>
-      <Annotation>
+      <Annotations Target="microsoft.graph.directoryObject">
         <Annotation Term="Org.OData.Core.V1.ExplicitOperationBindings" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
           <Collection>
             <String>microsoft.graph.getByIds</String>
@@ -1256,7 +1256,7 @@
             <String>microsoft.graph.checkMemberGroups</String>
           </Collection>
         </Annotation>
-      </Annotation>
+      </Annotations>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>


### PR DESCRIPTION
Closes #449 

Adds `Org.OData.Core.V1.ExplicitOperationBinding` and `Org.OData.Core.V1.RequiresExplicitBinding` annotations to functions bound to directory objects type to unlock generation of functions/actions on `/deletedItems` path

Depends on release of https://github.com/microsoft/OpenAPI.NET.OData/pull/430
