### PR TITLE
Adding `Readable` for `authenticationEventsFlow/conditions` complex property

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1703,6 +1703,18 @@
                     </xsl:element>
                 </xsl:when>
             </xsl:choose>
+
+            <!-- Add readability for complex property authenticationEventsFlow/conditions -->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.authenticationEventsFlow/conditions'])">
+                    <xsl:element name="Annotations">
+                        <xsl:attribute name="Target">microsoft.graph.authenticationEventsFlow/conditions</xsl:attribute>
+                        <xsl:call-template name="ReadRestrictionsTemplate">
+                            <xsl:with-param name="readable">true</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
         
         </xsl:copy>
     </xsl:template>
@@ -2097,6 +2109,19 @@
         </xsl:copy>
     </xsl:template>
 
+    <!-- Add readability for complex property authenticationEventsFlow/conditions -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.authenticationEventsFlow/conditions']/edm:Annotation[@Term='Org.OData.Capabilities.V1.ReadRestrictions']">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:element name="Record" namespace="{namespace-uri()}">
+                <xsl:copy-of select="edm:Record/edm:PropertyValue"/>
+                <xsl:call-template name="ReadableTemplate">
+                    <xsl:with-param name="readable">true</xsl:with-param>
+                </xsl:call-template>
+            </xsl:element>
+        </xsl:copy>
+    </xsl:template>
+
     <!-- If the grand-parent "Annotations" tag already exists, modify it -->
     
     <!-- Add readability for complex property externalUsersSelfServiceSignUpEventsFlow/onAttributeCollection -->
@@ -2121,6 +2146,26 @@
     
     <!-- Add readability for complex property externalUsersSelfServiceSignUpEventsFlow/onAuthenticationMethodLoadStart -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.externalUsersSelfServiceSignUpEventsFlow/onAuthenticationMethodLoadStart']">
+        <xsl:choose>
+            <!--ReadRestrictions not present-->
+            <xsl:when test="not(edm:Annotation[@Term='Org.OData.Capabilities.V1.ReadRestrictions'])">
+                <xsl:copy>
+                    <xsl:copy-of select="@*|node()"/>
+                    <xsl:call-template name="ReadableTemplate">
+                        <xsl:with-param name="readable">true</xsl:with-param>
+                    </xsl:call-template>
+                </xsl:copy>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy>
+                    <xsl:apply-templates select="@* | node()"/>
+                </xsl:copy>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- Add readability for complex property authenticationEventsFlow/conditions -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.authenticationEventsFlow/conditions']">
         <xsl:choose>
             <!--ReadRestrictions not present-->
             <xsl:when test="not(edm:Annotation[@Term='Org.OData.Capabilities.V1.ReadRestrictions'])">

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -102,6 +102,11 @@
                 <Property Name="onAttributeCollection" Type="graph.onAttributeCollectionHandler" />
                 <Property Name="onAuthenticationMethodLoadStart" Type="graph.onAuthenticationMethodLoadStartHandler" />
             </EntityType>
+            <EntityType Name="authenticationEventsFlow" BaseType="graph.entity" Abstract="true" OpenType="true">
+                <Property Name="conditions" Type="graph.authenticationConditions">
+                    <Annotation Term="Org.OData.Core.V1.Description" String="The conditions representing the context of the authentication request that will be used to decide whether the events policy will be invoked." />
+                </Property>                
+            </EntityType>
             <ComplexType Name="onAuthenticationMethodLoadStartExternalUsersSelfServiceSignUp" BaseType="graph.onAuthenticationMethodLoadStartHandler">
                 <NavigationProperty Name="identityProviders" Type="Collection(graph.identityProviderBase)" />
             </ComplexType>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -513,6 +513,11 @@
           </Annotation>
         </Property>
       </EntityType>
+      <EntityType Name="authenticationEventsFlow" BaseType="graph.entity" Abstract="true" OpenType="true">
+        <Property Name="conditions" Type="graph.authenticationConditions">
+          <Annotation Term="Org.OData.Core.V1.Description" String="The conditions representing the context of the authentication request that will be used to decide whether the events policy will be invoked." />
+        </Property>
+      </EntityType>
       <ComplexType Name="onAuthenticationMethodLoadStartExternalUsersSelfServiceSignUp" BaseType="graph.onAuthenticationMethodLoadStartHandler">
         <NavigationProperty Name="identityProviders" Type="Collection(graph.identityProviderBase)">
           <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
@@ -1351,6 +1356,13 @@
         </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.externalUsersSelfServiceSignUpEventsFlow/onAuthenticationMethodLoadStart">
+        <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+          <Record>
+            <PropertyValue Property="Readable" Bool="true" />
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.authenticationEventsFlow/conditions">
         <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
           <Record>
             <PropertyValue Property="Readable" Bool="true" />


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/465

Enabling this complex property will allow us to expand nested complex properties to generate nested navigation properties.

This path will thus be enabled: https://learn.microsoft.com/en-us/graph/api/authenticationconditionsapplications-list-includeapplications?view=graph-rest-beta&tabs=http#http-request

_/identity/authenticationEventsFlows/{authenticationEventsFlow-id}/conditions/applications/includeApplications/_