### PR TITLE
chore(deps): bump TypeSpec dependencies to 1.11.0 in /additions

### DIFF
--- a/additions/package-lock.json
+++ b/additions/package-lock.json
@@ -221,9 +221,9 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.11.tgz",
-      "integrity": "sha512-yxSO89MQ7t4LTCwtsXQ/ppcfw2otLsum6nF+TM9pKesy3k2AhVDUIkaiJIwG6lzm/csc5n38MaFKLY0TrSHzEA==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.12.tgz",
+      "integrity": "sha512-vOfrB33b7YIZfDauXS8vNNz2Z86FozTZLIt7e+7/dCaPJ1RXZsHCuI9TlcERzEUq57vkM+UdnBgxP0rFd23JYQ==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^11.1.8",
@@ -336,15 +336,15 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.0.tgz",
-      "integrity": "sha512-Z3pFkae4WSzK95tvbaxR3rD9JlScFIh6/Ufw60H8Ck7GugdzYCe/3FwZCfvXwHZXjyk671w8FnVuwvxx1eP7ug==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.1.tgz",
+      "integrity": "sha512-AH5xPQ997K7e0F0vulPlteIHke2awMkFi8F0dBemrDfmvtPmHJo82mdHbONC4F/t8d1NHwrbI5cGVI+RbLWdoQ==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/checkbox": "^5.1.3",
         "@inquirer/confirm": "^6.0.11",
         "@inquirer/editor": "^5.1.0",
-        "@inquirer/expand": "^5.0.11",
+        "@inquirer/expand": "^5.0.12",
         "@inquirer/input": "^5.0.11",
         "@inquirer/number": "^4.0.11",
         "@inquirer/password": "^5.0.11",
@@ -531,9 +531,9 @@
       }
     },
     "node_modules/@microsoft/typespec-msgraph/node_modules/@typespec/compiler/node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -719,24 +719,24 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.10.0.tgz",
-      "integrity": "sha512-R6BATDkughntPpaxeESJF+wxma5PEjgmnnKvH0/ByqUH8VyhIckQWE9kkP0Uc/EJ0o0VYhe8qCwWQvV70k5lTw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.11.0.tgz",
+      "integrity": "sha512-4vuWtoepc4rYJ81K+P7xn2ByXIRhBM40rfzAGnpagNuGSVHuKEC6lqJqs3ePvhCpnxiYAC8XWpaOi+BEDzyhnQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.29.0",
-        "@inquirer/prompts": "^8.0.1",
+        "@inquirer/prompts": "^8.3.0",
         "ajv": "~8.18.0",
         "change-case": "~5.4.4",
         "env-paths": "^4.0.0",
-        "globby": "~16.1.0",
+        "globby": "~16.1.1",
         "is-unicode-supported": "^2.1.0",
         "mustache": "~4.2.0",
         "picocolors": "~1.1.1",
-        "prettier": "~3.8.0",
-        "semver": "^7.7.1",
-        "tar": "^7.5.2",
-        "temporal-polyfill": "^0.3.0",
+        "prettier": "~3.8.1",
+        "semver": "^7.7.4",
+        "tar": "^7.5.11",
+        "temporal-polyfill": "^0.3.2",
         "vscode-languageserver": "~9.0.1",
         "vscode-languageserver-textdocument": "~1.0.12",
         "yaml": "~2.8.2",
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/@typespec/compiler/node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -779,16 +779,16 @@
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.10.0.tgz",
-      "integrity": "sha512-/fj55fmUj4m/FmNdfH0V52menVrmS2r5Xj9d1H+pnjQbxvvaxS906RSRcoF8kbg3PvlibP/Py5u82TAk53AyqA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.11.0.tgz",
+      "integrity": "sha512-/DOkN2+MUZyLdmqYmSMZDjxikJTOuNxikTeOwG2fVOibnu8e6S1jzPAuN/mn6YyQBKeBCItMPmUOXIj61Wy8Bg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/streams": "^0.80.0"
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/streams": "^0.81.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -797,22 +797,22 @@
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.10.0.tgz",
-      "integrity": "sha512-tukmyp+c9CFlA2FdF61XfT9eTe5WXWz6J8pOrJ9+IYg0BcBwhJkvDj6BYpDD6SjxbRr1wO5ZL2Whe6MequsyVw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.11.0.tgz",
+      "integrity": "sha512-xUQrHExKBh0XSP4cn+HcondDXjHJM5HCq2Xfy9tB1QflsFh5uP1JJt1+67g73VmHlhZVSUDcoFrnU95pfjyubg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/http": "^1.10.0"
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/http": "^1.11.0"
       }
     },
     "node_modules/@typespec/openapi3": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-1.10.0.tgz",
-      "integrity": "sha512-G2UTfsDuUprvhFIymHiLKly6FoA9UkRmTImqgmROP4JkKCdY/Mo6Xo03sufY8urywVjIWE3dryXpy5DjpOt9Eg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-1.11.0.tgz",
+      "integrity": "sha512-AjMpTkIUy8+YlRaqUyQ1NZxbmVbWyT4fPpztVzclyX+TXyvxo9gqLEdqoMfvQ9KUjcU0nsOjfPdaYb5rj25oIA==",
       "license": "MIT",
       "dependencies": {
         "@scalar/json-magic": "^0.11.5",
@@ -828,14 +828,14 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/events": "^0.80.0",
-        "@typespec/http": "^1.10.0",
-        "@typespec/json-schema": "^1.10.0",
-        "@typespec/openapi": "^1.10.0",
-        "@typespec/sse": "^0.80.0",
-        "@typespec/streams": "^0.80.0",
-        "@typespec/versioning": "^0.80.0"
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/events": "^0.81.0",
+        "@typespec/http": "^1.11.0",
+        "@typespec/json-schema": "^1.11.0",
+        "@typespec/openapi": "^1.11.0",
+        "@typespec/sse": "^0.81.0",
+        "@typespec/streams": "^0.81.0",
+        "@typespec/versioning": "^0.81.0"
       },
       "peerDependenciesMeta": {
         "@typespec/events": {
@@ -859,16 +859,16 @@
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.80.0.tgz",
-      "integrity": "sha512-xczXLoB2akSIDner41gQYTS9CG6TdCN0QHYvXBT6ZrYEnBh+pMvdymW//5CSOTamZLOGo9AOJVJaFfwbFA4vQQ==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.81.0.tgz",
+      "integrity": "sha512-qQXZRKEvq5aNlDFEUqBiiXXPIFyr/+PWgBY0kIrnhyZzMjfUqPInkB12QgXpVp2O2Wm3jmETJD45SaLHTCYBbg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/http": "^1.10.0"
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/http": "^1.11.0"
       }
     },
     "node_modules/@vue/reactivity": {


### PR DESCRIPTION
## Summary

Consolidates 5 open Dependabot PRs that all bump TypeSpec packages from the 1.10.0 release to the 1.11.0 release in `/additions`:

| Package | Old Version | New Version | Dependabot PR |
|---------|-------------|-------------|---------------|
| `@typespec/compiler` | 1.10.0 | 1.11.0 | #1070 |
| `@typespec/http` | 1.10.0 | 1.11.0 | #1069 |
| `@typespec/openapi` | 1.10.0 | 1.11.0 | #1072 |
| `@typespec/openapi3` | 1.10.0 | 1.11.0 | #1068 |
| `@typespec/rest` | 0.80.0 | 0.81.0 | #1071 |

Once this PR is merged, the individual Dependabot PRs (#1068, #1069, #1070, #1071, #1072) should be closed.