### PR TITLE
Adds `DerivedTypeConstraint`, `ReadRestrictions` and `Referenceable` annotations to complex and navigation properties

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -321,6 +321,16 @@
             </xsl:element>
         </xsl:copy>
     </xsl:template>
+
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:ComplexType[@Name='onAuthenticationMethodLoadStartExternalUsersSelfServiceSignUp']/edm:NavigationProperty[@Name='identityProviders']">
+        <xsl:copy>
+            <xsl:copy-of select="@* | node()" />
+            <xsl:call-template name="ReferenceableRestrictionsTemplate">
+                <xsl:with-param name="referenceable">true</xsl:with-param>
+            </xsl:call-template>
+        </xsl:copy>
+    </xsl:template>
+    
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='user']/edm:NavigationProperty[@Name='createdObjects']|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='servicePrincipal']/edm:NavigationProperty[@Name='createdObjects']">
         <xsl:copy>
@@ -424,6 +434,36 @@
             <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
                 <Collection>
                     <String>microsoft.graph.ediscovery.caseExportOperation</String>
+                </Collection>
+            </Annotation>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='identityContainer']/edm:NavigationProperty[@Name='authenticationEventsFlows']">
+        <xsl:copy>
+            <xsl:copy-of select="@* | node()" />
+            <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
+                <Collection>
+                    <String>microsoft.graph.externalUsersSelfServiceSignUpEventsFlow</String>
+                </Collection>
+            </Annotation>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='externalUsersSelfServiceSignUpEventsFlow']/edm:Property[@Name='onAttributeCollection']">
+        <xsl:copy>
+            <xsl:copy-of select="@* | node()" />
+            <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
+                <Collection>
+                    <String>microsoft.graph.onAttributeCollectionExternalUsersSelfServiceSignUp</String>
+                </Collection>
+            </Annotation>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='externalUsersSelfServiceSignUpEventsFlow']/edm:Property[@Name='onAuthenticationMethodLoadStart']">
+        <xsl:copy>
+            <xsl:copy-of select="@* | node()" />
+            <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
+                <Collection>
+                    <String>microsoft.graph.onAuthenticationMethodLoadStartExternalUsersSelfServiceSignUp</String>
                 </Collection>
             </Annotation>
         </xsl:copy>
@@ -1615,6 +1655,30 @@
                     </xsl:element>
                 </xsl:when>
             </xsl:choose>
+            
+            <!-- Add readability for complex property externalUsersSelfServiceSignUpEventsFlow/onAttributeCollection -->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.externalUsersSelfServiceSignUpEventsFlow/onAttributeCollection'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.externalUsersSelfServiceSignUpEventsFlow/onAttributeCollection</xsl:attribute>
+                        <xsl:call-template name="ReadRestrictionsTemplate">
+                            <xsl:with-param name="readable">true</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
+
+            <!-- Add readability for complex property externalUsersSelfServiceSignUpEventsFlow/onAuthenticationMethodLoadStart -->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.externalUsersSelfServiceSignUpEventsFlow/onAuthenticationMethodLoadStart'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.externalUsersSelfServiceSignUpEventsFlow/onAuthenticationMethodLoadStart</xsl:attribute>
+                        <xsl:call-template name="ReadRestrictionsTemplate">
+                            <xsl:with-param name="readable">true</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
         
         </xsl:copy>
     </xsl:template>
@@ -1981,6 +2045,76 @@
         </xsl:choose>
     </xsl:template>
 
+    <!-- If the parent "Annotation" tag already exists, modify it -->
+    
+    <!-- Add readability for complex property externalUsersSelfServiceSignUpEventsFlow/onAttributeCollection -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.externalUsersSelfServiceSignUpEventsFlow/onAttributeCollection']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ReadRestrictions']">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:element name="Record" namespace="{namespace-uri()}">
+                <xsl:copy-of select="edm:Record/edm:PropertyValue"/>
+                <xsl:call-template name="ReadableTemplate">
+                    <xsl:with-param name="readable">true</xsl:with-param>
+                </xsl:call-template>
+            </xsl:element>
+        </xsl:copy>
+    </xsl:template>
+    
+    <!-- Add readability for complex property externalUsersSelfServiceSignUpEventsFlow/onAuthenticationMethodLoadStart -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.externalUsersSelfServiceSignUpEventsFlow/onAuthenticationMethodLoadStart']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ReadRestrictions']">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:element name="Record" namespace="{namespace-uri()}">
+                <xsl:copy-of select="edm:Record/edm:PropertyValue"/>
+                <xsl:call-template name="ReadableTemplate">
+                    <xsl:with-param name="readable">true</xsl:with-param>
+                </xsl:call-template>
+            </xsl:element>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- If the grand-parent "Annotations" tag already exists, modify it -->
+    
+    <!-- Add readability for complex property externalUsersSelfServiceSignUpEventsFlow/onAttributeCollection -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.externalUsersSelfServiceSignUpEventsFlow/onAttributeCollection']">
+        <xsl:choose>
+            <!--ReadRestrictions not present-->
+            <xsl:when test="not(edm:Annotation[@Term='Org.OData.Capabilities.V1.ReadRestrictions'])">
+                <xsl:copy>
+                    <xsl:copy-of select="@*|node()"/>
+                    <xsl:call-template name="ReadableTemplate">
+                        <xsl:with-param name="readable">true</xsl:with-param>
+                    </xsl:call-template>
+                </xsl:copy>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy>
+                    <xsl:apply-templates select="@* | node()"/>
+                </xsl:copy>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- Add readability for complex property externalUsersSelfServiceSignUpEventsFlow/onAuthenticationMethodLoadStart -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.externalUsersSelfServiceSignUpEventsFlow/onAuthenticationMethodLoadStart']">
+        <xsl:choose>
+            <!--ReadRestrictions not present-->
+            <xsl:when test="not(edm:Annotation[@Term='Org.OData.Capabilities.V1.ReadRestrictions'])">
+                <xsl:copy>
+                    <xsl:copy-of select="@*|node()"/>
+                    <xsl:call-template name="ReadableTemplate">
+                        <xsl:with-param name="readable">true</xsl:with-param>
+                    </xsl:call-template>
+                </xsl:copy>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy>
+                    <xsl:apply-templates select="@* | node()"/>
+                </xsl:copy>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
     <!-- Remove directoryObject Capability Annotations -->
     <xsl:template match="edm:Schema[starts-with(@Namespace, 'microsoft.graph')]/edm:Annotations[@Target='microsoft.graph.directoryObject']/*[starts-with(@Term, 'Org.OData.Capabilities')]"/>
 

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -89,6 +89,24 @@
             <EntityType Name="rbacApplication" BaseType="graph.entity">                
                 <NavigationProperty Name="transitiveRoleAssignments" Type="Collection(graph.unifiedRoleAssignment)" ContainsTarget="true" />                
             </EntityType>
