### PR TITLE
Fixes date property casing in the innerError class

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1276,7 +1276,7 @@
                             </xsl:element>
                         </xsl:element>
                         <xsl:element name="Property">
-                            <xsl:attribute name="Name">Date</xsl:attribute>
+                            <xsl:attribute name="Name">date</xsl:attribute>
                             <xsl:attribute name="Type">Edm.DateTimeOffset</xsl:attribute>
                             <xsl:element name="Annotation">
                                 <xsl:attribute name="Term">Org.OData.Core.V1.Description</xsl:attribute>


### PR DESCRIPTION
Date property in the innerError class should be camelCased. Otherwise it fails to deserilaize in the correct property.

Fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2262