### PR TITLE
Sets `IsComposable=true` for `workbook*` bound types

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -644,6 +644,31 @@
         <xsl:attribute name="IsComposable">false</xsl:attribute>
     </xsl:template>
 
+    <!-- Set IsComposable to true for all functions with a bindparameter (NOT bindingparameter: possible CSDL error) of:
+         workbookRange/workbookNamedItem/workbookTable/workbookTableColumn/workbookTableRow/workbookWorksheet -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[edm:Parameter[@Name='bindparameter'][@Type='graph.workbookRange']] |
+                         edm:Schema[@Namespace='microsoft.graph']/edm:Function[edm:Parameter[@Name='bindparameter'][@Type='graph.workbookNamedItem']] |
+                         edm:Schema[@Namespace='microsoft.graph']/edm:Function[edm:Parameter[@Name='bindparameter'][@Type='graph.workbookTable']] |
+                         edm:Schema[@Namespace='microsoft.graph']/edm:Function[edm:Parameter[@Name='bindparameter'][@Type='graph.workbookTableColumn']] |
+                         edm:Schema[@Namespace='microsoft.graph']/edm:Function[edm:Parameter[@Name='bindparameter'][@Type='graph.workbookTableRow']] |
+                         edm:Schema[@Namespace='microsoft.graph']/edm:Function[edm:Parameter[@Name='bindparameter'][@Type='graph.workbookWorksheet']]">
+        <xsl:choose>
+            <!-- Enable only for Kiota-based OpenAPI generation because of the increase in number of paths this will cause -->
+            <xsl:when test="$open-api-generation='True'">
+                <xsl:copy>
+                    <xsl:apply-templates select="@*"/>
+                    <xsl:attribute name="IsComposable">true</xsl:attribute>
+                    <xsl:apply-templates select="node()"/>
+                </xsl:copy>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy>
+                    <xsl:copy-of select="@* | node()"/>
+                </xsl:copy>
+            </xsl:otherwise>
+        </xsl:choose>        
+    </xsl:template>
+
     <!-- Actions/Functions bound to directoryObject should have the 'RequiresExplicitBinding' annotation-->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@IsBound='true'][edm:Parameter[@Type='graph.directoryObject']] |
                          edm:Schema[@Namespace='microsoft.graph']/edm:Action[@IsBound='true'][edm:Parameter[@Type='Collection(graph.directoryObject)']] |


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/582

- There are no tests for this PR because to see the output the default variables values: `remove-capability-annotations` and `add-innererror-description` in the XSL file will have to be changed to `False` and `True` respectively.
- There seems to be a typo in the naming of `bindparameter` instead of `bindingparameter` in the CSDL for the respective APIs been updated. These affects both actions and functions of these APIs. The mistyped `bindparameter` is used in the XSL script so that a match is possible. When these have been resolved upstream, we shall make the necessary changes here as well. @marabooy are you able to help surface this to the relevant API owner(s)?
- We are specifically setting `IsComposable=true` for Kiota-based OpenApi generation. This is because the aftermath of this is an increase in the number of paths, which may potentially affect the PowerShell SDK. See below diffs for the expected change in the number of paths after this change goes out:
  - Powershell vs Kiota OpenApi diff.: https://www.diffchecker.com/0x24PNc6/
  - Kiota (current) vs Kiota (new) OpenApi diff: https://www.diffchecker.com/wAi8LjXR/