### PR TITLE
Remove autoReconcileProxyConflict parameter from restore action of graph.directoryObject

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -646,6 +646,10 @@
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='delta'][edm:Parameter[@Name='token']][edm:Parameter[@Type='Collection(graph.site)']]"/>
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='additionalAccess'][edm:Parameter[@Name='accessPackageId']][edm:Parameter[@Type='Collection(graph.accessPackageAssignment)']][1]"/>
 
+    <!-- Remove action parameter -->
+    <!-- This should be a temp fix, tracking: https://github.com/microsoft/OpenAPI.NET.OData/issues/582 -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='restore']/edm:Parameter[@Name='autoReconcileProxyConflict']"/>
+
     <!-- Remove action parameters -->
     <!-- This should be a temp fix, tracking: https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/261 -->
     <!-- <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='createUploadSession']/edm:Parameter[@Name='deferCommit']"/> -->
@@ -662,7 +666,7 @@
                          edm:Schema[@Namespace='microsoft.graph']/edm:Function[@IsBound='true'][edm:Parameter[@Type='graph.directoryObject']] |
                          edm:Schema[@Namespace='microsoft.graph']/edm:Function[@IsBound='true'][edm:Parameter[@Type='Collection(graph.directoryObject)']]">
         <xsl:copy>
-            <xsl:copy-of select="@* | node()" />
+            <xsl:apply-templates select="@* | node()" />
             <Annotation Term="Org.OData.Core.V1.RequiresExplicitBinding"/>
         </xsl:copy>
     </xsl:template>

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -442,6 +442,13 @@
 				<Parameter Name="method" Type="graph.Json" />
 				<ReturnType Type="graph.workbookFunctionResult" />
 			</Action>
+            <Action Name="restore" IsBound="true">
+                <Parameter Name="bindingParameter" Type="graph.directoryObject" Nullable="false" />
+                <Parameter Name="autoReconcileProxyConflict" Type="Edm.Boolean">
+                    <Annotation Term="Org.OData.Core.V1.OptionalParameter" />
+                </Parameter>
+                <ReturnType Type="graph.directoryObject" />
+            </Action>
             <Action Name="add" IsBound="true">
                 <Parameter Name="bindingParameter" Type="Collection(graph.site)" />
                 <Parameter Name="value" Type="Collection(graph.site)" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='preprocess_csdl.xsl'?>
 <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
   <edmx:DataServices>
@@ -562,11 +562,11 @@
             </Collection>
           </Annotation>
         </Property>
-      </EntityType>	  
-	  <EntityType Name="workbookFunctionResult" BaseType="graph.entity">
-		<Property Name="error" Type="Edm.String" />
-		<Property Name="value" Type="Edm.Untyped" />
-	  </EntityType>
+      </EntityType>
+      <EntityType Name="workbookFunctionResult" BaseType="graph.entity">
+        <Property Name="error" Type="Edm.String" />
+        <Property Name="value" Type="graph.Json" />
+      </EntityType>
       <EntityType Name="authenticationEventsFlow" BaseType="graph.entity" Abstract="true" OpenType="true">
         <Property Name="conditions" Type="graph.authenticationConditions">
           <Annotation Term="Org.OData.Core.V1.Description" String="The conditions representing the context of the authentication request that will be used to decide whether the events policy will be invoked." />
@@ -1190,10 +1190,15 @@
       </Function>
       <Action Name="days360" IsBound="true">
         <Parameter Name="bindparameter" Type="graph.workbookFunctions" />
-        <Parameter Name="startDate" Type="Edm.Untyped" />
-        <Parameter Name="endDate" Type="Edm.Untyped" />
-        <Parameter Name="method" Type="Edm.Untyped" />
+        <Parameter Name="startDate" Type="graph.Json" />
+        <Parameter Name="endDate" Type="graph.Json" />
+        <Parameter Name="method" Type="graph.Json" />
         <ReturnType Type="graph.workbookFunctionResult" />
+      </Action>
+      <Action Name="restore" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.directoryObject" Nullable="false" />
+        <ReturnType Type="graph.directoryObject" />
+        <Annotation Term="Org.OData.Core.V1.RequiresExplicitBinding" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm" />
       </Action>
       <Action Name="add" IsBound="true">
         <Parameter Name="bindingParameter" Type="Collection(graph.site)" />


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/694

Temporary fix for metadata as https://github.com/microsoft/OpenAPI.NET.OData/issues/582 is being resolved