### PR TITLE
Adds `deletability` support for `graph.user/photo` and `graph.group/photo`

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1695,19 +1695,8 @@
                 </xsl:when>
             </xsl:choose>
         
-            <!-- Remove Deletability for photo navigation properties of type profilePhoto -->
+            <!-- Remove Deletability for photo navigation properties of type profilePhoto; except user and group -->            
             
-            <xsl:choose>
-                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.user/photo'])">
-                    <xsl:element name="Annotations">
-                        <xsl:attribute name="Target">microsoft.graph.user/photo</xsl:attribute>
-                        <xsl:call-template name="DeleteRestrictionsTemplate">
-                            <xsl:with-param name="deletable">false</xsl:with-param>
-                        </xsl:call-template>                        
-                    </xsl:element>
-                </xsl:when>
-            </xsl:choose>
-        
             <xsl:choose>
                 <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.contact/photo'])">
                     <xsl:element name="Annotations">
@@ -1723,17 +1712,6 @@
                 <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.team/photo'])">
                     <xsl:element name="Annotations">
                         <xsl:attribute name="Target">microsoft.graph.team/photo</xsl:attribute>
-                        <xsl:call-template name="DeleteRestrictionsTemplate">
-                            <xsl:with-param name="deletable">false</xsl:with-param>
-                        </xsl:call-template>                        
-                    </xsl:element>
-                </xsl:when>
-            </xsl:choose>
-        
-            <xsl:choose>
-                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.group/photo'])">
-                    <xsl:element name="Annotations">
-                        <xsl:attribute name="Target">microsoft.graph.group/photo</xsl:attribute>
                         <xsl:call-template name="DeleteRestrictionsTemplate">
                             <xsl:with-param name="deletable">false</xsl:with-param>
                         </xsl:call-template>                        
@@ -2485,12 +2463,10 @@
         </xsl:copy>
     </xsl:template>
 
-    <!-- Remove Deletability for photo navigation properties of type profilePhoto -->
-    <!-- If the grand-parent "Annotations" tag already exists, add the DeleteRestrictions annotation -->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/photo']|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.contact/photo']|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.team/photo']|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.group/photo']">
+    <!-- Remove Deletability for photo navigation properties of type profilePhoto; except user and group -->
+<!-- If the grand-parent "Annotations" tag already exists, add the DeleteRestrictions annotation -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.contact/photo']|
+                         edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.team/photo']">
         <xsl:choose>
             <xsl:when test="not(edm:Annotation[@Term='Org.OData.Capabilities.V1.DeleteRestrictions'])">
                 <xsl:copy>
@@ -2508,12 +2484,10 @@
         </xsl:choose>
     </xsl:template>
     
-    <!-- Remove Deletability for photo navigation properties of type profilePhoto -->    
+    <!-- Remove Deletability for photo navigation properties of type profilePhoto; except user and group -->    
     <!--If the DeleteRestrictions exists, update the Bool attribute value to false-->
-    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.user/photo']/edm:Annotation[@Term='Org.OData.Capabilities.V1.DeleteRestrictions']|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.contact/photo']/edm:Annotation[@Term='Org.OData.Capabilities.V1.DeleteRestrictions']|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.team/photo']/edm:Annotation[@Term='Org.OData.Capabilities.V1.DeleteRestrictions']|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.group/photo']/edm:Annotation[@Term='Org.OData.Capabilities.V1.DeleteRestrictions']">
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.contact/photo']/edm:Annotation[@Term='Org.OData.Capabilities.V1.DeleteRestrictions']|
+                         edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.team/photo']/edm:Annotation[@Term='Org.OData.Capabilities.V1.DeleteRestrictions']">
        <xsl:copy>
         <xsl:attribute name="Term">
           <xsl:value-of select="@Term" />

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1695,7 +1695,7 @@
                 </xsl:when>
             </xsl:choose>
         
-            <!-- Remove Deletability for photo navigation properties of type profilePhoto; except user and group -->            
+            <!-- Remove Deletability for photo navigation properties of type profilePhoto; except user/photo and group/photo -->            
             
             <xsl:choose>
                 <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.contact/photo'])">
@@ -2463,7 +2463,7 @@
         </xsl:copy>
     </xsl:template>
 
