### PR TITLE
Removes containment for `drive` navigation property for `fileStorageContainer` entity type

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -531,7 +531,8 @@
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='group']/edm:NavigationProperty[@Name='rejectedSenders']/@ContainsTarget|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='connectedOrganization']/edm:NavigationProperty[@Name='externalSponsors']/@ContainsTarget|
                          edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='connectedOrganization']/edm:NavigationProperty[@Name='internalSponsors']/@ContainsTarget|
-                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='accessPackageCatalog']/edm:NavigationProperty[@Name='accessPackages']/@ContainsTarget">
+                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='accessPackageCatalog']/edm:NavigationProperty[@Name='accessPackages']/@ContainsTarget|
+                         edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='fileStorageContainer']/edm:NavigationProperty[@Name='drive']/@ContainsTarget">
         <xsl:apply-templates select="@* | node()"/>
     </xsl:template>
 

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -399,6 +399,9 @@
                 <Property Name="apiConnectorConfiguration" Type="graph.userFlowApiConnectorConfiguration" />
                 <NavigationProperty Name="identityProviders" Type="Collection(graph.identityProvider)" />                
             </EntityType>
+            <EntityType Name="fileStorageContainer" BaseType="graph.entity">
+                <NavigationProperty Name="drive" Type="graph.drive" ContainsTarget="true" />
+            </EntityType>
             <ComplexType Name="certificateAuthority">
                 <Property Name="certificate" Type="Edm.Binary" Nullable="false" />
                 <Property Name="isRootAuthority" Type="Edm.Boolean" Nullable="false" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -913,6 +913,9 @@
         <Property Name="apiConnectorConfiguration" Type="graph.userFlowApiConnectorConfiguration" />
         <NavigationProperty Name="identityProviders" Type="Collection(graph.identityProvider)" />
       </EntityType>
+      <EntityType Name="fileStorageContainer" BaseType="graph.entity">
+        <NavigationProperty Name="drive" Type="graph.drive" />
+      </EntityType>
       <ComplexType Name="certificateAuthority">
         <Property Name="certificate" Type="Edm.Binary" Nullable="false" />
         <Property Name="isRootAuthority" Type="Edm.Boolean" Nullable="false" />


### PR DESCRIPTION
This PR attempts to fix: https://github.com/microsoftgraph/msgraph-metadata/issues/644

Background conversation on this can be found from the same issue here: https://github.com/microsoftgraph/msgraph-metadata/issues/644#issuecomment-2233260116