### PR TITLE
fix: add missing `DerivedTypeConstraint` annotations for `protectionUnits` navigation property.

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -500,6 +500,18 @@
             </Annotation>
         </xsl:copy>
     </xsl:template>
+        <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='backupRestoreRoot']/edm:NavigationProperty[@Name='protectionUnits']">
+        <xsl:copy>
+            <xsl:copy-of select="@* | node()" />
+            <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
+                <Collection>
+					<String>microsoft.graph.siteProtectionUnit</String>
+					<String>microsoft.graph.mailboxProtectionUnit</String>
+					<String>microsoft.graph.driveProtectionUnit</String>
+				</Collection>
+            </Annotation>
+        </xsl:copy>
+    </xsl:template>
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='externalUsersSelfServiceSignUpEventsFlow']/edm:Property[@Name='onAttributeCollection']">
         <xsl:copy>
             <xsl:copy-of select="@* | node()" />

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -434,6 +434,14 @@
                 <Property Name="displayName" Type="Edm.String" />
                 <NavigationProperty Name="details" Type="Collection(graph.landingPageDetail)" />
             </EntityType>
+            <EntityType Name="protectionUnitBase" BaseType="graph.entity">
+                <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
+                <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" />
+            </EntityType>
+            <EntityType Name="backupRestoreRoot" BaseType="graph.entity">
+                <Property Name="serviceStatus" Type="graph.serviceStatus" />
+                <NavigationProperty Name="protectionUnits" Type="Collection(graph.protectionUnitBase)" />
+            </EntityType>
             <EntityType Name="b2xIdentityUserFlow" BaseType="graph.identityUserFlow">
                 <Property Name="apiConnectorConfiguration" Type="graph.userFlowApiConnectorConfiguration" />
                 <NavigationProperty Name="identityProviders" Type="Collection(graph.identityProvider)" />                

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -996,6 +996,22 @@
         <Property Name="displayName" Type="Edm.String" />
         <NavigationProperty Name="details" Type="Collection(graph.landingPageDetail)" ContainsTarget="true" />
       </EntityType>
+      <EntityType Name="protectionUnitBase" BaseType="graph.entity">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" />
+      </EntityType>
+      <EntityType Name="backupRestoreRoot" BaseType="graph.entity">
+        <Property Name="serviceStatus" Type="graph.serviceStatus" />
+        <NavigationProperty Name="protectionUnits" Type="Collection(graph.protectionUnitBase)">
+          <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
+            <Collection>
+              <String>microsoft.graph.siteProtectionUnit</String>
+              <String>microsoft.graph.mailboxProtectionUnit</String>
+              <String>microsoft.graph.driveProtectionUnit</String>
+            </Collection>
+          </Annotation>
+        </NavigationProperty>
+      </EntityType>
       <EntityType Name="b2xIdentityUserFlow" BaseType="graph.identityUserFlow">
         <Property Name="apiConnectorConfiguration" Type="graph.userFlowApiConnectorConfiguration" />
         <NavigationProperty Name="identityProviders" Type="Collection(graph.identityProvider)" />


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/3046

Adds missing derived type annotations blocking cmdlet generation cc @vidula-verma