### PR TITLE
Temporarily unblock generation

### DIFF
--- a/.github/policies/msgraph-metadata-branch-protection.yml
+++ b/.github/policies/msgraph-metadata-branch-protection.yml
@@ -22,7 +22,7 @@ configuration:
     # Specifies whether admins can overwrite branch protection. boolean
     isAdminEnforced: false
     # Indicates whether "Require a pull request before merging" is enabled. boolean
-    requiresPullRequestBeforeMerging: true
+    requiresPullRequestBeforeMerging: false
     # Specifies the number of pull request reviews before merging. int (0-6). Should be null/empty if PRs are not required
     requiredApprovingReviewsCount: 1
     # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean


### PR DESCRIPTION
Follow up to https://github.com/microsoftgraph/msgraph-metadata/pull/447#discussion_r1344538534

Sets `requiresPullRequestBeforeMerging` to false as generation pipeline fails with the error

```bash
remote: error: GH006: Protected branch update failed for refs/heads/master.        
remote: error: Changes must be made through a pull request. 
```