### PR TITLE
add ex[;icit bindings to offboard and cancelOffboard action

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -500,7 +500,7 @@
             </Annotation>
         </xsl:copy>
     </xsl:template>
-        <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='backupRestoreRoot']/edm:NavigationProperty[@Name='protectionUnits']">
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:EntityType[@Name='backupRestoreRoot']/edm:NavigationProperty[@Name='protectionUnits']">
         <xsl:copy>
             <xsl:copy-of select="@* | node()" />
             <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
@@ -509,6 +509,12 @@
 					<String>microsoft.graph.mailboxProtectionUnit</String>
 					<String>microsoft.graph.driveProtectionUnit</String>
 				</Collection>
+            </Annotation>
+            <Annotation Term="Org.OData.Core.V1.ExplicitOperationBindings">
+                <Collection>
+                    <String>microsoft.graph.cancelOffboard</String>
+                    <String>microsoft.graph.offboard</String>
+                </Collection>
             </Annotation>
         </xsl:copy>
     </xsl:template>
@@ -700,6 +706,15 @@
         <Annotation Term="Org.OData.Core.V1.RequiresExplicitBinding"/>
     </xsl:copy>
     </xsl:template>
+
+    <!-- Actions bound to protectionUnitBase should have the 'RequiresExplicitBinding' annotation-->
+    <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='offboard'][edm:Parameter[@Name='bindingParameter']][edm:Parameter[@Type='graph.protectionUnitBase']] |
+                         edm:Schema[@Namespace='microsoft.graph']/edm:Action[@Name='cancelOffboard'][edm:Parameter[@Name='bindingParameter']][edm:Parameter[@Type='graph.protectionUnitBase']]">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()" />
+            <Annotation Term="Org.OData.Core.V1.RequiresExplicitBinding"/>
+        </xsl:copy>
+    </xsl:template>    
     
     <!--Delta function for events need the start and end date parameters-->
     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Function[@Name='delta'][edm:Parameter[@Name='bindingparameter']][edm:Parameter[@Type='Collection(graph.event)']]">

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -543,6 +543,14 @@
                 </Parameter>
                 <ReturnType Type="graph.directoryObject" />
             </Action>
+            <Action Name="cancelOffboard" IsBound="true">
+                <Parameter Name="bindingParameter" Type="graph.protectionUnitBase" />
+                <ReturnType Type="graph.protectionUnitBase" />
+            </Action>
+            <Action Name="offboard" IsBound="true">
+                <Parameter Name="bindingParameter" Type="graph.protectionUnitBase" />
+                <ReturnType Type="graph.protectionUnitBase" />
+            </Action>
             <Action Name="add" IsBound="true">
                 <Parameter Name="bindingParameter" Type="Collection(graph.site)" />
                 <Parameter Name="value" Type="Collection(graph.site)" />

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -1065,6 +1065,12 @@
               <String>microsoft.graph.driveProtectionUnit</String>
             </Collection>
           </Annotation>
+          <Annotation Term="Org.OData.Core.V1.ExplicitOperationBindings" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm">
+            <Collection>
+              <String>microsoft.graph.cancelOffboard</String>
+              <String>microsoft.graph.offboard</String>
+            </Collection>
+          </Annotation>
         </NavigationProperty>
       </EntityType>
       <EntityType Name="b2xIdentityUserFlow" BaseType="graph.identityUserFlow">
@@ -1360,6 +1366,16 @@
       <Action Name="restore" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.directoryObject" Nullable="false" />
         <ReturnType Type="graph.directoryObject" />
+        <Annotation Term="Org.OData.Core.V1.RequiresExplicitBinding" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm" />
+      </Action>
+      <Action Name="cancelOffboard" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.protectionUnitBase" />
+        <ReturnType Type="graph.protectionUnitBase" />
+        <Annotation Term="Org.OData.Core.V1.RequiresExplicitBinding" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm" />
+      </Action>
+      <Action Name="offboard" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.protectionUnitBase" />
+        <ReturnType Type="graph.protectionUnitBase" />
         <Annotation Term="Org.OData.Core.V1.RequiresExplicitBinding" xmlns:edm="http://docs.oasis-open.org/odata/ns/edm" />
       </Action>
       <Action Name="add" IsBound="true">


### PR DESCRIPTION
Adding explicit bindings to the offboard and cancelOffboard action prompts the following generation in the openApi documents: 
```
  '/solutions/backupRestore/protectionUnits/{protectionUnitBase-id}/microsoft.graph.offboard':
    description: Provides operations to call the offboard method.
    post:
      tags:
        - solutions.backupRestoreRoot
      summary: Invoke action offboard
      description: Offboard a protectionUnitBase.
      operationId: solutions.backupRestore.protectionUnits.protectionUnitBase.offboard
      parameters:
        - name: protectionUnitBase-id
          in: path
          description: The unique identifier of protectionUnitBase
          required: true
          schema:
            type: string
          x-ms-docs-key-type: protectionUnitBase
      responses:
        2XX:
          description: Success
          content:
            application/json:
              schema:
                anyOf:
                  - $ref: '#/components/schemas/microsoft.graph.protectionUnitBase'
                  - type: 'null'
        default:
          $ref: '#/components/responses/error'
      x-ms-docs-operation-type: action
```
and 
```
  '/solutions/backupRestore/protectionUnits/{protectionUnitBase-id}/microsoft.graph.cancelOffboard':
    description: Provides operations to call the cancelOffboard method.
    post:
      tags:
        - solutions.backupRestoreRoot
      summary: Invoke action cancelOffboard
      description: Cancel offboard for a protectionUnitBase.
      operationId: solutions.backupRestore.protectionUnits.protectionUnitBase.cancelOffboard
      parameters:
        - name: protectionUnitBase-id
          in: path
          description: The unique identifier of protectionUnitBase
          required: true
          schema:
            type: string
          x-ms-docs-key-type: protectionUnitBase
      responses:
        2XX:
          description: Success
          content:
            application/json:
              schema:
                anyOf:
                  - $ref: '#/components/schemas/microsoft.graph.protectionUnitBase'
                  - type: 'null'
        default:
          $ref: '#/components/responses/error'
      x-ms-docs-operation-type: action

```
This closes https://github.com/microsoft/OpenAPI.NET.OData/issues/720