### PR TITLE
fix: remove approleAssignments entityset navigations

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -478,6 +478,8 @@
             </Annotation>
         </xsl:copy>
     </xsl:template>
+    <!-- Remove the appRoleAssignments entityset as it is not directly queriable from the root path -->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityContainer[@Name='GraphService']/edm:EntitySet[@Name='appRoleAssignments']"/>
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph.ediscovery']/edm:EntityType[@Name='case']/edm:NavigationProperty[@Name='operations']">
         <xsl:copy>
             <xsl:copy-of select="@* | node()" />

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -460,6 +460,7 @@
               <EntitySet Name="groups" EntityType="microsoft.graph.group" />
               <EntitySet Name="servicePrincipals" EntityType="microsoft.graph.servicePrincipal" />
               <EntitySet Name="directoryObjects" EntityType="microsoft.graph.directoryObject" />
+              <EntitySet Name="appRoleAssignments" EntityType="microsoft.graph.directoryObject" />
               <EntitySet Name="places" EntityType="microsoft.graph.place" />
             </EntityContainer>
             <Function Name="delta" IsBound="true">


### PR DESCRIPTION
fix: remove approleAssignments entityset navigations

Related to https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/2820

After following up with the workload owners, these paths are not queriable but necessary in the metadata to unblock odata.type detection for DQ deletion responses on the v1.0 endpoint. 

This PR removes the entity set for the purposes of SDK generation. 