+            <EntityType Name="externalUsersSelfServiceSignUpEventsFlow" BaseType="graph.authenticationEventsFlow">
+                <Property Name="onAttributeCollection" Type="graph.onAttributeCollectionHandler" />
+                <Property Name="onAuthenticationMethodLoadStart" Type="graph.onAuthenticationMethodLoadStartHandler" />
+            </EntityType>
+            <ComplexType Name="onAuthenticationMethodLoadStartExternalUsersSelfServiceSignUp" BaseType="graph.onAuthenticationMethodLoadStartHandler">
+                <NavigationProperty Name="identityProviders" Type="Collection(graph.identityProviderBase)" />
+            </ComplexType>
+            <EntityType Name="identityContainer">
+                <NavigationProperty Name="authenticationEventsFlows" Type="Collection(graph.authenticationEventsFlow)" ContainsTarget="true" />
+            </EntityType>
+            <Annotations Target="microsoft.graph.externalUsersSelfServiceSignUpEventsFlow/onAttributeCollection">
+                <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+                    <Record>
+                        <PropertyValue Property="Description" String="List onAttributeCollection" />
+                        <PropertyValue Property="LongDescription" String="Get the The configuration for what to invoke when attributes are ready to be collected from the user." />
+                    </Record>
+                </Annotation>
+            </Annotations>
             <Annotations Target="microsoft.graph.user/joinedGroups">
                 <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
                     <Record>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -404,6 +404,49 @@
           </Annotation>
         </NavigationProperty>
       </EntityType>
+      <EntityType Name="externalUsersSelfServiceSignUpEventsFlow" BaseType="graph.authenticationEventsFlow">
+        <Property Name="onAttributeCollection" Type="graph.onAttributeCollectionHandler">
+          <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
+            <Collection>
+              <String>microsoft.graph.onAttributeCollectionExternalUsersSelfServiceSignUp</String>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="onAuthenticationMethodLoadStart" Type="graph.onAuthenticationMethodLoadStartHandler">
+          <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
+            <Collection>
+              <String>microsoft.graph.onAuthenticationMethodLoadStartExternalUsersSelfServiceSignUp</String>
+            </Collection>
+          </Annotation>
+        </Property>
+      </EntityType>
+      <ComplexType Name="onAuthenticationMethodLoadStartExternalUsersSelfServiceSignUp" BaseType="graph.onAuthenticationMethodLoadStartHandler">
+        <NavigationProperty Name="identityProviders" Type="Collection(graph.identityProviderBase)">
+          <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+            <Record>
+              <PropertyValue Property="Referenceable" Bool="true" />
+            </Record>
+          </Annotation>
+        </NavigationProperty>
+      </ComplexType>
+      <EntityType Name="identityContainer">
+        <NavigationProperty Name="authenticationEventsFlows" Type="Collection(graph.authenticationEventsFlow)" ContainsTarget="true">
+          <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
+            <Collection>
+              <String>microsoft.graph.externalUsersSelfServiceSignUpEventsFlow</String>
+            </Collection>
+          </Annotation>
+        </NavigationProperty>
+      </EntityType>
+      <Annotations Target="microsoft.graph.externalUsersSelfServiceSignUpEventsFlow/onAttributeCollection">
+        <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+          <Record>
+            <PropertyValue Property="Description" String="List onAttributeCollection" />
+            <PropertyValue Property="LongDescription" String="Get the The configuration for what to invoke when attributes are ready to be collected from the user." />
+            <PropertyValue Property="Readable" Bool="true" />
+          </Record>
+        </Annotation>
+      </Annotations>
       <Annotations Target="microsoft.graph.user/joinedGroups">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
           <Record>
@@ -1211,6 +1254,13 @@
         <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
           <Record>
             <PropertyValue Property="Updatable" Bool="true" />
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.externalUsersSelfServiceSignUpEventsFlow/onAuthenticationMethodLoadStart">
+        <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+          <Record>
+            <PropertyValue Property="Readable" Bool="true" />
           </Record>
         </Annotation>
       </Annotations>


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/465

Specifically, this PR adds the required annotations to enable the 6 paths listed [here](https://github.com/microsoftgraph/msgraph-metadata/issues/465#issuecomment-1778887783).


Dependent on: https://github.com/microsoft/OpenAPI.NET.OData/issues/437