### PR TITLE
Fixes missing calendarView query parameters. 

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -883,6 +883,11 @@
                                 <xsl:with-param name="startDateTimeName">startDateTime</xsl:with-param>
                                 <xsl:with-param name="endDateTimeName">endDateTime</xsl:with-param>
                             </xsl:call-template>
+                            <xsl:call-template name="CalendarViewRestrictedPopertyTemplate">
+                                <xsl:with-param name="propertyPath">calendarGroups/calendars/calendarView</xsl:with-param>
+                                <xsl:with-param name="startDateTimeName">startDateTime</xsl:with-param>
+                                <xsl:with-param name="endDateTimeName">endDateTime</xsl:with-param>
+                            </xsl:call-template>
                         </xsl:element>
                     </xsl:element>
                 </xsl:element>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -973,6 +973,29 @@
                       </Record>
                     </PropertyValue>
                   </Record>
+                  <Record>
+                    <PropertyValue Property="NavigationProperty">
+                      <PropertyPath>calendarGroups/calendars/calendarView</PropertyPath>
+                    </PropertyValue>
+                    <PropertyValue Property="ReadRestrictions">
+                      <Record>
+                        <PropertyValue Property="CustomQueryOptions">
+                          <Collection>
+                            <Record>
+                              <PropertyValue Property="Name" String="startDateTime" />
+                              <PropertyValue Property="Description" String="The start date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T19:00:00-08:00" />
+                              <PropertyValue Property="Required" Bool="true" />
+                            </Record>
+                            <Record>
+                              <PropertyValue Property="Name" String="endDateTime" />
+                              <PropertyValue Property="Description" String="The end date and time of the time range, represented in ISO 8601 format. For example, 2019-11-08T20:00:00-08:00" />
+                              <PropertyValue Property="Required" Bool="true" />
+                            </Record>
+                          </Collection>
+                        </PropertyValue>
+                      </Record>
+                    </PropertyValue>
+                  </Record>
                 </Collection>
               </PropertyValue>
             </Record>


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-metadata/issues/538

Fixes the missing `endDateTime` and `startDateTime` query parameters for the `calendarView` nav property on the `/users/{id}/calendarGroups/{id}/calendars/{id}/calendarView` path