### PR TITLE
Temporarily unblock generation #2

### DIFF
--- a/.github/policies/msgraph-metadata-branch-protection.yml
+++ b/.github/policies/msgraph-metadata-branch-protection.yml
@@ -24,7 +24,7 @@ configuration:
     # Indicates whether "Require a pull request before merging" is enabled. boolean
     requiresPullRequestBeforeMerging: false
     # Specifies the number of pull request reviews before merging. int (0-6). Should be null/empty if PRs are not required
-    requiredApprovingReviewsCount: 1
+    requiredApprovingReviewsCount: 0
     # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
     requireCodeOwnersReview: true
     # Are commits required to be signed. boolean. TODO: all contributors must have commit signing on local machines.


### PR DESCRIPTION
Follow up to #453 

`requiresPullRequestBeforeMerging` only takes effect if `requiredApprovingReviewsCount` is 0 according to the docs at 
https://microsoft.github.io/GitOps/policies/branch-protection.html