### PR TITLE
Revert "Sets `IsComposable=true` for `workbook*` bound types"

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -644,31 +644,6 @@
         <xsl:attribute name="IsComposable">false</xsl:attribute>
     </xsl:template>
 
-    <!-- Set IsComposable to true for all functions with a bindparameter (NOT bindingparameter: possible CSDL error) of:
-         workbookRange/workbookNamedItem/workbookTable/workbookTableColumn/workbookTableRow/workbookWorksheet -->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[edm:Parameter[@Name='bindparameter'][@Type='graph.workbookRange']] |
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Function[edm:Parameter[@Name='bindparameter'][@Type='graph.workbookNamedItem']] |
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Function[edm:Parameter[@Name='bindparameter'][@Type='graph.workbookTable']] |
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Function[edm:Parameter[@Name='bindparameter'][@Type='graph.workbookTableColumn']] |
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Function[edm:Parameter[@Name='bindparameter'][@Type='graph.workbookTableRow']] |
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Function[edm:Parameter[@Name='bindparameter'][@Type='graph.workbookWorksheet']]">
-        <xsl:choose>
-            <!-- Enable only for Kiota-based OpenAPI generation because of the increase in number of paths this will cause -->
-            <xsl:when test="$open-api-generation='True'">
-                <xsl:copy>
-                    <xsl:apply-templates select="@*"/>
-                    <xsl:attribute name="IsComposable">true</xsl:attribute>
-                    <xsl:apply-templates select="node()"/>
-                </xsl:copy>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:copy>
-                    <xsl:copy-of select="@* | node()"/>
-                </xsl:copy>
-            </xsl:otherwise>
-        </xsl:choose>        
-    </xsl:template>
-
     <!-- Actions/Functions bound to directoryObject should have the 'RequiresExplicitBinding' annotation-->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@IsBound='true'][edm:Parameter[@Type='graph.directoryObject']] |
                          edm:Schema[@Namespace='microsoft.graph']/edm:Action[@IsBound='true'][edm:Parameter[@Type='Collection(graph.directoryObject)']] |


### PR DESCRIPTION
Temporarily Reverts microsoftgraph/msgraph-metadata#585

The generation pipeline isn't able to push some yamls because of the size exceeding 100MB so we would need to resolve https://github.com/microsoftgraph/msgraph-metadata/issues/184 first to enable git LFS if we are to go forward. 
https://github.com/microsoftgraph/msgraph-metadata/pull/585#issuecomment-1983469978

cc @baywet @irvinesunday 
