### PR TITLE
Set `ExpandDerivedTypesNavigationProperties = true`

### DIFF
--- a/conversion-settings/default.json
+++ b/conversion-settings/default.json
@@ -11,6 +11,6 @@
     "EnableDerivedTypesReferencesForRequestBody": false,
     "EnableDerivedTypesReferencesForResponses": false,
     "ShowRootPath": true,
-    "ExpandDerivedTypesNavigationProperties": false
+    "ExpandDerivedTypesNavigationProperties": true
   }
 }

--- a/conversion-settings/graphexplorer.json
+++ b/conversion-settings/graphexplorer.json
@@ -11,6 +11,6 @@
     "EnableDerivedTypesReferencesForRequestBody": false,
     "EnableDerivedTypesReferencesForResponses": false,
     "ShowRootPath": true,
-    "ExpandDerivedTypesNavigationProperties": false
+    "ExpandDerivedTypesNavigationProperties": true
   }
 }

--- a/conversion-settings/powershell.json
+++ b/conversion-settings/powershell.json
@@ -11,7 +11,7 @@
     "EnableDerivedTypesReferencesForRequestBody": false,
     "EnableDerivedTypesReferencesForResponses": false,
     "ShowRootPath": false,
-    "ExpandDerivedTypesNavigationProperties": false,
+    "ExpandDerivedTypesNavigationProperties": true,
     "ShowLinks": false,
     "DeclarePathParametersOnPathItem": false,
     "EnableODataAnnotationReferencesForResponses": false,

--- a/conversion-settings/powershell_v2.json
+++ b/conversion-settings/powershell_v2.json
@@ -11,7 +11,7 @@
     "EnableDerivedTypesReferencesForRequestBody": false,
     "EnableDerivedTypesReferencesForResponses": false,
     "ShowRootPath": false,
-    "ExpandDerivedTypesNavigationProperties": false,
+    "ExpandDerivedTypesNavigationProperties": true,
     "ShowLinks": false,
     "DeclarePathParametersOnPathItem": false,
     "EnableODataAnnotationReferencesForResponses": false,


### PR DESCRIPTION
This PR:
- Sets the convert setting `ExpandDerivedTypesNavigationProperties = true` for the remaining conversion settings profiles: _powershell_, _powershell_v2_, _graphexplorer_ and _default_
This setting set to `true` means we'll be generating navigation and complex properties of derived types.

The expected change in API paths (using the current CSDL as of the time of this PR) is as shown below:

**v1.0**
![image](https://github.com/microsoftgraph/msgraph-metadata/assets/40403681/8a3e3bc4-fb67-415d-aee0-9679174b0fb8)

Current v1.0 OpenAPI paths **9043**
New v1.0  OpenAPI paths **9266** 

**Beta**
![image](https://github.com/microsoftgraph/msgraph-metadata/assets/40403681/b08e71c8-88f2-43da-b921-b8a0e145f193)
![image](https://github.com/microsoftgraph/msgraph-metadata/assets/40403681/a46fdad9-4cdf-44cf-bd7f-ae3c3f5b3133)

Current beta paths **15,205**
New beta paths **15,542** 


Related work items:
https://github.com/microsoftgraph/msgraph-metadata/issues/465
https://github.com/microsoft/OpenAPI.NET.OData/issues/437