### PR TITLE
fix: pin hidi version for now.

### DIFF
--- a/scripts/run-metadata-validation.ps1
+++ b/scripts/run-metadata-validation.ps1
@@ -41,7 +41,8 @@ try {
     & $transformScript -xslPath $xsltPath -inputPath $snapshot -outputPath $transformed -addInnerErrorDescription $true -removeCapabilityAnnotations $false -csdlVersion $version
 
     Write-Host "Validating $transformed metadata after the transform..." -ForegroundColor Green
-    & dotnet tool install Microsoft.OpenApi.Hidi -g --prerelease
+    # pin the hidi version till odata to openApi conversion supports 2.0
+    & dotnet tool install --global Microsoft.OpenApi.Hidi --version 1.4.14
     & hidi transform --cs $transformed -o $yamlFilePath --co -f Yaml --sp "$conversionSettingsDirectory/$platformName.json"
 
 } catch {

--- a/scripts/run-openapi-validation.ps1
+++ b/scripts/run-openapi-validation.ps1
@@ -36,5 +36,6 @@ $yaml = Join-Path $repoDirectory "openapi" $version "$platformName.yaml"
 
 Write-Host "Validating $yaml OpenAPI doc..." -ForegroundColor Green
 
-& dotnet tool install Microsoft.OpenApi.Hidi -g --prerelease
+# pin the hidi version till odata to openApi conversion supports 2.0
+& dotnet tool install --global Microsoft.OpenApi.Hidi --version 1.4.14
 & hidi validate -d $yaml


### PR DESCRIPTION
Related to https://github.com/microsoft/OpenAPI.NET.OData/issues/603 
and generation failure at https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=170457&view=logs&j=c3323695-d032-5e61-7715-15770e0bec45&t=ffe81c7f-bcae-5066-faa7-4e42a6f2e612