-    <!-- Remove Deletability for photo navigation properties of type profilePhoto; except user and group -->
+    <!-- Remove Deletability for photo navigation properties of type profilePhoto; user/photo and group/photo -->
 <!-- If the grand-parent "Annotations" tag already exists, add the DeleteRestrictions annotation -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.contact/photo']|
                          edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.team/photo']">
@@ -2484,7 +2484,7 @@
         </xsl:choose>
     </xsl:template>
     
-    <!-- Remove Deletability for photo navigation properties of type profilePhoto; except user and group -->    
+    <!-- Remove Deletability for photo navigation properties of type profilePhoto; user/photo and group/photo -->    
     <!--If the DeleteRestrictions exists, update the Bool attribute value to false-->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.contact/photo']/edm:Annotation[@Term='Org.OData.Capabilities.V1.DeleteRestrictions']|
                          edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.team/photo']/edm:Annotation[@Term='Org.OData.Capabilities.V1.DeleteRestrictions']">

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -226,14 +226,14 @@
                     </Record>
                 </Annotation>
             </Annotations>
-            <Annotations Target="microsoft.graph.user/photo">
+            <Annotations Target="microsoft.graph.contact/photo">
                 <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
                     <Record>
                         <PropertyValue Property="Deletable" Bool="true" />
                     </Record>
                 </Annotation>
             </Annotations>
-            <Annotations Target="microsoft.graph.group/photo">
+            <Annotations Target="microsoft.graph.team/photo">
                 <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
                     <Record>
                         <PropertyValue Property="Insertable" Bool="false" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -731,14 +731,14 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="microsoft.graph.user/photo">
+      <Annotations Target="microsoft.graph.contact/photo">
         <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
           <Record>
             <PropertyValue Property="Deletable" Bool="false" />
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="microsoft.graph.group/photo">
+      <Annotations Target="microsoft.graph.team/photo">
         <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
           <Record>
             <PropertyValue Property="Insertable" Bool="false" />
@@ -1178,18 +1178,18 @@
         <ReturnType Type="Collection(graph.directoryObject)" Nullable="false" />
         <Annotation Term="Org.OData.Core.V1.RequiresExplicitBinding" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm" />
       </Function>
-      <Function Name="boundingRect" IsBound="true" IsComposable="true">
+      <Function Name="boundingRect" IsBound="true" IsComposable="false">
         <Parameter Name="bindparameter" Type="graph.workbookRange" />
         <Parameter Name="anotherRange" Type="Edm.String" Unicode="false" />
         <ReturnType Type="graph.workbookRange" />
       </Function>
-      <Function Name="cell" IsBound="true" IsComposable="true">
+      <Function Name="cell" IsBound="true" IsComposable="false">
         <Parameter Name="bindparameter" Type="graph.workbookRange" />
         <Parameter Name="row" Type="Edm.Int32" Nullable="false" />
         <Parameter Name="column" Type="Edm.Int32" Nullable="false" />
         <ReturnType Type="graph.workbookRange" />
       </Function>
-      <Function Name="cell" IsBound="true" IsComposable="true">
+      <Function Name="cell" IsBound="true" IsComposable="false">
         <Parameter Name="bindparameter" Type="graph.workbookWorksheet" />
         <Parameter Name="row" Type="Edm.Int32" Nullable="false" />
         <Parameter Name="column" Type="Edm.Int32" Nullable="false" />
@@ -1480,20 +1480,6 @@
       <Annotations Target="microsoft.graph.message/attachments">
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false" />
         <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="false" />
-      </Annotations>
-      <Annotations Target="microsoft.graph.contact/photo">
-        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
-          <Record>
-            <PropertyValue Property="Deletable" Bool="false" />
-          </Record>
-        </Annotation>
-      </Annotations>
-      <Annotations Target="microsoft.graph.team/photo">
-        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
-          <Record>
-            <PropertyValue Property="Deletable" Bool="false" />
-          </Record>
-        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.b2xIdentityUserFlow/apiConnectorConfiguration">
         <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/593

This PR reverts the transforms added via PR: https://github.com/microsoftgraph/msgraph-metadata/pull/392 to remove deletability for `graph.user/photo` and `graph.group/photo` navigation properties.