### PR TITLE
fix: only set Edm.Untyped for openApi related generation

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -36,10 +36,19 @@
 	
 	<!-- Changes Type attribute for properties and action/functions parameters from 'graph.Json' to 'Edm.UnTyped'-->
 	<xsl:template match="edm:Property[@Type='graph.Json'] | edm:Parameter[@Type='graph.Json']">
-        <xsl:copy>
-            <xsl:apply-templates select="@*"/>
-            <xsl:attribute name="Type">Edm.Untyped</xsl:attribute>
-        </xsl:copy>
+        <xsl:choose>
+            <xsl:when test="$open-api-generation='True'">
+                <xsl:copy>
+                    <xsl:apply-templates select="@*"/>
+                    <xsl:attribute name="Type">Edm.Untyped</xsl:attribute>
+                </xsl:copy>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy>
+                    <xsl:apply-templates select="@* | node()"/>
+                </xsl:copy>    
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
     <!-- Adds ContainsTarget attribute to navigation properties. These typically represent scenarios where we need to provide an improvement


### PR DESCRIPTION
Related to failing genation at https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=161941&view=logs&j=ae118d5a-6432-50f6-1c0d-bcd240c6a549&t=288df45d-d1d5-59e6-efbc-8364a9b6cd55

Makes the transform for Edm.Untyped to only be for OpenApi related generation as the generation for TS typing does not support the type yet. 

Follow up to https://github.com/microsoftgraph/msgraph-metadata/pull/628