### PR TITLE
Remove optional parameter `forceTakeover` to the `verify` action

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -650,6 +650,10 @@
     <!-- This should be a temp fix, tracking: https://github.com/microsoft/OpenAPI.NET.OData/issues/582 -->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='restore']/edm:Parameter[@Name='autoReconcileProxyConflict']"/>
 
+    <!-- Remove action parameter -->
+    <!-- This should be a temp fix, tracking: https://github.com/microsoft/OpenAPI.NET.OData/issues/582 -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='verify']/edm:Parameter[@Name='forceTakeover']"/>
+
     <!-- Remove action parameters -->
     <!-- This should be a temp fix, tracking: https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/261 -->
     <!-- <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='createUploadSession']/edm:Parameter[@Name='deferCommit']"/> -->

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -450,6 +450,13 @@
 				<Parameter Name="method" Type="graph.Json" />
 				<ReturnType Type="graph.workbookFunctionResult" />
 			</Action>
+            <Action Name="verify" EntitySetPath="bindingParameter" IsBound="true">
+                <Parameter Name="bindingParameter" Type="graph.domain" Nullable="false" />
+                <Parameter Name="forceTakeover" Type="Edm.Boolean">
+                    <Annotation Term="Org.OData.Core.V1.OptionalParameter" />
+                </Parameter>
+                <ReturnType Type="graph.domain" />
+            </Action>
             <Action Name="restore" IsBound="true">
                 <Parameter Name="bindingParameter" Type="graph.directoryObject" Nullable="false" />
                 <Parameter Name="autoReconcileProxyConflict" Type="Edm.Boolean">

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -1209,6 +1209,10 @@
         <Parameter Name="method" Type="graph.Json" />
         <ReturnType Type="graph.workbookFunctionResult" />
       </Action>
+      <Action Name="verify" EntitySetPath="bindingParameter" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.domain" Nullable="false" />
+        <ReturnType Type="graph.domain" />
+      </Action>
       <Action Name="restore" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.directoryObject" Nullable="false" />
         <ReturnType Type="graph.directoryObject" />


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/708

To unblock weekly SDK releases, temporarily remove this parameter as we wait for resolution of https://github.com/microsoft/OpenAPI.NET.OData/issues/582