### PR TITLE
Upload the correct artifacts in PR check

### DIFF
--- a/.github/workflows/metadata-parser-validation.yml
+++ b/.github/workflows/metadata-parser-validation.yml
@@ -43,7 +43,7 @@ jobs:
       uses: fluximus-prime/redocly-cli-github-action@v1
       continue-on-error: true # temporary workaround since our descriptions are invalid at the moment
       with:
-        args: 'lint openapi/${{ matrix.version }}/${{ matrix.settings }}.yaml --skip-rule operation-4xx-response --skip-rule no-server-trailing-slash --skip-rule no-unused-components --skip-rule security-defined --skip-rule info-license-url --skip-rule info-license --skip-rule no-empty-servers --skip-rule operation-summary --skip-rule tag-description --max-problems 1000'
+        args: 'lint transformed_${{ matrix.version }}_${{ matrix.settings }}_metadata.yml --skip-rule operation-4xx-response --skip-rule no-server-trailing-slash --skip-rule no-unused-components --skip-rule security-defined --skip-rule info-license-url --skip-rule info-license --skip-rule no-empty-servers --skip-rule operation-summary --skip-rule tag-description --max-problems 1000'
 
     - uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/metadata-parser-validation.yml
+++ b/.github/workflows/metadata-parser-validation.yml
@@ -49,4 +49,4 @@ jobs:
       if: always()
       with:
         name: ${{ matrix.version }}-${{ matrix.settings }}
-        path: openapi/${{ matrix.version }}/${{ matrix.settings }}.yaml
+        path: transformed_${{ matrix.version }}_${{ matrix.settings }}_metadata.yml

--- a/scripts/run-metadata-validation.ps1
+++ b/scripts/run-metadata-validation.ps1
@@ -34,6 +34,7 @@ $conversionSettingsDirectory = Join-Path $repoDirectory "conversion-settings"
 $snapshot = Join-Path $repoDirectory "schemas" "annotated-$($version)-Prod.csdl"
 
 $transformed = Join-Path $repoDirectory "transformed_$($version)_metadata.xml"
+$yamlFilePath = Join-Path $repoDirectory "transformed_$($version)_$($platformName)_metadata.yml"
 
 try {
     Write-Host "Tranforming $snapshot metadata using xslt with parameters used in the OpenAPI flow..." -ForegroundColor Green
@@ -41,7 +42,6 @@ try {
 
     Write-Host "Validating $transformed metadata after the transform..." -ForegroundColor Green
     & dotnet tool install Microsoft.OpenApi.Hidi -g --prerelease
-    $yamlFilePath = "$transformed.yaml"
     & hidi transform --cs $transformed -o $yamlFilePath --co -f Yaml --sp "$conversionSettingsDirectory/$platformName.json"
 
 } catch {


### PR DESCRIPTION
Changes made in PRs dont really upload the correct artifacts in the PR check. The simply end up uploading the same files already checked into the repository so transforms can't be validated from the artifacts.

This PR fixes the check to upload the generated file from the PR change. 
This change should still be compatible with the cleanup job done in the generation pipeline at https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/blob/9d5561d71147cfc8008b7bed8c2712e43d93c8f5/.azure-pipelines/generation-templates/capture-metadata.yml#L123