### PR TITLE
Fixes missing format query parameter for `driveItem` content. 

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -984,6 +984,27 @@
         </xsl:copy>
     </xsl:template>
 
+    <!-- Add custom query options - $format to driveItem/content -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='driveItem']/edm:Property[@Name='content']">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+            <xsl:element name="Annotation">
+                <xsl:attribute name="Term">Org.OData.Capabilities.V1.ReadRestrictions</xsl:attribute>
+                <xsl:element name="Record" namespace="{namespace-uri()}">
+                    <PropertyValue Property="CustomQueryOptions">
+                      <Collection>
+                        <Record>
+                          <PropertyValue Property="Name" String="$format" />
+                          <PropertyValue Property="Description" String="Format of the content" />
+                          <PropertyValue Property="Required" Bool="false" />
+                        </Record>
+                      </Collection>
+                    </PropertyValue>
+                </xsl:element>
+            </xsl:element>
+        </xsl:copy>
+    </xsl:template>
+
     <!-- Add custom query options - includeHiddenMessages to messages -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='user']/edm:NavigationProperty[@Name='messages']">
         <xsl:copy>

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -71,6 +71,7 @@
                 <Property Name="title" Type="Edm.String" />
             </EntityType>
             <EntityType Name="driveItem" BaseType="graph.baseItem">
+                <Property Name="content" Type="Edm.Stream" />
                 <NavigationProperty Name="analytics" Type="graph.itemAnalytics" ContainsTarget="true">
                     <Annotation Term="Org.OData.Core.V1.Description" String="Analytics about the view activities that took place on this item." />
                 </NavigationProperty>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -332,6 +332,21 @@
         <Property Name="title" Type="Edm.String" />
       </EntityType>
       <EntityType Name="driveItem" BaseType="graph.baseItem">
+        <Property Name="content" Type="Edm.Stream">
+          <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+            <Record>
+              <PropertyValue Property="CustomQueryOptions" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="Name" String="$format" />
+                    <PropertyValue Property="Description" String="Format of the content" />
+                    <PropertyValue Property="Required" Bool="false" />
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </Property>
         <NavigationProperty Name="analytics" Type="graph.itemAnalytics" ContainsTarget="true">
           <Annotation Term="Org.OData.Core.V1.Description" String="Analytics about the view activities that took place on this item." />
         </NavigationProperty>


### PR DESCRIPTION
Fixes missing annotation for driveItem content after fix made in https://github.com/microsoft/OpenAPI.NET.OData/pull/470 in the conversion library.

Fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1621