### PR TITLE
Removes indexability for `invitations` entity set

### DIFF
--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -132,6 +132,14 @@
             <EntityType Name="identityContainer">
                 <NavigationProperty Name="authenticationEventsFlows" Type="Collection(graph.authenticationEventsFlow)" ContainsTarget="true" />
             </EntityType>
+            <Annotations Target="microsoft.graph.GraphService/invitations">
+                <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+                    <Record>
+                        <PropertyValue Property="Description" String="Create invitation" />
+                        <PropertyValue Property="LongDescription" String="Use this API to create a new invitation. Invitation adds an external user to the organization. When creating a new invitation, you have several options available:" />
+                    </Record>
+                </Annotation>
+            </Annotations>
             <Annotations Target="microsoft.graph.directory/deletedItems">                
                 <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
                     <Record>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='preprocess_csdl.xsl'?>
 <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
   <edmx:DataServices>
@@ -599,6 +599,9 @@
           </Annotation>
         </NavigationProperty>
       </EntityType>
+      <Annotations Target="microsoft.graph.GraphService/invitations">
+        <Annotation Term="Org.OData.Capabilities.V1.IndexableByKey" Bool="false" />
+      </Annotations>
       <Annotations Target="microsoft.graph.directory/deletedItems">
         <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
           <Record>


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/427

Partially resolves: https://github.com/microsoftgraph/microsoft-graph-explorer-v4/issues/2787

Related to: https://github.com/microsoft/OpenAPI.NET.OData/pull/543