### PR TITLE
Follow up to #581

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -2366,6 +2366,7 @@
 
      <!-- Add ExplicitOperationBindings for followedSites and sites navigation props --> 
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='user']/edm:NavigationProperty[@Name='followedSites']|
+                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='sites']|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='site']/edm:NavigationProperty[@Name='sites']">
         <xsl:copy>
             <xsl:apply-templates select="@* | node()"/>


### PR DESCRIPTION
Follow up to https://github.com/microsoftgraph/msgraph-metadata/pull/581

`group/sites` also needs the `ExplicitOperationBindings` otherwise we witness removal of paths as seen in https://github.com/microsoftgraph/msgraph-sdk-dotnet/compare/dev...kiota/v1.0/pipelinebuild/138236