### PR TITLE
Ramsess/add casing check to metadata

### DIFF
--- a/.github/workflows/check-casing-changes.yml
+++ b/.github/workflows/check-casing-changes.yml
@@ -47,6 +47,8 @@ jobs:
   update-baselines:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/check-casing-changes.yml
+++ b/.github/workflows/check-casing-changes.yml
@@ -1,0 +1,78 @@
+# Validates that PRs don't introduce unintentional casing changes to type/enum names,
+# members, or properties in CSDL schema files. After a PR merges, automatically
+# regenerates the type-mapping baseline files to keep them current.
+
+name: Check type and enum casing changes
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'schemas/*-Prod.csdl'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'schemas/*-Prod.csdl'
+
+jobs:
+  # Runs on PRs: compares modified CSDL files against the committed type-mapping
+  # JSON baselines. Fails if any name matches case-insensitively but differs
+  # case-sensitively (e.g., "accessLevel" -> "AccessLevel"). New types are allowed.
+  check-casing:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Determine modified Prod CSDL files
+      id: changed-files
+      run: |
+        FILES=$(git diff --diff-filter=ACMR --name-only origin/${{ github.base_ref }}...HEAD -- 'schemas/*-Prod.csdl' | tr '\n' ',' | sed 's/,$//')
+        echo "files=$FILES" >> $GITHUB_OUTPUT
+        echo "Modified CSDL files: $FILES"
+
+    - name: Check for casing changes
+      if: steps.changed-files.outputs.files != ''
+      shell: pwsh
+      run: |
+        $files = "${{ steps.changed-files.outputs.files }}" -split ','
+        ./scripts/check-casing-changes.ps1 -CsdlFiles $files
+
+  # Runs on push to master (after PR merge): regenerates the type-mapping baseline
+  # JSON files from the updated CSDL schemas and auto-commits them if changed.
+  # This keeps baselines current so future PRs are checked against the latest state.
+  update-baselines:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Regenerate type mapping baselines
+      shell: pwsh
+      run: ./scripts/generate-type-mappings.ps1
+
+    - name: Check for changes
+      id: check-changes
+      run: |
+        if git diff --quiet schemas/type-mappings/; then
+          echo "changed=false" >> $GITHUB_OUTPUT
+          echo "No baseline changes detected."
+        else
+          echo "changed=true" >> $GITHUB_OUTPUT
+          echo "Baseline changes detected."
+        fi
+
+    - name: Commit updated baselines
+      if: steps.check-changes.outputs.changed == 'true'
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add schemas/type-mappings/
+        git commit -m "Update type mapping baselines
+
+        Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+        git push

--- a/schemas/type-mappings/beta-complex-types.json
+++ b/schemas/type-mappings/beta-complex-types.json
@@ -425,6 +425,13 @@
         "stageId"
       ]
     },
+    "accountAlias": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "idType"
+      ]
+    },
     "accountsWithAccess": {
       "navigationProperties": [],
       "properties": []
@@ -761,6 +768,34 @@
       "navigationProperties": [],
       "properties": [
         "coverImageItemId"
+      ]
+    },
+    "alertDetection": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionType",
+        "method",
+        "name"
+      ]
+    },
+    "alertHistoryState": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "assignedTo",
+        "comments",
+        "feedback",
+        "status",
+        "updatedDateTime",
+        "user"
+      ]
+    },
+    "alertTrigger": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "type",
+        "value"
       ]
     },
     "allAccountsWithAccess": {
@@ -3188,6 +3223,14 @@
       "navigationProperties": [],
       "properties": [
         "cloudAppSecurityType"
+      ]
+    },
+    "cloudAppSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "destinationServiceIp",
+        "destinationServiceName",
+        "riskScore"
       ]
     },
     "cloudCertificationAuthorityVersionUsage": {
@@ -6500,6 +6543,15 @@
         "domainName"
       ]
     },
+    "domainRegistrant": {
+      "navigationProperties": [],
+      "properties": [
+        "countryOrRegionCode",
+        "organization",
+        "url",
+        "vendor"
+      ]
+    },
     "domainState": {
       "navigationProperties": [],
       "properties": [
@@ -7085,6 +7137,10 @@
       "navigationProperties": [],
       "properties": []
     },
+    "entitySetNames": {
+      "navigationProperties": [],
+      "properties": []
+    },
     "enumeratedAccountsWithAccess": {
       "navigationProperties": [
         "accounts"
@@ -7449,6 +7505,22 @@
         "mac",
         "macKey",
         "profileIdentifier"
+      ]
+    },
+    "fileHash": {
+      "navigationProperties": [],
+      "properties": [
+        "hashType",
+        "hashValue"
+      ]
+    },
+    "fileSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "fileHash",
+        "name",
+        "path",
+        "riskScore"
       ]
     },
     "fileStorageContainerCustomPropertyDictionary": {
@@ -7894,6 +7966,20 @@
         "sources"
       ]
     },
+    "hostSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "fqdn",
+        "isAzureAdJoined",
+        "isAzureAdRegistered",
+        "isHybridAzureDomainJoined",
+        "netBiosName",
+        "os",
+        "privateIpAddress",
+        "publicIpAddress",
+        "riskScore"
+      ]
+    },
     "httpAuthSecurityScheme": {
       "navigationProperties": [],
       "properties": [
@@ -8246,6 +8332,13 @@
         "themeColor"
       ]
     },
+    "investigationSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "status"
+      ]
+    },
     "invitationParticipantInfo": {
       "navigationProperties": [],
       "properties": [
@@ -8543,9 +8636,28 @@
         "websiteList"
       ]
     },
+    "ipCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "name",
+        "vendor"
+      ]
+    },
     "ipRange": {
       "navigationProperties": [],
       "properties": []
+    },
+    "ipReferenceData": {
+      "navigationProperties": [],
+      "properties": [
+        "asn",
+        "city",
+        "countryOrRegionCode",
+        "organization",
+        "state",
+        "vendor"
+      ]
     },
     "ipSegmentConfiguration": {
       "navigationProperties": [
@@ -9008,6 +9120,18 @@
         "hideTermsOfUse"
       ]
     },
+    "logonUser": {
+      "navigationProperties": [],
+      "properties": [
+        "accountDomain",
+        "accountName",
+        "accountType",
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "logonId",
+        "logonTypes"
+      ]
+    },
     "lookupColumn": {
       "navigationProperties": [],
       "properties": [
@@ -9016,6 +9140,27 @@
         "columnName",
         "listId",
         "primaryLookupColumnId"
+      ]
+    },
+    "m365CapabilityInboundAccess": {
+      "navigationProperties": [],
+      "properties": [
+        "isAllowed",
+        "resourceScopes"
+      ]
+    },
+    "m365CapabilityResourceScope": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceId",
+        "resourceType"
+      ]
+    },
+    "m365CapabilityResourceScopes": {
+      "navigationProperties": [],
+      "properties": [
+        "excluded",
+        "included"
       ]
     },
     "macAppIdentifier": {
@@ -9318,6 +9463,16 @@
       "navigationProperties": [],
       "properties": [
         "description"
+      ]
+    },
+    "malwareState": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "family",
+        "name",
+        "severity",
+        "wasRunning"
       ]
     },
     "managedAppDiagnosticStatus": {
@@ -9801,6 +9956,20 @@
         "withinSizeRange"
       ]
     },
+    "messageSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "connectingIP",
+        "deliveryAction",
+        "deliveryLocation",
+        "directionality",
+        "internetMessageId",
+        "messageFingerprint",
+        "messageReceivedDateTime",
+        "messageSubject",
+        "networkMessageId"
+      ]
+    },
     "messageUnpinnedEventMessageDetail": {
       "navigationProperties": [],
       "properties": [
@@ -10029,6 +10198,41 @@
     "mutualTLSSecurityScheme": {
       "navigationProperties": [],
       "properties": []
+    },
+    "networkConnection": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationName",
+        "destinationAddress",
+        "destinationDomain",
+        "destinationLocation",
+        "destinationPort",
+        "destinationUrl",
+        "direction",
+        "domainRegisteredDateTime",
+        "localDnsName",
+        "natDestinationAddress",
+        "natDestinationPort",
+        "natSourceAddress",
+        "natSourcePort",
+        "protocol",
+        "riskScore",
+        "sourceAddress",
+        "sourceLocation",
+        "sourcePort",
+        "status",
+        "urlParameters"
+      ]
+    },
+    "networkInterface": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "ipV4Address",
+        "ipV6Address",
+        "localIpV6Address",
+        "macAddress"
+      ]
     },
     "networkLocationDetail": {
       "navigationProperties": [],
@@ -12047,6 +12251,23 @@
         "resourceId"
       ]
     },
+    "process": {
+      "navigationProperties": [],
+      "properties": [
+        "accountName",
+        "commandLine",
+        "createdDateTime",
+        "fileHash",
+        "integrityLevel",
+        "isElevated",
+        "name",
+        "parentProcessCreatedDateTime",
+        "parentProcessId",
+        "parentProcessName",
+        "path",
+        "processId"
+      ]
+    },
     "processContentBatchRequest": {
       "navigationProperties": [],
       "properties": [
@@ -12652,6 +12873,21 @@
         "authenticationMethodsRegistrationCampaign"
       ]
     },
+    "registryKeyState": {
+      "navigationProperties": [],
+      "properties": [
+        "hive",
+        "key",
+        "oldKey",
+        "oldValueData",
+        "oldValueName",
+        "operation",
+        "processId",
+        "valueData",
+        "valueName",
+        "valueType"
+      ]
+    },
     "rejectJoinResponse": {
       "navigationProperties": [],
       "properties": [
@@ -12772,6 +13008,14 @@
         "includeTarget",
         "state",
         "voiceReportingCode"
+      ]
+    },
+    "reputationCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "name",
+        "vendor"
       ]
     },
     "requestActivity": {
@@ -13496,6 +13740,15 @@
       "navigationProperties": [],
       "properties": []
     },
+    "securityActionState": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "status",
+        "updatedDateTime",
+        "user"
+      ]
+    },
     "securityBaselineContributingPolicy": {
       "navigationProperties": [],
       "properties": [
@@ -13508,9 +13761,26 @@
       "navigationProperties": [],
       "properties": []
     },
+    "securityProviderStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "enabled",
+        "endpoint",
+        "provider",
+        "region",
+        "vendor"
+      ]
+    },
     "securityRequirement": {
       "navigationProperties": [],
       "properties": []
+    },
+    "securityResource": {
+      "navigationProperties": [],
+      "properties": [
+        "resource",
+        "resourceType"
+      ]
     },
     "securityScheme": {
       "navigationProperties": [],
@@ -15760,6 +16030,17 @@
         "uploadUrl"
       ]
     },
+    "uriClickSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "clickAction",
+        "clickDateTime",
+        "id",
+        "sourceId",
+        "uriDomain",
+        "verdict"
+      ]
+    },
     "usageDetails": {
       "navigationProperties": [],
       "properties": [
@@ -15775,6 +16056,17 @@
         "allowExport",
         "allowPrint",
         "allowView"
+      ]
+    },
+    "userAccount": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastSeenDateTime",
+        "riskScore",
+        "service",
+        "signinName",
+        "status"
       ]
     },
     "userActionContext": {
@@ -15966,6 +16258,25 @@
     "userScope": {
       "navigationProperties": [],
       "properties": []
+    },
+    "userSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "aadUserId",
+        "accountName",
+        "domainName",
+        "emailRole",
+        "isVpn",
+        "logonDateTime",
+        "logonId",
+        "logonIp",
+        "logonLocation",
+        "logonType",
+        "onPremisesSecurityIdentifier",
+        "riskScore",
+        "userAccountType",
+        "userPrincipalName"
+      ]
     },
     "userSet": {
       "navigationProperties": [],
@@ -16354,6 +16665,14 @@
         "actionFailureReason",
         "failedLicensesCount",
         "totalLicensesCount"
+      ]
+    },
+    "vulnerabilityState": {
+      "navigationProperties": [],
+      "properties": [
+        "cve",
+        "severity",
+        "wasRunning"
       ]
     },
     "wafAllowedHeadersDictionary": {

--- a/schemas/type-mappings/beta-complex-types.json
+++ b/schemas/type-mappings/beta-complex-types.json
@@ -425,13 +425,6 @@
         "stageId"
       ]
     },
-    "accountAlias": {
-      "navigationProperties": [],
-      "properties": [
-        "id",
-        "idType"
-      ]
-    },
     "accountsWithAccess": {
       "navigationProperties": [],
       "properties": []
@@ -768,34 +761,6 @@
       "navigationProperties": [],
       "properties": [
         "coverImageItemId"
-      ]
-    },
-    "alertDetection": {
-      "navigationProperties": [],
-      "properties": [
-        "detectionType",
-        "method",
-        "name"
-      ]
-    },
-    "alertHistoryState": {
-      "navigationProperties": [],
-      "properties": [
-        "appId",
-        "assignedTo",
-        "comments",
-        "feedback",
-        "status",
-        "updatedDateTime",
-        "user"
-      ]
-    },
-    "alertTrigger": {
-      "navigationProperties": [],
-      "properties": [
-        "name",
-        "type",
-        "value"
       ]
     },
     "allAccountsWithAccess": {
@@ -1209,6 +1174,10 @@
       ]
     },
     "applicationEnforcedRestrictionsSessionControl": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "applicationIcon": {
       "navigationProperties": [],
       "properties": []
     },
@@ -2585,6 +2554,10 @@
         "webUrl"
       ]
     },
+    "browserInfo": {
+      "navigationProperties": [],
+      "properties": []
+    },
     "browserSharedCookieHistory": {
       "navigationProperties": [],
       "properties": [
@@ -2802,6 +2775,14 @@
         "launchDateTime",
         "status"
       ]
+    },
+    "capturedFlow": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "capturedOAuthDetails": {
+      "navigationProperties": [],
+      "properties": []
     },
     "certificateAuthority": {
       "navigationProperties": [],
@@ -3108,6 +3089,7 @@
     "claimBinding": {
       "navigationProperties": [],
       "properties": [
+        "matchConfidenceLevel",
         "sourceAttribute",
         "verifiedIdClaim"
       ]
@@ -3120,6 +3102,13 @@
         "givenName",
         "surname",
         "userId"
+      ]
+    },
+    "claimValidation": {
+      "navigationProperties": [],
+      "properties": [
+        "customExtensionId",
+        "isEnabled"
       ]
     },
     "classifcationErrorBase": {
@@ -3199,14 +3188,6 @@
       "navigationProperties": [],
       "properties": [
         "cloudAppSecurityType"
-      ]
-    },
-    "cloudAppSecurityState": {
-      "navigationProperties": [],
-      "properties": [
-        "destinationServiceIp",
-        "destinationServiceName",
-        "riskScore"
       ]
     },
     "cloudCertificationAuthorityVersionUsage": {
@@ -3906,6 +3887,14 @@
         "isSipEnabled"
       ]
     },
+    "cloudVideoInteropInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "moreInfoWebUrl",
+        "tenantKey",
+        "videoTeleconferenceId"
+      ]
+    },
     "coachmarkLocation": {
       "navigationProperties": [],
       "properties": [
@@ -4046,6 +4035,10 @@
       ]
     },
     "ComplexExtensionValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceAssessment": {
       "navigationProperties": [],
       "properties": []
     },
@@ -6467,6 +6460,10 @@
         "lastModfiedBy"
       ]
     },
+    "documentationFile": {
+      "navigationProperties": [],
+      "properties": []
+    },
     "documentSet": {
       "navigationProperties": [
         "sharedColumns",
@@ -6501,15 +6498,6 @@
       "properties": [
         "displayName",
         "domainName"
-      ]
-    },
-    "domainRegistrant": {
-      "navigationProperties": [],
-      "properties": [
-        "countryOrRegionCode",
-        "organization",
-        "url",
-        "vendor"
       ]
     },
     "domainState": {
@@ -7097,10 +7085,6 @@
       "navigationProperties": [],
       "properties": []
     },
-    "entitySetNames": {
-      "navigationProperties": [],
-      "properties": []
-    },
     "enumeratedAccountsWithAccess": {
       "navigationProperties": [
         "accounts"
@@ -7465,22 +7449,6 @@
         "mac",
         "macKey",
         "profileIdentifier"
-      ]
-    },
-    "fileHash": {
-      "navigationProperties": [],
-      "properties": [
-        "hashType",
-        "hashValue"
-      ]
-    },
-    "fileSecurityState": {
-      "navigationProperties": [],
-      "properties": [
-        "fileHash",
-        "name",
-        "path",
-        "riskScore"
       ]
     },
     "fileStorageContainerCustomPropertyDictionary": {
@@ -7926,20 +7894,6 @@
         "sources"
       ]
     },
-    "hostSecurityState": {
-      "navigationProperties": [],
-      "properties": [
-        "fqdn",
-        "isAzureAdJoined",
-        "isAzureAdRegistered",
-        "isHybridAzureDomainJoined",
-        "netBiosName",
-        "os",
-        "privateIpAddress",
-        "publicIpAddress",
-        "riskScore"
-      ]
-    },
     "httpAuthSecurityScheme": {
       "navigationProperties": [],
       "properties": [
@@ -8292,13 +8246,6 @@
         "themeColor"
       ]
     },
-    "investigationSecurityState": {
-      "navigationProperties": [],
-      "properties": [
-        "name",
-        "status"
-      ]
-    },
     "invitationParticipantInfo": {
       "navigationProperties": [],
       "properties": [
@@ -8596,28 +8543,9 @@
         "websiteList"
       ]
     },
-    "ipCategory": {
-      "navigationProperties": [],
-      "properties": [
-        "description",
-        "name",
-        "vendor"
-      ]
-    },
     "ipRange": {
       "navigationProperties": [],
       "properties": []
-    },
-    "ipReferenceData": {
-      "navigationProperties": [],
-      "properties": [
-        "asn",
-        "city",
-        "countryOrRegionCode",
-        "organization",
-        "state",
-        "vendor"
-      ]
     },
     "ipSegmentConfiguration": {
       "navigationProperties": [
@@ -8650,6 +8578,10 @@
         "lowerAddress",
         "upperAddress"
       ]
+    },
+    "isvCompanyInformation": {
+      "navigationProperties": [],
+      "properties": []
     },
     "itemActionSet": {
       "navigationProperties": [],
@@ -9076,18 +9008,6 @@
         "hideTermsOfUse"
       ]
     },
-    "logonUser": {
-      "navigationProperties": [],
-      "properties": [
-        "accountDomain",
-        "accountName",
-        "accountType",
-        "firstSeenDateTime",
-        "lastSeenDateTime",
-        "logonId",
-        "logonTypes"
-      ]
-    },
     "lookupColumn": {
       "navigationProperties": [],
       "properties": [
@@ -9398,16 +9318,6 @@
       "navigationProperties": [],
       "properties": [
         "description"
-      ]
-    },
-    "malwareState": {
-      "navigationProperties": [],
-      "properties": [
-        "category",
-        "family",
-        "name",
-        "severity",
-        "wasRunning"
       ]
     },
     "managedAppDiagnosticStatus": {
@@ -9891,20 +9801,6 @@
         "withinSizeRange"
       ]
     },
-    "messageSecurityState": {
-      "navigationProperties": [],
-      "properties": [
-        "connectingIP",
-        "deliveryAction",
-        "deliveryLocation",
-        "directionality",
-        "internetMessageId",
-        "messageFingerprint",
-        "messageReceivedDateTime",
-        "messageSubject",
-        "networkMessageId"
-      ]
-    },
     "messageUnpinnedEventMessageDetail": {
       "navigationProperties": [],
       "properties": [
@@ -10134,41 +10030,6 @@
       "navigationProperties": [],
       "properties": []
     },
-    "networkConnection": {
-      "navigationProperties": [],
-      "properties": [
-        "applicationName",
-        "destinationAddress",
-        "destinationDomain",
-        "destinationLocation",
-        "destinationPort",
-        "destinationUrl",
-        "direction",
-        "domainRegisteredDateTime",
-        "localDnsName",
-        "natDestinationAddress",
-        "natDestinationPort",
-        "natSourceAddress",
-        "natSourcePort",
-        "protocol",
-        "riskScore",
-        "sourceAddress",
-        "sourceLocation",
-        "sourcePort",
-        "status",
-        "urlParameters"
-      ]
-    },
-    "networkInterface": {
-      "navigationProperties": [],
-      "properties": [
-        "description",
-        "ipV4Address",
-        "ipV6Address",
-        "localIpV6Address",
-        "macAddress"
-      ]
-    },
     "networkLocationDetail": {
       "navigationProperties": [],
       "properties": [
@@ -10264,6 +10125,10 @@
         "displayLogo",
         "displayName"
       ]
+    },
+    "oauthDetails": {
+      "navigationProperties": [],
+      "properties": []
     },
     "oAuthFlow": {
       "navigationProperties": [],
@@ -10378,6 +10243,10 @@
       ]
     },
     "oidcPrivateJwtKeyClientAuthentication": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "oidcTestResults": {
       "navigationProperties": [],
       "properties": []
     },
@@ -10935,6 +10804,10 @@
         "isOutOfOffice",
         "message"
       ]
+    },
+    "overallComplianceAssessment": {
+      "navigationProperties": [],
+      "properties": []
     },
     "package": {
       "navigationProperties": [],
@@ -12174,23 +12047,6 @@
         "resourceId"
       ]
     },
-    "process": {
-      "navigationProperties": [],
-      "properties": [
-        "accountName",
-        "commandLine",
-        "createdDateTime",
-        "fileHash",
-        "integrityLevel",
-        "isElevated",
-        "name",
-        "parentProcessCreatedDateTime",
-        "parentProcessId",
-        "parentProcessName",
-        "path",
-        "processId"
-      ]
-    },
     "processContentBatchRequest": {
       "navigationProperties": [],
       "properties": [
@@ -12796,21 +12652,6 @@
         "authenticationMethodsRegistrationCampaign"
       ]
     },
-    "registryKeyState": {
-      "navigationProperties": [],
-      "properties": [
-        "hive",
-        "key",
-        "oldKey",
-        "oldValueData",
-        "oldValueName",
-        "operation",
-        "processId",
-        "valueData",
-        "valueName",
-        "valueType"
-      ]
-    },
     "rejectJoinResponse": {
       "navigationProperties": [],
       "properties": [
@@ -12931,14 +12772,6 @@
         "includeTarget",
         "state",
         "voiceReportingCode"
-      ]
-    },
-    "reputationCategory": {
-      "navigationProperties": [],
-      "properties": [
-        "description",
-        "name",
-        "vendor"
       ]
     },
     "requestActivity": {
@@ -13225,6 +13058,7 @@
     "retrievalExtract": {
       "navigationProperties": [],
       "properties": [
+        "pageNumbers",
         "relevanceScore",
         "text"
       ]
@@ -13236,6 +13070,7 @@
         "resourceMetadata",
         "resourceType",
         "sensitivityLabel",
+        "thumbnails",
         "webUrl"
       ]
     },
@@ -13243,6 +13078,14 @@
       "navigationProperties": [],
       "properties": [
         "retrievalHits"
+      ]
+    },
+    "retrievalThumbnail": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "mediaType",
+        "pageNumber"
       ]
     },
     "retrieveRemoteHelpSessionResponse": {
@@ -13398,6 +13241,10 @@
         "relayState"
       ]
     },
+    "samlTestResults": {
+      "navigationProperties": [],
+      "properties": []
+    },
     "samsungEFotaFirmwareVersion": {
       "navigationProperties": [],
       "properties": [
@@ -13457,6 +13304,34 @@
         "displayName",
         "schedulingGroupId"
       ]
+    },
+    "scimCapabilities": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "scimConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "scimTest": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "scimTestData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "scimValidationAttestations": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "scimValidationPrerequisites": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "scopeAnalysis": {
+      "navigationProperties": [],
+      "properties": []
     },
     "scopeBase": {
       "navigationProperties": [],
@@ -13621,15 +13496,6 @@
       "navigationProperties": [],
       "properties": []
     },
-    "securityActionState": {
-      "navigationProperties": [],
-      "properties": [
-        "appId",
-        "status",
-        "updatedDateTime",
-        "user"
-      ]
-    },
     "securityBaselineContributingPolicy": {
       "navigationProperties": [],
       "properties": [
@@ -13638,26 +13504,13 @@
         "sourceType"
       ]
     },
-    "securityProviderStatus": {
+    "securityFeatures": {
       "navigationProperties": [],
-      "properties": [
-        "enabled",
-        "endpoint",
-        "provider",
-        "region",
-        "vendor"
-      ]
+      "properties": []
     },
     "securityRequirement": {
       "navigationProperties": [],
       "properties": []
-    },
-    "securityResource": {
-      "navigationProperties": [],
-      "properties": [
-        "resource",
-        "resourceType"
-      ]
     },
     "securityScheme": {
       "navigationProperties": [],
@@ -14442,6 +14295,10 @@
       "properties": [
         "allowedBundleIdentifiers"
       ]
+    },
+    "ssoConfiguration": {
+      "navigationProperties": [],
+      "properties": []
     },
     "staffAvailabilityItem": {
       "navigationProperties": [],
@@ -15309,6 +15166,10 @@
         "userPrincipalName"
       ]
     },
+    "technicalContact": {
+      "navigationProperties": [],
+      "properties": []
+    },
     "teleconferenceDeviceAudioQuality": {
       "navigationProperties": [],
       "properties": []
@@ -15373,6 +15234,10 @@
         "enabled"
       ]
     },
+    "tenantFlow": {
+      "navigationProperties": [],
+      "properties": []
+    },
     "tenantInformation": {
       "navigationProperties": [],
       "properties": [
@@ -15403,6 +15268,10 @@
         "allowMultipleValues",
         "showFullyQualifiedName"
       ]
+    },
+    "termsAgreements": {
+      "navigationProperties": [],
+      "properties": []
     },
     "termsExpiration": {
       "navigationProperties": [],
@@ -15891,17 +15760,6 @@
         "uploadUrl"
       ]
     },
-    "uriClickSecurityState": {
-      "navigationProperties": [],
-      "properties": [
-        "clickAction",
-        "clickDateTime",
-        "id",
-        "sourceId",
-        "uriDomain",
-        "verdict"
-      ]
-    },
     "usageDetails": {
       "navigationProperties": [],
       "properties": [
@@ -15917,17 +15775,6 @@
         "allowExport",
         "allowPrint",
         "allowView"
-      ]
-    },
-    "userAccount": {
-      "navigationProperties": [],
-      "properties": [
-        "displayName",
-        "lastSeenDateTime",
-        "riskScore",
-        "service",
-        "signinName",
-        "status"
       ]
     },
     "userActionContext": {
@@ -16120,25 +15967,6 @@
       "navigationProperties": [],
       "properties": []
     },
-    "userSecurityState": {
-      "navigationProperties": [],
-      "properties": [
-        "aadUserId",
-        "accountName",
-        "domainName",
-        "emailRole",
-        "isVpn",
-        "logonDateTime",
-        "logonId",
-        "logonIp",
-        "logonLocation",
-        "logonType",
-        "onPremisesSecurityIdentifier",
-        "riskScore",
-        "userAccountType",
-        "userPrincipalName"
-      ]
-    },
     "userSet": {
       "navigationProperties": [],
       "properties": [
@@ -16324,6 +16152,7 @@
         "acceptedIssuer",
         "claimBindings",
         "claimBindingSource",
+        "claimValidation",
         "type"
       ]
     },
@@ -16525,14 +16354,6 @@
         "actionFailureReason",
         "failedLicensesCount",
         "totalLicensesCount"
-      ]
-    },
-    "vulnerabilityState": {
-      "navigationProperties": [],
-      "properties": [
-        "cve",
-        "severity",
-        "wasRunning"
       ]
     },
     "wafAllowedHeadersDictionary": {

--- a/schemas/type-mappings/beta-complex-types.json
+++ b/schemas/type-mappings/beta-complex-types.json
@@ -1,0 +1,23643 @@
+{
+  "microsoft.graph": {
+    "aadSource": {
+      "navigationProperties": [],
+      "properties": [
+        "domain"
+      ]
+    },
+    "aadUserConversationMemberResult": {
+      "navigationProperties": [],
+      "properties": [
+        "userId"
+      ]
+    },
+    "aadUserNotificationRecipient": {
+      "navigationProperties": [],
+      "properties": [
+        "userId"
+      ]
+    },
+    "acceptJoinResponse": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessDriftReportRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "catalogId",
+        "reportFormat",
+        "resourceIds",
+        "resourceType"
+      ]
+    },
+    "accessPackageAnswer": {
+      "navigationProperties": [],
+      "properties": [
+        "answeredQuestion",
+        "displayValue"
+      ]
+    },
+    "accessPackageAnswerChoice": {
+      "navigationProperties": [],
+      "properties": [
+        "actualValue",
+        "displayValue"
+      ]
+    },
+    "accessPackageAnswerString": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "accessPackageApprovalStage": {
+      "navigationProperties": [],
+      "properties": [
+        "approverInformationVisibility",
+        "durationBeforeAutomaticDenial",
+        "durationBeforeEscalation",
+        "escalationApprovers",
+        "fallbackEscalationApprovers",
+        "fallbackPrimaryApprovers",
+        "isApproverJustificationRequired",
+        "isEscalationEnabled",
+        "primaryApprovers"
+      ]
+    },
+    "accessPackageAssignmentRequestCallbackData": {
+      "navigationProperties": [],
+      "properties": [
+        "customExtensionStageInstanceDetail",
+        "customExtensionStageInstanceId",
+        "stage",
+        "state"
+      ]
+    },
+    "accessPackageAssignmentRequestRequirements": {
+      "navigationProperties": [],
+      "properties": [
+        "existingAnswers",
+        "isApprovalRequired",
+        "isApprovalRequiredForExtension",
+        "isCustomAssignmentScheduleAllowed",
+        "isRequestorJustificationRequired",
+        "policyDescription",
+        "policyDisplayName",
+        "policyId",
+        "questions",
+        "schedule",
+        "verifiableCredentialRequirementStatus"
+      ]
+    },
+    "accessPackageDynamicApprovalStage": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": []
+    },
+    "accessPackageLocalizedContent": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultText",
+        "localizedTexts"
+      ]
+    },
+    "accessPackageLocalizedText": {
+      "navigationProperties": [],
+      "properties": [
+        "languageCode",
+        "text"
+      ]
+    },
+    "accessPackageMultipleChoiceQuestion": {
+      "navigationProperties": [],
+      "properties": [
+        "allowsMultipleSelection",
+        "choices"
+      ]
+    },
+    "accessPackageNotificationSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isAssignmentNotificationDisabled"
+      ]
+    },
+    "accessPackageQuestion": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "isAnswerEditable",
+        "isRequired",
+        "sequence",
+        "text"
+      ]
+    },
+    "accessPackageRequestApprovalStageCallbackConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessPackageResourceAttribute": {
+      "navigationProperties": [],
+      "properties": [
+        "attributeDestination",
+        "attributeName",
+        "attributeSource",
+        "id",
+        "isEditable",
+        "isPersistedOnAssignmentRemoval"
+      ]
+    },
+    "accessPackageResourceAttributeDestination": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessPackageResourceAttributeQuestion": {
+      "navigationProperties": [],
+      "properties": [
+        "question"
+      ]
+    },
+    "accessPackageResourceAttributeSource": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessPackageSuggestionReason": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessPackageSuggestionRelatedPeopleBased": {
+      "navigationProperties": [],
+      "properties": [
+        "relatedPeople",
+        "relatedPeopleAssignmentCount"
+      ]
+    },
+    "accessPackageSuggestionSelfAssignmentHistoryBased": {
+      "navigationProperties": [],
+      "properties": [
+        "lastAssignmentDateTime",
+        "pastAssigmentCount"
+      ]
+    },
+    "accessPackageTextInputQuestion": {
+      "navigationProperties": [],
+      "properties": [
+        "isSingleLineQuestion",
+        "regexPattern"
+      ]
+    },
+    "accessPackageUserDirectoryAttributeStore": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessReviewAccessPackageAssignmentPolicyScope": {
+      "navigationProperties": [],
+      "properties": [
+        "accessPackageDisplayName",
+        "accessPackageId",
+        "catalogDisplayName",
+        "catalogId"
+      ]
+    },
+    "accessReviewApplyAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessReviewDataUploadTriggerCallbackData": {
+      "navigationProperties": [],
+      "properties": [
+        "permissionDescription",
+        "permissionId",
+        "permissionName",
+        "permissionType",
+        "principalId",
+        "principalType"
+      ]
+    },
+    "accessReviewError": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessReviewHistoryScheduleSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "recurrence",
+        "reportRange"
+      ]
+    },
+    "accessReviewInactiveUsersQueryScope": {
+      "navigationProperties": [],
+      "properties": [
+        "inactiveDuration"
+      ]
+    },
+    "accessReviewInstanceDecisionItemAccessPackageAssignmentPolicyResource": {
+      "navigationProperties": [],
+      "properties": [
+        "accessPackageDisplayName",
+        "accessPackageId"
+      ]
+    },
+    "accessReviewInstanceDecisionItemAzureRoleResource": {
+      "navigationProperties": [],
+      "properties": [
+        "scope"
+      ]
+    },
+    "accessReviewInstanceDecisionItemCustomDataProvidedResource": {
+      "navigationProperties": [],
+      "properties": [
+        "customData",
+        "scopeDisplayName",
+        "scopeId"
+      ]
+    },
+    "accessReviewInstanceDecisionItemPermission": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "id",
+        "type"
+      ]
+    },
+    "accessReviewInstanceDecisionItemResource": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "id",
+        "type"
+      ]
+    },
+    "accessReviewInstanceDecisionItemServicePrincipalResource": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "appRoleDisplayName",
+        "appRoleId"
+      ]
+    },
+    "accessReviewInstanceDecisionItemServicePrincipalTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "servicePrincipalDisplayName",
+        "servicePrincipalId"
+      ]
+    },
+    "accessReviewInstanceDecisionItemTarget": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessReviewInstanceDecisionItemUserTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "userDisplayName",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "accessReviewNotificationRecipientItem": {
+      "navigationProperties": [],
+      "properties": [
+        "notificationRecipientScope",
+        "notificationTemplateType"
+      ]
+    },
+    "accessReviewNotificationRecipientQueryScope": {
+      "navigationProperties": [],
+      "properties": [
+        "query",
+        "queryRoot",
+        "queryType"
+      ]
+    },
+    "accessReviewNotificationRecipientScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessReviewPrincipalScope": {
+      "navigationProperties": [],
+      "properties": [
+        "scopeType"
+      ]
+    },
+    "accessReviewQueryScope": {
+      "navigationProperties": [],
+      "properties": [
+        "query",
+        "queryRoot",
+        "queryType"
+      ]
+    },
+    "accessReviewRecommendationInsightSetting": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessReviewRecurrenceSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "durationInDays",
+        "recurrenceCount",
+        "recurrenceEndType",
+        "recurrenceType"
+      ]
+    },
+    "accessReviewResourceDataUploadSessionContextData": {
+      "navigationProperties": [],
+      "properties": [
+        "accessReviewId",
+        "accessReviewInstanceId"
+      ]
+    },
+    "accessReviewResourceScope": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "resourceId",
+        "scopeType"
+      ]
+    },
+    "accessReviewReviewerScope": {
+      "navigationProperties": [],
+      "properties": [
+        "query",
+        "queryRoot",
+        "queryType",
+        "reviewerId",
+        "scopeType"
+      ]
+    },
+    "accessReviewScheduleSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "applyActions",
+        "autoApplyDecisionsEnabled",
+        "decisionHistoriesForReviewersEnabled",
+        "defaultDecision",
+        "defaultDecisionEnabled",
+        "instanceDurationInDays",
+        "isAgenticExperienceEnabled",
+        "justificationRequiredOnApproval",
+        "mailNotificationsEnabled",
+        "recommendationInsightSettings",
+        "recommendationLookBackDuration",
+        "recommendationsEnabled",
+        "recurrence",
+        "reminderNotificationsEnabled"
+      ]
+    },
+    "accessReviewScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessReviewSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "accessRecommendationsEnabled",
+        "activityDurationInDays",
+        "autoApplyReviewResultsEnabled",
+        "autoReviewEnabled",
+        "autoReviewSettings",
+        "justificationRequiredOnApproval",
+        "mailNotificationsEnabled",
+        "recurrenceSettings",
+        "remindersEnabled"
+      ]
+    },
+    "accessReviewStageSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "decisionsThatWillMoveToNextStage",
+        "dependsOn",
+        "durationInDays",
+        "fallbackReviewers",
+        "recommendationInsightSettings",
+        "recommendationLookBackDuration",
+        "recommendationsEnabled",
+        "reviewers",
+        "stageId"
+      ]
+    },
+    "accountAlias": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "idType"
+      ]
+    },
+    "accountsWithAccess": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accountTargetContent": {
+      "navigationProperties": [],
+      "properties": [
+        "type"
+      ]
+    },
+    "acl": {
+      "navigationProperties": [],
+      "properties": [
+        "accessType",
+        "identitySource",
+        "type",
+        "value"
+      ]
+    },
+    "actionItem": {
+      "navigationProperties": [],
+      "properties": [
+        "ownerDisplayName",
+        "text",
+        "title"
+      ]
+    },
+    "actionResultPart": {
+      "navigationProperties": [],
+      "properties": [
+        "error"
+      ]
+    },
+    "actionStep": {
+      "navigationProperties": [],
+      "properties": [
+        "actionUrl",
+        "stepNumber",
+        "text"
+      ]
+    },
+    "actionSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "assigned",
+        "available",
+        "exercised"
+      ]
+    },
+    "actionUrl": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "url"
+      ]
+    },
+    "activateDeviceEsimActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "carrierUrl"
+      ]
+    },
+    "activityMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "activity"
+      ]
+    },
+    "activityTransport": {
+      "navigationProperties": [],
+      "properties": [
+        "connectionType",
+        "url"
+      ]
+    },
+    "addContentFooterAction": {
+      "navigationProperties": [],
+      "properties": [
+        "alignment",
+        "fontColor",
+        "fontName",
+        "fontSize",
+        "margin",
+        "text",
+        "uiElementName"
+      ]
+    },
+    "addContentHeaderAction": {
+      "navigationProperties": [],
+      "properties": [
+        "alignment",
+        "fontColor",
+        "fontName",
+        "fontSize",
+        "margin",
+        "text",
+        "uiElementName"
+      ]
+    },
+    "addFooter": {
+      "navigationProperties": [],
+      "properties": [
+        "alignment",
+        "margin"
+      ]
+    },
+    "addHeader": {
+      "navigationProperties": [],
+      "properties": [
+        "alignment",
+        "margin"
+      ]
+    },
+    "addIn": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "properties",
+        "type"
+      ]
+    },
+    "addressBookAccountTargetContent": {
+      "navigationProperties": [],
+      "properties": [
+        "accountTargetEmails"
+      ]
+    },
+    "addWatermark": {
+      "navigationProperties": [],
+      "properties": [
+        "orientation"
+      ]
+    },
+    "addWatermarkAction": {
+      "navigationProperties": [],
+      "properties": [
+        "fontColor",
+        "fontName",
+        "fontSize",
+        "layout",
+        "text",
+        "uiElementName"
+      ]
+    },
+    "adminConsent": {
+      "navigationProperties": [],
+      "properties": [
+        "shareAPNSData",
+        "shareUserExperienceAnalyticsData"
+      ]
+    },
+    "agentCapabilities": {
+      "navigationProperties": [],
+      "properties": [
+        "extensions",
+        "pushNotifications",
+        "stateTransitionHistory",
+        "streaming"
+      ]
+    },
+    "agentCardSignature": {
+      "navigationProperties": [],
+      "properties": [
+        "header",
+        "protected",
+        "signature"
+      ]
+    },
+    "agentExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "params",
+        "required",
+        "uri"
+      ]
+    },
+    "agentExtensionParams": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "agentInterface": {
+      "navigationProperties": [],
+      "properties": [
+        "transport",
+        "url"
+      ]
+    },
+    "agentProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "organization",
+        "url"
+      ]
+    },
+    "agentSignIn": {
+      "navigationProperties": [],
+      "properties": [
+        "agentServicePrincipalId"
+      ]
+    },
+    "agentSkill": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "examples",
+        "id",
+        "inputModes",
+        "outputModes",
+        "security",
+        "tags"
+      ]
+    },
+    "aggregationOption": {
+      "navigationProperties": [],
+      "properties": [
+        "bucketDefinition",
+        "field",
+        "size"
+      ]
+    },
+    "agreementFileData": {
+      "navigationProperties": [],
+      "properties": [
+        "data"
+      ]
+    },
+    "aiAgentInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "blueprintId"
+      ]
+    },
+    "aiInteractionAttachment": {
+      "navigationProperties": [],
+      "properties": [
+        "attachmentId",
+        "content",
+        "contentType",
+        "contentUrl",
+        "name"
+      ]
+    },
+    "aiInteractionContext": {
+      "navigationProperties": [],
+      "properties": [
+        "contextReference",
+        "contextType",
+        "displayName"
+      ]
+    },
+    "aiInteractionEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier",
+        "name",
+        "version"
+      ]
+    },
+    "aiInteractionLink": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "linkType",
+        "linkUrl"
+      ]
+    },
+    "aiInteractionMention": {
+      "navigationProperties": [],
+      "properties": [
+        "mentioned",
+        "mentionId",
+        "mentionText"
+      ]
+    },
+    "aiInteractionMentionedIdentitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "conversation",
+        "tag"
+      ]
+    },
+    "aiInteractionPlugin": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "airPrintDestination": {
+      "navigationProperties": [],
+      "properties": [
+        "forceTls",
+        "ipAddress",
+        "port",
+        "resourcePath"
+      ]
+    },
+    "airPrintSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "incompatiblePrinters"
+      ]
+    },
+    "akamaiAttackGroupActionModel": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "group"
+      ]
+    },
+    "akamaiCustomRuleModel": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "name",
+        "ruleId"
+      ]
+    },
+    "akamaiRapidRulesModel": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultAction",
+        "isEnabled"
+      ]
+    },
+    "akamaiVerifiedDetailsModel": {
+      "navigationProperties": [],
+      "properties": [
+        "activeAttackGroups",
+        "activeCustomRules",
+        "rapidRules"
+      ]
+    },
+    "album": {
+      "navigationProperties": [],
+      "properties": [
+        "coverImageItemId"
+      ]
+    },
+    "alertDetection": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionType",
+        "method",
+        "name"
+      ]
+    },
+    "alertHistoryState": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "assignedTo",
+        "comments",
+        "feedback",
+        "status",
+        "updatedDateTime",
+        "user"
+      ]
+    },
+    "alertTrigger": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "type",
+        "value"
+      ]
+    },
+    "allAccountsWithAccess": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "allAllowedScopes": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "allDeviceRegistrationMembership": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "allDevicesAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "allDomains": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "allInboundPorts": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "allLicensedUsersAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "allowedTenantsAudience": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedTenantIds",
+        "isHomeTenantAllowed"
+      ]
+    },
+    "allPreApprovedPermissions": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "allPreApprovedPermissionsOnResourceApp": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceApplicationId"
+      ]
+    },
+    "allScopeSensitivityLabels": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "alterationResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "originalQueryString",
+        "queryAlteration",
+        "queryAlterationType"
+      ]
+    },
+    "alteredQueryToken": {
+      "navigationProperties": [],
+      "properties": [
+        "length",
+        "offset",
+        "suggestion"
+      ]
+    },
+    "alternativeSecurityId": {
+      "navigationProperties": [],
+      "properties": [
+        "identityProvider",
+        "key",
+        "type"
+      ]
+    },
+    "androidDeviceOwnerDelegatedScopeAppSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "appDetail",
+        "appScopes"
+      ]
+    },
+    "androidDeviceOwnerGlobalProxy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "androidDeviceOwnerGlobalProxyAutoConfig": {
+      "navigationProperties": [],
+      "properties": [
+        "proxyAutoConfigURL"
+      ]
+    },
+    "androidDeviceOwnerGlobalProxyDirect": {
+      "navigationProperties": [],
+      "properties": [
+        "excludedHosts",
+        "host",
+        "port"
+      ]
+    },
+    "androidDeviceOwnerKioskModeApp": {
+      "navigationProperties": [],
+      "properties": [
+        "className",
+        "offlineAppAccessEnabled",
+        "package",
+        "preSignInAppAccessEnabled"
+      ]
+    },
+    "androidDeviceOwnerKioskModeAppPositionItem": {
+      "navigationProperties": [],
+      "properties": [
+        "item",
+        "position"
+      ]
+    },
+    "androidDeviceOwnerKioskModeFolderItem": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "androidDeviceOwnerKioskModeHomeScreenItem": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "androidDeviceOwnerKioskModeManagedFolder": {
+      "navigationProperties": [],
+      "properties": [
+        "folderIdentifier",
+        "folderName",
+        "items"
+      ]
+    },
+    "androidDeviceOwnerKioskModeManagedFolderReference": {
+      "navigationProperties": [],
+      "properties": [
+        "folderIdentifier",
+        "folderName"
+      ]
+    },
+    "androidDeviceOwnerKioskModeWeblink": {
+      "navigationProperties": [],
+      "properties": [
+        "label",
+        "link"
+      ]
+    },
+    "androidDeviceOwnerSilentCertificateAccess": {
+      "navigationProperties": [],
+      "properties": [
+        "packageId"
+      ]
+    },
+    "androidDeviceOwnerSystemUpdateFreezePeriod": {
+      "navigationProperties": [],
+      "properties": [
+        "endDay",
+        "endMonth",
+        "startDay",
+        "startMonth"
+      ]
+    },
+    "androidDeviceOwnerUserFacingMessage": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultMessage",
+        "localizedMessages"
+      ]
+    },
+    "androidEnrollmentCompanyCode": {
+      "navigationProperties": [],
+      "properties": [
+        "enrollmentToken",
+        "qrCodeContent",
+        "qrCodeImage"
+      ]
+    },
+    "androidForWorkAppConfigurationSchemaItem": {
+      "navigationProperties": [],
+      "properties": [
+        "dataType",
+        "defaultBoolValue",
+        "defaultIntValue",
+        "defaultStringArrayValue",
+        "defaultStringValue",
+        "description",
+        "displayName",
+        "schemaItemKey",
+        "selections"
+      ]
+    },
+    "androidLobAppConfigurationSchemaRequestDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "appId"
+      ]
+    },
+    "androidManagedStoreAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "androidManagedStoreAppTrackIds",
+        "autoUpdateMode"
+      ]
+    },
+    "androidManagedStoreAppConfigurationSchemaItem": {
+      "navigationProperties": [],
+      "properties": [
+        "dataType",
+        "defaultBoolValue",
+        "defaultIntValue",
+        "defaultStringArrayValue",
+        "defaultStringValue",
+        "description",
+        "displayName",
+        "index",
+        "parentIndex",
+        "schemaItemKey",
+        "selections"
+      ]
+    },
+    "androidManagedStoreAppTrack": {
+      "navigationProperties": [],
+      "properties": [
+        "trackAlias",
+        "trackId"
+      ]
+    },
+    "androidMinimumOperatingSystem": {
+      "navigationProperties": [],
+      "properties": [
+        "v10_0",
+        "v11_0",
+        "v12_0",
+        "v13_0",
+        "v14_0",
+        "v15_0",
+        "v4_0",
+        "v4_0_3",
+        "v4_1",
+        "v4_2",
+        "v4_3",
+        "v4_4",
+        "v5_0",
+        "v5_1",
+        "v6_0",
+        "v7_0",
+        "v7_1",
+        "v8_0",
+        "v8_1",
+        "v9_0"
+      ]
+    },
+    "androidMobileAppIdentifier": {
+      "navigationProperties": [],
+      "properties": [
+        "packageId"
+      ]
+    },
+    "androidPermissionAction": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "permission"
+      ]
+    },
+    "apiApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "acceptMappedClaims",
+        "knownClientApplications",
+        "oauth2PermissionScopes",
+        "preAuthorizedApplications",
+        "requestedAccessTokenVersion"
+      ]
+    },
+    "apiAuthenticationConfigurationBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "apiKeySecurityScheme": {
+      "navigationProperties": [],
+      "properties": [
+        "in",
+        "name"
+      ]
+    },
+    "apiServicePrincipal": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceSpecificApplicationPermissions"
+      ]
+    },
+    "appConfigurationSchemaItemBooleanType": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue"
+      ]
+    },
+    "appConfigurationSchemaItemBundleArray": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "appConfigurationSchemaItemBundleType": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "appConfigurationSchemaItemChoiceType": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue",
+        "selections"
+      ]
+    },
+    "appConfigurationSchemaItemHiddenType": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue"
+      ]
+    },
+    "appConfigurationSchemaItemIntegerType": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue"
+      ]
+    },
+    "appConfigurationSchemaItemMultiselectType": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue",
+        "selections"
+      ]
+    },
+    "appConfigurationSchemaItemStringType": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue"
+      ]
+    },
+    "appConfigurationSchemaItemType": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "index",
+        "parentIndex",
+        "schemaItemKey"
+      ]
+    },
+    "appConfigurationSchemaRequestDetail": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "appConfigurationSettingItem": {
+      "navigationProperties": [],
+      "properties": [
+        "appConfigKey",
+        "appConfigKeyType",
+        "appConfigKeyValue"
+      ]
+    },
+    "appConsentRequestScope": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "appHostedMediaConfig": {
+      "navigationProperties": [],
+      "properties": [
+        "blob"
+      ]
+    },
+    "appIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "displayName",
+        "servicePrincipalId",
+        "servicePrincipalName"
+      ]
+    },
+    "appleAppListItem": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "appleOwnerTypeEnrollmentType": {
+      "navigationProperties": [],
+      "properties": [
+        "enrollmentType",
+        "ownerType"
+      ]
+    },
+    "appleVpnAlwaysOnConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "airPrintExceptionAction",
+        "allowAllCaptiveNetworkPlugins",
+        "allowCaptiveWebSheet",
+        "allowedCaptiveNetworkPlugins",
+        "cellularExceptionAction",
+        "natKeepAliveIntervalInSeconds",
+        "natKeepAliveOffloadEnable",
+        "tunnelConfiguration",
+        "userToggleEnabled",
+        "voicemailExceptionAction"
+      ]
+    },
+    "applicationContext": {
+      "navigationProperties": [],
+      "properties": [
+        "includeApplications"
+      ]
+    },
+    "applicationEnforcedRestrictionsSessionControl": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "applicationLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "dataCenter",
+        "headquarters"
+      ]
+    },
+    "applicationRiskFactorCertificateInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "hasBadCommonName",
+        "hasInsecureSignature",
+        "hasNoChainOfTrust",
+        "isDenylisted",
+        "isHostnameMismatch",
+        "isNotAfter",
+        "isNotBefore",
+        "isRevoked",
+        "isSelfSigned"
+      ]
+    },
+    "applicationRiskFactorGeneralInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "consumerPopularity",
+        "domainRegistrationDate",
+        "founded",
+        "hasDisasterRecoveryPlan",
+        "hold",
+        "hostingCompanyName",
+        "location",
+        "privacyPolicy",
+        "processedDataTypes",
+        "termsOfService"
+      ]
+    },
+    "applicationRiskFactorLegalInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "dataRetention",
+        "gdpr",
+        "hasDataOwnership",
+        "hasDmca"
+      ]
+    },
+    "applicationRiskFactorLegalInfoGdpr": {
+      "navigationProperties": [],
+      "properties": [
+        "dataProtection",
+        "hasRightToErasure",
+        "isReportingDataBreaches",
+        "statementUrl",
+        "userOwnership"
+      ]
+    },
+    "applicationRiskFactors": {
+      "navigationProperties": [],
+      "properties": [
+        "compliance",
+        "general",
+        "legal",
+        "security"
+      ]
+    },
+    "applicationRiskFactorSecurityInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "certificate",
+        "domainToCheck",
+        "hasAdminAuditTrail",
+        "hasAnonymousUsage",
+        "hasDataAuditTrail",
+        "hasDataClassification",
+        "hasDataEncrypted",
+        "hasEnforceTransportEnc",
+        "hasIpRestriction",
+        "hasMFA",
+        "hasPenTest",
+        "hasRememberPassword",
+        "hasSamlSupport",
+        "hasUserAuditLogs",
+        "hasUserDataUpload",
+        "hasUserRolesSupport",
+        "hasValidCertName",
+        "httpsSecurityHeaders",
+        "isCertTrusted",
+        "isDrownVulnerable",
+        "isHeartbleedProof",
+        "lastBreachDate",
+        "latestValidSSL",
+        "passwordPolicy",
+        "restEncryptionType"
+      ]
+    },
+    "applicationRiskScore": {
+      "navigationProperties": [],
+      "properties": [
+        "compliance",
+        "legal",
+        "provider",
+        "security",
+        "total"
+      ]
+    },
+    "applicationSecurityCompliance": {
+      "navigationProperties": [],
+      "properties": [
+        "cobit",
+        "coppa",
+        "csaStar",
+        "fedRamp",
+        "ferpa",
+        "ffiec",
+        "finra",
+        "fisma",
+        "gaap",
+        "gapp",
+        "glba",
+        "hipaa",
+        "hitrust",
+        "isae3402",
+        "iso27001",
+        "iso27002",
+        "iso27017",
+        "iso27018",
+        "itar",
+        "jerichoForumCommandments",
+        "pci",
+        "privacyShield",
+        "safeHarbor",
+        "soc1",
+        "soc2",
+        "soc3",
+        "sox",
+        "sp800_53",
+        "ssae16",
+        "ustr"
+      ]
+    },
+    "applicationServicePrincipal": {
+      "navigationProperties": [
+        "application",
+        "servicePrincipal"
+      ],
+      "properties": []
+    },
+    "appliedAuthenticationEventListener": {
+      "navigationProperties": [],
+      "properties": [
+        "eventType",
+        "executedListenerId",
+        "handlerResult"
+      ]
+    },
+    "appliedConditionalAccessPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationStrength",
+        "conditionsNotSatisfied",
+        "conditionsSatisfied",
+        "displayName",
+        "enforcedGrantControls",
+        "enforcedSessionControls",
+        "excludeRulesSatisfied",
+        "id",
+        "includeRulesSatisfied",
+        "result",
+        "sessionControlsNotSatisfied"
+      ]
+    },
+    "appListItem": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "appStoreUrl",
+        "name",
+        "publisher"
+      ]
+    },
+    "appLogCollectionDownloadDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "appLogDecryptionAlgorithm",
+        "decryptionKey",
+        "downloadUrl"
+      ]
+    },
+    "applyLabelAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actions",
+        "actionSource",
+        "label",
+        "responsibleSensitiveTypeIds"
+      ]
+    },
+    "appManagementApplicationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "audiences",
+        "identifierUris",
+        "redirectUris"
+      ]
+    },
+    "appManagementConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "keyCredentials",
+        "passwordCredentials"
+      ]
+    },
+    "appManagementPolicyActorExemptions": {
+      "navigationProperties": [],
+      "properties": [
+        "customSecurityAttributes"
+      ]
+    },
+    "appManagementServicePrincipalConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "appMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "data",
+        "version"
+      ]
+    },
+    "appMetadataEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "appRole": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedMemberTypes",
+        "description",
+        "displayName",
+        "id",
+        "isEnabled",
+        "origin",
+        "value"
+      ]
+    },
+    "approvalIdentitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "group"
+      ]
+    },
+    "approvalItemViewPoint": {
+      "navigationProperties": [],
+      "properties": [
+        "roles"
+      ]
+    },
+    "approvalSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalMode",
+        "approvalStages",
+        "isApprovalRequired",
+        "isApprovalRequiredForExtension",
+        "isRequestorJustificationRequired"
+      ]
+    },
+    "approvalStage": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalStageTimeOutInDays",
+        "approverInformationVisibility",
+        "escalationApprovers",
+        "escalationTimeInMinutes",
+        "isApproverJustificationRequired",
+        "isEscalationEnabled",
+        "primaryApprovers"
+      ]
+    },
+    "approverDelegate": {
+      "navigationProperties": [],
+      "properties": [
+        "delegate",
+        "schedule"
+      ]
+    },
+    "appsAndServicesSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isAppAndServicesTrialEnabled",
+        "isOfficeStoreEnabled"
+      ]
+    },
+    "appsInstallationOptionsForMac": {
+      "navigationProperties": [],
+      "properties": [
+        "isMicrosoft365AppsEnabled",
+        "isSkypeForBusinessEnabled"
+      ]
+    },
+    "appsInstallationOptionsForWindows": {
+      "navigationProperties": [],
+      "properties": [
+        "isMicrosoft365AppsEnabled",
+        "isProjectEnabled",
+        "isSkypeForBusinessEnabled",
+        "isVisioEnabled"
+      ]
+    },
+    "archivedPrintJob": {
+      "navigationProperties": [],
+      "properties": [
+        "acquiredByPrinter",
+        "acquiredDateTime",
+        "blackAndWhitePageCount",
+        "colorPageCount",
+        "completionDateTime",
+        "copiesPrinted",
+        "createdBy",
+        "createdDateTime",
+        "duplexPageCount",
+        "id",
+        "pageCount",
+        "printerId",
+        "printerName",
+        "processingState",
+        "simplexPageCount"
+      ]
+    },
+    "artifactQuery": {
+      "navigationProperties": [],
+      "properties": [
+        "artifactType",
+        "queryExpression"
+      ]
+    },
+    "assignedLabel": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "labelId"
+      ]
+    },
+    "assignedLicense": {
+      "navigationProperties": [],
+      "properties": [
+        "disabledPlans",
+        "skuId"
+      ]
+    },
+    "assignedPlaceMode": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedUserEmailAddress",
+        "assignedUserId"
+      ]
+    },
+    "assignedPlan": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedDateTime",
+        "capabilityStatus",
+        "service",
+        "servicePlanId"
+      ]
+    },
+    "assignedTrainingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedUserCount",
+        "completedUserCount",
+        "displayName"
+      ]
+    },
+    "assignmentFilterEvaluateRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "orderBy",
+        "platform",
+        "rule",
+        "search",
+        "skip",
+        "top"
+      ]
+    },
+    "assignmentFilterEvaluationSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentFilterDisplayName",
+        "assignmentFilterId",
+        "assignmentFilterLastModifiedDateTime",
+        "assignmentFilterPlatform",
+        "assignmentFilterType",
+        "assignmentFilterTypeAndEvaluationResults",
+        "evaluationDateTime",
+        "evaluationResult"
+      ]
+    },
+    "assignmentFilterState": {
+      "navigationProperties": [],
+      "properties": [
+        "enabled"
+      ]
+    },
+    "assignmentFilterStatusDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceProperties",
+        "evalutionSummaries",
+        "managedDeviceId",
+        "payloadId",
+        "userId"
+      ]
+    },
+    "assignmentFilterSupportedProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "dataType",
+        "isCollection",
+        "name",
+        "propertyRegexConstraint",
+        "supportedOperators",
+        "supportedValues"
+      ]
+    },
+    "assignmentFilterTypeAndEvaluationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentFilterType",
+        "evaluationResult"
+      ]
+    },
+    "assignmentFilterValidationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "isValidRule"
+      ]
+    },
+    "assignmentOrder": {
+      "navigationProperties": [],
+      "properties": [
+        "order"
+      ]
+    },
+    "assignmentRequestApprovalStageCallbackData": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalStage"
+      ]
+    },
+    "assignmentReviewSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "accessReviewTimeoutBehavior",
+        "durationInDays",
+        "isAccessRecommendationEnabled",
+        "isAgenticExperienceEnabled",
+        "isApprovalJustificationRequired",
+        "isEnabled",
+        "recurrenceType",
+        "reviewers",
+        "reviewerType",
+        "startDateTime"
+      ]
+    },
+    "attachmentInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "attachmentType",
+        "contentType",
+        "name",
+        "size"
+      ]
+    },
+    "attachmentItem": {
+      "navigationProperties": [],
+      "properties": [
+        "attachmentType",
+        "contentId",
+        "contentType",
+        "isInline",
+        "name",
+        "size"
+      ]
+    },
+    "attackSimulationRepeatOffender": {
+      "navigationProperties": [],
+      "properties": [
+        "attackSimulationUser",
+        "repeatOffenceCount"
+      ]
+    },
+    "attackSimulationSimulationUserCoverage": {
+      "navigationProperties": [],
+      "properties": [
+        "attackSimulationUser",
+        "clickCount",
+        "compromisedCount",
+        "latestSimulationDateTime",
+        "simulationCount"
+      ]
+    },
+    "attackSimulationTrainingUserCoverage": {
+      "navigationProperties": [],
+      "properties": [
+        "attackSimulationUser",
+        "userTrainings"
+      ]
+    },
+    "attackSimulationUser": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "email",
+        "outOfOfficeDays",
+        "userId"
+      ]
+    },
+    "attendanceInterval": {
+      "navigationProperties": [],
+      "properties": [
+        "durationInSeconds",
+        "joinDateTime",
+        "leaveDateTime"
+      ]
+    },
+    "attendee": {
+      "navigationProperties": [],
+      "properties": [
+        "proposedNewTime",
+        "status"
+      ]
+    },
+    "attendeeAvailability": {
+      "navigationProperties": [],
+      "properties": [
+        "attendee",
+        "availability"
+      ]
+    },
+    "attendeeBase": {
+      "navigationProperties": [],
+      "properties": [
+        "type"
+      ]
+    },
+    "attendeeNotificationInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "phoneNumber",
+        "timeZone"
+      ]
+    },
+    "attributeDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "anchor",
+        "apiExpressions",
+        "caseExact",
+        "defaultValue",
+        "flowNullValues",
+        "metadata",
+        "multivalued",
+        "mutability",
+        "name",
+        "referencedObjects",
+        "required",
+        "type"
+      ]
+    },
+    "attributeDefinitionMetadataEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "attributeInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "value"
+      ]
+    },
+    "attributeMapping": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue",
+        "exportMissingReferences",
+        "flowBehavior",
+        "flowType",
+        "matchingPriority",
+        "source",
+        "targetAttributeName"
+      ]
+    },
+    "attributeMappingParameterSchema": {
+      "navigationProperties": [],
+      "properties": [
+        "allowMultipleOccurrences",
+        "name",
+        "required",
+        "type"
+      ]
+    },
+    "attributeMappingSource": {
+      "navigationProperties": [],
+      "properties": [
+        "expression",
+        "name",
+        "parameters",
+        "type"
+      ]
+    },
+    "attributeRuleMembers": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "membershipRule"
+      ]
+    },
+    "audienceRestriction": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeActors",
+        "isStateSetByMicrosoft",
+        "restrictForAppsCreatedAfterDateTime",
+        "state"
+      ]
+    },
+    "audiencesConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "azureAdMultipleOrgs",
+        "personalMicrosoftAccount"
+      ]
+    },
+    "audio": {
+      "navigationProperties": [],
+      "properties": [
+        "album",
+        "albumArtist",
+        "artist",
+        "bitrate",
+        "composers",
+        "copyright",
+        "disc",
+        "discCount",
+        "duration",
+        "genre",
+        "hasDrm",
+        "isVariableBitrate",
+        "title",
+        "track",
+        "trackCount",
+        "year"
+      ]
+    },
+    "audioConferencing": {
+      "navigationProperties": [],
+      "properties": [
+        "conferenceId",
+        "dialinUrl",
+        "tollFreeNumber",
+        "tollFreeNumbers",
+        "tollNumber",
+        "tollNumbers"
+      ]
+    },
+    "auditActivityInitiator": {
+      "navigationProperties": [],
+      "properties": [
+        "app",
+        "linkableIdentifiers",
+        "user"
+      ]
+    },
+    "auditActivityPerformer": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "blueprintId",
+        "identityType"
+      ]
+    },
+    "auditActor": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationDisplayName",
+        "applicationId",
+        "auditActorType",
+        "ipAddress",
+        "remoteTenantId",
+        "remoteUserId",
+        "servicePrincipalName",
+        "type",
+        "userId",
+        "userPermissions",
+        "userPrincipalName",
+        "userRoleScopeTags"
+      ]
+    },
+    "auditProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "newValue",
+        "oldValue"
+      ]
+    },
+    "auditResource": {
+      "navigationProperties": [],
+      "properties": [
+        "auditResourceType",
+        "displayName",
+        "modifiedProperties",
+        "resourceId",
+        "type"
+      ]
+    },
+    "auditUserIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "homeTenantId",
+        "homeTenantName"
+      ]
+    },
+    "authContext": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationContextValue"
+      ]
+    },
+    "authenticationAppDeviceDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "appVersion",
+        "clientApp",
+        "deviceId",
+        "operatingSystem"
+      ]
+    },
+    "authenticationAppPolicyDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "adminConfiguration",
+        "authenticationEvaluation",
+        "policyName",
+        "status"
+      ]
+    },
+    "authenticationAttributeCollectionInputConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "attribute",
+        "defaultValue",
+        "editable",
+        "hidden",
+        "inputType",
+        "label",
+        "options",
+        "required",
+        "validationRegEx",
+        "writeToDirectory"
+      ]
+    },
+    "authenticationAttributeCollectionOptionConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "label",
+        "value"
+      ]
+    },
+    "authenticationAttributeCollectionPage": {
+      "navigationProperties": [],
+      "properties": [
+        "customStringsFileId",
+        "views"
+      ]
+    },
+    "authenticationAttributeCollectionPageViewConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "inputs",
+        "title"
+      ]
+    },
+    "authenticationBehaviors": {
+      "navigationProperties": [],
+      "properties": [
+        "blockAzureADGraphAccess",
+        "removeUnverifiedEmailClaim",
+        "requireClientServicePrincipal"
+      ]
+    },
+    "authenticationConditions": {
+      "navigationProperties": [],
+      "properties": [
+        "applications"
+      ]
+    },
+    "authenticationConditionsApplications": {
+      "navigationProperties": [
+        "includeApplications"
+      ],
+      "properties": [
+        "includeAllApplications"
+      ]
+    },
+    "authenticationConfigurationValidation": {
+      "navigationProperties": [],
+      "properties": [
+        "errors",
+        "warnings"
+      ]
+    },
+    "authenticationContext": {
+      "navigationProperties": [],
+      "properties": [
+        "detail",
+        "id"
+      ]
+    },
+    "authenticationDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationMethod",
+        "authenticationMethodDetail",
+        "authenticationStepDateTime",
+        "authenticationStepRequirement",
+        "authenticationStepResultDetail",
+        "succeeded"
+      ]
+    },
+    "authenticationEventHandlerResult": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "authenticationFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "transferMethod"
+      ]
+    },
+    "authenticationMethodFeatureConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeTarget",
+        "includeTarget",
+        "state"
+      ]
+    },
+    "authenticationMethodsRegistrationCampaign": {
+      "navigationProperties": [],
+      "properties": [
+        "enforceRegistrationAfterAllowedSnoozes",
+        "excludeTargets",
+        "includeTargets",
+        "snoozeDurationInDays",
+        "state"
+      ]
+    },
+    "authenticationMethodsRegistrationCampaignIncludeTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "targetedAuthenticationMethod",
+        "targetType"
+      ]
+    },
+    "authenticationRequirementPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "detail",
+        "requirementProvider"
+      ]
+    },
+    "authenticationSourceFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "includeApplications"
+      ]
+    },
+    "authenticationStrength": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationStrengthId",
+        "authenticationStrengthResult",
+        "displayName"
+      ]
+    },
+    "authenticationStrengthUsage": {
+      "navigationProperties": [
+        "mfa",
+        "none"
+      ],
+      "properties": []
+    },
+    "authorizationInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateUserIds"
+      ]
+    },
+    "authorizationSystemIdentitySource": {
+      "navigationProperties": [],
+      "properties": [
+        "identityProviderType"
+      ]
+    },
+    "authorizationSystemInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "authorizationSystemType",
+        "displayName",
+        "id"
+      ]
+    },
+    "autoLabeling": {
+      "navigationProperties": [],
+      "properties": [
+        "message",
+        "sensitiveTypeIds"
+      ]
+    },
+    "automaticRepliesMailTips": {
+      "navigationProperties": [],
+      "properties": [
+        "message",
+        "messageLanguage",
+        "scheduledEndTime",
+        "scheduledStartTime"
+      ]
+    },
+    "automaticRepliesSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "externalAudience",
+        "externalReplyMessage",
+        "internalReplyMessage",
+        "scheduledEndDateTime",
+        "scheduledStartDateTime",
+        "status"
+      ]
+    },
+    "autoReviewSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "notReviewedResult"
+      ]
+    },
+    "availabilityItem": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "serviceId",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "averageComparativeScore": {
+      "navigationProperties": [],
+      "properties": [
+        "averageScore",
+        "basis"
+      ]
+    },
+    "awsAccessKeyDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastUsedDateTime"
+      ]
+    },
+    "awsActionsPermissionsDefinitionAction": {
+      "navigationProperties": [
+        "statements"
+      ],
+      "properties": [
+        "assignToRoleId"
+      ]
+    },
+    "awsAssociatedIdentities": {
+      "navigationProperties": [
+        "all",
+        "roles",
+        "users"
+      ],
+      "properties": []
+    },
+    "awsCondition": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "awsIdentitySource": {
+      "navigationProperties": [],
+      "properties": [
+        "authorizationSystemInfo"
+      ]
+    },
+    "awsPermissionsDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "actionInfo"
+      ]
+    },
+    "awsPermissionsDefinitionAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "awsPolicyPermissionsDefinitionAction": {
+      "navigationProperties": [
+        "policies"
+      ],
+      "properties": [
+        "assignToRoleId"
+      ]
+    },
+    "awsSource": {
+      "navigationProperties": [],
+      "properties": [
+        "accountId"
+      ]
+    },
+    "azureActionPermissionsDefinitionAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actions"
+      ]
+    },
+    "azureActiveDirectoryTenant": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "tenantId"
+      ]
+    },
+    "azureADJoinPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedToJoin",
+        "isAdminConfigurable",
+        "localAdmins"
+      ]
+    },
+    "azureAdMultipleOrgsAudienceRestriction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azureAdPopTokenAuthentication": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azureADPremiumFeatureUtilization": {
+      "navigationProperties": [],
+      "properties": [
+        "userCount"
+      ]
+    },
+    "azureADPremiumP1FeatureUtilizations": {
+      "navigationProperties": [],
+      "properties": [
+        "conditionalAccess",
+        "conditionalAccessGuestUsers"
+      ]
+    },
+    "azureADPremiumP2FeatureUtilizations": {
+      "navigationProperties": [],
+      "properties": [
+        "riskBasedConditionalAccess",
+        "riskBasedConditionalAccessGuestUsers"
+      ]
+    },
+    "azureADRegistrationPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedToRegister",
+        "isAdminConfigurable"
+      ]
+    },
+    "azureAdTokenAuthentication": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceId"
+      ]
+    },
+    "azureAssociatedIdentities": {
+      "navigationProperties": [
+        "all",
+        "managedIdentities",
+        "servicePrincipals",
+        "users"
+      ],
+      "properties": []
+    },
+    "azureCommunicationServicesUserIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "azureCommunicationServicesResourceId"
+      ]
+    },
+    "azurePermissionsDefinitionAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azureRolePermissionsDefinitionAction": {
+      "navigationProperties": [
+        "roles"
+      ],
+      "properties": []
+    },
+    "azureSource": {
+      "navigationProperties": [],
+      "properties": [
+        "subscriptionId"
+      ]
+    },
+    "backupCountStatistics": {
+      "navigationProperties": [],
+      "properties": [
+        "lastComputedDateTime",
+        "offboardRequested",
+        "protectedCompleted",
+        "protectedFailed",
+        "protectedInProgress",
+        "removed",
+        "total",
+        "unprotectedCompleted",
+        "unprotectedFailed",
+        "unprotectedInProgress"
+      ]
+    },
+    "backupPolicyReport": {
+      "navigationProperties": [],
+      "properties": [
+        "backupPolicyId",
+        "countStatistics",
+        "displayName"
+      ]
+    },
+    "baseActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "resultInfo",
+        "status",
+        "transport"
+      ]
+    },
+    "baseEndUserNotification": {
+      "navigationProperties": [
+        "endUserNotification"
+      ],
+      "properties": [
+        "defaultLanguage"
+      ]
+    },
+    "baselineParameter": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "parameterType"
+      ]
+    },
+    "baselineResource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "properties",
+        "resourceType"
+      ]
+    },
+    "basicAuthentication": {
+      "navigationProperties": [],
+      "properties": [
+        "password",
+        "username"
+      ]
+    },
+    "binaryContent": {
+      "navigationProperties": [],
+      "properties": [
+        "data"
+      ]
+    },
+    "bitLockerFixedDrivePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "encryptionMethod",
+        "recoveryOptions",
+        "requireEncryptionForWriteAccess"
+      ]
+    },
+    "bitLockerRecoveryOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "blockDataRecoveryAgent",
+        "enableBitLockerAfterRecoveryInformationToStore",
+        "enableRecoveryInformationSaveToStore",
+        "hideRecoveryOptions",
+        "recoveryInformationToStore",
+        "recoveryKeyUsage",
+        "recoveryPasswordUsage"
+      ]
+    },
+    "bitLockerRemovableDrivePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "blockCrossOrganizationWriteAccess",
+        "encryptionMethod",
+        "requireEncryptionForWriteAccess"
+      ]
+    },
+    "bitLockerSystemDrivePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "encryptionMethod",
+        "minimumPinLength",
+        "prebootRecoveryEnableMessageAndUrl",
+        "prebootRecoveryMessage",
+        "prebootRecoveryUrl",
+        "recoveryOptions",
+        "startupAuthenticationBlockWithoutTpmChip",
+        "startupAuthenticationRequired",
+        "startupAuthenticationTpmKeyUsage",
+        "startupAuthenticationTpmPinAndKeyUsage",
+        "startupAuthenticationTpmPinUsage",
+        "startupAuthenticationTpmUsage"
+      ]
+    },
+    "blockAccessAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "bookingCustomerInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "customerId",
+        "customQuestionAnswers",
+        "emailAddress",
+        "location",
+        "name",
+        "notes",
+        "phone",
+        "smsNotificationsEnabled",
+        "timeZone"
+      ]
+    },
+    "bookingCustomerInformationBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "bookingPageSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "accessControl",
+        "bookingPageColorCode",
+        "businessTimeZone",
+        "customerConsentMessage",
+        "enforceOneTimePassword",
+        "isBusinessLogoDisplayEnabled",
+        "isCustomerConsentEnabled",
+        "isSearchEngineIndexabilityDisabled",
+        "isTimeSlotTimeZoneSetToBusinessTimeZone",
+        "privacyPolicyWebUrl",
+        "termsAndConditionsWebUrl"
+      ]
+    },
+    "bookingQuestionAnswer": {
+      "navigationProperties": [],
+      "properties": [
+        "answer",
+        "answerInputType",
+        "answerOptions",
+        "isRequired",
+        "question",
+        "questionId",
+        "selectedOptions"
+      ]
+    },
+    "bookingQuestionAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "isRequired",
+        "questionId"
+      ]
+    },
+    "bookingReminder": {
+      "navigationProperties": [],
+      "properties": [
+        "message",
+        "offset",
+        "recipients"
+      ]
+    },
+    "bookingsAvailability": {
+      "navigationProperties": [],
+      "properties": [
+        "availabilityType",
+        "businessHours"
+      ]
+    },
+    "bookingsAvailabilityWindow": {
+      "navigationProperties": [],
+      "properties": [
+        "endDate",
+        "startDate"
+      ]
+    },
+    "bookingSchedulingPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "allowStaffSelection",
+        "customAvailabilities",
+        "generalAvailability",
+        "isMeetingInviteToCustomersEnabled",
+        "maximumAdvance",
+        "minimumLeadTime",
+        "sendConfirmationsToOwner",
+        "timeSlotInterval"
+      ]
+    },
+    "bookingWorkHours": {
+      "navigationProperties": [],
+      "properties": [
+        "day",
+        "timeSlots"
+      ]
+    },
+    "bookingWorkTimeSlot": {
+      "navigationProperties": [],
+      "properties": [
+        "end",
+        "start"
+      ]
+    },
+    "booleanColumn": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "broadcastMeetingCaptionSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isCaptionEnabled",
+        "spokenLanguage",
+        "translationLanguages"
+      ]
+    },
+    "broadcastMeetingSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedAudience",
+        "captions",
+        "isAttendeeReportEnabled",
+        "isQuestionAndAnswerEnabled",
+        "isRecordingEnabled",
+        "isVideoOnDemandEnabled"
+      ]
+    },
+    "browseQueryResponseItem": {
+      "navigationProperties": [],
+      "properties": [
+        "itemKey",
+        "itemsCount",
+        "name",
+        "sizeInBytes",
+        "type",
+        "webUrl"
+      ]
+    },
+    "browserSharedCookieHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "comment",
+        "displayName",
+        "hostOnly",
+        "hostOrDomain",
+        "lastModifiedBy",
+        "path",
+        "publishedDateTime",
+        "sourceEnvironment"
+      ]
+    },
+    "browserSiteHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "allowRedirect",
+        "comment",
+        "compatibilityMode",
+        "lastModifiedBy",
+        "mergeType",
+        "publishedDateTime",
+        "targetEnvironment"
+      ]
+    },
+    "bucketAggregationDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "isDescending",
+        "minimumCount",
+        "prefixFilter",
+        "ranges",
+        "sortBy"
+      ]
+    },
+    "bucketAggregationRange": {
+      "navigationProperties": [],
+      "properties": [
+        "from",
+        "to"
+      ]
+    },
+    "bufferDecryptionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "decryptedBuffer"
+      ]
+    },
+    "bufferEncryptionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "encryptedBuffer",
+        "publishingLicense"
+      ]
+    },
+    "bulkCatalogItemActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "failedIds",
+        "successfulIds"
+      ]
+    },
+    "bulkDriverActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "failedDriverIds",
+        "notFoundDriverIds",
+        "successfulDriverIds"
+      ]
+    },
+    "bulkManagedDeviceActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "failedDeviceIds",
+        "notFoundDeviceIds",
+        "notSupportedDeviceIds",
+        "successfulDeviceIds"
+      ]
+    },
+    "bundle": {
+      "navigationProperties": [],
+      "properties": [
+        "album",
+        "childCount"
+      ]
+    },
+    "businessFlowSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "durationInDays"
+      ]
+    },
+    "businessScenarioGroupTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "groupId"
+      ]
+    },
+    "businessScenarioProperties": {
+      "navigationProperties": [],
+      "properties": [
+        "externalBucketId",
+        "externalContextId",
+        "externalObjectId",
+        "externalObjectVersion",
+        "webUrl"
+      ]
+    },
+    "businessScenarioTaskTargetBase": {
+      "navigationProperties": [],
+      "properties": [
+        "taskTargetKind"
+      ]
+    },
+    "calculatedColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "format",
+        "formula",
+        "outputType"
+      ]
+    },
+    "calendarSharingMessageAction": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "actionType",
+        "importance"
+      ]
+    },
+    "callAiInsightViewPoint": {
+      "navigationProperties": [],
+      "properties": [
+        "mentionEvents"
+      ]
+    },
+    "callEndedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "callDuration",
+        "callEventType",
+        "callId",
+        "callParticipants",
+        "initiator"
+      ]
+    },
+    "callMediaState": {
+      "navigationProperties": [],
+      "properties": [
+        "audio"
+      ]
+    },
+    "callOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "hideBotAfterEscalation",
+        "isContentSharingNotificationEnabled",
+        "isDeltaRosterEnabled",
+        "isInteractiveRosterEnabled"
+      ]
+    },
+    "callParticipantInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "participant"
+      ]
+    },
+    "callRecordingEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "callId",
+        "callRecordingDisplayName",
+        "callRecordingDuration",
+        "callRecordingStatus",
+        "callRecordingUrl",
+        "initiator",
+        "meetingOrganizer"
+      ]
+    },
+    "callRoute": {
+      "navigationProperties": [],
+      "properties": [
+        "final",
+        "original",
+        "routingType"
+      ]
+    },
+    "callStartedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "callEventType",
+        "callId",
+        "initiator"
+      ]
+    },
+    "callTranscriptEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "callId",
+        "callTranscriptICalUid",
+        "meetingOrganizer"
+      ]
+    },
+    "callTranscriptionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedDateTime",
+        "state"
+      ]
+    },
+    "campaignSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "completionDateTime",
+        "launchDateTime",
+        "status"
+      ]
+    },
+    "certificateAuthority": {
+      "navigationProperties": [],
+      "properties": [
+        "certificate",
+        "certificateRevocationListUrl",
+        "deltaCertificateRevocationListUrl",
+        "isRootAuthority",
+        "issuer",
+        "issuerSki"
+      ]
+    },
+    "certificateConnectorHealthMetricValue": {
+      "navigationProperties": [],
+      "properties": [
+        "dateTime",
+        "failureCount",
+        "successCount"
+      ]
+    },
+    "certificateConnectorSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "certExpiryTime",
+        "connectorVersion",
+        "enrollmentError",
+        "lastConnectorConnectionTime",
+        "lastUploadVersion",
+        "status"
+      ]
+    },
+    "certification": {
+      "navigationProperties": [],
+      "properties": [
+        "certificationDetailsUrl",
+        "certificationExpirationDateTime",
+        "isCertifiedByMicrosoft",
+        "isPublisherAttested",
+        "lastCertificationDateTime"
+      ]
+    },
+    "certificationControl": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "url"
+      ]
+    },
+    "challengingWord": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "word"
+      ]
+    },
+    "changeAssignmentsActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceAssignmentItems"
+      ]
+    },
+    "changeNotification": {
+      "navigationProperties": [],
+      "properties": [
+        "changeType",
+        "clientState",
+        "encryptedContent",
+        "id",
+        "lifecycleEvent",
+        "resource",
+        "resourceData",
+        "subscriptionExpirationDateTime",
+        "subscriptionId",
+        "tenantId"
+      ]
+    },
+    "changeNotificationCollection": {
+      "navigationProperties": [],
+      "properties": [
+        "validationTokens",
+        "value"
+      ]
+    },
+    "changeNotificationEncryptedContent": {
+      "navigationProperties": [],
+      "properties": [
+        "data",
+        "dataKey",
+        "dataSignature",
+        "encryptionCertificateId",
+        "encryptionCertificateThumbprint"
+      ]
+    },
+    "channelAddedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "channelDisplayName",
+        "channelId",
+        "initiator"
+      ]
+    },
+    "channelDeletedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "channelDisplayName",
+        "channelId",
+        "initiator"
+      ]
+    },
+    "channelDescriptionUpdatedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "channelDescription",
+        "channelId",
+        "initiator"
+      ]
+    },
+    "channelIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "channelId",
+        "teamId"
+      ]
+    },
+    "channelMembersNotificationRecipient": {
+      "navigationProperties": [],
+      "properties": [
+        "channelId",
+        "teamId"
+      ]
+    },
+    "channelModerationSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowNewMessageFromBots",
+        "allowNewMessageFromConnectors",
+        "replyRestriction",
+        "userNewMessageRestriction"
+      ]
+    },
+    "channelRenamedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "channelDisplayName",
+        "channelId",
+        "initiator"
+      ]
+    },
+    "channelSetAsFavoriteByDefaultEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "channelId",
+        "initiator"
+      ]
+    },
+    "channelSharingUpdatedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "ownerTeamId",
+        "ownerTenantId",
+        "sharedChannelId"
+      ]
+    },
+    "channelSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "guestsCount",
+        "hasMembersFromOtherTenants",
+        "membersCount",
+        "ownersCount"
+      ]
+    },
+    "channelUnsetAsFavoriteByDefaultEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "channelId",
+        "initiator"
+      ]
+    },
+    "chatInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "messageId",
+        "replyChainMessageId",
+        "threadId"
+      ]
+    },
+    "chatMembersNotificationRecipient": {
+      "navigationProperties": [],
+      "properties": [
+        "chatId"
+      ]
+    },
+    "chatMessageAttachment": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "contentType",
+        "contentUrl",
+        "id",
+        "name",
+        "teamsAppId",
+        "thumbnailUrl"
+      ]
+    },
+    "chatMessageFromIdentitySet": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "chatMessageHistoryItem": {
+      "navigationProperties": [],
+      "properties": [
+        "actions",
+        "modifiedDateTime",
+        "reaction"
+      ]
+    },
+    "chatMessageMention": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "mentioned",
+        "mentionText"
+      ]
+    },
+    "chatMessageMentionedIdentitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "conversation",
+        "tag"
+      ]
+    },
+    "chatMessagePolicyViolation": {
+      "navigationProperties": [],
+      "properties": [
+        "dlpAction",
+        "justificationText",
+        "policyTip",
+        "userAction",
+        "verdictDetails"
+      ]
+    },
+    "chatMessagePolicyViolationPolicyTip": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceUrl",
+        "generalText",
+        "matchedConditionDescriptions"
+      ]
+    },
+    "chatMessageReaction": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "reactionContentUrl",
+        "reactionType",
+        "user"
+      ]
+    },
+    "chatMessageReactionIdentitySet": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "chatRenamedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "chatDisplayName",
+        "chatId",
+        "initiator"
+      ]
+    },
+    "chatRestrictions": {
+      "navigationProperties": [],
+      "properties": [
+        "allowTextOnly"
+      ]
+    },
+    "chatViewpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "isHidden",
+        "lastMessageReadDateTime"
+      ]
+    },
+    "choiceColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "allowTextEntry",
+        "choices",
+        "displayAs"
+      ]
+    },
+    "chromeOSDeviceProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "updatable",
+        "value",
+        "valueType"
+      ]
+    },
+    "claimBinding": {
+      "navigationProperties": [],
+      "properties": [
+        "sourceAttribute",
+        "verifiedIdClaim"
+      ]
+    },
+    "claimsMapping": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "email",
+        "givenName",
+        "surname",
+        "userId"
+      ]
+    },
+    "classifcationErrorBase": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "innerError",
+        "message",
+        "target"
+      ]
+    },
+    "classificationAttribute": {
+      "navigationProperties": [],
+      "properties": [
+        "confidence",
+        "count"
+      ]
+    },
+    "classificationError": {
+      "navigationProperties": [],
+      "properties": [
+        "details"
+      ]
+    },
+    "classificationInnerError": {
+      "navigationProperties": [],
+      "properties": [
+        "activityId",
+        "clientRequestId",
+        "code",
+        "errorDateTime"
+      ]
+    },
+    "classificationLimit": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedLimit",
+        "code",
+        "impactedSensitiveTypeIds"
+      ]
+    },
+    "classificationRequestContentMetaData": {
+      "navigationProperties": [],
+      "properties": [
+        "sourceId"
+      ]
+    },
+    "classificationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "confidenceLevel",
+        "count",
+        "sensitiveTypeId"
+      ]
+    },
+    "classifierDiagnostic": {
+      "navigationProperties": [],
+      "properties": [
+        "classificationId",
+        "classificationMethod"
+      ]
+    },
+    "clientCertificateAuthentication": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateList"
+      ]
+    },
+    "clientCredentials": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateName",
+        "keyVaultUri"
+      ]
+    },
+    "cloudAppSecuritySessionControl": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudAppSecurityType"
+      ]
+    },
+    "cloudAppSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "destinationServiceIp",
+        "destinationServiceName",
+        "riskScore"
+      ]
+    },
+    "cloudCertificationAuthorityVersionUsage": {
+      "navigationProperties": [],
+      "properties": [
+        "issuedStagedLeafCertificateCount"
+      ]
+    },
+    "cloudClipboardItemPayload": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "formatName"
+      ]
+    },
+    "cloudFlareRuleModel": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "name",
+        "ruleId"
+      ]
+    },
+    "cloudFlareRulesetModel": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "phaseName",
+        "rulesetId"
+      ]
+    },
+    "cloudFlareVerifiedDetailsModel": {
+      "navigationProperties": [],
+      "properties": [
+        "enabledCustomRules",
+        "enabledRecommendedRulesets",
+        "zoneId"
+      ]
+    },
+    "cloudPcAgentHealthCheckDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalDetails",
+        "errorMessage",
+        "errorType",
+        "healthCheckName",
+        "healthCheckResultType",
+        "lastHealthCheckDateTime"
+      ]
+    },
+    "cloudPcAgentHealthCheckStatusDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalHealthCheckMessage",
+        "cloudPcId",
+        "healthCheckState",
+        "lastModifiedDateTime",
+        "startDateTime"
+      ]
+    },
+    "cloudPcAgentHealthCheckSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "agentHealthCheckDetails",
+        "lastSucceededHealthCheckDateTime",
+        "latestHealthCheckStatus"
+      ]
+    },
+    "cloudPcAgentPoolBillingConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "billingPlanId",
+        "billingType"
+      ]
+    },
+    "cloudPcAgentPoolCapabilityConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "enableSingleSignOn"
+      ]
+    },
+    "cloudPcAgentPoolScalingPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumCount",
+        "minimumCount"
+      ]
+    },
+    "cloudPcAgentPoolSessionUsage": {
+      "navigationProperties": [],
+      "properties": [
+        "activeSessionsCount",
+        "availableSessionsCount"
+      ]
+    },
+    "cloudPcAgentStatusDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "agentVersionNumber",
+        "cloudPcId",
+        "diagnosticResultMessage",
+        "diagnosticResultType",
+        "healthCheckSummary",
+        "healthStatus",
+        "lastHealthStatusCheckedDateTime",
+        "managedDeviceName",
+        "userPrincipalName"
+      ]
+    },
+    "cloudPcAuditActor": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationDisplayName",
+        "applicationId",
+        "ipAddress",
+        "remoteTenantId",
+        "remoteUserId",
+        "servicePrincipalName",
+        "type",
+        "userId",
+        "userPermissions",
+        "userPrincipalName",
+        "userRoleScopeTags"
+      ]
+    },
+    "cloudPcAuditProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "newValue",
+        "oldValue"
+      ]
+    },
+    "cloudPcAuditResource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "modifiedProperties",
+        "resourceId",
+        "resourceType"
+      ]
+    },
+    "cloudPcAutomaticDiscoveredAppDetail": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcAutopilotConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationTimeoutInMinutes",
+        "devicePreparationProfileId",
+        "onFailureDeviceAccessDenied"
+      ]
+    },
+    "cloudPcBulkActionSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedCount",
+        "inProgressCount",
+        "notSupportedCount",
+        "pendingCount",
+        "successfulCount"
+      ]
+    },
+    "cloudPcBulkRemoteActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "failedDeviceIds",
+        "notFoundDeviceIds",
+        "notSupportedDeviceIds",
+        "successfulDeviceIds"
+      ]
+    },
+    "cloudPcCloudAppDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "commandLineArguments",
+        "filePath",
+        "iconIndex",
+        "iconPath"
+      ]
+    },
+    "cloudPcConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "imageDisplayName",
+        "imageId",
+        "imageType",
+        "osLocale"
+      ]
+    },
+    "cloudPcConnectionSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "enableSingleSignOn"
+      ]
+    },
+    "cloudPcConnectionSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "enableSingleSignOn"
+      ]
+    },
+    "cloudPcConnectivityEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "activityId",
+        "eventDateTime",
+        "eventName",
+        "eventResult",
+        "eventType",
+        "message"
+      ]
+    },
+    "cloudPcConnectivityResult": {
+      "navigationProperties": [],
+      "properties": [
+        "failedHealthCheckItems",
+        "lastModifiedDateTime",
+        "status",
+        "updatedDateTime"
+      ]
+    },
+    "cloudPcCrossRegionDisasterRecoverySetting": {
+      "navigationProperties": [],
+      "properties": [
+        "crossRegionDisasterRecoveryEnabled",
+        "disasterRecoveryNetworkSetting",
+        "disasterRecoveryType",
+        "maintainCrossRegionRestorePointEnabled",
+        "userInitiatedDisasterRecoveryAllowed"
+      ]
+    },
+    "cloudPcDisasterRecoveryAzureConnectionSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "onPremisesConnectionId"
+      ]
+    },
+    "cloudPcDisasterRecoveryCapability": {
+      "navigationProperties": [],
+      "properties": [
+        "capabilityType",
+        "licenseType",
+        "primaryRegion",
+        "secondaryRegion"
+      ]
+    },
+    "cloudPcDisasterRecoveryMicrosoftHostedNetworkSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "regionGroup",
+        "regionName"
+      ]
+    },
+    "cloudPcDisasterRecoveryNetworkSetting": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcDiscoveredApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appDetail",
+        "appName",
+        "discoveredAppId",
+        "sourceId"
+      ]
+    },
+    "cloudPcDomainJoinConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "domainJoinType",
+        "geographicLocationType",
+        "onPremisesConnectionId",
+        "regionGroup",
+        "regionName",
+        "type"
+      ]
+    },
+    "cloudPcEntraGroupDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "groupDisplayName",
+        "groupId"
+      ]
+    },
+    "cloudPcEntraUserDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "userDisplayName",
+        "userId"
+      ]
+    },
+    "cloudPcExternalPartnerActionReport": {
+      "navigationProperties": [],
+      "properties": [
+        "actionType",
+        "activityId",
+        "activityMessage",
+        "agentName",
+        "agentSetting",
+        "authenticatedAppId",
+        "authenticatedAppName",
+        "authenticatedMethod",
+        "authenticatedUserPrincipalName",
+        "cloudPcId",
+        "cloudPcName",
+        "createdDateTime"
+      ]
+    },
+    "cloudPcExternalPartnerActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "activityId",
+        "cloudPcId",
+        "errorCode",
+        "errorMessage",
+        "lastModifiedDateTime",
+        "startDateTime",
+        "state"
+      ]
+    },
+    "cloudPcExternalPartnerAgentSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "agentSha256",
+        "agentUrl",
+        "autoDeploymentEnabled",
+        "installParameters"
+      ]
+    },
+    "cloudPcFilePathAppDetail": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcForensicStorageAccount": {
+      "navigationProperties": [],
+      "properties": [
+        "accessTier",
+        "immutableStorage",
+        "storageAccountId",
+        "storageAccountName"
+      ]
+    },
+    "cloudPcFrontlineSharedDeviceDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedToUserPrincipalName",
+        "sessionStartDateTime"
+      ]
+    },
+    "cloudPcHealthCheckItem": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalDetails",
+        "displayName",
+        "lastHealthCheckDateTime",
+        "result"
+      ]
+    },
+    "cloudPcLaunchDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudPcId",
+        "cloudPcLaunchUrl",
+        "windows365SwitchCompatibilityFailureReasonType",
+        "windows365SwitchCompatible"
+      ]
+    },
+    "cloudPcLaunchInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudPcId",
+        "cloudPcLaunchUrl",
+        "windows365SwitchCompatible",
+        "windows365SwitchNotCompatibleReason"
+      ]
+    },
+    "cloudPcLoginResult": {
+      "navigationProperties": [],
+      "properties": [
+        "time"
+      ]
+    },
+    "cloudPcManagementAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcManagementGroupAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "allotmentDisplayName",
+        "allotmentLicensesCount",
+        "groupId",
+        "servicePlanId"
+      ]
+    },
+    "cloudPcMicrosoftHostedNetworkConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "geographicLocationType",
+        "regionGroups"
+      ]
+    },
+    "cloudPcNetworkConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcNotificationSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "restartPromptsDisabled"
+      ]
+    },
+    "cloudPcOnPremisesConnectionHealthCheck": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalDetail",
+        "additionalDetails",
+        "correlationId",
+        "displayName",
+        "endDateTime",
+        "errorType",
+        "recommendedAction",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "cloudPcOnPremisesConnectionStatusDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "healthChecks",
+        "startDateTime"
+      ]
+    },
+    "cloudPcOnPremisesConnectionStatusDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "healthChecks",
+        "startDateTime"
+      ]
+    },
+    "cloudPcOnPremisesConnectionSubnetIpDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "subnetAvailableIpCount",
+        "subnetAvailableIpCountLastSyncDateTime"
+      ]
+    },
+    "cloudPcOrganizationActionDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "errorDescription",
+        "status"
+      ]
+    },
+    "cloudPcPartnerAgentInstallResult": {
+      "navigationProperties": [],
+      "properties": [
+        "errorMessage",
+        "installStatus",
+        "isThirdPartyPartner",
+        "partnerAgentName",
+        "retriable"
+      ]
+    },
+    "cloudPcPolicyApplyActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "finishDateTime",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "cloudPcPolicyScheduledApplyActionDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "cronScheduleExpression",
+        "endDateTime",
+        "nextRunDateTime",
+        "reservePercentage",
+        "startDateTime",
+        "timezone"
+      ]
+    },
+    "cloudPcPoolCapabilityConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcProvisioningPolicyAutopatch": {
+      "navigationProperties": [],
+      "properties": [
+        "autopatchGroupId"
+      ]
+    },
+    "cloudPcRegionGroupConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "regionGroup",
+        "regions"
+      ]
+    },
+    "cloudPcRemoteActionCapability": {
+      "navigationProperties": [],
+      "properties": [
+        "actionCapability",
+        "actionName"
+      ]
+    },
+    "cloudPcRemoteActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "actionName",
+        "actionState",
+        "cloudPcId",
+        "lastUpdatedDateTime",
+        "managedDeviceId",
+        "startDateTime",
+        "statusDetail",
+        "statusDetails"
+      ]
+    },
+    "cloudPcResizeValidationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudPcId",
+        "validationResult"
+      ]
+    },
+    "cloudPcRestorePointSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "frequencyInHours",
+        "frequencyType",
+        "userRestoreEnabled"
+      ]
+    },
+    "cloudPcReviewStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "accessTier",
+        "azureStorageAccountId",
+        "azureStorageAccountName",
+        "azureStorageContainerName",
+        "inReview",
+        "restorePointDateTime",
+        "reviewStartDateTime",
+        "subscriptionId",
+        "subscriptionName",
+        "userAccessLevel"
+      ]
+    },
+    "cloudPcScopedPermission": {
+      "navigationProperties": [],
+      "properties": [
+        "permission",
+        "scopeIds"
+      ]
+    },
+    "cloudPcSnapshotImportActionDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "fileType",
+        "sasUrl",
+        "sourceType",
+        "storageBlobInfo"
+      ]
+    },
+    "cloudPcSnapshotImportActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalDetail",
+        "assignedUserPrincipalName",
+        "endDateTime",
+        "filename",
+        "importStatus",
+        "policyName",
+        "snapshotId",
+        "startDateTime",
+        "usageStatus"
+      ]
+    },
+    "cloudPcSourceDeviceImage": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "displayName",
+        "id",
+        "resourceId",
+        "subscriptionDisplayName",
+        "subscriptionId"
+      ]
+    },
+    "cloudPcStatusDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformation",
+        "code",
+        "message"
+      ]
+    },
+    "cloudPcStatusDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformation",
+        "code",
+        "message"
+      ]
+    },
+    "cloudPcStatusSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "status"
+      ]
+    },
+    "cloudPcStorageBlobDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "containerName",
+        "fileName",
+        "storageAccountId"
+      ]
+    },
+    "cloudPcSubscription": {
+      "navigationProperties": [],
+      "properties": [
+        "subscriptionId",
+        "subscriptionName"
+      ]
+    },
+    "cloudPcSupportedRegionRestrictionDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "availabilityZoneRestricted",
+        "cPURestricted",
+        "gPURestricted",
+        "nestedVirtualizationRestricted"
+      ]
+    },
+    "cloudPcTenantEncryptionSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "lastSyncDateTime",
+        "tenantDiskEncryptionType"
+      ]
+    },
+    "cloudPcUserRoleScopeTagInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "roleScopeTagId"
+      ]
+    },
+    "cloudPcUserSettingsPersistenceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "userSettingsPersistenceEnabled",
+        "userSettingsPersistenceStorageSizeCategory"
+      ]
+    },
+    "cloudPCUserSettingsPersistenceProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "lastProfileAttachedDateTime",
+        "profileId",
+        "profileSizeInGB",
+        "status",
+        "userPrincipalName"
+      ]
+    },
+    "cloudPCUserSettingsPersistenceUsageResult": {
+      "navigationProperties": [],
+      "properties": [
+        "remainingAvailableStorageInGB",
+        "totalAllocatedStorageInGB",
+        "usedStorageInGB"
+      ]
+    },
+    "cloudPcWindowsSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "locale"
+      ]
+    },
+    "cloudPcWindowsSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "language"
+      ]
+    },
+    "cloudRealtimeCommunicationInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "isSipEnabled"
+      ]
+    },
+    "coachmarkLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "length",
+        "offset",
+        "type"
+      ]
+    },
+    "collapseProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "fields",
+        "limit"
+      ]
+    },
+    "columnValidation": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultLanguage",
+        "descriptions",
+        "formula"
+      ]
+    },
+    "comanagedDevicesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "compliancePolicyCount",
+        "configurationSettingsCount",
+        "endpointProtectionCount",
+        "inventoryCount",
+        "modernAppsCount",
+        "officeAppsCount",
+        "resourceAccessCount",
+        "totalComanagedCount",
+        "windowsUpdateForBusinessCount"
+      ]
+    },
+    "comanagementEligibleDevicesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "comanagedCount",
+        "eligibleButNotAzureAdJoinedCount",
+        "eligibleCount",
+        "ineligibleCount",
+        "needsOsUpdateCount",
+        "scheduledForEnrollmentCount"
+      ]
+    },
+    "commentAction": {
+      "navigationProperties": [],
+      "properties": [
+        "isReply",
+        "parentAuthor",
+        "participants"
+      ]
+    },
+    "commsNotification": {
+      "navigationProperties": [],
+      "properties": [
+        "changeType",
+        "resourceUrl"
+      ]
+    },
+    "commsNotifications": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "communicationsApplicationIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationType",
+        "hidden"
+      ]
+    },
+    "communicationsApplicationInstanceIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "hidden",
+        "tenantId"
+      ]
+    },
+    "communicationsEncryptedIdentity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "communicationsGuestIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "email"
+      ]
+    },
+    "communicationsIdentitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationInstance",
+        "assertedIdentity",
+        "azureCommunicationServicesUser",
+        "encrypted",
+        "endpointType",
+        "guest",
+        "onPremises",
+        "phone"
+      ]
+    },
+    "communicationsPhoneIdentity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "communicationsUserIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "tenantId"
+      ]
+    },
+    "companyDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "companyCode",
+        "costCenter",
+        "department",
+        "displayName",
+        "division",
+        "officeLocation",
+        "pronunciation",
+        "secondaryDepartment",
+        "webUrl"
+      ]
+    },
+    "companyPortalBlockedAction": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "ownerType",
+        "platform"
+      ]
+    },
+    "ComplexExtensionValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "certificationControls",
+        "certificationName"
+      ]
+    },
+    "complianceManagementPartnerAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "computeRightsAndInheritanceResult": {
+      "navigationProperties": [
+        "contentRights",
+        "inheritedLabel",
+        "sensitivityLabels"
+      ],
+      "properties": []
+    },
+    "conditionalAccessAllExternalTenants": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "conditionalAccessApplications": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationFilter",
+        "excludeApplications",
+        "globalSecureAccess",
+        "includeApplications",
+        "includeAuthenticationContextClassReferences",
+        "includeUserActions",
+        "networkAccess"
+      ]
+    },
+    "conditionalAccessAuthenticationFlows": {
+      "navigationProperties": [],
+      "properties": [
+        "transferMethods"
+      ]
+    },
+    "conditionalAccessClientApplications": {
+      "navigationProperties": [],
+      "properties": [
+        "agentIdServicePrincipalFilter",
+        "excludeAgentIdServicePrincipals",
+        "excludeServicePrincipals",
+        "includeAgentIdServicePrincipals",
+        "includeServicePrincipals",
+        "servicePrincipalFilter"
+      ]
+    },
+    "conditionalAccessConditionSet": {
+      "navigationProperties": [],
+      "properties": [
+        "agentIdRiskLevels",
+        "applications",
+        "authenticationFlows",
+        "clientApplications",
+        "clientAppTypes",
+        "devices",
+        "deviceStates",
+        "insiderRiskLevels",
+        "locations",
+        "platforms",
+        "servicePrincipalRiskLevels",
+        "signInRiskLevels",
+        "userRiskLevels",
+        "users"
+      ]
+    },
+    "conditionalAccessDevices": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceFilter",
+        "excludeDevices",
+        "excludeDeviceStates",
+        "includeDevices",
+        "includeDeviceStates"
+      ]
+    },
+    "conditionalAccessDeviceStates": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeStates",
+        "includeStates"
+      ]
+    },
+    "conditionalAccessEnumeratedExternalTenants": {
+      "navigationProperties": [],
+      "properties": [
+        "members"
+      ]
+    },
+    "conditionalAccessExternalTenants": {
+      "navigationProperties": [],
+      "properties": [
+        "membershipKind"
+      ]
+    },
+    "conditionalAccessFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "mode",
+        "rule"
+      ]
+    },
+    "conditionalAccessGlobalSecureAccess": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "conditionalAccessGrantControls": {
+      "navigationProperties": [
+        "authenticationStrength"
+      ],
+      "properties": [
+        "builtInControls",
+        "customAuthenticationFactors",
+        "operator",
+        "termsOfUse"
+      ]
+    },
+    "conditionalAccessGuestsOrExternalUsers": {
+      "navigationProperties": [],
+      "properties": [
+        "externalTenants",
+        "guestOrExternalUserTypes"
+      ]
+    },
+    "conditionalAccessLocations": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeLocations",
+        "includeLocations"
+      ]
+    },
+    "conditionalAccessNetworkAccess": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "conditionalAccessPlatforms": {
+      "navigationProperties": [],
+      "properties": [
+        "excludePlatforms",
+        "includePlatforms"
+      ]
+    },
+    "conditionalAccessPolicyDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "conditions",
+        "grantControls",
+        "sessionControls"
+      ]
+    },
+    "conditionalAccessRuleSatisfied": {
+      "navigationProperties": [],
+      "properties": [
+        "conditionalAccessCondition",
+        "ruleSatisfied"
+      ]
+    },
+    "conditionalAccessSessionControl": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "conditionalAccessSessionControls": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationEnforcedRestrictions",
+        "cloudAppSecurity",
+        "continuousAccessEvaluation",
+        "disableResilienceDefaults",
+        "globalSecureAccessFilteringProfile",
+        "persistentBrowser",
+        "secureSignInSession",
+        "signInFrequency"
+      ]
+    },
+    "conditionalAccessUsers": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeGroups",
+        "excludeGuestsOrExternalUsers",
+        "excludeRoles",
+        "excludeUsers",
+        "includeGroups",
+        "includeGuestsOrExternalUsers",
+        "includeRoles",
+        "includeUsers"
+      ]
+    },
+    "configManagerPolicySummary": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantDeviceCount",
+        "enforcedDeviceCount",
+        "failedDeviceCount",
+        "nonCompliantDeviceCount",
+        "pendingDeviceCount",
+        "targetedDeviceCount"
+      ]
+    },
+    "configuration": {
+      "navigationProperties": [],
+      "properties": [
+        "authorizedAppIds",
+        "authorizedApps"
+      ]
+    },
+    "configurationManagerAction": {
+      "navigationProperties": [],
+      "properties": [
+        "action"
+      ]
+    },
+    "configurationManagerActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "actionDeliveryStatus",
+        "errorCode"
+      ]
+    },
+    "configurationManagerClientEnabledFeatures": {
+      "navigationProperties": [],
+      "properties": [
+        "compliancePolicy",
+        "deviceConfiguration",
+        "endpointProtection",
+        "inventory",
+        "modernApps",
+        "officeApps",
+        "resourceAccess",
+        "windowsUpdateForBusiness"
+      ]
+    },
+    "configurationManagerClientHealthState": {
+      "navigationProperties": [],
+      "properties": [
+        "errorCode",
+        "lastSyncDateTime",
+        "state"
+      ]
+    },
+    "configurationManagerClientInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "clientIdentifier",
+        "clientVersion",
+        "isBlocked"
+      ]
+    },
+    "configurationManagerCollectionAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "collectionId"
+      ]
+    },
+    "configurationUri": {
+      "navigationProperties": [],
+      "properties": [
+        "appliesToSingleSignOnMode",
+        "examples",
+        "isRequired",
+        "usage",
+        "values"
+      ]
+    },
+    "connectedOrganizationMembers": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "id"
+      ]
+    },
+    "connectionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "url"
+      ]
+    },
+    "connectionItem": {
+      "navigationProperties": [],
+      "properties": [
+        "connectionId"
+      ]
+    },
+    "connectivityParameterEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "connectorStatusDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "connectorInstanceId",
+        "connectorName",
+        "eventDateTime",
+        "status"
+      ]
+    },
+    "containerFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "includedContainers"
+      ]
+    },
+    "containsTransformation": {
+      "navigationProperties": [],
+      "properties": [
+        "output",
+        "value"
+      ]
+    },
+    "contentActivityMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "enforcementResultStatus",
+        "recordType"
+      ]
+    },
+    "contentApprovalStatusColumn": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "contentBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "contentClassification": {
+      "navigationProperties": [],
+      "properties": [
+        "confidence",
+        "matches",
+        "sensitiveTypeId",
+        "uniqueCount"
+      ]
+    },
+    "contentCustomization": {
+      "navigationProperties": [],
+      "properties": [
+        "attributeCollection",
+        "attributeCollectionRelativeUrl",
+        "registrationCampaign",
+        "registrationCampaignRelativeUrl"
+      ]
+    },
+    "contentInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "format",
+        "identifier",
+        "metadata",
+        "state"
+      ]
+    },
+    "contentMetadata": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "contentModelUsage": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "driveId",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "modelId",
+        "modelVersion"
+      ]
+    },
+    "contentProperties": {
+      "navigationProperties": [],
+      "properties": [
+        "extensions",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "metadata"
+      ]
+    },
+    "contentSensitivityLabelAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentMethod",
+        "justificationText",
+        "sensitivityLabelId",
+        "tenantId"
+      ]
+    },
+    "contentTypeInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "name"
+      ]
+    },
+    "contentTypeOrder": {
+      "navigationProperties": [],
+      "properties": [
+        "default",
+        "position"
+      ]
+    },
+    "continuousAccessEvaluationSessionControl": {
+      "navigationProperties": [],
+      "properties": [
+        "mode"
+      ]
+    },
+    "controlScore": {
+      "navigationProperties": [],
+      "properties": [
+        "controlCategory",
+        "controlName",
+        "description",
+        "score"
+      ]
+    },
+    "conversationMemberRoleUpdatedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "conversationMemberRoles",
+        "conversationMemberUser",
+        "initiator"
+      ]
+    },
+    "conversionUserDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "convertedToInternalUserDateTime",
+        "displayName",
+        "mail",
+        "userPrincipalName"
+      ]
+    },
+    "convertIdResult": {
+      "navigationProperties": [],
+      "properties": [
+        "errorDetails",
+        "sourceId",
+        "targetId"
+      ]
+    },
+    "copilotChatResponseOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "isAdaptiveCardEnabled",
+        "isAnnotationsEnabled",
+        "isDeltaStreamingEnabled"
+      ]
+    },
+    "copilotContextMessage": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "text"
+      ]
+    },
+    "copilotContextualResources": {
+      "navigationProperties": [],
+      "properties": [
+        "files",
+        "webContext"
+      ]
+    },
+    "copilotConversationAttribution": {
+      "navigationProperties": [],
+      "properties": [
+        "attributionSource",
+        "attributionType",
+        "imageFavIcon",
+        "imageHeight",
+        "imageWebUrl",
+        "imageWidth",
+        "providerDisplayName",
+        "seeMoreWebUrl"
+      ]
+    },
+    "copilotConversationLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "countryOrRegion",
+        "countryOrRegionConfidence",
+        "latitude",
+        "longitude",
+        "timeZone"
+      ]
+    },
+    "copilotConversationMessageParameter": {
+      "navigationProperties": [],
+      "properties": [
+        "text"
+      ]
+    },
+    "copilotConversationRequestMessageParameter": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "copilotDeleteConversationRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "threadId"
+      ]
+    },
+    "copilotFile": {
+      "navigationProperties": [],
+      "properties": [
+        "uri"
+      ]
+    },
+    "copilotPackageUpdateResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "id"
+      ]
+    },
+    "copilotSearchDataSourcesConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "oneDrive"
+      ]
+    },
+    "copilotSearchHit": {
+      "navigationProperties": [],
+      "properties": [
+        "preview",
+        "resourceMetadata",
+        "resourceType",
+        "webUrl"
+      ]
+    },
+    "copilotSearchResourceMetadataDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "copilotSearchResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "nextLink",
+        "searchHits",
+        "totalCount"
+      ]
+    },
+    "copilotWebContext": {
+      "navigationProperties": [],
+      "properties": [
+        "isWebEnabled"
+      ]
+    },
+    "CopyNotebookModel": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdByIdentity",
+        "createdTime",
+        "id",
+        "isDefault",
+        "isShared",
+        "lastModifiedBy",
+        "lastModifiedByIdentity",
+        "lastModifiedTime",
+        "links",
+        "name",
+        "sectionGroupsUrl",
+        "sectionsUrl",
+        "self",
+        "userRole"
+      ]
+    },
+    "corsConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedHeaders",
+        "allowedMethods",
+        "allowedOrigins",
+        "maxAgeInSeconds",
+        "resource"
+      ]
+    },
+    "createAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "createRemoteHelpSessionResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "sessionKey"
+      ]
+    },
+    "credential": {
+      "navigationProperties": [],
+      "properties": [
+        "fieldId",
+        "type",
+        "value"
+      ]
+    },
+    "credentialSingleSignOnExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "configurations",
+        "domains",
+        "extensionIdentifier",
+        "realm",
+        "teamIdentifier"
+      ]
+    },
+    "crossCloudAzureActiveDirectoryTenant": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudInstance",
+        "displayName",
+        "tenantId"
+      ]
+    },
+    "crossTenantAccessPolicyAppServiceConnectSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "applications"
+      ]
+    },
+    "crossTenantAccessPolicyB2BSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "applications",
+        "usersAndGroups"
+      ]
+    },
+    "crossTenantAccessPolicyInboundTrust": {
+      "navigationProperties": [],
+      "properties": [
+        "isCompliantDeviceAccepted",
+        "isHybridAzureADJoinedDeviceAccepted",
+        "isMfaAccepted"
+      ]
+    },
+    "crossTenantAccessPolicyM365CollaborationInboundSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "users"
+      ]
+    },
+    "crossTenantAccessPolicyM365CollaborationOutboundSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "usersAndGroups"
+      ]
+    },
+    "crossTenantAccessPolicyTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "target",
+        "targetType"
+      ]
+    },
+    "crossTenantAccessPolicyTargetConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accessType",
+        "targets"
+      ]
+    },
+    "crossTenantAccessPolicyTenantRestrictions": {
+      "navigationProperties": [],
+      "properties": [
+        "devices"
+      ]
+    },
+    "crossTenantGroupSyncInbound": {
+      "navigationProperties": [],
+      "properties": [
+        "isSyncAllowed"
+      ]
+    },
+    "crossTenantMigrationCancelResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "message",
+        "status"
+      ]
+    },
+    "crossTenantMigrationServiceStatusDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "errors",
+        "message",
+        "service",
+        "status"
+      ]
+    },
+    "crossTenantUserSyncInbound": {
+      "navigationProperties": [],
+      "properties": [
+        "isSyncAllowed"
+      ]
+    },
+    "cryptographySuite": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationTransformConstants",
+        "cipherTransformConstants",
+        "dhGroup",
+        "encryptionMethod",
+        "integrityCheckMethod",
+        "pfsGroup"
+      ]
+    },
+    "currencyColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "locale"
+      ]
+    },
+    "currentLabel": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationMode",
+        "id"
+      ]
+    },
+    "customAction": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "properties"
+      ]
+    },
+    "customAppManagementApplicationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "audiences",
+        "identifierUris",
+        "redirectUris"
+      ]
+    },
+    "customAppManagementConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationRestrictions"
+      ]
+    },
+    "customAppScopeAttributesDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customAppSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "developerToolsForShowingAppUsageMetrics"
+      ]
+    },
+    "customClaim": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "namespace",
+        "samlAttributeNameFormat",
+        "tokenFormat"
+      ]
+    },
+    "customClaimAttributeBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customClaimBase": {
+      "navigationProperties": [],
+      "properties": [
+        "configurations"
+      ]
+    },
+    "customClaimCondition": {
+      "navigationProperties": [],
+      "properties": [
+        "memberOf",
+        "userType"
+      ]
+    },
+    "customClaimConditionBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customClaimConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "attribute",
+        "condition",
+        "transformations"
+      ]
+    },
+    "customClaimTransformation": {
+      "navigationProperties": [],
+      "properties": [
+        "input"
+      ]
+    },
+    "customDataProvidedResourceUploadSessionRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "data",
+        "source",
+        "type"
+      ]
+    },
+    "customDataProvidedResourceUploadStats": {
+      "navigationProperties": [],
+      "properties": [
+        "filesUploaded",
+        "totalBytesUploaded"
+      ]
+    },
+    "customerVoiceSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isInOrgFormsPhishingScanEnabled",
+        "isRecordIdentityByDefaultEnabled",
+        "isRestrictedSurveyAccessEnabled"
+      ]
+    },
+    "customExtensionAuthenticationConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customExtensionBehaviorOnError": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customExtensionCallbackConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "timeoutDuration"
+      ]
+    },
+    "customExtensionCalloutInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "customExtensionId",
+        "detail",
+        "externalCorrelationId",
+        "id",
+        "status"
+      ]
+    },
+    "customExtensionCalloutRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "data",
+        "source",
+        "type"
+      ]
+    },
+    "customExtensionCalloutResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "data",
+        "source",
+        "type"
+      ]
+    },
+    "customExtensionCalloutResult": {
+      "navigationProperties": [],
+      "properties": [
+        "calloutDateTime",
+        "customExtensionId",
+        "errorCode",
+        "httpStatus",
+        "numberOfAttempts"
+      ]
+    },
+    "customExtensionClientConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumRetries",
+        "timeoutInMilliseconds"
+      ]
+    },
+    "customExtensionData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customExtensionEndpointConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customExtensionHandlerInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "customExtensionId",
+        "externalCorrelationId",
+        "stage",
+        "status"
+      ]
+    },
+    "customExtensionOverwriteConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "behaviorOnError",
+        "clientConfiguration"
+      ]
+    },
+    "customMetadataDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customQuestionAnswer": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "questionId",
+        "value"
+      ]
+    },
+    "customSecurityAttributeExemption": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "operator"
+      ]
+    },
+    "customSecurityAttributeStringValueExemption": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "customSecurityAttributeValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customSubjectAlternativeName": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "sanType"
+      ]
+    },
+    "customTimeZone": {
+      "navigationProperties": [],
+      "properties": [
+        "bias",
+        "daylightOffset",
+        "standardOffset"
+      ]
+    },
+    "customTrainingSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedTo",
+        "description",
+        "displayName",
+        "durationInMinutes",
+        "url"
+      ]
+    },
+    "customUpdateTimeWindow": {
+      "navigationProperties": [],
+      "properties": [
+        "endDay",
+        "endTime",
+        "startDay",
+        "startTime"
+      ]
+    },
+    "dataProcessorServiceForWindowsFeaturesOnboarding": {
+      "navigationProperties": [],
+      "properties": [
+        "areDataProcessorServiceForWindowsFeaturesEnabled",
+        "hasValidWindowsLicense"
+      ]
+    },
+    "dataProviderStoragePath": {
+      "navigationProperties": [],
+      "properties": [
+        "containerName",
+        "dataProviderId",
+        "path",
+        "storageAccountName"
+      ]
+    },
+    "dataSourceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "externalItem"
+      ]
+    },
+    "dataStoreField": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "searchable",
+        "unique"
+      ]
+    },
+    "dataSubject": {
+      "navigationProperties": [],
+      "properties": [
+        "email",
+        "firstName",
+        "lastName",
+        "residency"
+      ]
+    },
+    "dateTimeColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "displayAs",
+        "format"
+      ]
+    },
+    "dateTimeTimeZone": {
+      "navigationProperties": [],
+      "properties": [
+        "dateTime",
+        "timeZone"
+      ]
+    },
+    "dateTimeTimeZoneType": {
+      "navigationProperties": [],
+      "properties": [
+        "dateTime"
+      ]
+    },
+    "daylightTimeZoneOffset": {
+      "navigationProperties": [],
+      "properties": [
+        "daylightBias"
+      ]
+    },
+    "decisionItemPrincipalResourceMembership": {
+      "navigationProperties": [],
+      "properties": [
+        "membershipType"
+      ]
+    },
+    "defaultColumnValue": {
+      "navigationProperties": [],
+      "properties": [
+        "formula",
+        "value"
+      ]
+    },
+    "defaultInvitationRedemptionIdentityProviderConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "defaultSharingLink": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultToExistingAccess",
+        "role",
+        "scope"
+      ]
+    },
+    "defaultUserRolePermissions": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedToCreateApps",
+        "allowedToCreateSecurityGroups",
+        "allowedToCreateTenants",
+        "allowedToReadBitlockerKeysForOwnedDevice",
+        "allowedToReadOtherUsers"
+      ]
+    },
+    "defenderDetectedMalwareActions": {
+      "navigationProperties": [],
+      "properties": [
+        "highSeverity",
+        "lowSeverity",
+        "moderateSeverity",
+        "severeSeverity"
+      ]
+    },
+    "delegateAllowedActions": {
+      "navigationProperties": [],
+      "properties": [
+        "joinActiveCalls",
+        "makeCalls",
+        "manageCallAndDelegateSettings",
+        "pickUpHeldCalls",
+        "receiveCalls"
+      ]
+    },
+    "delegatedAdminAccessContainer": {
+      "navigationProperties": [],
+      "properties": [
+        "accessContainerId",
+        "accessContainerType"
+      ]
+    },
+    "delegatedAdminAccessDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "unifiedRoles"
+      ]
+    },
+    "delegatedAdminRelationshipCustomerParticipant": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "tenantId"
+      ]
+    },
+    "deleteAction": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "objectType"
+      ]
+    },
+    "deleted": {
+      "navigationProperties": [],
+      "properties": [
+        "state"
+      ]
+    },
+    "deleteUserFromSharedAppleDeviceActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "userPrincipalName"
+      ]
+    },
+    "deliveryOptimizationBandwidth": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deliveryOptimizationBandwidthAbsolute": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumDownloadBandwidthInKilobytesPerSecond",
+        "maximumUploadBandwidthInKilobytesPerSecond"
+      ]
+    },
+    "deliveryOptimizationBandwidthBusinessHoursLimit": {
+      "navigationProperties": [],
+      "properties": [
+        "bandwidthBeginBusinessHours",
+        "bandwidthEndBusinessHours",
+        "bandwidthPercentageDuringBusinessHours",
+        "bandwidthPercentageOutsideBusinessHours"
+      ]
+    },
+    "deliveryOptimizationBandwidthHoursWithPercentage": {
+      "navigationProperties": [],
+      "properties": [
+        "bandwidthBackgroundPercentageHours",
+        "bandwidthForegroundPercentageHours"
+      ]
+    },
+    "deliveryOptimizationBandwidthPercentage": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumBackgroundBandwidthPercentage",
+        "maximumForegroundBandwidthPercentage"
+      ]
+    },
+    "deliveryOptimizationGroupIdCustom": {
+      "navigationProperties": [],
+      "properties": [
+        "groupIdCustom"
+      ]
+    },
+    "deliveryOptimizationGroupIdSource": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deliveryOptimizationGroupIdSourceOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "groupIdSourceOption"
+      ]
+    },
+    "deliveryOptimizationMaxCacheSize": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deliveryOptimizationMaxCacheSizeAbsolute": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumCacheSizeInGigabytes"
+      ]
+    },
+    "deliveryOptimizationMaxCacheSizePercentage": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumCacheSizePercentage"
+      ]
+    },
+    "depProfileAdminAccountPasswordRotationSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "autoRotationPeriodInDays",
+        "depProfileDelayAutoRotationSetting"
+      ]
+    },
+    "depProfileDelayAutoRotationSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "onRetrievalAutoRotatePasswordEnabled",
+        "onRetrievalDelayAutoRotatePasswordInHours"
+      ]
+    },
+    "detailsInfo": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "detectedSensitiveContent": {
+      "navigationProperties": [],
+      "properties": [
+        "classificationAttributes",
+        "classificationMethod",
+        "matches",
+        "scope",
+        "sensitiveTypeSource"
+      ]
+    },
+    "detectedSensitiveContentBase": {
+      "navigationProperties": [],
+      "properties": [
+        "confidence",
+        "displayName",
+        "id",
+        "recommendedConfidence",
+        "uniqueCount"
+      ]
+    },
+    "detectedSensitiveContentWrapper": {
+      "navigationProperties": [],
+      "properties": [
+        "classification"
+      ]
+    },
+    "deviceActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "actionName",
+        "actionState",
+        "lastUpdatedDateTime",
+        "startDateTime"
+      ]
+    },
+    "deviceAndAppManagementAssignedRoleDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "permissions",
+        "roleDefinitionDisplayName"
+      ]
+    },
+    "deviceAndAppManagementAssignedRoleDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "permissions",
+        "roleDefinitions"
+      ]
+    },
+    "deviceAndAppManagementAssignedRoleDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "roleAssignmentIds",
+        "roleDefinitionIds"
+      ]
+    },
+    "deviceAndAppManagementAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceAndAppManagementAssignmentFilterId",
+        "deviceAndAppManagementAssignmentFilterType"
+      ]
+    },
+    "deviceAndAppManagementData": {
+      "navigationProperties": [],
+      "properties": [
+        "content"
+      ]
+    },
+    "deviceAssignmentItem": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentItemActionIntent",
+        "assignmentItemActionStatus",
+        "errorCode",
+        "intentActionMessage",
+        "itemDisplayName",
+        "itemId",
+        "itemSubTypeDisplayName",
+        "itemType",
+        "lastActionDateTime",
+        "lastModifiedDateTime"
+      ]
+    },
+    "deviceCompliancePolicyScript": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceComplianceScriptId",
+        "rulesContent"
+      ]
+    },
+    "deviceCompliancePolicySettingState": {
+      "navigationProperties": [],
+      "properties": [
+        "currentValue",
+        "errorCode",
+        "errorDescription",
+        "instanceDisplayName",
+        "setting",
+        "settingInstanceId",
+        "settingName",
+        "sources",
+        "state",
+        "userEmail",
+        "userId",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceComplianceScriptError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "deviceComplianceScriptRulesValidationError",
+        "message"
+      ]
+    },
+    "deviceComplianceScriptRule": {
+      "navigationProperties": [],
+      "properties": [
+        "dataType",
+        "deviceComplianceScriptRuleDataType",
+        "deviceComplianceScriptRulOperator",
+        "operand",
+        "operator",
+        "settingName"
+      ]
+    },
+    "deviceComplianceScriptRuleError": {
+      "navigationProperties": [],
+      "properties": [
+        "settingName"
+      ]
+    },
+    "deviceComplianceScriptValidationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "ruleErrors",
+        "rules",
+        "scriptErrors"
+      ]
+    },
+    "deviceConfigurationSettingState": {
+      "navigationProperties": [],
+      "properties": [
+        "currentValue",
+        "errorCode",
+        "errorDescription",
+        "instanceDisplayName",
+        "setting",
+        "settingInstanceId",
+        "settingName",
+        "sources",
+        "state",
+        "userEmail",
+        "userId",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceConfigurationTargetedUserAndDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "deviceName",
+        "lastCheckinDateTime",
+        "userDisplayName",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "deviceDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "browser",
+        "browserId",
+        "deviceId",
+        "displayName",
+        "isCompliant",
+        "isManaged",
+        "operatingSystem",
+        "trustType"
+      ]
+    },
+    "deviceEnrollmentPlatformRestriction": {
+      "navigationProperties": [],
+      "properties": [
+        "blockedManufacturers",
+        "blockedSkus",
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "personalDeviceEnrollmentBlocked",
+        "platformBlocked"
+      ]
+    },
+    "deviceExchangeAccessStateSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedDeviceCount",
+        "blockedDeviceCount",
+        "quarantinedDeviceCount",
+        "unavailableDeviceCount",
+        "unknownDeviceCount"
+      ]
+    },
+    "deviceGeoLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "altitude",
+        "heading",
+        "horizontalAccuracy",
+        "lastCollectedDateTime",
+        "latitude",
+        "longitude",
+        "speed",
+        "verticalAccuracy"
+      ]
+    },
+    "deviceHealth": {
+      "navigationProperties": [],
+      "properties": [
+        "lastConnectionTime"
+      ]
+    },
+    "deviceHealthAttestationState": {
+      "navigationProperties": [],
+      "properties": [
+        "attestationIdentityKey",
+        "bitLockerStatus",
+        "bootAppSecurityVersion",
+        "bootDebugging",
+        "bootManagerSecurityVersion",
+        "bootManagerVersion",
+        "bootRevisionListInfo",
+        "codeIntegrity",
+        "codeIntegrityCheckVersion",
+        "codeIntegrityPolicy",
+        "contentNamespaceUrl",
+        "contentVersion",
+        "dataExcutionPolicy",
+        "deviceHealthAttestationStatus",
+        "earlyLaunchAntiMalwareDriverProtection",
+        "firmwareProtection",
+        "healthAttestationSupportedStatus",
+        "healthStatusMismatchInfo",
+        "issuedDateTime",
+        "lastUpdateDateTime",
+        "memoryAccessProtection",
+        "memoryIntegrityProtection",
+        "operatingSystemKernelDebugging",
+        "operatingSystemRevListInfo",
+        "pcr0",
+        "pcrHashAlgorithm",
+        "resetCount",
+        "restartCount",
+        "safeMode",
+        "secureBoot",
+        "secureBootConfigurationPolicyFingerPrint",
+        "securedCorePC",
+        "systemManagementMode",
+        "testSigning",
+        "tpmVersion",
+        "virtualizationBasedSecurity",
+        "virtualSecureMode",
+        "windowsPE"
+      ]
+    },
+    "deviceHealthScriptBooleanParameter": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue"
+      ]
+    },
+    "deviceHealthScriptDailySchedule": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceHealthScriptHourlySchedule": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceHealthScriptIntegerParameter": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue"
+      ]
+    },
+    "deviceHealthScriptParameter": {
+      "navigationProperties": [],
+      "properties": [
+        "applyDefaultValueWhenNotAssigned",
+        "description",
+        "isRequired",
+        "name"
+      ]
+    },
+    "deviceHealthScriptRemediationHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "historyData",
+        "lastModifiedDateTime"
+      ]
+    },
+    "deviceHealthScriptRemediationHistoryData": {
+      "navigationProperties": [],
+      "properties": [
+        "date",
+        "detectFailedDeviceCount",
+        "noIssueDeviceCount",
+        "remediatedDeviceCount"
+      ]
+    },
+    "deviceHealthScriptRemediationSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "remediatedDeviceCount",
+        "scriptCount"
+      ]
+    },
+    "deviceHealthScriptRunOnceSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "date"
+      ]
+    },
+    "deviceHealthScriptRunSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "interval"
+      ]
+    },
+    "deviceHealthScriptStringParameter": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue"
+      ]
+    },
+    "deviceHealthScriptTimeSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "time",
+        "useUtc"
+      ]
+    },
+    "deviceIdentityAttestationDetail": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "displayName",
+        "enrollmentProfileName",
+        "extensionAttribute1",
+        "extensionAttribute10",
+        "extensionAttribute11",
+        "extensionAttribute12",
+        "extensionAttribute13",
+        "extensionAttribute14",
+        "extensionAttribute15",
+        "extensionAttribute2",
+        "extensionAttribute3",
+        "extensionAttribute4",
+        "extensionAttribute5",
+        "extensionAttribute6",
+        "extensionAttribute7",
+        "extensionAttribute8",
+        "extensionAttribute9",
+        "isCompliant",
+        "manufacturer",
+        "mdmAppId",
+        "model",
+        "operatingSystem",
+        "operatingSystemVersion",
+        "ownership",
+        "physicalIds",
+        "profileType",
+        "systemLabels",
+        "trustType"
+      ]
+    },
+    "deviceKey": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "keyMaterial",
+        "keyType"
+      ]
+    },
+    "deviceLocalAdminAccountDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "passwordLastRotationDateTime"
+      ]
+    },
+    "deviceLocalCredential": {
+      "navigationProperties": [],
+      "properties": [
+        "accountName",
+        "accountSid",
+        "backupDateTime",
+        "passwordBase64"
+      ]
+    },
+    "deviceLogCollectionRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "templateType"
+      ]
+    },
+    "deviceManagementApplicabilityRuleDeviceMode": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceMode",
+        "name",
+        "ruleType"
+      ]
+    },
+    "deviceManagementApplicabilityRuleOsEdition": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "osEditionTypes",
+        "ruleType"
+      ]
+    },
+    "deviceManagementApplicabilityRuleOsVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "maxOSVersion",
+        "minOSVersion",
+        "name",
+        "ruleType"
+      ]
+    },
+    "deviceManagementConfigurationAndroidSettingApplicability": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementConfigurationAppleOSSupportedVersions": {
+      "navigationProperties": [],
+      "properties": [
+        "includesMaxVersion",
+        "includesMinVersion",
+        "maxVersion",
+        "minVersion"
+      ]
+    },
+    "deviceManagementConfigurationAppleSettingVersionApplicability": {
+      "navigationProperties": [],
+      "properties": [
+        "constraints",
+        "deviceType",
+        "supportedVersions"
+      ]
+    },
+    "deviceManagementConfigurationApplicationSettingApplicability": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementConfigurationChoiceSettingCollectionInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "choiceSettingCollectionValue"
+      ]
+    },
+    "deviceManagementConfigurationChoiceSettingCollectionInstanceTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "allowUnmanagedValues",
+        "choiceSettingCollectionValueTemplate"
+      ]
+    },
+    "deviceManagementConfigurationChoiceSettingInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "choiceSettingValue"
+      ]
+    },
+    "deviceManagementConfigurationChoiceSettingInstanceTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "choiceSettingValueTemplate"
+      ]
+    },
+    "deviceManagementConfigurationChoiceSettingValue": {
+      "navigationProperties": [],
+      "properties": [
+        "children",
+        "value"
+      ]
+    },
+    "deviceManagementConfigurationChoiceSettingValueConstantDefaultTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "children",
+        "settingDefinitionOptionId"
+      ]
+    },
+    "deviceManagementConfigurationChoiceSettingValueDefaultTemplate": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementConfigurationChoiceSettingValueDefinitionTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedOptions"
+      ]
+    },
+    "deviceManagementConfigurationChoiceSettingValueTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue",
+        "recommendedValueDefinition",
+        "requiredValueDefinition",
+        "settingValueTemplateId"
+      ]
+    },
+    "deviceManagementConfigurationDependentOn": {
+      "navigationProperties": [],
+      "properties": [
+        "dependentOn",
+        "parentSettingId"
+      ]
+    },
+    "deviceManagementConfigurationEdgeSettingApplicability": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementConfigurationExchangeOnlineSettingApplicability": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementConfigurationFloatSettingValueDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumValue",
+        "minimumValue"
+      ]
+    },
+    "deviceManagementConfigurationGroupSettingCollectionInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "groupSettingCollectionValue"
+      ]
+    },
+    "deviceManagementConfigurationGroupSettingCollectionInstanceTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "allowUnmanagedValues",
+        "groupSettingCollectionValueTemplate"
+      ]
+    },
+    "deviceManagementConfigurationGroupSettingInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "groupSettingValue"
+      ]
+    },
+    "deviceManagementConfigurationGroupSettingInstanceTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "groupSettingValueTemplate"
+      ]
+    },
+    "deviceManagementConfigurationGroupSettingValue": {
+      "navigationProperties": [],
+      "properties": [
+        "children"
+      ]
+    },
+    "deviceManagementConfigurationGroupSettingValueTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "children",
+        "settingValueTemplateId"
+      ]
+    },
+    "deviceManagementConfigurationIntegerSettingValue": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "deviceManagementConfigurationIntegerSettingValueConstantDefaultTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "constantValue"
+      ]
+    },
+    "deviceManagementConfigurationIntegerSettingValueDefaultTemplate": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementConfigurationIntegerSettingValueDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumValue",
+        "minimumValue"
+      ]
+    },
+    "deviceManagementConfigurationIntegerSettingValueDefinitionTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "maxValue",
+        "minValue"
+      ]
+    },
+    "deviceManagementConfigurationIntegerSettingValueTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue",
+        "recommendedValueDefinition",
+        "requiredValueDefinition"
+      ]
+    },
+    "deviceManagementConfigurationIosSettingApplicability": {
+      "navigationProperties": [],
+      "properties": [
+        "versionApplicabilities"
+      ]
+    },
+    "deviceManagementConfigurationLinuxSettingApplicability": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementConfigurationOptionDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "dependedOnBy",
+        "dependentOn",
+        "description",
+        "displayName",
+        "helpText",
+        "itemId",
+        "name",
+        "optionValue"
+      ]
+    },
+    "deviceManagementConfigurationOptionDefinitionTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "children",
+        "itemId"
+      ]
+    },
+    "deviceManagementConfigurationPolicyTemplateReference": {
+      "navigationProperties": [],
+      "properties": [
+        "templateDisplayName",
+        "templateDisplayVersion",
+        "templateFamily",
+        "templateId"
+      ]
+    },
+    "deviceManagementConfigurationReferenceSettingValue": {
+      "navigationProperties": [],
+      "properties": [
+        "note"
+      ]
+    },
+    "deviceManagementConfigurationReferredSettingInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "settingDefinitionId"
+      ]
+    },
+    "deviceManagementConfigurationSecretSettingValue": {
+      "navigationProperties": [],
+      "properties": [
+        "value",
+        "valueState"
+      ]
+    },
+    "deviceManagementConfigurationSettingApplicability": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "deviceMode",
+        "platform",
+        "technologies"
+      ]
+    },
+    "deviceManagementConfigurationSettingDependedOnBy": {
+      "navigationProperties": [],
+      "properties": [
+        "dependedOnBy",
+        "required"
+      ]
+    },
+    "deviceManagementConfigurationSettingGroupCollectionInstance": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementConfigurationSettingGroupInstance": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementConfigurationSettingInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "settingDefinitionId",
+        "settingInstanceTemplateReference"
+      ]
+    },
+    "deviceManagementConfigurationSettingInstanceTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "isRequired",
+        "settingDefinitionId",
+        "settingInstanceTemplateId"
+      ]
+    },
+    "deviceManagementConfigurationSettingInstanceTemplateReference": {
+      "navigationProperties": [],
+      "properties": [
+        "settingInstanceTemplateId"
+      ]
+    },
+    "deviceManagementConfigurationSettingOccurrence": {
+      "navigationProperties": [],
+      "properties": [
+        "maxDeviceOccurrence",
+        "minDeviceOccurrence"
+      ]
+    },
+    "deviceManagementConfigurationSettingValue": {
+      "navigationProperties": [],
+      "properties": [
+        "settingValueTemplateReference"
+      ]
+    },
+    "deviceManagementConfigurationSettingValueDefinition": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementConfigurationSettingValueTemplateReference": {
+      "navigationProperties": [],
+      "properties": [
+        "settingValueTemplateId",
+        "useTemplateDefault"
+      ]
+    },
+    "deviceManagementConfigurationSimpleSettingCollectionInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "simpleSettingCollectionValue"
+      ]
+    },
+    "deviceManagementConfigurationSimpleSettingCollectionInstanceTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "allowUnmanagedValues",
+        "simpleSettingCollectionValueTemplate"
+      ]
+    },
+    "deviceManagementConfigurationSimpleSettingInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "simpleSettingValue"
+      ]
+    },
+    "deviceManagementConfigurationSimpleSettingInstanceTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "simpleSettingValueTemplate"
+      ]
+    },
+    "deviceManagementConfigurationSimpleSettingValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementConfigurationSimpleSettingValueTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "settingValueTemplateId"
+      ]
+    },
+    "deviceManagementConfigurationStringSettingValue": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "deviceManagementConfigurationStringSettingValueConstantDefaultTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "constantValue"
+      ]
+    },
+    "deviceManagementConfigurationStringSettingValueDefaultTemplate": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementConfigurationStringSettingValueDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "fileTypes",
+        "format",
+        "inputValidationSchema",
+        "isSecret",
+        "maximumLength",
+        "minimumLength"
+      ]
+    },
+    "deviceManagementConfigurationStringSettingValueTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue"
+      ]
+    },
+    "deviceManagementConfigurationWindowsSettingApplicability": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationServiceProviderVersion",
+        "maximumSupportedVersion",
+        "minimumSupportedVersion",
+        "requiredAzureAdTrustType",
+        "requiresAzureAd",
+        "windowsSkus"
+      ]
+    },
+    "deviceManagementConstraint": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementEnumConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "values"
+      ]
+    },
+    "deviceManagementEnumValue": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "value"
+      ]
+    },
+    "deviceManagementExchangeAccessRule": {
+      "navigationProperties": [],
+      "properties": [
+        "accessLevel",
+        "deviceClass"
+      ]
+    },
+    "deviceManagementExchangeDeviceClass": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "type"
+      ]
+    },
+    "deviceManagementIntentCustomizedSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "customizedJson",
+        "defaultJson",
+        "definitionId"
+      ]
+    },
+    "deviceManagementIntentSettingSecretConstraint": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementPartnerAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "deviceManagementPriorityMetaData": {
+      "navigationProperties": [],
+      "properties": [
+        "priority"
+      ]
+    },
+    "deviceManagementSettingAbstractImplementationConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedAbstractImplementationDefinitionIds"
+      ]
+    },
+    "deviceManagementSettingAppConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "supportedTypes"
+      ]
+    },
+    "deviceManagementSettingBooleanConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "deviceManagementSettingCollectionConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumLength",
+        "minimumLength"
+      ]
+    },
+    "deviceManagementSettingComparison": {
+      "navigationProperties": [],
+      "properties": [
+        "comparisonResult",
+        "currentValueJson",
+        "definitionId",
+        "displayName",
+        "id",
+        "newValueJson"
+      ]
+    },
+    "deviceManagementSettingDependency": {
+      "navigationProperties": [],
+      "properties": [
+        "constraints",
+        "definitionId"
+      ]
+    },
+    "deviceManagementSettingEnrollmentTypeConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "enrollmentTypes"
+      ]
+    },
+    "deviceManagementSettingFileConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "supportedExtensions"
+      ]
+    },
+    "deviceManagementSettingInsightsDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "settingDefinitionId",
+        "settingInsight"
+      ]
+    },
+    "deviceManagementSettingIntegerConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumValue",
+        "minimumValue"
+      ]
+    },
+    "deviceManagementSettingProfileConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "source",
+        "types"
+      ]
+    },
+    "deviceManagementSettingRegexConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "regex"
+      ]
+    },
+    "deviceManagementSettingRequiredConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "notConfiguredValue"
+      ]
+    },
+    "deviceManagementSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "androidDeviceAdministratorEnrollmentEnabled",
+        "derivedCredentialProvider",
+        "derivedCredentialUrl",
+        "deviceComplianceCheckinThresholdDays",
+        "deviceInactivityBeforeRetirementInDay",
+        "enableAutopilotDiagnostics",
+        "enableDeviceGroupMembershipReport",
+        "enableEnhancedTroubleshootingExperience",
+        "enableLogCollection",
+        "enhancedJailBreak",
+        "ignoreDevicesForUnsupportedSettingsEnabled",
+        "isScheduledActionEnabled",
+        "m365AppDiagnosticsEnabled",
+        "secureByDefault"
+      ]
+    },
+    "deviceManagementSettingSddlConstraint": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementSettingStringLengthConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumLength",
+        "minimumLength"
+      ]
+    },
+    "deviceManagementSettingXmlConstraint": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementTroubleshootingErrorDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "context",
+        "failure",
+        "failureDetails",
+        "remediation",
+        "resources"
+      ]
+    },
+    "deviceManagementTroubleshootingErrorResource": {
+      "navigationProperties": [],
+      "properties": [
+        "link",
+        "text"
+      ]
+    },
+    "deviceManagementUserRightsLocalUserOrGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "name",
+        "securityIdentifier"
+      ]
+    },
+    "deviceManagementUserRightsSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "localUsersOrGroups",
+        "state"
+      ]
+    },
+    "deviceMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceType",
+        "ipAddress",
+        "operatingSystemSpecifications"
+      ]
+    },
+    "deviceOperatingSystemSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "androidCorporateWorkProfileCount",
+        "androidCount",
+        "androidDedicatedCount",
+        "androidDeviceAdminCount",
+        "androidFullyManagedCount",
+        "androidWorkProfileCount",
+        "aospUserAssociatedCount",
+        "aospUserlessCount",
+        "chromeOSCount",
+        "configMgrDeviceCount",
+        "iosCount",
+        "linuxCount",
+        "macOSCount",
+        "unknownCount",
+        "windowsCount",
+        "windowsMobileCount"
+      ]
+    },
+    "deviceProperties": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceIdentifiers"
+      ]
+    },
+    "deviceProtectionOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "cleanDeviceCount",
+        "criticalFailuresDeviceCount",
+        "inactiveThreatAgentDeviceCount",
+        "pendingFullScanDeviceCount",
+        "pendingManualStepsDeviceCount",
+        "pendingOfflineScanDeviceCount",
+        "pendingQuickScanDeviceCount",
+        "pendingRestartDeviceCount",
+        "pendingSignatureUpdateDeviceCount",
+        "totalReportedDeviceCount",
+        "unknownStateThreatAgentDeviceCount"
+      ]
+    },
+    "deviceRegistrationMembership": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceScopeActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceScopeAction",
+        "deviceScopeId",
+        "failedMessage",
+        "status"
+      ]
+    },
+    "devicesFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "mode",
+        "rule"
+      ]
+    },
+    "diagnostic": {
+      "navigationProperties": [],
+      "properties": [
+        "message",
+        "url"
+      ]
+    },
+    "diagnosticMetadata": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "dictionaries": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "Dictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "directorySizeQuota": {
+      "navigationProperties": [],
+      "properties": [
+        "total",
+        "used"
+      ]
+    },
+    "directSharingAbilities": {
+      "navigationProperties": [],
+      "properties": [
+        "addExistingExternalUsers",
+        "addInternalUsers",
+        "addNewExternalUsers",
+        "requestGrantAccess"
+      ]
+    },
+    "disableAndDeleteUserApplyAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "discoveredSensitiveType": {
+      "navigationProperties": [],
+      "properties": [
+        "classificationAttributes",
+        "confidence",
+        "count",
+        "id"
+      ]
+    },
+    "displayNameLocalization": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "languageTag"
+      ]
+    },
+    "dlpActionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "action"
+      ]
+    },
+    "dlpEvaluatePoliciesRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "evaluationInput",
+        "notificationInfo",
+        "target"
+      ]
+    },
+    "dlpEvaluationInput": {
+      "navigationProperties": [],
+      "properties": [
+        "currentLabel",
+        "discoveredSensitiveTypes"
+      ]
+    },
+    "dlpEvaluationWindowsDevicesInput": {
+      "navigationProperties": [],
+      "properties": [
+        "contentProperties",
+        "sharedBy"
+      ]
+    },
+    "dlpNotification": {
+      "navigationProperties": [],
+      "properties": [
+        "author"
+      ]
+    },
+    "dlpPoliciesJobResult": {
+      "navigationProperties": [],
+      "properties": [
+        "auditCorrelationId",
+        "evaluationDateTime",
+        "matchingRules"
+      ]
+    },
+    "dlpWindowsDevicesNotification": {
+      "navigationProperties": [],
+      "properties": [
+        "contentName",
+        "lastModfiedBy"
+      ]
+    },
+    "documentSet": {
+      "navigationProperties": [
+        "sharedColumns",
+        "welcomePageColumns"
+      ],
+      "properties": [
+        "allowedContentTypes",
+        "defaultContents",
+        "propagateWelcomePageChanges",
+        "shouldPrefixNameToFile",
+        "welcomePageUrl"
+      ]
+    },
+    "documentSetContent": {
+      "navigationProperties": [],
+      "properties": [
+        "contentType",
+        "fileName",
+        "folderName"
+      ]
+    },
+    "documentSetVersionItem": {
+      "navigationProperties": [],
+      "properties": [
+        "itemId",
+        "title",
+        "versionId"
+      ]
+    },
+    "domainIdentitySource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "domainName"
+      ]
+    },
+    "domainRegistrant": {
+      "navigationProperties": [],
+      "properties": [
+        "countryOrRegionCode",
+        "organization",
+        "url",
+        "vendor"
+      ]
+    },
+    "domainState": {
+      "navigationProperties": [],
+      "properties": [
+        "lastActionDateTime",
+        "operation",
+        "status"
+      ]
+    },
+    "domainVerificationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "holdingTenantId",
+        "verifiedDomain"
+      ]
+    },
+    "downgradeJustification": {
+      "navigationProperties": [],
+      "properties": [
+        "isDowngradeJustified",
+        "justificationMessage"
+      ]
+    },
+    "driftedProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "currentValue",
+        "desiredValue",
+        "propertyName"
+      ]
+    },
+    "driveItemAccessOperationsViewpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "canComment",
+        "canCreateFile",
+        "canCreateFolder",
+        "canDelete",
+        "canDownload",
+        "canRead",
+        "canUpdate"
+      ]
+    },
+    "driveItemSource": {
+      "navigationProperties": [],
+      "properties": [
+        "application",
+        "externalId"
+      ]
+    },
+    "driveItemUploadableProperties": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "driveItemSource",
+        "fileSize",
+        "fileSystemInfo",
+        "mediaSource",
+        "name"
+      ]
+    },
+    "driveItemViewpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "accessOperations",
+        "sharing"
+      ]
+    },
+    "driveRecipient": {
+      "navigationProperties": [],
+      "properties": [
+        "alias",
+        "email",
+        "objectId"
+      ]
+    },
+    "dropInPlaceMode": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "edgeHomeButtonConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "edgeHomeButtonHidden": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "edgeHomeButtonLoadsStartPage": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "edgeHomeButtonOpensCustomURL": {
+      "navigationProperties": [],
+      "properties": [
+        "homeButtonCustomURL"
+      ]
+    },
+    "edgeHomeButtonOpensNewTab": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "edgeSearchEngine": {
+      "navigationProperties": [],
+      "properties": [
+        "edgeSearchEngineType"
+      ]
+    },
+    "edgeSearchEngineBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "edgeSearchEngineCustom": {
+      "navigationProperties": [],
+      "properties": [
+        "edgeSearchEngineOpenSearchXmlUrl"
+      ]
+    },
+    "edIdentitySource": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "editAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "educationAiFeedbackAudienceEngagementSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "areEngagementStrategiesEnabled",
+        "isCallToActionEnabled",
+        "isEmotionalAndIntellectualAppealEnabled"
+      ]
+    },
+    "educationAiFeedbackContentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isMessageClarityEnabled",
+        "isQualityOfInformationEnabled",
+        "isSpeechOrganizationEnabled"
+      ]
+    },
+    "educationAiFeedbackCriteria": {
+      "navigationProperties": [],
+      "properties": [
+        "aiFeedbackSettings",
+        "speechType"
+      ]
+    },
+    "educationAiFeedbackDeliverySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "areRhetoricalTechniquesEnabled",
+        "isLanguageUseEnabled",
+        "isStyleEnabled"
+      ]
+    },
+    "educationAiFeedbackSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "audienceEngagementSettings",
+        "contentSettings",
+        "deliverySettings"
+      ]
+    },
+    "educationalActivityDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "abbreviation",
+        "activities",
+        "awards",
+        "description",
+        "displayName",
+        "fieldsOfStudy",
+        "grade",
+        "notes",
+        "webUrl"
+      ]
+    },
+    "educationAssignmentClassRecipient": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "educationAssignmentGrade": {
+      "navigationProperties": [],
+      "properties": [
+        "gradedBy",
+        "gradedDateTime"
+      ]
+    },
+    "educationAssignmentGradeType": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "educationAssignmentGroupRecipient": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "educationAssignmentIndividualRecipient": {
+      "navigationProperties": [],
+      "properties": [
+        "recipients"
+      ]
+    },
+    "educationAssignmentPointsGrade": {
+      "navigationProperties": [],
+      "properties": [
+        "grade",
+        "points"
+      ]
+    },
+    "educationAssignmentPointsGradeType": {
+      "navigationProperties": [],
+      "properties": [
+        "maxPoints"
+      ]
+    },
+    "educationAssignmentRecipient": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "educationChannelResource": {
+      "navigationProperties": [],
+      "properties": [
+        "url"
+      ]
+    },
+    "educationCourse": {
+      "navigationProperties": [],
+      "properties": [
+        "courseNumber",
+        "description",
+        "displayName",
+        "externalId",
+        "subject"
+      ]
+    },
+    "educationExcelResource": {
+      "navigationProperties": [],
+      "properties": [
+        "fileUrl"
+      ]
+    },
+    "educationExternalResource": {
+      "navigationProperties": [],
+      "properties": [
+        "webUrl"
+      ]
+    },
+    "educationFeedback": {
+      "navigationProperties": [],
+      "properties": [
+        "feedbackBy",
+        "feedbackDateTime",
+        "text"
+      ]
+    },
+    "educationFileResource": {
+      "navigationProperties": [],
+      "properties": [
+        "fileUrl"
+      ]
+    },
+    "educationGradingSchemeGrade": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultPercentage",
+        "displayName",
+        "minPercentage"
+      ]
+    },
+    "educationItemBody": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "contentType"
+      ]
+    },
+    "educationLinkedAssignmentResource": {
+      "navigationProperties": [],
+      "properties": [
+        "url"
+      ]
+    },
+    "educationLinkResource": {
+      "navigationProperties": [],
+      "properties": [
+        "link"
+      ]
+    },
+    "educationMediaResource": {
+      "navigationProperties": [],
+      "properties": [
+        "fileUrl"
+      ]
+    },
+    "educationOnPremisesInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "immutableId"
+      ]
+    },
+    "educationPowerPointResource": {
+      "navigationProperties": [],
+      "properties": [
+        "fileUrl"
+      ]
+    },
+    "educationResource": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "educationSpeakerCoachAudienceEngagementSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isBodyLanguageEnabled"
+      ]
+    },
+    "educationSpeakerCoachContentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isInclusivenessEnabled",
+        "isRepetitiveLanguageEnabled"
+      ]
+    },
+    "educationSpeakerCoachDeliverySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "areFillerWordsEnabled",
+        "isPaceEnabled",
+        "isPitchEnabled",
+        "isPronunciationEnabled"
+      ]
+    },
+    "educationSpeakerCoachSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "audienceEngagementSettings",
+        "contentSettings",
+        "deliverySettings"
+      ]
+    },
+    "educationSpeakerProgressResource": {
+      "navigationProperties": [],
+      "properties": [
+        "aiFeedbackCriteria",
+        "isAiFeedbackEnabled",
+        "isVideoRequired",
+        "maxRecordingAttempts",
+        "presentationTitle",
+        "recordingTimeLimitInMinutes",
+        "showRehearsalReportToStudentBeforeMediaUpload",
+        "speakerCoachSettings",
+        "spokenLanguageLocale"
+      ]
+    },
+    "educationStudent": {
+      "navigationProperties": [],
+      "properties": [
+        "birthDate",
+        "externalId",
+        "gender",
+        "grade",
+        "graduationYear",
+        "studentNumber"
+      ]
+    },
+    "educationSubmissionIndividualRecipient": {
+      "navigationProperties": [],
+      "properties": [
+        "userId"
+      ]
+    },
+    "educationSubmissionRecipient": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "educationTeacher": {
+      "navigationProperties": [],
+      "properties": [
+        "externalId",
+        "teacherNumber"
+      ]
+    },
+    "educationTeamsAppResource": {
+      "navigationProperties": [],
+      "properties": [
+        "appIconWebUrl",
+        "appId",
+        "teamsEmbeddedContentUrl",
+        "webUrl"
+      ]
+    },
+    "educationTerm": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "endDate",
+        "externalId",
+        "startDate"
+      ]
+    },
+    "educationWordResource": {
+      "navigationProperties": [],
+      "properties": [
+        "fileUrl"
+      ]
+    },
+    "elevationRequestApplicationDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "fileDescription",
+        "fileHash",
+        "fileName",
+        "filePath",
+        "productInternalName",
+        "productName",
+        "productVersion",
+        "publisherCert",
+        "publisherName"
+      ]
+    },
+    "emailAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "name"
+      ]
+    },
+    "emailDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "body",
+        "senderEmailAddress",
+        "subject"
+      ]
+    },
+    "emailIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "email"
+      ]
+    },
+    "emailPayloadDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "fromEmail",
+        "fromName",
+        "isExternalSender",
+        "subject"
+      ]
+    },
+    "emailSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "senderDomain",
+        "useCompanyBranding"
+      ]
+    },
+    "embeddedSIMActivationCode": {
+      "navigationProperties": [],
+      "properties": [
+        "integratedCircuitCardIdentifier",
+        "matchingIdentifier",
+        "smdpPlusServerAddress"
+      ]
+    },
+    "emergencyCallerInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "location",
+        "phoneNumber",
+        "tenantId",
+        "upn"
+      ]
+    },
+    "employeeOrgData": {
+      "navigationProperties": [],
+      "properties": [
+        "costCenter",
+        "division"
+      ]
+    },
+    "encryptContent": {
+      "navigationProperties": [],
+      "properties": [
+        "encryptWith"
+      ]
+    },
+    "encryptionReportPolicyDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "policyId",
+        "policyName"
+      ]
+    },
+    "encryptWithTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "availableForEncryption",
+        "templateId"
+      ]
+    },
+    "encryptWithUserDefinedRights": {
+      "navigationProperties": [],
+      "properties": [
+        "allowAdHocPermissions",
+        "allowMailForwarding",
+        "decryptionRightsManagementTemplateId"
+      ]
+    },
+    "endsWithTransformation": {
+      "navigationProperties": [],
+      "properties": [
+        "output",
+        "value"
+      ]
+    },
+    "endUserNotificationSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "notificationPreference",
+        "positiveReinforcement",
+        "settingType"
+      ]
+    },
+    "enforceAppPIN": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeTargets",
+        "includeTargets"
+      ]
+    },
+    "engagementIdentitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "audience",
+        "group"
+      ]
+    },
+    "engagementUploadSession": {
+      "navigationProperties": [],
+      "properties": [
+        "id"
+      ]
+    },
+    "enrollmentTimeDeviceMembershipTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "targetId",
+        "targetType"
+      ]
+    },
+    "enrollmentTimeDeviceMembershipTargetResult": {
+      "navigationProperties": [],
+      "properties": [
+        "enrollmentTimeDeviceMembershipTargetValidationStatuses",
+        "validationSucceeded"
+      ]
+    },
+    "enrollmentTimeDeviceMembershipTargetStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "targetId",
+        "targetValidationErrorCode"
+      ]
+    },
+    "entitlementsDataCollection": {
+      "navigationProperties": [],
+      "properties": [
+        "lastCollectionDateTime",
+        "permissionsModificationCapability",
+        "status"
+      ]
+    },
+    "entitlementsDataCollectionInfo": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "entitySetNames": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "enumeratedAccountsWithAccess": {
+      "navigationProperties": [
+        "accounts"
+      ],
+      "properties": []
+    },
+    "enumeratedDeviceRegistrationMembership": {
+      "navigationProperties": [],
+      "properties": [
+        "groups",
+        "users"
+      ]
+    },
+    "enumeratedDomains": {
+      "navigationProperties": [],
+      "properties": [
+        "domainNames"
+      ]
+    },
+    "enumeratedInboundPorts": {
+      "navigationProperties": [],
+      "properties": [
+        "ports"
+      ]
+    },
+    "enumeratedPreApprovedPermissions": {
+      "navigationProperties": [],
+      "properties": [
+        "permissionIds",
+        "resourceApplicationId"
+      ]
+    },
+    "enumeratedScopes": {
+      "navigationProperties": [],
+      "properties": [
+        "scopes"
+      ]
+    },
+    "enumeratedScopeSensitivityLabels": {
+      "navigationProperties": [],
+      "properties": [
+        "sensitivityLabels"
+      ]
+    },
+    "error": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message"
+      ]
+    },
+    "errorDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "errorMessage",
+        "resourceInstanceName",
+        "resourceType"
+      ]
+    },
+    "evaluateDynamicMembershipResult": {
+      "navigationProperties": [],
+      "properties": [
+        "membershipRule",
+        "membershipRuleEvaluationDetails",
+        "membershipRuleEvaluationResult"
+      ]
+    },
+    "evaluateLabelJobResult": {
+      "navigationProperties": [],
+      "properties": [
+        "responsiblePolicy",
+        "responsibleSensitiveTypes",
+        "sensitivityLabel"
+      ]
+    },
+    "evaluateLabelJobResultGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "automatic",
+        "recommended"
+      ]
+    },
+    "evaluateSensitivityLabelsRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "currentLabel",
+        "discoveredSensitiveTypes"
+      ]
+    },
+    "eventMessageDetail": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "exactDataMatchDiagnostic": {
+      "navigationProperties": [],
+      "properties": [
+        "classificationLimits",
+        "unmatchedItems"
+      ]
+    },
+    "exactDataMatchStoreColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "ignoredDelimiters",
+        "isCaseInsensitive",
+        "isSearchable",
+        "name"
+      ]
+    },
+    "exactMatchClassificationRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "contentClassifications",
+        "sensitiveTypeIds",
+        "text",
+        "timeoutInMs"
+      ]
+    },
+    "exactMatchClassificationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "classification",
+        "errors"
+      ]
+    },
+    "exactMatchDetectedSensitiveContent": {
+      "navigationProperties": [],
+      "properties": [
+        "matches"
+      ]
+    },
+    "exactMatchDiagnostic": {
+      "navigationProperties": [],
+      "properties": [
+        "classificationId",
+        "classificationLimits",
+        "unmatchedItems"
+      ]
+    },
+    "exchangeOnlineCrossTenantMigrationSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "sourceEndpoint",
+        "targetDeliveryDomain"
+      ]
+    },
+    "excludedApps": {
+      "navigationProperties": [],
+      "properties": [
+        "access",
+        "bing",
+        "excel",
+        "groove",
+        "infoPath",
+        "lync",
+        "oneDrive",
+        "oneNote",
+        "outlook",
+        "powerPoint",
+        "publisher",
+        "sharePointDesigner",
+        "teams",
+        "visio",
+        "word"
+      ]
+    },
+    "excludeTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "targetType"
+      ]
+    },
+    "exclusionGroupAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "expeditedWindowsQualityUpdateSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "daysUntilForcedReboot",
+        "qualityUpdateRelease"
+      ]
+    },
+    "expirationPattern": {
+      "navigationProperties": [],
+      "properties": [
+        "duration",
+        "endDateTime",
+        "type"
+      ]
+    },
+    "exportItemResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "changeKey",
+        "data",
+        "error",
+        "itemId"
+      ]
+    },
+    "expressionEvaluationDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "expression",
+        "expressionEvaluationDetails",
+        "expressionResult",
+        "propertyToEvaluate"
+      ]
+    },
+    "expressionInputObject": {
+      "navigationProperties": [],
+      "properties": [
+        "definition",
+        "properties"
+      ]
+    },
+    "extendedKeyUsage": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "objectIdentifier"
+      ]
+    },
+    "extendRemoteHelpSessionResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "acsHelperUserToken",
+        "pubSubHelperAccessUri",
+        "sessionExpirationDateTime",
+        "sessionKey"
+      ]
+    },
+    "extensionSchemaProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "type"
+      ]
+    },
+    "externalDomainFederation": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "domainName",
+        "issuerUri"
+      ]
+    },
+    "externalItemConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "connections"
+      ]
+    },
+    "externalItemContent": {
+      "navigationProperties": [],
+      "properties": [
+        "type",
+        "value"
+      ]
+    },
+    "externalLink": {
+      "navigationProperties": [],
+      "properties": [
+        "href"
+      ]
+    },
+    "externalSponsors": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "externalTokenBasedSapIagConnectionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "accessTokenUrl",
+        "clientId",
+        "keyVaultName",
+        "resourceGroup",
+        "secretName",
+        "subscriptionId"
+      ]
+    },
+    "extractAlphaTransformation": {
+      "navigationProperties": [],
+      "properties": [
+        "type"
+      ]
+    },
+    "extractMailPrefixTransformation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "extractNumberTransformation": {
+      "navigationProperties": [],
+      "properties": [
+        "type"
+      ]
+    },
+    "extractSensitivityLabelsResult": {
+      "navigationProperties": [],
+      "properties": [
+        "labels"
+      ]
+    },
+    "extractTransformation": {
+      "navigationProperties": [],
+      "properties": [
+        "type",
+        "value",
+        "value2"
+      ]
+    },
+    "faceCheckConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "sourcePhotoClaimName"
+      ]
+    },
+    "fallbackToMicrosoftProviderOnError": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "featureTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "targetType"
+      ]
+    },
+    "federatedIdentityExpression": {
+      "navigationProperties": [],
+      "properties": [
+        "languageVersion",
+        "value"
+      ]
+    },
+    "fido2KeyRestrictions": {
+      "navigationProperties": [],
+      "properties": [
+        "aaGuids",
+        "enforcementType",
+        "isEnforced"
+      ]
+    },
+    "file": {
+      "navigationProperties": [],
+      "properties": [
+        "archiveStatus",
+        "hashes",
+        "mimeType",
+        "processingMetadata"
+      ]
+    },
+    "fileEncryptionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "encryptionKey",
+        "fileDigest",
+        "fileDigestAlgorithm",
+        "initializationVector",
+        "mac",
+        "macKey",
+        "profileIdentifier"
+      ]
+    },
+    "fileHash": {
+      "navigationProperties": [],
+      "properties": [
+        "hashType",
+        "hashValue"
+      ]
+    },
+    "fileSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "fileHash",
+        "name",
+        "path",
+        "riskScore"
+      ]
+    },
+    "fileStorageContainerCustomPropertyDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "fileStorageContainerCustomPropertyValue": {
+      "navigationProperties": [],
+      "properties": [
+        "isSearchable",
+        "value"
+      ]
+    },
+    "fileStorageContainerSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isItemVersioningEnabled",
+        "isOcrEnabled",
+        "itemDefaultSensitivityLabelId",
+        "itemMajorVersionLimit"
+      ]
+    },
+    "fileStorageContainerTypeAgentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "chatEmbedAllowedHosts"
+      ]
+    },
+    "fileStorageContainerTypeRegistrationSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "agent",
+        "isDiscoverabilityEnabled",
+        "isItemVersioningEnabled",
+        "isSearchEnabled",
+        "isSharingRestricted",
+        "itemMajorVersionLimit",
+        "maxStoragePerContainerInBytes",
+        "sharingCapability",
+        "urlTemplate"
+      ]
+    },
+    "fileStorageContainerTypeSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "agent",
+        "consumingTenantOverridables",
+        "isDiscoverabilityEnabled",
+        "isItemVersioningEnabled",
+        "isSearchEnabled",
+        "isSharingRestricted",
+        "itemMajorVersionLimit",
+        "maxStoragePerContainerInBytes",
+        "sharingCapability",
+        "urlTemplate"
+      ]
+    },
+    "fileStorageContainerViewpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "effectiveRole"
+      ]
+    },
+    "fileSystemInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastAccessedDateTime",
+        "lastModifiedDateTime"
+      ]
+    },
+    "filter": {
+      "navigationProperties": [],
+      "properties": [
+        "categoryFilterGroups",
+        "groups",
+        "inputFilterGroups"
+      ]
+    },
+    "filterClause": {
+      "navigationProperties": [],
+      "properties": [
+        "operatorName",
+        "sourceOperandName",
+        "targetOperand"
+      ]
+    },
+    "filterGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "clauses",
+        "name"
+      ]
+    },
+    "filterOperand": {
+      "navigationProperties": [],
+      "properties": [
+        "values"
+      ]
+    },
+    "flexSchemaContainer": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "folder": {
+      "navigationProperties": [],
+      "properties": [
+        "childCount",
+        "view"
+      ]
+    },
+    "folderView": {
+      "navigationProperties": [],
+      "properties": [
+        "sortBy",
+        "sortOrder",
+        "viewType"
+      ]
+    },
+    "followupFlag": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "dueDateTime",
+        "flagStatus",
+        "startDateTime"
+      ]
+    },
+    "formsSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isBingImageSearchEnabled",
+        "isExternalSendFormEnabled",
+        "isExternalShareCollaborationEnabled",
+        "isExternalShareResultEnabled",
+        "isExternalShareTemplateEnabled",
+        "isInOrgFormsPhishingScanEnabled",
+        "isRecordIdentityByDefaultEnabled"
+      ]
+    },
+    "forwardToChatResult": {
+      "navigationProperties": [],
+      "properties": [
+        "forwardedMessageId",
+        "targetChatId"
+      ]
+    },
+    "fraudProtectionConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "fraudProtectionDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "providerErrorMessages",
+        "providerHttpStatusCodes",
+        "providerName",
+        "providerResponseTimes",
+        "providerSessionId",
+        "reason",
+        "verdict"
+      ]
+    },
+    "fraudProtectionProviderConfiguration": {
+      "navigationProperties": [
+        "fraudProtectionProvider"
+      ],
+      "properties": []
+    },
+    "freeBusyError": {
+      "navigationProperties": [],
+      "properties": [
+        "message",
+        "responseCode"
+      ]
+    },
+    "frontlineCloudPcDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "frontlineCloudPcAvailability"
+      ]
+    },
+    "gcpActionPermissionsDefinitionAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actions"
+      ]
+    },
+    "gcpAssociatedIdentities": {
+      "navigationProperties": [
+        "all",
+        "serviceAccounts",
+        "users"
+      ],
+      "properties": []
+    },
+    "gcpPermissionsDefinitionAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "gcpRolePermissionsDefinitionAction": {
+      "navigationProperties": [
+        "roles"
+      ],
+      "properties": []
+    },
+    "gcpScope": {
+      "navigationProperties": [
+        "service"
+      ],
+      "properties": [
+        "resourceType"
+      ]
+    },
+    "genericError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message"
+      ]
+    },
+    "geoCoordinates": {
+      "navigationProperties": [],
+      "properties": [
+        "altitude",
+        "latitude",
+        "longitude"
+      ]
+    },
+    "geolocationColumn": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "getArtifactsResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "nextLink",
+        "payloads"
+      ]
+    },
+    "globalSecureAccessFilteringProfileSessionControl": {
+      "navigationProperties": [],
+      "properties": [
+        "profileId"
+      ]
+    },
+    "governanceCriteria": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "governanceNotificationPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "enabledTemplateTypes",
+        "notificationTemplates"
+      ]
+    },
+    "governanceNotificationTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "culture",
+        "id",
+        "source",
+        "type",
+        "version"
+      ]
+    },
+    "governancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "decisionMakerCriteria",
+        "notificationPolicy"
+      ]
+    },
+    "governanceRoleAssignmentRequestStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "status",
+        "statusDetails",
+        "subStatus"
+      ]
+    },
+    "governanceRuleSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "ruleIdentifier",
+        "setting"
+      ]
+    },
+    "governanceSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "duration",
+        "endDateTime",
+        "startDateTime",
+        "type"
+      ]
+    },
+    "groundingResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "extracts",
+        "resourceMetadata",
+        "resourceType",
+        "sensitivityLabel",
+        "webUrl"
+      ]
+    },
+    "groupAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "groupId"
+      ]
+    },
+    "groupChatTeamsAppInstallationScopeInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "chatId"
+      ]
+    },
+    "groupFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "includedGroups"
+      ]
+    },
+    "groupIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "mailNickname"
+      ]
+    },
+    "groupMembers": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "id"
+      ]
+    },
+    "groupMembershipGovernanceCriteria": {
+      "navigationProperties": [],
+      "properties": [
+        "groupId"
+      ]
+    },
+    "groupPeerOutlierRecommendationInsightSettings": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "groupPolicyPresentationDropdownListItem": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "value"
+      ]
+    },
+    "groupPolicyUploadedLanguageFile": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "fileName",
+        "id",
+        "languageCode",
+        "lastModifiedDateTime"
+      ]
+    },
+    "groupScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "groupWritebackConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "onPremisesGroupType"
+      ]
+    },
+    "gsuiteSource": {
+      "navigationProperties": [],
+      "properties": [
+        "domain"
+      ]
+    },
+    "hardwareInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "batteryChargeCycles",
+        "batteryHealthPercentage",
+        "batteryLevelPercentage",
+        "batterySerialNumber",
+        "cellularTechnology",
+        "deviceFullQualifiedDomainName",
+        "deviceGuardLocalSystemAuthorityCredentialGuardState",
+        "deviceGuardVirtualizationBasedSecurityHardwareRequirementState",
+        "deviceGuardVirtualizationBasedSecurityState",
+        "deviceLicensingLastErrorCode",
+        "deviceLicensingLastErrorDescription",
+        "deviceLicensingStatus",
+        "esimIdentifier",
+        "freeStorageSpace",
+        "imei",
+        "ipAddressV4",
+        "isEncrypted",
+        "isSharedDevice",
+        "isSupervised",
+        "manufacturer",
+        "meid",
+        "model",
+        "operatingSystemEdition",
+        "operatingSystemLanguage",
+        "operatingSystemProductType",
+        "osBuildNumber",
+        "phoneNumber",
+        "productName",
+        "residentUsersCount",
+        "serialNumber",
+        "sharedDeviceCachedUsers",
+        "subnetAddress",
+        "subscriberCarrier",
+        "systemManagementBIOSVersion",
+        "totalStorageSpace",
+        "tpmManufacturer",
+        "tpmSpecificationVersion",
+        "tpmVersion",
+        "wifiMac",
+        "wiredIPv4Addresses"
+      ]
+    },
+    "hashes": {
+      "navigationProperties": [],
+      "properties": [
+        "crc32Hash",
+        "quickXorHash",
+        "sha1Hash",
+        "sha256Hash"
+      ]
+    },
+    "hasPayloadLinkResultItem": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "hasLink",
+        "payloadId",
+        "sources"
+      ]
+    },
+    "hostSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "fqdn",
+        "isAzureAdJoined",
+        "isAzureAdRegistered",
+        "isHybridAzureDomainJoined",
+        "netBiosName",
+        "os",
+        "privateIpAddress",
+        "publicIpAddress",
+        "riskScore"
+      ]
+    },
+    "httpAuthSecurityScheme": {
+      "navigationProperties": [],
+      "properties": [
+        "bearerFormat",
+        "scheme"
+      ]
+    },
+    "httpRequestEndpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "targetUrl"
+      ]
+    },
+    "hybridAgentUpdaterConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowUpdateConfigurationOverride",
+        "deferUpdateDateTime",
+        "updateWindow"
+      ]
+    },
+    "hyperlinkOrPictureColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "isPicture"
+      ]
+    },
+    "identifierUriConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "nonDefaultUriAddition",
+        "uriAdditionWithoutUniqueTenantIdentifier"
+      ]
+    },
+    "identifierUriRestriction": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeActors",
+        "excludeAppsReceivingV2Tokens",
+        "excludeSaml",
+        "isStateSetByMicrosoft",
+        "restrictForAppsCreatedAfterDateTime",
+        "state"
+      ]
+    },
+    "identity": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "id"
+      ]
+    },
+    "identityDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastActiveDateTime"
+      ]
+    },
+    "identityGovernanceUserSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "approverDelegate"
+      ]
+    },
+    "identityInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "anchor",
+        "details",
+        "identityType",
+        "matchingProperty"
+      ]
+    },
+    "identityInput": {
+      "navigationProperties": [],
+      "properties": [
+        "alias",
+        "email",
+        "objectId"
+      ]
+    },
+    "identitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "application",
+        "device",
+        "user"
+      ]
+    },
+    "identitySource": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "idleSessionSignOut": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "signOutAfterInSeconds",
+        "warnAfterInSeconds"
+      ]
+    },
+    "ifEmptyTransformation": {
+      "navigationProperties": [],
+      "properties": [
+        "output"
+      ]
+    },
+    "ifNotEmptyTransformation": {
+      "navigationProperties": [],
+      "properties": [
+        "output"
+      ]
+    },
+    "image": {
+      "navigationProperties": [],
+      "properties": [
+        "height",
+        "width"
+      ]
+    },
+    "imageInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "addImageQuery",
+        "alternateText",
+        "alternativeText",
+        "iconUrl"
+      ]
+    },
+    "implicitGrantSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "enableAccessTokenIssuance",
+        "enableIdTokenIssuance"
+      ]
+    },
+    "importBuildingMapSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "isDryRun"
+      ]
+    },
+    "importedWindowsAutopilotDeviceIdentityState": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceErrorCode",
+        "deviceErrorName",
+        "deviceImportStatus",
+        "deviceRegistrationId"
+      ]
+    },
+    "inboundOutboundPolicyConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "inboundAllowed",
+        "outboundAllowed"
+      ]
+    },
+    "inboundPorts": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "includeAllAccountTargetContent": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "includeTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "targetType"
+      ]
+    },
+    "incomingCallOptions": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "incomingContext": {
+      "navigationProperties": [],
+      "properties": [
+        "observedParticipantId",
+        "onBehalfOf",
+        "sourceParticipantId",
+        "transferor"
+      ]
+    },
+    "incompleteData": {
+      "navigationProperties": [],
+      "properties": [
+        "missingDataBeforeDateTime",
+        "wasThrottled"
+      ]
+    },
+    "inferenceData": {
+      "navigationProperties": [],
+      "properties": [
+        "confidenceScore",
+        "userHasVerifiedAccuracy"
+      ]
+    },
+    "informationalUrl": {
+      "navigationProperties": [],
+      "properties": [
+        "logoUrl",
+        "marketingUrl",
+        "privacyStatementUrl",
+        "supportUrl",
+        "termsOfServiceUrl"
+      ]
+    },
+    "informationalUrls": {
+      "navigationProperties": [],
+      "properties": [
+        "appSignUpUrl",
+        "singleSignOnDocumentationUrl"
+      ]
+    },
+    "informationBarrier": {
+      "navigationProperties": [],
+      "properties": [
+        "mode",
+        "segmentIds"
+      ]
+    },
+    "informationProtectionAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "informationProtectionContentLabel": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentMethod",
+        "creationDateTime",
+        "label"
+      ]
+    },
+    "inheritableScopes": {
+      "navigationProperties": [],
+      "properties": [
+        "kind"
+      ]
+    },
+    "initiator": {
+      "navigationProperties": [],
+      "properties": [
+        "initiatorType"
+      ]
+    },
+    "insightIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "displayName",
+        "id"
+      ]
+    },
+    "insightValueDouble": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "insightValueInt": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "instanceResourceAccess": {
+      "navigationProperties": [],
+      "properties": [
+        "permissions",
+        "resourceAppId"
+      ]
+    },
+    "institutionData": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "location",
+        "webUrl"
+      ]
+    },
+    "integerRange": {
+      "navigationProperties": [],
+      "properties": [
+        "end",
+        "maximum",
+        "minimum",
+        "start"
+      ]
+    },
+    "integratedApplicationMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "version"
+      ]
+    },
+    "internalSponsors": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "internetAccessFeatureUtilizations": {
+      "navigationProperties": [],
+      "properties": [
+        "internetAccess",
+        "internetAccessM365"
+      ]
+    },
+    "internetMessageHeader": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "value"
+      ]
+    },
+    "intuneBrand": {
+      "navigationProperties": [],
+      "properties": [
+        "companyPortalBlockedActions",
+        "contactITEmailAddress",
+        "contactITName",
+        "contactITNotes",
+        "contactITPhoneNumber",
+        "customCanSeePrivacyMessage",
+        "customCantSeePrivacyMessage",
+        "customPrivacyMessage",
+        "darkBackgroundLogo",
+        "disableClientTelemetry",
+        "disableDeviceCategorySelection",
+        "displayName",
+        "enrollmentAvailability",
+        "isFactoryResetDisabled",
+        "isRemoveDeviceDisabled",
+        "landingPageCustomizedImage",
+        "lightBackgroundLogo",
+        "onlineSupportSiteName",
+        "onlineSupportSiteUrl",
+        "privacyUrl",
+        "roleScopeTagIds",
+        "showAzureADEnterpriseApps",
+        "showConfigurationManagerApps",
+        "showDisplayNameNextToLogo",
+        "showLogo",
+        "showNameNextToLogo",
+        "showOfficeWebApps",
+        "themeColor"
+      ]
+    },
+    "investigationSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "status"
+      ]
+    },
+    "invitationParticipantInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "endpointType",
+        "hidden",
+        "identity",
+        "participantId",
+        "removeFromDefaultAudioRoutingGroup",
+        "replacesCallId"
+      ]
+    },
+    "invitationRedemptionIdentityProviderConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "fallbackIdentityProvider",
+        "primaryIdentityProviderPrecedenceOrder"
+      ]
+    },
+    "invitedUserMessageInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "ccRecipients",
+        "customizedMessageBody",
+        "messageLanguage"
+      ]
+    },
+    "inviteNewBotResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "inviteUri"
+      ]
+    },
+    "iosAvailableUpdateVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "expirationDateTime",
+        "postingDateTime",
+        "productVersion",
+        "supportedDevices"
+      ]
+    },
+    "iosAzureAdSingleSignOnExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "bundleIdAccessControlList",
+        "configurations",
+        "enableSharedDeviceMode"
+      ]
+    },
+    "iosBookmark": {
+      "navigationProperties": [],
+      "properties": [
+        "bookmarkFolder",
+        "displayName",
+        "url"
+      ]
+    },
+    "iosCredentialSingleSignOnExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "configurations",
+        "domains",
+        "extensionIdentifier",
+        "realm",
+        "teamIdentifier"
+      ]
+    },
+    "iosDdmLobAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "associatedDomains",
+        "associatedDomainsDirectDownloadAllowed",
+        "preventManagedAppBackup",
+        "tapToPayScreenLockEnabled",
+        "vpnConfigurationId"
+      ]
+    },
+    "iosDeviceType": {
+      "navigationProperties": [],
+      "properties": [
+        "iPad",
+        "iPhoneAndIPod"
+      ]
+    },
+    "iosEduCertificateSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "certFileName",
+        "certificateTemplateName",
+        "certificateValidityPeriodScale",
+        "certificateValidityPeriodValue",
+        "certificationAuthority",
+        "certificationAuthorityName",
+        "renewalThresholdPercentage",
+        "trustedRootCertificate"
+      ]
+    },
+    "iosHomeScreenApp": {
+      "navigationProperties": [],
+      "properties": [
+        "bundleID",
+        "isWebClip"
+      ]
+    },
+    "iosHomeScreenFolder": {
+      "navigationProperties": [],
+      "properties": [
+        "pages"
+      ]
+    },
+    "iosHomeScreenFolderPage": {
+      "navigationProperties": [],
+      "properties": [
+        "apps",
+        "displayName"
+      ]
+    },
+    "iosHomeScreenItem": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "iosHomeScreenPage": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "icons"
+      ]
+    },
+    "iosKerberosSingleSignOnExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDirectorySiteCode",
+        "blockActiveDirectorySiteAutoDiscovery",
+        "blockAutomaticLogin",
+        "cacheName",
+        "credentialBundleIdAccessControlList",
+        "domainRealms",
+        "domains",
+        "isDefaultRealm",
+        "managedAppsInBundleIdACLIncluded",
+        "passwordBlockModification",
+        "passwordChangeUrl",
+        "passwordEnableLocalSync",
+        "passwordExpirationDays",
+        "passwordExpirationNotificationDays",
+        "passwordMinimumAgeDays",
+        "passwordMinimumLength",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequireActiveDirectoryComplexity",
+        "passwordRequirementsDescription",
+        "realm",
+        "requireUserPresence",
+        "signInHelpText",
+        "userPrincipalName"
+      ]
+    },
+    "iosLobAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isRemovable",
+        "preventManagedAppBackup",
+        "uninstallOnDeviceRemoval",
+        "vpnConfigurationId"
+      ]
+    },
+    "iosMinimumOperatingSystem": {
+      "navigationProperties": [],
+      "properties": [
+        "v10_0",
+        "v11_0",
+        "v12_0",
+        "v13_0",
+        "v14_0",
+        "v15_0",
+        "v16_0",
+        "v17_0",
+        "v18_0",
+        "v26_0",
+        "v8_0",
+        "v9_0"
+      ]
+    },
+    "iosMobileAppIdentifier": {
+      "navigationProperties": [],
+      "properties": [
+        "bundleId"
+      ]
+    },
+    "iosNetworkUsageRule": {
+      "navigationProperties": [],
+      "properties": [
+        "cellularDataBlocked",
+        "cellularDataBlockWhenRoaming",
+        "managedApps"
+      ]
+    },
+    "iosNotificationSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "alertType",
+        "appName",
+        "badgesEnabled",
+        "bundleID",
+        "enabled",
+        "previewVisibility",
+        "publisher",
+        "showInNotificationCenter",
+        "showOnLockScreen",
+        "soundsEnabled"
+      ]
+    },
+    "iosRedirectSingleSignOnExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "configurations",
+        "extensionIdentifier",
+        "teamIdentifier",
+        "urlPrefixes"
+      ]
+    },
+    "iosSingleSignOnExtension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "iosSingleSignOnSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedAppsList",
+        "allowedUrls",
+        "displayName",
+        "kerberosPrincipalName",
+        "kerberosRealm"
+      ]
+    },
+    "iosStoreAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isRemovable",
+        "preventManagedAppBackup",
+        "uninstallOnDeviceRemoval",
+        "vpnConfigurationId"
+      ]
+    },
+    "iosVpnSecurityAssociationParameters": {
+      "navigationProperties": [],
+      "properties": [
+        "lifetimeInMinutes",
+        "securityDiffieHellmanGroup",
+        "securityEncryptionAlgorithm",
+        "securityIntegrityAlgorithm"
+      ]
+    },
+    "iosVppAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isRemovable",
+        "preventAutoAppUpdate",
+        "preventManagedAppBackup",
+        "uninstallOnDeviceRemoval",
+        "useDeviceLicensing",
+        "vpnConfigurationId"
+      ]
+    },
+    "iosVppAppRevokeLicensesActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "actionFailureReason",
+        "actionName",
+        "actionState",
+        "failedLicensesCount",
+        "lastUpdatedDateTime",
+        "managedDeviceId",
+        "startDateTime",
+        "totalLicensesCount",
+        "userId"
+      ]
+    },
+    "iosWebContentFilterAutoFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedUrls",
+        "blockedUrls"
+      ]
+    },
+    "iosWebContentFilterBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "iosWebContentFilterSpecificWebsitesAccess": {
+      "navigationProperties": [],
+      "properties": [
+        "specificWebsitesOnly",
+        "websiteList"
+      ]
+    },
+    "ipCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "name",
+        "vendor"
+      ]
+    },
+    "ipRange": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ipReferenceData": {
+      "navigationProperties": [],
+      "properties": [
+        "asn",
+        "city",
+        "countryOrRegionCode",
+        "organization",
+        "state",
+        "vendor"
+      ]
+    },
+    "ipSegmentConfiguration": {
+      "navigationProperties": [
+        "applicationSegments"
+      ],
+      "properties": []
+    },
+    "iPv4CidrRange": {
+      "navigationProperties": [],
+      "properties": [
+        "cidrAddress"
+      ]
+    },
+    "iPv4Range": {
+      "navigationProperties": [],
+      "properties": [
+        "lowerAddress",
+        "upperAddress"
+      ]
+    },
+    "iPv6CidrRange": {
+      "navigationProperties": [],
+      "properties": [
+        "cidrAddress"
+      ]
+    },
+    "iPv6Range": {
+      "navigationProperties": [],
+      "properties": [
+        "lowerAddress",
+        "upperAddress"
+      ]
+    },
+    "itemActionSet": {
+      "navigationProperties": [],
+      "properties": [
+        "comment",
+        "create",
+        "delete",
+        "edit",
+        "mention",
+        "move",
+        "rename",
+        "restore",
+        "share",
+        "version"
+      ]
+    },
+    "itemActionStat": {
+      "navigationProperties": [],
+      "properties": [
+        "actionCount",
+        "actorCount"
+      ]
+    },
+    "itemActivityTimeSet": {
+      "navigationProperties": [],
+      "properties": [
+        "lastRecordedDateTime",
+        "observedDateTime",
+        "recordedDateTime"
+      ]
+    },
+    "itemBody": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "contentType"
+      ]
+    },
+    "itemPreviewInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "getUrl",
+        "postParameters",
+        "postUrl"
+      ]
+    },
+    "itemReference": {
+      "navigationProperties": [],
+      "properties": [
+        "driveId",
+        "driveType",
+        "id",
+        "name",
+        "path",
+        "shareId",
+        "sharepointIds",
+        "siteId"
+      ]
+    },
+    "joinMeetingIdMeetingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "joinMeetingId",
+        "passcode"
+      ]
+    },
+    "joinMeetingIdSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isPasscodeRequired",
+        "joinMeetingId",
+        "passcode"
+      ]
+    },
+    "joinTransformation": {
+      "navigationProperties": [],
+      "properties": [
+        "input2",
+        "separator"
+      ]
+    },
+    "Json": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "justifyAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "justInTimeAuditConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "justInTimeEnforcementConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "jwsHeader": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "kerberosSignOnSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "kerberosServicePrincipalName",
+        "kerberosSignOnMappingAttributeType"
+      ]
+    },
+    "kerberosSingleSignOnExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDirectorySiteCode",
+        "blockActiveDirectorySiteAutoDiscovery",
+        "blockAutomaticLogin",
+        "cacheName",
+        "credentialBundleIdAccessControlList",
+        "domainRealms",
+        "domains",
+        "isDefaultRealm",
+        "passwordBlockModification",
+        "passwordChangeUrl",
+        "passwordEnableLocalSync",
+        "passwordExpirationDays",
+        "passwordExpirationNotificationDays",
+        "passwordMinimumAgeDays",
+        "passwordMinimumLength",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequireActiveDirectoryComplexity",
+        "passwordRequirementsDescription",
+        "realm",
+        "requireUserPresence",
+        "userPrincipalName"
+      ]
+    },
+    "keyBooleanValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "keyCredential": {
+      "navigationProperties": [],
+      "properties": [
+        "customKeyIdentifier",
+        "displayName",
+        "endDateTime",
+        "key",
+        "keyId",
+        "startDateTime",
+        "type",
+        "usage"
+      ]
+    },
+    "keyCredentialConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateBasedApplicationConfigurationIds",
+        "excludeActors",
+        "maxLifetime",
+        "restrictForAppsCreatedAfterDateTime",
+        "restrictionType",
+        "state"
+      ]
+    },
+    "keyIntegerValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "keyLongValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "value"
+      ]
+    },
+    "keyRealValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "keyStringValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "keyTypedValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "key"
+      ]
+    },
+    "keyValue": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "keyValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "value"
+      ]
+    },
+    "labelActionBase": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "labelDetails": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "labelingOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentMethod",
+        "downgradeJustification",
+        "extendedProperties",
+        "labelId"
+      ]
+    },
+    "labelPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "name"
+      ]
+    },
+    "lastSignIn": {
+      "navigationProperties": [],
+      "properties": [
+        "interactiveDateTime",
+        "nonInteractiveDateTime"
+      ]
+    },
+    "licenseAssignmentState": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedByGroup",
+        "disabledPlans",
+        "error",
+        "lastUpdatedDateTime",
+        "skuId",
+        "state"
+      ]
+    },
+    "licenseProcessingState": {
+      "navigationProperties": [],
+      "properties": [
+        "state"
+      ]
+    },
+    "licenseUnitsDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "enabled",
+        "lockedOut",
+        "suspended",
+        "warning"
+      ]
+    },
+    "linkableIdentifiers": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "sessionId",
+        "tokenDetails"
+      ]
+    },
+    "linkRoleAbilities": {
+      "navigationProperties": [],
+      "properties": [
+        "addExistingExternalUsers",
+        "addNewExternalUsers",
+        "applyVariants",
+        "createLink",
+        "deleteLink",
+        "linkAllowsExternalUsers",
+        "linkExpiration",
+        "retrieveLink",
+        "updateLink"
+      ]
+    },
+    "linkScopeAbilities": {
+      "navigationProperties": [],
+      "properties": [
+        "blockDownloadLinkAbilities",
+        "editLinkAbilities",
+        "manageListLinkAbilities",
+        "readLinkAbilities",
+        "reviewLinkAbilities",
+        "submitOnlyLinkAbilities"
+      ]
+    },
+    "listInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "contentTypesEnabled",
+        "hidden",
+        "template"
+      ]
+    },
+    "liveCaptionOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "streamUrl"
+      ]
+    },
+    "lobbyBypassSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isDialInBypassEnabled",
+        "scope"
+      ]
+    },
+    "localAdminPasswordSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "localAdminSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "enableGlobalAdmins",
+        "registeringUsers"
+      ]
+    },
+    "localeInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "locale"
+      ]
+    },
+    "localIdentitySource": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "locateDeviceActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceLocation"
+      ]
+    },
+    "location": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "coordinates",
+        "displayName",
+        "locationEmailAddress",
+        "locationType",
+        "locationUri",
+        "uniqueId",
+        "uniqueIdType"
+      ]
+    },
+    "locationConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "isRequired",
+        "locations",
+        "suggestLocation"
+      ]
+    },
+    "locationConstraintItem": {
+      "navigationProperties": [],
+      "properties": [
+        "resolveAvailability"
+      ]
+    },
+    "loggedOnUser": {
+      "navigationProperties": [],
+      "properties": [
+        "lastLogOnDateTime",
+        "userId"
+      ]
+    },
+    "logicAppTriggerEndpointConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "logicAppWorkflowName",
+        "resourceGroupName",
+        "subscriptionId",
+        "url"
+      ]
+    },
+    "loginPageBrandingVisualElement": {
+      "navigationProperties": [],
+      "properties": [
+        "customText",
+        "customUrl",
+        "isHidden"
+      ]
+    },
+    "loginPageLayoutConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isFooterShown",
+        "isHeaderShown",
+        "layoutTemplateType"
+      ]
+    },
+    "loginPageTextVisibilitySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "hideAccountResetCredentials",
+        "hideCannotAccessYourAccount",
+        "hideForgotMyPassword",
+        "hidePrivacyAndCookies",
+        "hideResetItNow",
+        "hideTermsOfUse"
+      ]
+    },
+    "logonUser": {
+      "navigationProperties": [],
+      "properties": [
+        "accountDomain",
+        "accountName",
+        "accountType",
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "logonId",
+        "logonTypes"
+      ]
+    },
+    "lookupColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "allowMultipleValues",
+        "allowUnlimitedLength",
+        "columnName",
+        "listId",
+        "primaryLookupColumnId"
+      ]
+    },
+    "macAppIdentifier": {
+      "navigationProperties": [],
+      "properties": [
+        "bundleId"
+      ]
+    },
+    "machineLearningDetectedSensitiveContent": {
+      "navigationProperties": [],
+      "properties": [
+        "matchTolerance",
+        "modelVersion"
+      ]
+    },
+    "macOSAppleEventReceiver": {
+      "navigationProperties": [],
+      "properties": [
+        "allowed",
+        "codeRequirement",
+        "identifier",
+        "identifierType"
+      ]
+    },
+    "macOSAppScript": {
+      "navigationProperties": [],
+      "properties": [
+        "scriptContent"
+      ]
+    },
+    "macOSAssociatedDomainsItem": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationIdentifier",
+        "directDownloadsEnabled",
+        "domains"
+      ]
+    },
+    "macOSAzureAdSingleSignOnExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "bundleIdAccessControlList",
+        "configurations",
+        "enableSharedDeviceMode"
+      ]
+    },
+    "macOSCredentialSingleSignOnExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "configurations",
+        "domains",
+        "extensionIdentifier",
+        "realm",
+        "teamIdentifier"
+      ]
+    },
+    "macOSDeviceLocalAdminAccountDetail": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "macOSFirewallApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "allowsIncomingConnections",
+        "bundleId"
+      ]
+    },
+    "macOSIncludedApp": {
+      "navigationProperties": [],
+      "properties": [
+        "bundleId",
+        "bundleVersion"
+      ]
+    },
+    "macOSKerberosSingleSignOnExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDirectorySiteCode",
+        "blockActiveDirectorySiteAutoDiscovery",
+        "blockAutomaticLogin",
+        "cacheName",
+        "credentialBundleIdAccessControlList",
+        "credentialsCacheMonitored",
+        "domainRealms",
+        "domains",
+        "isDefaultRealm",
+        "kerberosAppsInBundleIdACLIncluded",
+        "managedAppsInBundleIdACLIncluded",
+        "modeCredentialUsed",
+        "passwordBlockModification",
+        "passwordChangeUrl",
+        "passwordEnableLocalSync",
+        "passwordExpirationDays",
+        "passwordExpirationNotificationDays",
+        "passwordMinimumAgeDays",
+        "passwordMinimumLength",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequireActiveDirectoryComplexity",
+        "passwordRequirementsDescription",
+        "preferredKDCs",
+        "realm",
+        "requireUserPresence",
+        "signInHelpText",
+        "tlsForLDAPRequired",
+        "usernameLabelCustom",
+        "userPrincipalName",
+        "userSetupDelayed"
+      ]
+    },
+    "macOSKernelExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "bundleId",
+        "teamIdentifier"
+      ]
+    },
+    "macOSLaunchItem": {
+      "navigationProperties": [],
+      "properties": [
+        "hide",
+        "path"
+      ]
+    },
+    "macOsLobAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "uninstallOnDeviceRemoval"
+      ]
+    },
+    "macOSLobChildApp": {
+      "navigationProperties": [],
+      "properties": [
+        "buildNumber",
+        "bundleId",
+        "versionNumber"
+      ]
+    },
+    "macOSManagedDeviceLocalAdminAccountDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "adminAccountPassword",
+        "passwordLastRotatedDateTime"
+      ]
+    },
+    "macOSMinimumOperatingSystem": {
+      "navigationProperties": [],
+      "properties": [
+        "v10_10",
+        "v10_11",
+        "v10_12",
+        "v10_13",
+        "v10_14",
+        "v10_15",
+        "v10_7",
+        "v10_8",
+        "v10_9",
+        "v11_0",
+        "v12_0",
+        "v13_0",
+        "v14_0",
+        "v15_0",
+        "v26_0"
+      ]
+    },
+    "macOSPrivacyAccessControlItem": {
+      "navigationProperties": [],
+      "properties": [
+        "accessibility",
+        "addressBook",
+        "appleEventsAllowedReceivers",
+        "blockCamera",
+        "blockListenEvent",
+        "blockMicrophone",
+        "blockScreenCapture",
+        "calendar",
+        "codeRequirement",
+        "displayName",
+        "fileProviderPresence",
+        "identifier",
+        "identifierType",
+        "mediaLibrary",
+        "photos",
+        "postEvent",
+        "reminders",
+        "speechRecognition",
+        "staticCodeValidation",
+        "systemPolicyAllFiles",
+        "systemPolicyDesktopFolder",
+        "systemPolicyDocumentsFolder",
+        "systemPolicyDownloadsFolder",
+        "systemPolicyNetworkVolumes",
+        "systemPolicyRemovableVolumes",
+        "systemPolicySystemAdminFiles"
+      ]
+    },
+    "macOSRedirectSingleSignOnExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "configurations",
+        "extensionIdentifier",
+        "teamIdentifier",
+        "urlPrefixes"
+      ]
+    },
+    "macOSSingleSignOnExtension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "macOSSystemExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "bundleId",
+        "teamIdentifier"
+      ]
+    },
+    "macOSSystemExtensionTypeMapping": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedTypes",
+        "teamIdentifier"
+      ]
+    },
+    "macOsVppAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "preventAutoAppUpdate",
+        "preventManagedAppBackup",
+        "uninstallOnDeviceRemoval",
+        "useDeviceLicensing"
+      ]
+    },
+    "macOsVppAppRevokeLicensesActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "actionFailureReason",
+        "actionName",
+        "actionState",
+        "failedLicensesCount",
+        "lastUpdatedDateTime",
+        "managedDeviceId",
+        "startDateTime",
+        "totalLicensesCount",
+        "userId"
+      ]
+    },
+    "mailboxDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "emailAddress",
+        "externalDirectoryObjectId"
+      ]
+    },
+    "mailboxItemImportSession": {
+      "navigationProperties": [],
+      "properties": [
+        "expirationDateTime",
+        "importUrl"
+      ]
+    },
+    "mailboxSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "archiveFolder",
+        "automaticRepliesSetting",
+        "dateFormat",
+        "delegateMeetingMessageDeliveryOptions",
+        "language",
+        "timeFormat",
+        "timeZone",
+        "userPurpose",
+        "userPurposeV2",
+        "workingHours"
+      ]
+    },
+    "mailTips": {
+      "navigationProperties": [],
+      "properties": [
+        "automaticReplies",
+        "customMailTip",
+        "deliveryRestricted",
+        "emailAddress",
+        "error",
+        "externalMemberCount",
+        "isModerated",
+        "mailboxFull",
+        "maxMessageSize",
+        "recipientScope",
+        "recipientSuggestions",
+        "totalMemberCount"
+      ]
+    },
+    "mailTipsError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message"
+      ]
+    },
+    "malware": {
+      "navigationProperties": [],
+      "properties": [
+        "description"
+      ]
+    },
+    "malwareState": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "family",
+        "name",
+        "severity",
+        "wasRunning"
+      ]
+    },
+    "managedAppDiagnosticStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "mitigationInstruction",
+        "state",
+        "validationName"
+      ]
+    },
+    "managedAppLogUpload": {
+      "navigationProperties": [],
+      "properties": [
+        "managedAppComponentDescription",
+        "referenceId",
+        "status"
+      ]
+    },
+    "managedAppPolicyDeploymentSummaryPerApp": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationAppliedUserCount",
+        "mobileAppIdentifier"
+      ]
+    },
+    "managedDeviceCleanupSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceInactivityBeforeRetirementInDays"
+      ]
+    },
+    "managedDeviceMobileAppConfigurationSettingState": {
+      "navigationProperties": [],
+      "properties": [
+        "currentValue",
+        "errorCode",
+        "errorDescription",
+        "instanceDisplayName",
+        "setting",
+        "settingInstanceId",
+        "settingName",
+        "sources",
+        "state",
+        "userEmail",
+        "userId",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "managedDeviceModelsAndManufacturers": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceManufacturers",
+        "deviceModels"
+      ]
+    },
+    "managedDeviceReportedApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appId"
+      ]
+    },
+    "managedDeviceSummarizedAppState": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "summarizedAppState"
+      ]
+    },
+    "managedDeviceWindowsOperatingSystemEdition": {
+      "navigationProperties": [],
+      "properties": [
+        "editionType",
+        "supportEndDate"
+      ]
+    },
+    "managedDeviceWindowsOperatingSystemUpdate": {
+      "navigationProperties": [],
+      "properties": [
+        "buildVersion",
+        "releaseMonth",
+        "releaseYear"
+      ]
+    },
+    "managedIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "associatedResourceId",
+        "federatedTokenId",
+        "federatedTokenIssuer",
+        "msiType"
+      ]
+    },
+    "managedStoreAppConfigurationSchemaRequestDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "packageName"
+      ]
+    },
+    "managementCertificateWithThumbprint": {
+      "navigationProperties": [],
+      "properties": [
+        "certificate",
+        "thumbprint"
+      ]
+    },
+    "markContent": {
+      "navigationProperties": [],
+      "properties": [
+        "fontColor",
+        "fontSize",
+        "text"
+      ]
+    },
+    "matchedCondition": {
+      "navigationProperties": [],
+      "properties": [
+        "condition",
+        "displayName",
+        "values"
+      ]
+    },
+    "matchingDlpRule": {
+      "navigationProperties": [],
+      "properties": [
+        "actions",
+        "isMostRestrictive",
+        "policyId",
+        "policyName",
+        "priority",
+        "ruleId",
+        "ruleMode",
+        "ruleName"
+      ]
+    },
+    "matchingLabel": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationMode",
+        "description",
+        "displayName",
+        "id",
+        "isEndpointProtectionEnabled",
+        "labelActions",
+        "name",
+        "policyTip",
+        "priority",
+        "toolTip"
+      ]
+    },
+    "matchLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "length",
+        "offset"
+      ]
+    },
+    "matrixChoiceGroupQuizInfo": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "media": {
+      "navigationProperties": [],
+      "properties": [
+        "isTranscriptionShown",
+        "mediaSource"
+      ]
+    },
+    "mediaConfig": {
+      "navigationProperties": [],
+      "properties": [
+        "removeFromDefaultAudioGroup"
+      ]
+    },
+    "mediaContentRatingAustralia": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingCanada": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingFrance": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingGermany": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingIreland": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingJapan": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingNewZealand": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingUnitedKingdom": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingUnitedStates": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceId",
+        "uri"
+      ]
+    },
+    "mediaPrompt": {
+      "navigationProperties": [],
+      "properties": [
+        "loop",
+        "mediaInfo"
+      ]
+    },
+    "mediaSource": {
+      "navigationProperties": [],
+      "properties": [
+        "contentCategory"
+      ]
+    },
+    "mediaStream": {
+      "navigationProperties": [],
+      "properties": [
+        "direction",
+        "label",
+        "mediaType",
+        "serverMuted",
+        "sourceId"
+      ]
+    },
+    "meetingCapability": {
+      "navigationProperties": [],
+      "properties": [
+        "allowAnonymousUsersToDialOut",
+        "allowAnonymousUsersToStartMeeting",
+        "autoAdmittedUsers"
+      ]
+    },
+    "meetingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "allowConversationWithoutHost"
+      ]
+    },
+    "meetingLocationSuggestion": {
+      "navigationProperties": [],
+      "properties": [
+        "availability",
+        "location",
+        "timeSlotAvailabilities"
+      ]
+    },
+    "meetingLocationSuggestionsResult": {
+      "navigationProperties": [],
+      "properties": [
+        "emptySuggestionsReason",
+        "meetingLocationSuggestions"
+      ]
+    },
+    "meetingNote": {
+      "navigationProperties": [],
+      "properties": [
+        "subpoints",
+        "text",
+        "title"
+      ]
+    },
+    "meetingNoteSubpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "text",
+        "title"
+      ]
+    },
+    "meetingParticipantInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "identity",
+        "role",
+        "upn"
+      ]
+    },
+    "meetingParticipants": {
+      "navigationProperties": [],
+      "properties": [
+        "attendees",
+        "contributors",
+        "organizer",
+        "producers"
+      ]
+    },
+    "meetingPolicyUpdatedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "meetingChatEnabled",
+        "meetingChatId"
+      ]
+    },
+    "meetingSpeaker": {
+      "navigationProperties": [],
+      "properties": [
+        "bio",
+        "displayName"
+      ]
+    },
+    "meetingTimeSuggestion": {
+      "navigationProperties": [],
+      "properties": [
+        "attendeeAvailability",
+        "confidence",
+        "locations",
+        "meetingTimeSlot",
+        "order",
+        "organizerAvailability",
+        "suggestionReason"
+      ]
+    },
+    "meetingTimeSuggestionsResult": {
+      "navigationProperties": [],
+      "properties": [
+        "emptySuggestionsReason",
+        "meetingTimeSuggestions"
+      ]
+    },
+    "membersAddedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "members",
+        "visibleHistoryStartDateTime"
+      ]
+    },
+    "membersDeletedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "members"
+      ]
+    },
+    "membershipRuleEvaluationDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "membershipRuleEvaluationDetails"
+      ]
+    },
+    "membershipRuleProcessingStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "errorMessage",
+        "lastMembershipUpdated",
+        "status"
+      ]
+    },
+    "membersJoinedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "members"
+      ]
+    },
+    "membersLeftEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "members"
+      ]
+    },
+    "mentionAction": {
+      "navigationProperties": [],
+      "properties": [
+        "mentionees"
+      ]
+    },
+    "mentionEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "eventDateTime",
+        "speaker",
+        "transcriptUtterance"
+      ]
+    },
+    "mentionsPreview": {
+      "navigationProperties": [],
+      "properties": [
+        "isMentioned"
+      ]
+    },
+    "messagePinnedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "eventDateTime",
+        "initiator"
+      ]
+    },
+    "messageRuleActions": {
+      "navigationProperties": [],
+      "properties": [
+        "assignCategories",
+        "copyToFolder",
+        "delete",
+        "forwardAsAttachmentTo",
+        "forwardTo",
+        "markAsRead",
+        "markImportance",
+        "moveToFolder",
+        "permanentDelete",
+        "redirectTo",
+        "stopProcessingRules"
+      ]
+    },
+    "messageRulePredicates": {
+      "navigationProperties": [],
+      "properties": [
+        "bodyContains",
+        "bodyOrSubjectContains",
+        "categories",
+        "fromAddresses",
+        "hasAttachments",
+        "headerContains",
+        "importance",
+        "isApprovalRequest",
+        "isAutomaticForward",
+        "isAutomaticReply",
+        "isEncrypted",
+        "isMeetingRequest",
+        "isMeetingResponse",
+        "isNonDeliveryReport",
+        "isPermissionControlled",
+        "isReadReceipt",
+        "isSigned",
+        "isVoicemail",
+        "messageActionFlag",
+        "notSentToMe",
+        "recipientContains",
+        "senderContains",
+        "sensitivity",
+        "sentCcMe",
+        "sentOnlyToMe",
+        "sentToAddresses",
+        "sentToMe",
+        "sentToOrCcMe",
+        "subjectContains",
+        "withinSizeRange"
+      ]
+    },
+    "messageSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "connectingIP",
+        "deliveryAction",
+        "deliveryLocation",
+        "directionality",
+        "internetMessageId",
+        "messageFingerprint",
+        "messageReceivedDateTime",
+        "messageSubject",
+        "networkMessageId"
+      ]
+    },
+    "messageUnpinnedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "eventDateTime",
+        "initiator"
+      ]
+    },
+    "metadataAction": {
+      "navigationProperties": [],
+      "properties": [
+        "metadataToAdd",
+        "metadataToRemove"
+      ]
+    },
+    "metadataEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "metaDataKeyStringPair": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "metaDataKeyValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "metricTimeSeriesDataPoint": {
+      "navigationProperties": [],
+      "properties": [
+        "dateTime",
+        "value"
+      ]
+    },
+    "mfaDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "authDetail",
+        "authMethod"
+      ]
+    },
+    "microsoftAuthenticatorFeatureSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "companionAppAllowedState",
+        "displayAppInformationRequiredState",
+        "displayLocationInformationRequiredState",
+        "numberMatchingRequiredState"
+      ]
+    },
+    "microsoftAuthenticatorPlatformSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "enforceAppPIN"
+      ]
+    },
+    "microsoftCustomTrainingSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "completionDateTime",
+        "trainingAssignmentMappings",
+        "trainingCompletionDuration"
+      ]
+    },
+    "microsoftManagedDesktop": {
+      "navigationProperties": [],
+      "properties": [
+        "managedType",
+        "profile",
+        "type"
+      ]
+    },
+    "microsoftManagedTrainingSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "completionDateTime",
+        "trainingCompletionDuration"
+      ]
+    },
+    "microsoftPersonalizationSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isBingRewardsFeatureEnabled"
+      ]
+    },
+    "microsoftStoreForBusinessAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "useDeviceContext"
+      ]
+    },
+    "microsoftTrainingAssignmentMapping": {
+      "navigationProperties": [
+        "training"
+      ],
+      "properties": [
+        "assignedTo"
+      ]
+    },
+    "mimeContent": {
+      "navigationProperties": [],
+      "properties": [
+        "type",
+        "value"
+      ]
+    },
+    "mobileAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mobileAppIdentifier": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mobileAppInstallTimeSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "deadlineDateTime",
+        "startDateTime",
+        "useLocalTime"
+      ]
+    },
+    "mobileAppIntentAndStateDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationId",
+        "displayName",
+        "displayVersion",
+        "installState",
+        "mobileAppIntent",
+        "supportedDeviceTypes"
+      ]
+    },
+    "mobileAppScriptReference": {
+      "navigationProperties": [],
+      "properties": [
+        "targetId"
+      ]
+    },
+    "mobileAppSupportedDeviceType": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumOperatingSystemVersion",
+        "minimumOperatingSystemVersion",
+        "type"
+      ]
+    },
+    "mobileAppTroubleshootingAppPolicyCreationHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "errorCode",
+        "runState"
+      ]
+    },
+    "mobileAppTroubleshootingAppStateHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "actionType",
+        "errorCode",
+        "runState"
+      ]
+    },
+    "mobileAppTroubleshootingAppTargetHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "errorCode",
+        "runState",
+        "securityGroupId"
+      ]
+    },
+    "mobileAppTroubleshootingAppUpdateHistory": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mobileAppTroubleshootingDeviceCheckinHistory": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mobileAppTroubleshootingHistoryItem": {
+      "navigationProperties": [],
+      "properties": [
+        "occurrenceDateTime",
+        "troubleshootingErrorDetails"
+      ]
+    },
+    "modifiedProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "newValue",
+        "oldValue"
+      ]
+    },
+    "moveAction": {
+      "navigationProperties": [],
+      "properties": [
+        "from",
+        "to"
+      ]
+    },
+    "multiTenantOrganizationJoinRequestTransitionDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "desiredMemberState",
+        "details",
+        "status"
+      ]
+    },
+    "multiTenantOrganizationMemberTransitionDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "desiredRole",
+        "desiredState",
+        "details",
+        "status"
+      ]
+    },
+    "mutualTLSSecurityScheme": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "networkConnection": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationName",
+        "destinationAddress",
+        "destinationDomain",
+        "destinationLocation",
+        "destinationPort",
+        "destinationUrl",
+        "direction",
+        "domainRegisteredDateTime",
+        "localDnsName",
+        "natDestinationAddress",
+        "natDestinationPort",
+        "natSourceAddress",
+        "natSourcePort",
+        "protocol",
+        "riskScore",
+        "sourceAddress",
+        "sourceLocation",
+        "sourcePort",
+        "status",
+        "urlParameters"
+      ]
+    },
+    "networkInterface": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "ipV4Address",
+        "ipV6Address",
+        "localIpV6Address",
+        "macAddress"
+      ]
+    },
+    "networkLocationDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "networkNames",
+        "networkType"
+      ]
+    },
+    "noDeviceRegistrationMembership": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "noEntitlementsDataCollection": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "noScopes": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "notebookLinks": {
+      "navigationProperties": [],
+      "properties": [
+        "oneNoteClientUrl",
+        "oneNoteWebUrl"
+      ]
+    },
+    "notificationRecipients": {
+      "navigationProperties": [],
+      "properties": [
+        "customRecipients",
+        "role"
+      ]
+    },
+    "notifyUserAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actionLastModifiedDateTime",
+        "emailText",
+        "policyTip",
+        "recipients"
+      ]
+    },
+    "noTrainingNotificationSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "simulationNotification"
+      ]
+    },
+    "noTrainingSetting": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "npsQuizInfo": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "numberColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "decimalPlaces",
+        "displayAs",
+        "maximum",
+        "minimum"
+      ]
+    },
+    "numberRange": {
+      "navigationProperties": [],
+      "properties": [
+        "lowerNumber",
+        "upperNumber"
+      ]
+    },
+    "oathTokenMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "enabled",
+        "manufacturer",
+        "manufacturerProperties",
+        "serialNumber",
+        "tokenType"
+      ]
+    },
+    "oAuth2SecurityScheme": {
+      "navigationProperties": [],
+      "properties": [
+        "flows"
+      ]
+    },
+    "oAuthConsentAppDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "appScope",
+        "displayLogo",
+        "displayName"
+      ]
+    },
+    "oAuthFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "authorizationUrl",
+        "refreshUrl",
+        "scopes",
+        "tokenUrl"
+      ]
+    },
+    "oAuthFlows": {
+      "navigationProperties": [],
+      "properties": [
+        "authorizationCode",
+        "clientCredentials",
+        "implicit",
+        "password"
+      ]
+    },
+    "oAuthScopeDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "objectDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "attributes",
+        "metadata",
+        "name",
+        "supportedApis"
+      ]
+    },
+    "objectDefinitionMetadataEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "objectIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "issuer",
+        "issuerAssignedId",
+        "signInType"
+      ]
+    },
+    "objectMapping": {
+      "navigationProperties": [],
+      "properties": [
+        "attributeMappings",
+        "enabled",
+        "flowTypes",
+        "metadata",
+        "name",
+        "scope",
+        "sourceObjectName",
+        "targetObjectName"
+      ]
+    },
+    "objectMappingMetadataEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "offboardingDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "cancelledCount",
+        "failedCount",
+        "offboardedCount",
+        "offboardEndDateTime",
+        "offboardingStatus",
+        "offboardStartDateTime",
+        "totalRequestedCount"
+      ]
+    },
+    "oidcAddressInboundClaims": {
+      "navigationProperties": [],
+      "properties": [
+        "country",
+        "locality",
+        "postal_code",
+        "region",
+        "street_address"
+      ]
+    },
+    "oidcClientAuthentication": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "oidcClientSecretAuthentication": {
+      "navigationProperties": [],
+      "properties": [
+        "clientSecret"
+      ]
+    },
+    "oidcInboundClaimMappingOverride": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "email",
+        "email_verified",
+        "family_name",
+        "given_name",
+        "name",
+        "phone_number",
+        "phone_number_verified",
+        "sub"
+      ]
+    },
+    "oidcPrivateJwtKeyClientAuthentication": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "omaSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "isEncrypted",
+        "omaUri",
+        "secretReferenceValueId"
+      ]
+    },
+    "omaSettingBase64": {
+      "navigationProperties": [],
+      "properties": [
+        "fileName",
+        "value"
+      ]
+    },
+    "omaSettingBoolean": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "omaSettingDateTime": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "omaSettingFloatingPoint": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "omaSettingInteger": {
+      "navigationProperties": [],
+      "properties": [
+        "isReadOnly",
+        "value"
+      ]
+    },
+    "omaSettingString": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "omaSettingStringXml": {
+      "navigationProperties": [],
+      "properties": [
+        "fileName",
+        "value"
+      ]
+    },
+    "onAttributeCollectionExternalUsersSelfServiceSignUp": {
+      "navigationProperties": [
+        "attributes"
+      ],
+      "properties": [
+        "attributeCollectionPage"
+      ]
+    },
+    "onAttributeCollectionHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onAttributeCollectionStartCustomExtensionHandler": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "configuration"
+      ]
+    },
+    "onAttributeCollectionStartHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onAttributeCollectionSubmitCustomExtensionHandler": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "configuration"
+      ]
+    },
+    "onAttributeCollectionSubmitHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onAuthenticationMethodLoadStartExternalUsersSelfServiceSignUp": {
+      "navigationProperties": [
+        "identityProviders"
+      ],
+      "properties": []
+    },
+    "onAuthenticationMethodLoadStartHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "oneDriveDataSourceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "filterExpression",
+        "resourceMetadataNames"
+      ]
+    },
+    "onenoteOperationError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message"
+      ]
+    },
+    "onenotePagePreview": {
+      "navigationProperties": [],
+      "properties": [
+        "links",
+        "previewText"
+      ]
+    },
+    "onenotePagePreviewLinks": {
+      "navigationProperties": [],
+      "properties": [
+        "previewImageUrl"
+      ]
+    },
+    "onenotePatchContentCommand": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "content",
+        "position",
+        "target"
+      ]
+    },
+    "onFraudProtectionLoadStartExternalUsersAuthHandler": {
+      "navigationProperties": [],
+      "properties": [
+        "signUp"
+      ]
+    },
+    "onFraudProtectionLoadStartHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onInteractiveAuthFlowStartExternalUsersSelfServiceSignUp": {
+      "navigationProperties": [],
+      "properties": [
+        "isSignUpAllowed"
+      ]
+    },
+    "onInteractiveAuthFlowStartHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onlineMeetingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "conferenceId",
+        "joinUrl",
+        "phones",
+        "quickDial",
+        "tollFreeNumbers",
+        "tollNumber"
+      ]
+    },
+    "onlineMeetingRestricted": {
+      "navigationProperties": [],
+      "properties": [
+        "contentSharingDisabled",
+        "videoDisabled"
+      ]
+    },
+    "onlineMeetingSensitivityLabelAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "sensitivityLabelId"
+      ]
+    },
+    "onOtpSendCustomExtensionHandler": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "configuration"
+      ]
+    },
+    "onOtpSendHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onPasswordMigrationCustomExtensionHandler": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "configuration",
+        "migrationPropertyId"
+      ]
+    },
+    "onPasswordSubmitHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onPhoneMethodLoadStartExternalUsersAuthHandler": {
+      "navigationProperties": [],
+      "properties": [
+        "smsOptions",
+        "voiceOptions"
+      ]
+    },
+    "onPhoneMethodLoadStartHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onPremisesAccidentalDeletionPrevention": {
+      "navigationProperties": [],
+      "properties": [
+        "alertThreshold",
+        "synchronizationPreventionType"
+      ]
+    },
+    "onPremisesApplicationSegment": {
+      "navigationProperties": [],
+      "properties": [
+        "alternateUrl",
+        "corsConfigurations",
+        "externalUrl",
+        "internalUrl"
+      ]
+    },
+    "onPremisesCurrentExportData": {
+      "navigationProperties": [],
+      "properties": [
+        "clientMachineName",
+        "pendingObjectsAddition",
+        "pendingObjectsDeletion",
+        "pendingObjectsUpdate",
+        "serviceAccount",
+        "successfulLinksProvisioningCount",
+        "successfulObjectsProvisioningCount",
+        "totalConnectorSpaceObjects"
+      ]
+    },
+    "onPremisesDirectorySynchronizationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accidentalDeletionPrevention",
+        "anchorAttribute",
+        "applicationId",
+        "currentExportData",
+        "customerRequestedSynchronizationInterval",
+        "synchronizationClientVersion",
+        "synchronizationInterval",
+        "writebackConfiguration"
+      ]
+    },
+    "onPremisesDirectorySynchronizationFeature": {
+      "navigationProperties": [],
+      "properties": [
+        "blockCloudObjectTakeoverThroughHardMatchEnabled",
+        "blockSoftMatchEnabled",
+        "bypassDirSyncOverridesEnabled",
+        "cloudPasswordPolicyForPasswordSyncedUsersEnabled",
+        "concurrentCredentialUpdateEnabled",
+        "concurrentOrgIdProvisioningEnabled",
+        "deviceWritebackEnabled",
+        "directoryExtensionsEnabled",
+        "fopeConflictResolutionEnabled",
+        "groupWriteBackEnabled",
+        "passwordSyncEnabled",
+        "passwordWritebackEnabled",
+        "quarantineUponProxyAddressesConflictEnabled",
+        "quarantineUponUpnConflictEnabled",
+        "softMatchOnUpnEnabled",
+        "synchronizeUpnForManagedUsersEnabled",
+        "unifiedGroupWritebackEnabled",
+        "userForcePasswordChangeOnLogonEnabled",
+        "userWritebackEnabled"
+      ]
+    },
+    "onPremisesExtensionAttributes": {
+      "navigationProperties": [],
+      "properties": [
+        "extensionAttribute1",
+        "extensionAttribute10",
+        "extensionAttribute11",
+        "extensionAttribute12",
+        "extensionAttribute13",
+        "extensionAttribute14",
+        "extensionAttribute15",
+        "extensionAttribute2",
+        "extensionAttribute3",
+        "extensionAttribute4",
+        "extensionAttribute5",
+        "extensionAttribute6",
+        "extensionAttribute7",
+        "extensionAttribute8",
+        "extensionAttribute9"
+      ]
+    },
+    "onPremisesProvisioningError": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "occurredDateTime",
+        "propertyCausingError",
+        "value"
+      ]
+    },
+    "onPremisesPublishing": {
+      "navigationProperties": [],
+      "properties": [
+        "alternateUrl",
+        "applicationServerTimeout",
+        "applicationType",
+        "externalAuthenticationType",
+        "externalUrl",
+        "internalUrl",
+        "isAccessibleViaZTNAClient",
+        "isBackendCertificateValidationEnabled",
+        "isContinuousAccessEvaluationEnabled",
+        "isDnsResolutionEnabled",
+        "isHttpOnlyCookieEnabled",
+        "isOnPremPublishingEnabled",
+        "isPersistentCookieEnabled",
+        "isSecureCookieEnabled",
+        "isStateSessionEnabled",
+        "isTranslateHostHeaderEnabled",
+        "isTranslateLinksInBodyEnabled",
+        "onPremisesApplicationSegments",
+        "segmentsConfiguration",
+        "singleSignOnSettings",
+        "trafficRoutingMethod",
+        "useAlternateUrlForTranslationAndRedirect",
+        "verifiedCustomDomainCertificatesMetadata",
+        "verifiedCustomDomainKeyCredential",
+        "verifiedCustomDomainPasswordCredential",
+        "wafAllowedHeaders",
+        "wafIpRanges",
+        "wafProvider"
+      ]
+    },
+    "onPremisesPublishingSingleSignOn": {
+      "navigationProperties": [],
+      "properties": [
+        "kerberosSignOnSettings",
+        "singleSignOnMode"
+      ]
+    },
+    "onPremisesSipInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "isSipEnabled",
+        "sipDeploymentLocation",
+        "sipPrimaryAddress"
+      ]
+    },
+    "onPremisesWritebackConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "unifiedGroupContainer",
+        "userContainer"
+      ]
+    },
+    "onTokenIssuanceStartCustomExtensionHandler": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "configuration"
+      ]
+    },
+    "onTokenIssuanceStartHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onTokenIssuanceStartReturnClaim": {
+      "navigationProperties": [],
+      "properties": [
+        "claimIdInApiResponse"
+      ]
+    },
+    "onUserCreateStartExternalUsersSelfServiceSignUp": {
+      "navigationProperties": [],
+      "properties": [
+        "userTypeToCreate"
+      ]
+    },
+    "onUserCreateStartHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onVerifiedIdClaimValidationCustomExtensionHandler": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "configuration"
+      ]
+    },
+    "onVerifiedIdClaimValidationHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "openComplexDictionaryType": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "openIdConnectSecurityScheme": {
+      "navigationProperties": [],
+      "properties": [
+        "openIdConnectUrl"
+      ]
+    },
+    "openIdConnectSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "clientId",
+        "discoveryUrl"
+      ]
+    },
+    "openShiftItem": {
+      "navigationProperties": [],
+      "properties": [
+        "openSlotCount"
+      ]
+    },
+    "operatingSystemSpecifications": {
+      "navigationProperties": [],
+      "properties": [
+        "operatingSystemPlatform",
+        "operatingSystemVersion"
+      ]
+    },
+    "operatingSystemVersionRange": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "highestVersion",
+        "lowestVersion"
+      ]
+    },
+    "operationApprovalPolicySet": {
+      "navigationProperties": [],
+      "properties": [
+        "policyPlatform",
+        "policyType"
+      ]
+    },
+    "operationApprovalRequestEntityStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "entityLocked",
+        "requestExpirationDateTime",
+        "requestId",
+        "requestStatus"
+      ]
+    },
+    "operationError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message"
+      ]
+    },
+    "opticalCharacterRecognitionConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "optionalClaim": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalProperties",
+        "essential",
+        "name",
+        "source"
+      ]
+    },
+    "optionalClaims": {
+      "navigationProperties": [],
+      "properties": [
+        "accessToken",
+        "idToken",
+        "saml2Token"
+      ]
+    },
+    "organizerMeetingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "organizer"
+      ]
+    },
+    "originTenantInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "originTenantId",
+        "originUserId"
+      ]
+    },
+    "osVersionCount": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "lastUpdateDateTime",
+        "osVersion"
+      ]
+    },
+    "outgoingCallOptions": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "outlookGeoCoordinates": {
+      "navigationProperties": [],
+      "properties": [
+        "accuracy",
+        "altitude",
+        "altitudeAccuracy",
+        "latitude",
+        "longitude"
+      ]
+    },
+    "outOfBoxExperienceSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceUsageType",
+        "escapeLinkHidden",
+        "eulaHidden",
+        "keyboardSelectionPageSkipped",
+        "privacySettingsHidden",
+        "userType"
+      ]
+    },
+    "outOfBoxExperienceSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceUsageType",
+        "hideEscapeLink",
+        "hideEULA",
+        "hidePrivacySettings",
+        "skipKeyboardSelectionPage",
+        "userType"
+      ]
+    },
+    "outOfOfficeSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isOutOfOffice",
+        "message"
+      ]
+    },
+    "package": {
+      "navigationProperties": [],
+      "properties": [
+        "type"
+      ]
+    },
+    "packageAccessEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceId",
+        "resourceType"
+      ]
+    },
+    "packageElement": {
+      "navigationProperties": [],
+      "properties": [
+        "definition",
+        "id"
+      ]
+    },
+    "packageElementDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "elements",
+        "elementType"
+      ]
+    },
+    "pageLinks": {
+      "navigationProperties": [],
+      "properties": [
+        "oneNoteClientUrl",
+        "oneNoteWebUrl"
+      ]
+    },
+    "parentalControlSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "countriesBlockedForMinors",
+        "legalAgeGroupRule"
+      ]
+    },
+    "parentLabelDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "color",
+        "description",
+        "id",
+        "isActive",
+        "name",
+        "parent",
+        "sensitivity",
+        "tooltip"
+      ]
+    },
+    "parseExpressionResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "evaluationResult",
+        "evaluationSucceeded",
+        "parsedExpression",
+        "parsingSucceeded"
+      ]
+    },
+    "participantInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "countryCode",
+        "endpointType",
+        "identity",
+        "languageId",
+        "nonAnonymizedIdentity",
+        "participantId",
+        "platformId",
+        "region"
+      ]
+    },
+    "participantJoiningResponse": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "passkeyProfileStructure": {
+      "navigationProperties": [],
+      "properties": [
+        "attestationEnforcement",
+        "id",
+        "isAttestationEnforced",
+        "keyRestrictions",
+        "name",
+        "passkeyTypes"
+      ]
+    },
+    "passwordCredential": {
+      "navigationProperties": [],
+      "properties": [
+        "customKeyIdentifier",
+        "displayName",
+        "endDateTime",
+        "hint",
+        "keyId",
+        "secretText",
+        "startDateTime"
+      ]
+    },
+    "passwordCredentialConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeActors",
+        "maxLifetime",
+        "restrictForAppsCreatedAfterDateTime",
+        "restrictionType",
+        "state"
+      ]
+    },
+    "passwordProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "forceChangePasswordNextSignIn",
+        "forceChangePasswordNextSignInWithMfa",
+        "password"
+      ]
+    },
+    "passwordResetResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "newPassword"
+      ]
+    },
+    "passwordSingleSignOnCredentialSet": {
+      "navigationProperties": [],
+      "properties": [
+        "credentials",
+        "id"
+      ]
+    },
+    "passwordSingleSignOnField": {
+      "navigationProperties": [],
+      "properties": [
+        "customizedLabel",
+        "defaultLabel",
+        "fieldId",
+        "type"
+      ]
+    },
+    "passwordSingleSignOnSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "fields"
+      ]
+    },
+    "passwordValidationInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "isValid",
+        "validationResults"
+      ]
+    },
+    "patternedRecurrence": {
+      "navigationProperties": [],
+      "properties": [
+        "pattern",
+        "range"
+      ]
+    },
+    "payloadByFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentFilterType",
+        "groupId",
+        "payloadId",
+        "payloadType"
+      ]
+    },
+    "payloadCoachmark": {
+      "navigationProperties": [],
+      "properties": [
+        "coachmarkLocation",
+        "description",
+        "indicator",
+        "isValid",
+        "language",
+        "order"
+      ]
+    },
+    "payloadDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "coachmarks",
+        "content",
+        "phishingUrl"
+      ]
+    },
+    "payloadRequest": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "payloadTypes": {
+      "navigationProperties": [],
+      "properties": [
+        "rawContent",
+        "visualContent"
+      ]
+    },
+    "pendingContentUpdate": {
+      "navigationProperties": [],
+      "properties": [
+        "queuedDateTime"
+      ]
+    },
+    "pendingOperations": {
+      "navigationProperties": [],
+      "properties": [
+        "pendingContentUpdate"
+      ]
+    },
+    "permissionsAnalyticsAggregatedIamKeySummary": {
+      "navigationProperties": [],
+      "properties": [
+        "findingsCountOverLimit",
+        "totalCount"
+      ]
+    },
+    "permissionsAnalyticsAggregatedIdentitySummary": {
+      "navigationProperties": [],
+      "properties": [
+        "findingsCount",
+        "totalCount"
+      ]
+    },
+    "permissionsAnalyticsAggregatedResourceSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "findingsCount",
+        "totalCount"
+      ]
+    },
+    "permissionScope": {
+      "navigationProperties": [],
+      "properties": [
+        "adminConsentDescription",
+        "adminConsentDisplayName",
+        "id",
+        "isEnabled",
+        "origin",
+        "type",
+        "userConsentDescription",
+        "userConsentDisplayName",
+        "value"
+      ]
+    },
+    "permissionsCreepIndex": {
+      "navigationProperties": [],
+      "properties": [
+        "score"
+      ]
+    },
+    "permissionsDefinition": {
+      "navigationProperties": [
+        "identityInfo"
+      ],
+      "properties": [
+        "authorizationSystemInfo"
+      ]
+    },
+    "permissionsDefinitionAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "permissionsDefinitionAuthorizationSystem": {
+      "navigationProperties": [],
+      "properties": [
+        "authorizationSystemId",
+        "authorizationSystemType"
+      ]
+    },
+    "permissionsDefinitionIdentitySource": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "persistentBrowserSessionControl": {
+      "navigationProperties": [],
+      "properties": [
+        "mode"
+      ]
+    },
+    "personalTeamsAppInstallationScopeInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "userId"
+      ]
+    },
+    "personDataSource": {
+      "navigationProperties": [],
+      "properties": [
+        "type"
+      ]
+    },
+    "personDataSources": {
+      "navigationProperties": [],
+      "properties": [
+        "type"
+      ]
+    },
+    "personNamePronounciation": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "first",
+        "last",
+        "maiden",
+        "middle"
+      ]
+    },
+    "personOrGroupColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "allowMultipleSelection",
+        "chooseFromType",
+        "displayAs"
+      ]
+    },
+    "perTenantTrafficSegmentsOverride": {
+      "navigationProperties": [],
+      "properties": [
+        "percentage",
+        "tenantId"
+      ]
+    },
+    "phone": {
+      "navigationProperties": [],
+      "properties": [
+        "number",
+        "type"
+      ]
+    },
+    "phoneOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultRegions",
+        "excludeRegions",
+        "includeAdditionalRegions"
+      ]
+    },
+    "photo": {
+      "navigationProperties": [],
+      "properties": [
+        "cameraMake",
+        "cameraModel",
+        "exposureDenominator",
+        "exposureNumerator",
+        "fNumber",
+        "focalLength",
+        "iso",
+        "orientation",
+        "takenDateTime"
+      ]
+    },
+    "photoAllowedOperations": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "physicalAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "city",
+        "countryOrRegion",
+        "postalCode",
+        "postOfficeBox",
+        "state",
+        "street",
+        "type"
+      ]
+    },
+    "physicalOfficeAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "city",
+        "countryOrRegion",
+        "officeLocation",
+        "postalCode",
+        "state",
+        "street"
+      ]
+    },
+    "pkcs12Certificate": {
+      "navigationProperties": [],
+      "properties": [
+        "password",
+        "pkcs12Value"
+      ]
+    },
+    "pkcs12CertificateInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "isActive",
+        "notAfter",
+        "notBefore",
+        "thumbprint"
+      ]
+    },
+    "placeExecutionResult": {
+      "navigationProperties": [
+        "succeededPlace"
+      ],
+      "properties": [
+        "children",
+        "error"
+      ]
+    },
+    "placeMode": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "placeOperationProgress": {
+      "navigationProperties": [],
+      "properties": [
+        "failedPlaceCount",
+        "succeededPlaceCount",
+        "totalPlaceCount"
+      ]
+    },
+    "plannerAppliedCategories": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerApprovalRequirement": {
+      "navigationProperties": [],
+      "properties": [
+        "isApprovalRequired"
+      ]
+    },
+    "plannerArchivalInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "justification",
+        "statusChangedBy",
+        "statusChangedDateTime"
+      ]
+    },
+    "plannerAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedBy",
+        "assignedDateTime",
+        "orderHint"
+      ]
+    },
+    "plannerAssignments": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerBaseApprovalAttachment": {
+      "navigationProperties": [],
+      "properties": [
+        "status"
+      ]
+    },
+    "plannerBasicApprovalAttachment": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalId"
+      ]
+    },
+    "plannerBucketCreation": {
+      "navigationProperties": [],
+      "properties": [
+        "creationSourceKind"
+      ]
+    },
+    "plannerBucketPropertyRule": {
+      "navigationProperties": [],
+      "properties": [
+        "order",
+        "title"
+      ]
+    },
+    "plannerCategoryDescriptions": {
+      "navigationProperties": [],
+      "properties": [
+        "category1",
+        "category10",
+        "category11",
+        "category12",
+        "category13",
+        "category14",
+        "category15",
+        "category16",
+        "category17",
+        "category18",
+        "category19",
+        "category2",
+        "category20",
+        "category21",
+        "category22",
+        "category23",
+        "category24",
+        "category25",
+        "category3",
+        "category4",
+        "category5",
+        "category6",
+        "category7",
+        "category8",
+        "category9"
+      ]
+    },
+    "plannerChecklistItem": {
+      "navigationProperties": [],
+      "properties": [
+        "isChecked",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "orderHint",
+        "title"
+      ]
+    },
+    "plannerChecklistItems": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerChecklistRequirement": {
+      "navigationProperties": [],
+      "properties": [
+        "requiredChecklistItemIds"
+      ]
+    },
+    "plannerExternalBucketSource": {
+      "navigationProperties": [],
+      "properties": [
+        "contextScenarioId",
+        "externalContextId",
+        "externalObjectId"
+      ]
+    },
+    "plannerExternalPlanSource": {
+      "navigationProperties": [],
+      "properties": [
+        "contextScenarioId",
+        "externalContextId",
+        "externalObjectId"
+      ]
+    },
+    "plannerExternalReference": {
+      "navigationProperties": [],
+      "properties": [
+        "alias",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "previewPriority",
+        "type"
+      ]
+    },
+    "plannerExternalReferences": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerExternalTaskSource": {
+      "navigationProperties": [],
+      "properties": [
+        "contextScenarioId",
+        "displayLinkType",
+        "displayNameSegments",
+        "externalContextId",
+        "externalObjectId",
+        "externalObjectVersion",
+        "webUrl"
+      ]
+    },
+    "plannerFavoritePlanReference": {
+      "navigationProperties": [],
+      "properties": [
+        "orderHint",
+        "planTitle"
+      ]
+    },
+    "plannerFavoritePlanReferenceCollection": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerFieldRules": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultRules",
+        "overrides"
+      ]
+    },
+    "plannerFormReference": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "formResponse",
+        "formWebUrl"
+      ]
+    },
+    "plannerFormsDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerFormsRequirement": {
+      "navigationProperties": [],
+      "properties": [
+        "requiredForms"
+      ]
+    },
+    "plannerOrderHintsByAssignee": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerPlanConfigurationBucketDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "externalBucketId"
+      ]
+    },
+    "plannerPlanConfigurationBucketLocalization": {
+      "navigationProperties": [],
+      "properties": [
+        "externalBucketId",
+        "name"
+      ]
+    },
+    "plannerPlanContainer": {
+      "navigationProperties": [],
+      "properties": [
+        "containerId",
+        "type",
+        "url"
+      ]
+    },
+    "plannerPlanContext": {
+      "navigationProperties": [],
+      "properties": [
+        "associationType",
+        "createdDateTime",
+        "displayNameSegments",
+        "isCreationContext",
+        "ownerAppId"
+      ]
+    },
+    "plannerPlanContextCollection": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerPlanContextDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "customLinkText",
+        "displayLinkType",
+        "state",
+        "url"
+      ]
+    },
+    "plannerPlanContextDetailsCollection": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerPlanCreation": {
+      "navigationProperties": [],
+      "properties": [
+        "creationSourceKind"
+      ]
+    },
+    "plannerPlanPropertyRule": {
+      "navigationProperties": [],
+      "properties": [
+        "buckets",
+        "categoryDescriptions",
+        "tasks",
+        "title"
+      ]
+    },
+    "plannerPropertyRule": {
+      "navigationProperties": [],
+      "properties": [
+        "ruleKind"
+      ]
+    },
+    "plannerRecentPlanReference": {
+      "navigationProperties": [],
+      "properties": [
+        "lastAccessedDateTime",
+        "planTitle"
+      ]
+    },
+    "plannerRecentPlanReferenceCollection": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerRecurrenceSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "nextOccurrenceDateTime",
+        "pattern",
+        "patternStartDateTime"
+      ]
+    },
+    "plannerRelationshipBasedUserType": {
+      "navigationProperties": [],
+      "properties": [
+        "role"
+      ]
+    },
+    "plannerRuleOverride": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "rules"
+      ]
+    },
+    "plannerSharedWithContainer": {
+      "navigationProperties": [],
+      "properties": [
+        "accessLevel"
+      ]
+    },
+    "plannerTaskChatMention": {
+      "navigationProperties": [],
+      "properties": [
+        "mentioned",
+        "mentionType",
+        "position"
+      ]
+    },
+    "plannerTaskChatReaction": {
+      "navigationProperties": [],
+      "properties": [
+        "reactionEvents",
+        "reactionType"
+      ]
+    },
+    "plannerTaskChatReactionEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime"
+      ]
+    },
+    "plannerTaskCompletionRequirementDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalRequirement",
+        "checklistRequirement",
+        "formsRequirement"
+      ]
+    },
+    "plannerTaskConfigurationRoleBase": {
+      "navigationProperties": [],
+      "properties": [
+        "roleKind"
+      ]
+    },
+    "plannerTaskCreation": {
+      "navigationProperties": [],
+      "properties": [
+        "creationSourceKind",
+        "teamsPublicationInfo"
+      ]
+    },
+    "plannerTaskPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "rules"
+      ]
+    },
+    "plannerTaskPropertyRule": {
+      "navigationProperties": [],
+      "properties": [
+        "appliedCategories",
+        "approvalAttachment",
+        "assignments",
+        "checkLists",
+        "completionRequirements",
+        "delete",
+        "dueDate",
+        "forms",
+        "move",
+        "notes",
+        "order",
+        "percentComplete",
+        "previewType",
+        "priority",
+        "references",
+        "startDate",
+        "title"
+      ]
+    },
+    "plannerTaskRecurrence": {
+      "navigationProperties": [],
+      "properties": [
+        "nextInSeriesTaskId",
+        "occurrenceId",
+        "previousInSeriesTaskId",
+        "recurrenceStartDateTime",
+        "schedule",
+        "seriesId"
+      ]
+    },
+    "plannerTaskRoleBasedRule": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultRule",
+        "propertyRule",
+        "role"
+      ]
+    },
+    "plannerTeamsPublicationInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedDateTime",
+        "publicationId",
+        "publicationName",
+        "publishedToPlanId",
+        "publishingTeamId",
+        "publishingTeamName"
+      ]
+    },
+    "plannerUserIds": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "planUsageRight": {
+      "navigationProperties": [],
+      "properties": [
+        "hasSensitivityLabel",
+        "planId",
+        "usageRights"
+      ]
+    },
+    "policyBinding": {
+      "navigationProperties": [],
+      "properties": [
+        "exclusions",
+        "inclusions"
+      ]
+    },
+    "policyLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "policyLocationApplication": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "policyLocationDomain": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "policyLocationUrl": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "policyScopeBase": {
+      "navigationProperties": [],
+      "properties": [
+        "activities",
+        "executionMode",
+        "locations",
+        "policyActions"
+      ]
+    },
+    "policyTenantScope": {
+      "navigationProperties": [],
+      "properties": [
+        "policyScope"
+      ]
+    },
+    "policyUserScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "positionDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "company",
+        "description",
+        "employeeId",
+        "employeeType",
+        "endMonthYear",
+        "jobTitle",
+        "layer",
+        "level",
+        "role",
+        "secondaryJobTitle",
+        "secondaryRole",
+        "startMonthYear",
+        "summary"
+      ]
+    },
+    "positiveReinforcementNotification": {
+      "navigationProperties": [],
+      "properties": [
+        "deliveryPreference"
+      ]
+    },
+    "postalAddressType": {
+      "navigationProperties": [],
+      "properties": [
+        "city",
+        "countryLetterCode",
+        "postalCode",
+        "state",
+        "street"
+      ]
+    },
+    "powerliftAppDiagnosticDownloadRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "files",
+        "powerliftId"
+      ]
+    },
+    "powerliftDownloadRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "files",
+        "powerliftId"
+      ]
+    },
+    "powerliftIncidentDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationName",
+        "clientApplicationVersion",
+        "createdDateTime",
+        "easyId",
+        "fileNames",
+        "locale",
+        "platformDisplayName",
+        "powerliftId"
+      ]
+    },
+    "powerliftIncidentMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "application",
+        "clientVersion",
+        "createdAtDateTime",
+        "easyId",
+        "fileNames",
+        "locale",
+        "platform",
+        "powerliftId"
+      ]
+    },
+    "preApprovalDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "permissions",
+        "scopeType",
+        "sensitivityLabels"
+      ]
+    },
+    "preApprovedPermissions": {
+      "navigationProperties": [],
+      "properties": [
+        "permissionKind",
+        "permissionType"
+      ]
+    },
+    "preAuthorizedApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "permissionIds"
+      ]
+    },
+    "presenceStatusMessage": {
+      "navigationProperties": [],
+      "properties": [
+        "expiryDateTime",
+        "message",
+        "publishedDateTime"
+      ]
+    },
+    "principalResourceMembershipsScope": {
+      "navigationProperties": [],
+      "properties": [
+        "principalScopes",
+        "resourceScopes"
+      ]
+    },
+    "printCertificateSigningRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "transportKey"
+      ]
+    },
+    "printDocumentUploadProperties": {
+      "navigationProperties": [],
+      "properties": [
+        "contentType",
+        "documentName",
+        "size"
+      ]
+    },
+    "printerCapabilities": {
+      "navigationProperties": [],
+      "properties": [
+        "bottomMargins",
+        "collation",
+        "colorModes",
+        "contentTypes",
+        "copiesPerJob",
+        "dpis",
+        "duplexModes",
+        "feedDirections",
+        "feedOrientations",
+        "finishings",
+        "inputBins",
+        "isColorPrintingSupported",
+        "isPageRangeSupported",
+        "leftMargins",
+        "mediaColors",
+        "mediaSizes",
+        "mediaTypes",
+        "multipageLayouts",
+        "orientations",
+        "outputBins",
+        "pagesPerSheet",
+        "qualities",
+        "rightMargins",
+        "scalings",
+        "supportedColorConfigurations",
+        "supportedCopiesPerJob",
+        "supportedDocumentMimeTypes",
+        "supportedDuplexConfigurations",
+        "supportedFinishings",
+        "supportedMediaColors",
+        "supportedMediaSizes",
+        "supportedMediaTypes",
+        "supportedOrientations",
+        "supportedOutputBins",
+        "supportedPagesPerSheet",
+        "supportedPresentationDirections",
+        "supportedPrintQualities",
+        "supportsFitPdfToPage",
+        "topMargins"
+      ]
+    },
+    "printerDefaults": {
+      "navigationProperties": [],
+      "properties": [
+        "colorMode",
+        "contentType",
+        "copiesPerJob",
+        "documentMimeType",
+        "dpi",
+        "duplexConfiguration",
+        "duplexMode",
+        "finishings",
+        "fitPdfToPage",
+        "inputBin",
+        "mediaColor",
+        "mediaSize",
+        "mediaType",
+        "multipageLayout",
+        "orientation",
+        "outputBin",
+        "pagesPerSheet",
+        "pdfFitToPage",
+        "presentationDirection",
+        "printColorConfiguration",
+        "printQuality",
+        "quality",
+        "scaling"
+      ]
+    },
+    "printerDiscoverySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "airPrint"
+      ]
+    },
+    "printerDocumentConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "collate",
+        "colorMode",
+        "copies",
+        "dpi",
+        "duplexMode",
+        "feedDirection",
+        "feedOrientation",
+        "finishings",
+        "fitPdfToPage",
+        "inputBin",
+        "margin",
+        "mediaSize",
+        "mediaType",
+        "multipageLayout",
+        "orientation",
+        "outputBin",
+        "pageRanges",
+        "pagesPerSheet",
+        "quality",
+        "scaling"
+      ]
+    },
+    "printerLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "altitudeInMeters",
+        "building",
+        "city",
+        "countryOrRegion",
+        "floor",
+        "floorDescription",
+        "floorNumber",
+        "latitude",
+        "longitude",
+        "organization",
+        "postalCode",
+        "roomDescription",
+        "roomName",
+        "roomNumber",
+        "site",
+        "stateOrProvince",
+        "streetAddress",
+        "subdivision",
+        "subunit"
+      ]
+    },
+    "printerShareViewpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "lastUsedDateTime"
+      ]
+    },
+    "printerStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "details",
+        "processingState",
+        "processingStateDescription",
+        "processingStateReasons",
+        "state"
+      ]
+    },
+    "printJobConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "collate",
+        "colorMode",
+        "copies",
+        "dpi",
+        "duplexMode",
+        "feedOrientation",
+        "finishings",
+        "fitPdfToPage",
+        "inputBin",
+        "margin",
+        "mediaSize",
+        "mediaType",
+        "multipageLayout",
+        "orientation",
+        "outputBin",
+        "pageRanges",
+        "pagesPerSheet",
+        "quality",
+        "scaling"
+      ]
+    },
+    "printJobStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "acquiredByPrinter",
+        "description",
+        "details",
+        "isAcquiredByPrinter",
+        "processingState",
+        "processingStateDescription",
+        "state"
+      ]
+    },
+    "printLogAnalyticsSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "dataCollectionRuleImmutableId",
+        "logIngestionEndpoint",
+        "workspaceResourceId"
+      ]
+    },
+    "printMargin": {
+      "navigationProperties": [],
+      "properties": [
+        "bottom",
+        "left",
+        "right",
+        "top"
+      ]
+    },
+    "printOperationStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "state"
+      ]
+    },
+    "printSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "documentConversionEnabled",
+        "printerDiscoverySettings"
+      ]
+    },
+    "printTaskStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "state"
+      ]
+    },
+    "privacyProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "contactEmail",
+        "statementUrl"
+      ]
+    },
+    "privateAccessFeatureUtilizations": {
+      "navigationProperties": [],
+      "properties": [
+        "privateAccess"
+      ]
+    },
+    "privateLinkDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "policyId",
+        "policyName",
+        "policyTenantId",
+        "resourceId"
+      ]
+    },
+    "process": {
+      "navigationProperties": [],
+      "properties": [
+        "accountName",
+        "commandLine",
+        "createdDateTime",
+        "fileHash",
+        "integrityLevel",
+        "isElevated",
+        "name",
+        "parentProcessCreatedDateTime",
+        "parentProcessId",
+        "parentProcessName",
+        "path",
+        "processId"
+      ]
+    },
+    "processContentBatchRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "contentToProcess",
+        "requestId",
+        "userId"
+      ]
+    },
+    "processContentMetadataBase": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "contentCategory",
+        "correlationId",
+        "createdDateTime",
+        "identifier",
+        "isTruncated",
+        "length",
+        "modifiedDateTime",
+        "name",
+        "sequenceNumber"
+      ]
+    },
+    "processContentRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "activityMetadata",
+        "contentEntries",
+        "deviceMetadata",
+        "integratedAppMetadata",
+        "protectedAppMetadata"
+      ]
+    },
+    "processContentResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "policyActions",
+        "processingErrors",
+        "protectionScopeState"
+      ]
+    },
+    "processContentResponses": {
+      "navigationProperties": [],
+      "properties": [
+        "requestId",
+        "results"
+      ]
+    },
+    "processConversationMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "accessedResources",
+        "accessedResources_v2",
+        "agents",
+        "parentMessageId",
+        "plugins"
+      ]
+    },
+    "processFileMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "customProperties",
+        "ownerId"
+      ]
+    },
+    "processingError": {
+      "navigationProperties": [],
+      "properties": [
+        "errorType"
+      ]
+    },
+    "profileCardAnnotation": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "localizations"
+      ]
+    },
+    "profileSourceAnnotation": {
+      "navigationProperties": [],
+      "properties": [
+        "isDefaultSource",
+        "properties",
+        "sourceId"
+      ]
+    },
+    "profileSourceLocalization": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "languageTag",
+        "webUrl"
+      ]
+    },
+    "programResource": {
+      "navigationProperties": [],
+      "properties": [
+        "type"
+      ]
+    },
+    "prompt": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "properties": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "property": {
+      "navigationProperties": [],
+      "properties": [
+        "aliases",
+        "isQueryable",
+        "isRefinable",
+        "isRetrievable",
+        "isSearchable",
+        "labels",
+        "name",
+        "type"
+      ]
+    },
+    "propertyToEvaluate": {
+      "navigationProperties": [],
+      "properties": [
+        "propertyName",
+        "propertyValue"
+      ]
+    },
+    "protectAdhocAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "protectByTemplateAction": {
+      "navigationProperties": [],
+      "properties": [
+        "templateId"
+      ]
+    },
+    "protectDoNotForwardAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "protectedApplicationMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationLocation"
+      ]
+    },
+    "protectedContent": {
+      "navigationProperties": [],
+      "properties": [
+        "cid",
+        "format",
+        "labelId"
+      ]
+    },
+    "protectGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "allowEmailFromGuestUsers",
+        "allowGuestUsers",
+        "privacy"
+      ]
+    },
+    "protectionPolicyArtifactCount": {
+      "navigationProperties": [],
+      "properties": [
+        "completed",
+        "failed",
+        "inProgress",
+        "total"
+      ]
+    },
+    "protectionUnitDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "addedCount",
+        "backupConfigurationType",
+        "failedCount",
+        "removedCount",
+        "requestedToAddCount",
+        "requestedToRemoveCount"
+      ]
+    },
+    "protectOnlineMeetingAction": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedForwarders",
+        "allowedPresenters",
+        "isCopyToClipboardEnabled",
+        "isLobbyEnabled",
+        "lobbyBypassSettings"
+      ]
+    },
+    "protectSite": {
+      "navigationProperties": [],
+      "properties": [
+        "accessType",
+        "conditionalAccessProtectionLevelId"
+      ]
+    },
+    "provisionChannelEmailResult": {
+      "navigationProperties": [],
+      "properties": [
+        "email"
+      ]
+    },
+    "provisionedIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "details",
+        "identityType"
+      ]
+    },
+    "provisionedPlan": {
+      "navigationProperties": [],
+      "properties": [
+        "capabilityStatus",
+        "provisioningStatus",
+        "service"
+      ]
+    },
+    "provisioningErrorInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalDetails",
+        "errorCategory",
+        "errorCode",
+        "reason",
+        "recommendedAction"
+      ]
+    },
+    "provisioningServicePrincipal": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "provisioningStatusInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "errorInformation",
+        "status"
+      ]
+    },
+    "provisioningStep": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "details",
+        "name",
+        "provisioningStepType",
+        "status"
+      ]
+    },
+    "provisioningSystem": {
+      "navigationProperties": [],
+      "properties": [
+        "details"
+      ]
+    },
+    "proxiedDomain": {
+      "navigationProperties": [],
+      "properties": [
+        "ipAddressOrFQDN",
+        "proxy"
+      ]
+    },
+    "publicationFacet": {
+      "navigationProperties": [],
+      "properties": [
+        "checkedOutBy",
+        "level",
+        "versionId"
+      ]
+    },
+    "publicClientApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "redirectUris"
+      ]
+    },
+    "publicError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "details",
+        "innerError",
+        "message",
+        "target"
+      ]
+    },
+    "publicErrorDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message",
+        "target"
+      ]
+    },
+    "publicErrorResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "error"
+      ]
+    },
+    "publicInnerError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "details",
+        "message",
+        "target"
+      ]
+    },
+    "qrCodeImageDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "binaryValue",
+        "errorCorrectionLevel",
+        "rawContent",
+        "version"
+      ]
+    },
+    "quizInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "maxPoints"
+      ]
+    },
+    "quota": {
+      "navigationProperties": [],
+      "properties": [
+        "deleted",
+        "remaining",
+        "state",
+        "storagePlanInformation",
+        "total",
+        "used"
+      ]
+    },
+    "rankedEmailAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "rank"
+      ]
+    },
+    "reactionsFacet": {
+      "navigationProperties": [],
+      "properties": [
+        "commentCount",
+        "likeCount",
+        "shareCount"
+      ]
+    },
+    "recentNotebook": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastAccessedTime",
+        "links",
+        "sourceService"
+      ]
+    },
+    "recentNotebookLinks": {
+      "navigationProperties": [],
+      "properties": [
+        "oneNoteClientUrl",
+        "oneNoteWebUrl"
+      ]
+    },
+    "recipient": {
+      "navigationProperties": [],
+      "properties": [
+        "emailAddress"
+      ]
+    },
+    "recommendedAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actionWebUrl",
+        "potentialScoreImpact",
+        "title"
+      ]
+    },
+    "recommendLabelAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actions",
+        "actionSource",
+        "label",
+        "responsibleSensitiveTypeIds"
+      ]
+    },
+    "reconciliationCounter": {
+      "navigationProperties": [],
+      "properties": [
+        "correlatedObjectCount",
+        "sourceObjectCount",
+        "targetObjectCount",
+        "uncorrelatedObjectCount"
+      ]
+    },
+    "reconciliationCounters": {
+      "navigationProperties": [],
+      "properties": [
+        "user"
+      ]
+    },
+    "recordingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "initiatedBy",
+        "initiator",
+        "recordingStatus"
+      ]
+    },
+    "recordingState": {
+      "navigationProperties": [],
+      "properties": [
+        "sequenceNumber",
+        "state"
+      ]
+    },
+    "recurrencePattern": {
+      "navigationProperties": [],
+      "properties": [
+        "dayOfMonth",
+        "daysOfWeek",
+        "firstDayOfWeek",
+        "index",
+        "interval",
+        "month",
+        "type"
+      ]
+    },
+    "recurrenceRange": {
+      "navigationProperties": [],
+      "properties": [
+        "endDate",
+        "numberOfOccurrences",
+        "recurrenceTimeZone",
+        "startDate",
+        "type"
+      ]
+    },
+    "recycleBinSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "retentionPeriodOverrideDays"
+      ]
+    },
+    "redirectSingleSignOnExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "configurations",
+        "extensionIdentifier",
+        "teamIdentifier",
+        "urlPrefixes"
+      ]
+    },
+    "redirectUriAllowedDomainConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedDomains",
+        "excludeActors",
+        "isStateSetByMicrosoft",
+        "publicClient",
+        "restrictForAppsCreatedAfterDateTime",
+        "spa",
+        "state",
+        "web"
+      ]
+    },
+    "redirectUriAllowedSchemeConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedSchemes",
+        "excludeActors",
+        "isStateSetByMicrosoft",
+        "publicClient",
+        "restrictForAppsCreatedAfterDateTime",
+        "spa",
+        "state",
+        "web"
+      ]
+    },
+    "redirectUriBlockedDomainConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "blockedDomains",
+        "excludeActors",
+        "isStateSetByMicrosoft",
+        "publicClient",
+        "restrictForAppsCreatedAfterDateTime",
+        "spa",
+        "state",
+        "web"
+      ]
+    },
+    "redirectUriBlockedSchemeConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "blockedSchemes",
+        "excludeActors",
+        "exemptFormats",
+        "isStateSetByMicrosoft",
+        "publicClient",
+        "restrictForAppsCreatedAfterDateTime",
+        "spa",
+        "state",
+        "web"
+      ]
+    },
+    "redirectUriConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "uriWithBlockedDomain",
+        "uriWithBlockedScheme",
+        "uriWithoutAllowedDomain",
+        "uriWithoutAllowedScheme",
+        "uriWithWildcard"
+      ]
+    },
+    "redirectUriPlatformAllowedDomainConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedDomains"
+      ]
+    },
+    "redirectUriPlatformAllowedSchemeConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedSchemes"
+      ]
+    },
+    "redirectUriPlatformBlockedDomainConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "blockedDomains"
+      ]
+    },
+    "redirectUriPlatformBlockedSchemeConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "blockedSchemes",
+        "exemptFormats"
+      ]
+    },
+    "redirectUriSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "index",
+        "uri"
+      ]
+    },
+    "redirectUriWildcardConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeActors",
+        "excludeFormats",
+        "isStateSetByMicrosoft",
+        "restrictForAppsCreatedAfterDateTime",
+        "state"
+      ]
+    },
+    "redirectUriWildcardExcludeFormats": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeWildcardsInPath",
+        "excludeWildcardsInPathWithDomains"
+      ]
+    },
+    "referencedObject": {
+      "navigationProperties": [],
+      "properties": [
+        "referencedObjectName",
+        "referencedProperty"
+      ]
+    },
+    "regexReplaceTransformation": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalAttributes",
+        "regex",
+        "replacement"
+      ]
+    },
+    "regionalFormatOverrides": {
+      "navigationProperties": [],
+      "properties": [
+        "calendar",
+        "firstDayOfWeek",
+        "longDateFormat",
+        "longTimeFormat",
+        "shortDateFormat",
+        "shortTimeFormat",
+        "timeZone"
+      ]
+    },
+    "registrationEnforcement": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationMethodsRegistrationCampaign"
+      ]
+    },
+    "registryKeyState": {
+      "navigationProperties": [],
+      "properties": [
+        "hive",
+        "key",
+        "oldKey",
+        "oldValueData",
+        "oldValueName",
+        "operation",
+        "processId",
+        "valueData",
+        "valueName",
+        "valueType"
+      ]
+    },
+    "rejectJoinResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "reason"
+      ]
+    },
+    "relatedContact": {
+      "navigationProperties": [],
+      "properties": [
+        "accessConsent",
+        "displayName",
+        "emailAddress",
+        "id",
+        "mobilePhone",
+        "relationship"
+      ]
+    },
+    "relatedPerson": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "relationship",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "reminder": {
+      "navigationProperties": [],
+      "properties": [
+        "changeKey",
+        "eventEndTime",
+        "eventId",
+        "eventLocation",
+        "eventStartTime",
+        "eventSubject",
+        "eventWebLink",
+        "reminderFireTime"
+      ]
+    },
+    "remoteItem": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "file",
+        "fileSystemInfo",
+        "folder",
+        "id",
+        "image",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "name",
+        "package",
+        "parentReference",
+        "shared",
+        "sharepointIds",
+        "size",
+        "specialFolder",
+        "video",
+        "webDavUrl",
+        "webUrl"
+      ]
+    },
+    "remoteLockActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "unlockPin"
+      ]
+    },
+    "removeAccessApplyAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "removeContentFooterAction": {
+      "navigationProperties": [],
+      "properties": [
+        "uiElementNames"
+      ]
+    },
+    "removeContentHeaderAction": {
+      "navigationProperties": [],
+      "properties": [
+        "uiElementNames"
+      ]
+    },
+    "removedState": {
+      "navigationProperties": [],
+      "properties": [
+        "reason"
+      ]
+    },
+    "removeProtectionAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "removeWatermarkAction": {
+      "navigationProperties": [],
+      "properties": [
+        "uiElementNames"
+      ]
+    },
+    "renameAction": {
+      "navigationProperties": [],
+      "properties": [
+        "newName",
+        "oldName"
+      ]
+    },
+    "report": {
+      "navigationProperties": [],
+      "properties": [
+        "content"
+      ]
+    },
+    "reportSuspiciousActivitySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "includeTarget",
+        "state",
+        "voiceReportingCode"
+      ]
+    },
+    "reputationCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "name",
+        "vendor"
+      ]
+    },
+    "requestActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "actionDateTime",
+        "detail",
+        "scheduledDateTime",
+        "userDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "requestorManager": {
+      "navigationProperties": [],
+      "properties": [
+        "managerLevel"
+      ]
+    },
+    "requestorSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "acceptRequests",
+        "allowedRequestors",
+        "scopeType"
+      ]
+    },
+    "requestRemoteHelpSessionAccessResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "pubSubEncryption",
+        "pubSubEncryptionKey",
+        "sessionKey"
+      ]
+    },
+    "requestSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "expiration",
+        "recurrence",
+        "startDateTime"
+      ]
+    },
+    "requestSignatureVerification": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedWeakAlgorithms",
+        "isSignedRequestRequired"
+      ]
+    },
+    "requiredResourceAccess": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceAccess",
+        "resourceAppId"
+      ]
+    },
+    "reservablePlaceMode": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "resetPasscodeActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "errorCode",
+        "passcode"
+      ]
+    },
+    "resourceAccess": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "type"
+      ]
+    },
+    "resourceAccessDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "accessType",
+        "identifier",
+        "isCrossPromptInjectionDetected",
+        "labelId",
+        "name",
+        "status",
+        "storageId",
+        "url"
+      ]
+    },
+    "resourceAction": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedResourceActions",
+        "notAllowedResourceActions"
+      ]
+    },
+    "resourceData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "resourceInputObject": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceId",
+        "resourceType"
+      ]
+    },
+    "resourceLink": {
+      "navigationProperties": [],
+      "properties": [
+        "linkType",
+        "name",
+        "value"
+      ]
+    },
+    "resourcePermission": {
+      "navigationProperties": [],
+      "properties": [
+        "type",
+        "value"
+      ]
+    },
+    "resourceReference": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "type",
+        "webUrl"
+      ]
+    },
+    "resourceSpecificPermission": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "id",
+        "isEnabled",
+        "value"
+      ]
+    },
+    "resourceVisualization": {
+      "navigationProperties": [],
+      "properties": [
+        "containerDisplayName",
+        "containerType",
+        "containerWebUrl",
+        "mediaType",
+        "previewImageUrl",
+        "previewText",
+        "title",
+        "type"
+      ]
+    },
+    "responseStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "response",
+        "time"
+      ]
+    },
+    "responsiblePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "name"
+      ]
+    },
+    "responsibleSensitiveType": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "id",
+        "name",
+        "publisherName",
+        "rulePackageId",
+        "rulePackageType"
+      ]
+    },
+    "restoreAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "restoreArtifactDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "failedCount",
+        "restoredCount",
+        "totalArtifactsCount"
+      ]
+    },
+    "restorePointSearchResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "noResultProtectionUnitIds",
+        "searchResponseId",
+        "searchResults"
+      ]
+    },
+    "restorePointSearchResult": {
+      "navigationProperties": [
+        "restorePoint"
+      ],
+      "properties": [
+        "artifactHitCount"
+      ]
+    },
+    "restoreSessionArtifactCount": {
+      "navigationProperties": [],
+      "properties": [
+        "completed",
+        "failed",
+        "inProgress",
+        "total"
+      ]
+    },
+    "restrictAccessAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "restrictAccessActionBase": {
+      "navigationProperties": [],
+      "properties": [
+        "restrictionAction"
+      ]
+    },
+    "resultInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message",
+        "subcode"
+      ]
+    },
+    "resultTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "body",
+        "displayName"
+      ]
+    },
+    "resultTemplateDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "resultTemplateOption": {
+      "navigationProperties": [],
+      "properties": [
+        "enableResultTemplate"
+      ]
+    },
+    "retentionLabelSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "behaviorDuringRetentionPeriod",
+        "isContentUpdateAllowed",
+        "isDeleteAllowed",
+        "isLabelUpdateAllowed",
+        "isMetadataUpdateAllowed",
+        "isRecordLocked"
+      ]
+    },
+    "retentionSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "interval",
+        "period"
+      ]
+    },
+    "retireScheduledManagedDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceState",
+        "deviceCompliancePolicyId",
+        "deviceCompliancePolicyName",
+        "deviceType",
+        "id",
+        "managedDeviceId",
+        "managedDeviceName",
+        "managementAgent",
+        "ownerType",
+        "retireAfterDateTime",
+        "roleScopeTagIds"
+      ]
+    },
+    "retrievalExtract": {
+      "navigationProperties": [],
+      "properties": [
+        "relevanceScore",
+        "text"
+      ]
+    },
+    "retrievalHit": {
+      "navigationProperties": [],
+      "properties": [
+        "extracts",
+        "resourceMetadata",
+        "resourceType",
+        "sensitivityLabel",
+        "webUrl"
+      ]
+    },
+    "retrievalResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "retrievalHits"
+      ]
+    },
+    "retrieveRemoteHelpSessionResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "acsGroupId",
+        "acsHelperUserId",
+        "acsHelperUserToken",
+        "acsSharerUserId",
+        "deviceName",
+        "pubSubGroupId",
+        "pubSubHelperAccessUri",
+        "sessionExpirationDateTime",
+        "sessionKey",
+        "webClientUri"
+      ]
+    },
+    "revokeAppleVppLicensesActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "failedLicensesCount",
+        "totalLicensesCount"
+      ]
+    },
+    "rgbColor": {
+      "navigationProperties": [],
+      "properties": [
+        "b",
+        "g",
+        "r"
+      ]
+    },
+    "riskProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "humanCount",
+        "nonHumanCount"
+      ]
+    },
+    "riskServicePrincipalActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "detail",
+        "riskEventTypes"
+      ]
+    },
+    "riskUserActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "detail",
+        "eventTypes",
+        "riskEventTypes"
+      ]
+    },
+    "roleMembershipGovernanceCriteria": {
+      "navigationProperties": [],
+      "properties": [
+        "roleId",
+        "roleTemplateId"
+      ]
+    },
+    "rolePermission": {
+      "navigationProperties": [],
+      "properties": [
+        "actions",
+        "resourceActions"
+      ]
+    },
+    "roleScopeTagInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "roleScopeTagId"
+      ]
+    },
+    "roleSuccessStatistics": {
+      "navigationProperties": [],
+      "properties": [
+        "permanentFail",
+        "permanentSuccess",
+        "removeFail",
+        "removeSuccess",
+        "roleId",
+        "roleName",
+        "temporaryFail",
+        "temporarySuccess",
+        "unknownFail"
+      ]
+    },
+    "root": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "rotateBitLockerKeysDeviceActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "errorCode"
+      ]
+    },
+    "rubricCriterion": {
+      "navigationProperties": [],
+      "properties": [
+        "description"
+      ]
+    },
+    "rubricLevel": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "grading",
+        "levelId"
+      ]
+    },
+    "rubricQuality": {
+      "navigationProperties": [],
+      "properties": [
+        "criteria",
+        "description",
+        "displayName",
+        "qualityId",
+        "weight"
+      ]
+    },
+    "rubricQualityFeedbackModel": {
+      "navigationProperties": [],
+      "properties": [
+        "feedback",
+        "qualityId"
+      ]
+    },
+    "rubricQualitySelectedColumnModel": {
+      "navigationProperties": [],
+      "properties": [
+        "columnId",
+        "qualityId"
+      ]
+    },
+    "samlIdentitySource": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "samlNameIdClaim": {
+      "navigationProperties": [],
+      "properties": [
+        "nameIdFormat",
+        "serviceProviderNameQualifier"
+      ]
+    },
+    "samlSingleSignOnSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "relayState"
+      ]
+    },
+    "samsungEFotaFirmwareVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "androidProcessorVersionName",
+        "consumerSoftwareCustomizationCode",
+        "description",
+        "deviceModelName",
+        "firmwareVersion",
+        "id",
+        "osVersionName",
+        "releaseDateTime",
+        "requestFirmwareTypeName",
+        "salesCode",
+        "securityPatchVersion"
+      ]
+    },
+    "samsungEFotaFirmwareVersionTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "firmwareVersion",
+        "id"
+      ]
+    },
+    "scheduleEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "startDateTime",
+        "theme"
+      ]
+    },
+    "scheduleInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "availabilityView",
+        "error",
+        "scheduleId",
+        "scheduleItems",
+        "workingHours"
+      ]
+    },
+    "scheduleItem": {
+      "navigationProperties": [],
+      "properties": [
+        "end",
+        "isPrivate",
+        "location",
+        "start",
+        "status",
+        "subject"
+      ]
+    },
+    "schedulingGroupInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "displayName",
+        "schedulingGroupId"
+      ]
+    },
+    "scopeBase": {
+      "navigationProperties": [],
+      "properties": [
+        "identity"
+      ]
+    },
+    "scopeSensitivityLabels": {
+      "navigationProperties": [],
+      "properties": [
+        "labelKind"
+      ]
+    },
+    "searchAggregation": {
+      "navigationProperties": [],
+      "properties": [
+        "buckets",
+        "field"
+      ]
+    },
+    "searchAlteration": {
+      "navigationProperties": [],
+      "properties": [
+        "alteredHighlightedQueryString",
+        "alteredQueryString",
+        "alteredQueryTokens"
+      ]
+    },
+    "searchAlterationOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "enableModification",
+        "enableSuggestion"
+      ]
+    },
+    "searchBucket": {
+      "navigationProperties": [],
+      "properties": [
+        "aggregationFilterToken",
+        "count",
+        "key"
+      ]
+    },
+    "searchHit": {
+      "navigationProperties": [
+        "_source",
+        "resource"
+      ],
+      "properties": [
+        "_id",
+        "_score",
+        "_summary",
+        "contentSource",
+        "hitId",
+        "isCollapsed",
+        "rank",
+        "resultTemplateId",
+        "summary"
+      ]
+    },
+    "searchHitsContainer": {
+      "navigationProperties": [],
+      "properties": [
+        "aggregations",
+        "hits",
+        "moreResultsAvailable",
+        "total"
+      ]
+    },
+    "searchQuery": {
+      "navigationProperties": [],
+      "properties": [
+        "query_string",
+        "queryString",
+        "queryTemplate"
+      ]
+    },
+    "searchQueryString": {
+      "navigationProperties": [],
+      "properties": [
+        "query"
+      ]
+    },
+    "searchRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "aggregationFilters",
+        "aggregations",
+        "collapseProperties",
+        "contentSources",
+        "enableTopResults",
+        "entityTypes",
+        "fields",
+        "from",
+        "query",
+        "queryAlterationOptions",
+        "region",
+        "resultTemplateOptions",
+        "sharePointOneDriveOptions",
+        "size",
+        "sortProperties",
+        "stored_fields",
+        "trimDuplicates"
+      ]
+    },
+    "searchResourceMetadataDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "searchResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "hitsContainers",
+        "queryAlterationResponse",
+        "resultTemplates",
+        "searchTerms"
+      ]
+    },
+    "searchResult": {
+      "navigationProperties": [],
+      "properties": [
+        "onClickTelemetryUrl"
+      ]
+    },
+    "searchSensitivityLabelInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "color",
+        "displayName",
+        "priority",
+        "sensitivityLabelId",
+        "tooltip"
+      ]
+    },
+    "sectionDisplayIcon": {
+      "navigationProperties": [],
+      "properties": [
+        "contentUrl",
+        "displayName",
+        "iconType",
+        "skinTone"
+      ]
+    },
+    "sectionLinks": {
+      "navigationProperties": [],
+      "properties": [
+        "oneNoteClientUrl",
+        "oneNoteWebUrl"
+      ]
+    },
+    "secureScoreControlStateUpdate": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedTo",
+        "comment",
+        "state",
+        "updatedBy",
+        "updatedDateTime"
+      ]
+    },
+    "secureSignInSessionControl": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityActionState": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "status",
+        "updatedDateTime",
+        "user"
+      ]
+    },
+    "securityBaselineContributingPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "sourceId",
+        "sourceType"
+      ]
+    },
+    "securityProviderStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "enabled",
+        "endpoint",
+        "provider",
+        "region",
+        "vendor"
+      ]
+    },
+    "securityRequirement": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityResource": {
+      "navigationProperties": [],
+      "properties": [
+        "resource",
+        "resourceType"
+      ]
+    },
+    "securityScheme": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "type"
+      ]
+    },
+    "securitySchemes": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityVendorInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "provider",
+        "providerVersion",
+        "subProvider",
+        "vendor"
+      ]
+    },
+    "segmentConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "selfServiceSignUpAuthenticationFlowConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "selfSignedCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "customKeyIdentifier",
+        "displayName",
+        "endDateTime",
+        "key",
+        "keyId",
+        "startDateTime",
+        "thumbprint",
+        "type",
+        "usage"
+      ]
+    },
+    "sensitiveContentEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "length",
+        "match",
+        "offset"
+      ]
+    },
+    "sensitiveContentLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "confidence",
+        "evidences",
+        "idMatch",
+        "length",
+        "offset"
+      ]
+    },
+    "sensitivityLabelAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentMethod",
+        "sensitivityLabelId",
+        "tenantId"
+      ]
+    },
+    "sensitivityLabelInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "color",
+        "displayName",
+        "priority",
+        "sensitivityLabelId",
+        "tooltip"
+      ]
+    },
+    "serverProcessedContent": {
+      "navigationProperties": [],
+      "properties": [
+        "componentDependencies",
+        "customMetadata",
+        "htmlStrings",
+        "imageSources",
+        "links",
+        "searchablePlainTexts"
+      ]
+    },
+    "serviceActivityPerformanceMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "intervalStartDateTime",
+        "percentage"
+      ]
+    },
+    "serviceActivityValueMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "intervalStartDateTime",
+        "value"
+      ]
+    },
+    "serviceHealthIssuePost": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "postType"
+      ]
+    },
+    "serviceHostedMediaConfig": {
+      "navigationProperties": [],
+      "properties": [
+        "liveCaptionOptions",
+        "preFetchMedia"
+      ]
+    },
+    "serviceInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "webUrl"
+      ]
+    },
+    "serviceLevelAgreementAttainment": {
+      "navigationProperties": [],
+      "properties": [
+        "endDate",
+        "score",
+        "startDate"
+      ]
+    },
+    "serviceNowAuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "serviceNowOauthSecretAuthentication": {
+      "navigationProperties": [],
+      "properties": [
+        "appId"
+      ]
+    },
+    "servicePlanInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "appliesTo",
+        "provisioningStatus",
+        "servicePlanId",
+        "servicePlanName"
+      ]
+    },
+    "servicePrincipalIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "appId"
+      ]
+    },
+    "servicePrincipalLockConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allProperties",
+        "credentialsWithUsageSign",
+        "credentialsWithUsageVerify",
+        "isEnabled",
+        "tokenEncryptionKeyId"
+      ]
+    },
+    "servicePrincipalSignIn": {
+      "navigationProperties": [],
+      "properties": [
+        "servicePrincipalId"
+      ]
+    },
+    "serviceProvisioningError": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "isResolved",
+        "serviceInstance"
+      ]
+    },
+    "serviceProvisioningLinkedResourceErrorDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "propertyName",
+        "target"
+      ]
+    },
+    "serviceProvisioningResourceError": {
+      "navigationProperties": [],
+      "properties": [
+        "errors"
+      ]
+    },
+    "serviceProvisioningResourceErrorDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "details",
+        "message"
+      ]
+    },
+    "serviceProvisioningXmlError": {
+      "navigationProperties": [],
+      "properties": [
+        "errorDetail"
+      ]
+    },
+    "serviceStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "backupServiceConsumer",
+        "disableReason",
+        "gracePeriodDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "restoreAllowedTillDateTime",
+        "status"
+      ]
+    },
+    "serviceUpdateMessageViewpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "isArchived",
+        "isFavorited",
+        "isRead"
+      ]
+    },
+    "sessionLifetimePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "detail",
+        "expirationRequirement"
+      ]
+    },
+    "settings": {
+      "navigationProperties": [],
+      "properties": [
+        "hasGraphMailbox",
+        "hasLicense",
+        "hasOptedOut"
+      ]
+    },
+    "settingSource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "id",
+        "sourceType"
+      ]
+    },
+    "settingTemplateValue": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue",
+        "description",
+        "name",
+        "type"
+      ]
+    },
+    "settingValue": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "value"
+      ]
+    },
+    "shareAction": {
+      "navigationProperties": [],
+      "properties": [
+        "recipients"
+      ]
+    },
+    "shared": {
+      "navigationProperties": [],
+      "properties": [
+        "owner",
+        "scope",
+        "sharedBy",
+        "sharedDateTime"
+      ]
+    },
+    "sharedAppleDeviceUser": {
+      "navigationProperties": [],
+      "properties": [
+        "dataQuota",
+        "dataToSync",
+        "dataUsed",
+        "userPrincipalName"
+      ]
+    },
+    "sharedPCAccountManagerPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "accountDeletionPolicy",
+        "cacheAccountsAboveDiskFreePercentage",
+        "inactiveThresholdDays",
+        "removeAccountsBelowDiskFreePercentage"
+      ]
+    },
+    "sharePointApiUsageDataPoint": {
+      "navigationProperties": [],
+      "properties": [
+        "activeApps",
+        "appId",
+        "serviceArea",
+        "tenantId",
+        "usageDateTime",
+        "usageMB",
+        "usageRequests"
+      ]
+    },
+    "sharePointApiUsageReport": {
+      "navigationProperties": [],
+      "properties": [
+        "dataPoints"
+      ]
+    },
+    "sharePointGroupIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "principalId",
+        "title"
+      ]
+    },
+    "sharePointGroupMigrationTaskParameters": {
+      "navigationProperties": [],
+      "properties": [
+        "sourceGroupIdentity",
+        "targetGroupIdentity"
+      ]
+    },
+    "sharePointIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "loginName"
+      ]
+    },
+    "sharePointIdentityMappingGroupMigrationData": {
+      "navigationProperties": [],
+      "properties": [
+        "mailNickname"
+      ]
+    },
+    "sharePointIdentityMappingUserMigrationData": {
+      "navigationProperties": [],
+      "properties": [
+        "email"
+      ]
+    },
+    "sharePointIdentitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "group",
+        "sharePointGroup",
+        "siteGroup",
+        "siteUser"
+      ]
+    },
+    "sharepointIds": {
+      "navigationProperties": [],
+      "properties": [
+        "listId",
+        "listItemId",
+        "listItemUniqueId",
+        "siteId",
+        "siteUrl",
+        "tenantId",
+        "webId"
+      ]
+    },
+    "sharePointMigrationContainerInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "dataContainerUri",
+        "encryptionKey",
+        "metadataContainerUri"
+      ]
+    },
+    "sharePointMigrationTaskParameters": {
+      "navigationProperties": [],
+      "properties": [
+        "preferredLatestStartDateTime",
+        "preferredStartDateTime",
+        "sourceSiteUrl",
+        "targetDataLocationCode",
+        "targetOrganizationHost",
+        "targetOrganizationId",
+        "targetSiteUrl",
+        "validateOnly"
+      ]
+    },
+    "sharePointOneDriveOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "includeContent",
+        "includeHiddenContent"
+      ]
+    },
+    "sharePointSharingAbilities": {
+      "navigationProperties": [],
+      "properties": [
+        "anyoneLinkAbilities",
+        "directSharingAbilities",
+        "organizationLinkAbilities",
+        "specificPeopleLinkAbilities"
+      ]
+    },
+    "sharePointSiteMigrationTaskParameters": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointUserMigrationTaskParameters": {
+      "navigationProperties": [],
+      "properties": [
+        "sourceUserIdentity",
+        "targetUserIdentity"
+      ]
+    },
+    "sharingDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "sharedBy",
+        "sharedDateTime",
+        "sharingReference",
+        "sharingSubject",
+        "sharingType"
+      ]
+    },
+    "sharingInvitation": {
+      "navigationProperties": [],
+      "properties": [
+        "email",
+        "invitedBy",
+        "redeemedBy",
+        "signInRequired"
+      ]
+    },
+    "sharingLink": {
+      "navigationProperties": [],
+      "properties": [
+        "application",
+        "configuratorUrl",
+        "preventsDownload",
+        "scope",
+        "type",
+        "webHtml",
+        "webUrl"
+      ]
+    },
+    "sharingLinkExpirationStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultExpirationInDays",
+        "disabledReason",
+        "enabled"
+      ]
+    },
+    "sharingLinkVariants": {
+      "navigationProperties": [],
+      "properties": [
+        "addressBarLinkPermission",
+        "allowEmbed",
+        "passwordProtected",
+        "requiresAuthentication"
+      ]
+    },
+    "sharingOperationStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "disabledReason",
+        "enabled"
+      ]
+    },
+    "sharingViewpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultSharingLink",
+        "sharingAbilities"
+      ]
+    },
+    "shiftActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "displayName",
+        "endDateTime",
+        "isPaid",
+        "startDateTime",
+        "theme"
+      ]
+    },
+    "shiftAvailability": {
+      "navigationProperties": [],
+      "properties": [
+        "recurrence",
+        "timeSlots",
+        "timeZone"
+      ]
+    },
+    "shiftItem": {
+      "navigationProperties": [],
+      "properties": [
+        "activities",
+        "displayName",
+        "notes"
+      ]
+    },
+    "shiftsRolePermission": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedResourceActions"
+      ]
+    },
+    "shiftsTeamInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "teamId"
+      ]
+    },
+    "shiftsUserInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "userId"
+      ]
+    },
+    "signInActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "lastNonInteractiveSignInDateTime",
+        "lastNonInteractiveSignInRequestId",
+        "lastSignInDateTime",
+        "lastSignInRequestId",
+        "lastSuccessfulSignInDateTime",
+        "lastSuccessfulSignInRequestId"
+      ]
+    },
+    "signInAudienceRestrictionsBase": {
+      "navigationProperties": [],
+      "properties": [
+        "kind"
+      ]
+    },
+    "signInConditions": {
+      "navigationProperties": [],
+      "properties": [
+        "agentIdRiskLevel",
+        "authenticationFlow",
+        "clientAppType",
+        "country",
+        "deviceInfo",
+        "devicePlatform",
+        "insiderRiskLevel",
+        "ipAddress",
+        "servicePrincipalRiskLevel",
+        "signInRiskLevel",
+        "userRiskLevel"
+      ]
+    },
+    "signInContext": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "signInCounts": {
+      "navigationProperties": [],
+      "properties": [
+        "noSignIn",
+        "withSignIn"
+      ]
+    },
+    "signInFrequencySessionControl": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationType",
+        "frequencyInterval",
+        "type",
+        "value"
+      ]
+    },
+    "signingCertificateUpdateStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateUpdateResult",
+        "lastRunDateTime"
+      ]
+    },
+    "signingResult": {
+      "navigationProperties": [],
+      "properties": [
+        "signature",
+        "signingKeyId"
+      ]
+    },
+    "signInIdentity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "signInLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "city",
+        "countryOrRegion",
+        "geoCoordinates",
+        "state"
+      ]
+    },
+    "signInPreferences": {
+      "navigationProperties": [],
+      "properties": [
+        "isSystemPreferredAuthenticationMethodEnabled",
+        "userPreferredMethodForSecondaryAuthentication"
+      ]
+    },
+    "signInStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalDetails",
+        "errorCode",
+        "failureReason"
+      ]
+    },
+    "signUpIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "signUpIdentifier",
+        "signUpIdentifierType"
+      ]
+    },
+    "signUpStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalDetails",
+        "errorCode",
+        "failureReason"
+      ]
+    },
+    "simulationEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "eventName"
+      ]
+    },
+    "simulationEventsContent": {
+      "navigationProperties": [],
+      "properties": [
+        "compromisedRate",
+        "events"
+      ]
+    },
+    "simulationNotification": {
+      "navigationProperties": [],
+      "properties": [
+        "targettedUserType"
+      ]
+    },
+    "simulationReport": {
+      "navigationProperties": [],
+      "properties": [
+        "overview",
+        "simulationUsers"
+      ]
+    },
+    "simulationReportOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "recommendedActions",
+        "resolvedTargetsCount",
+        "simulationEventsContent",
+        "trainingEventsContent"
+      ]
+    },
+    "singleResourceAzurePermissionsDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "actionInfo",
+        "resourceId"
+      ]
+    },
+    "singleResourceGcpPermissionsDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "actionInfo",
+        "resourceId"
+      ]
+    },
+    "singleSignOnExtension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "singleUser": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "id"
+      ]
+    },
+    "siteArchivalDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "archivedBy",
+        "archivedDateTime",
+        "archiveStatus"
+      ]
+    },
+    "siteCollection": {
+      "navigationProperties": [],
+      "properties": [
+        "archivalDetails",
+        "dataLocationCode",
+        "hostname",
+        "root"
+      ]
+    },
+    "siteSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "languageTag",
+        "timeZone"
+      ]
+    },
+    "sizeRange": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumSize",
+        "minimumSize"
+      ]
+    },
+    "socialIdentitySource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "socialIdentitySourceType"
+      ]
+    },
+    "sortProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "isDescending",
+        "name"
+      ]
+    },
+    "sourcedAttribute": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "isExtensionAttribute",
+        "source"
+      ]
+    },
+    "sourceProvisionedIdentity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "spaApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "redirectUris"
+      ]
+    },
+    "speakerInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "rawId"
+      ]
+    },
+    "specialFolder": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "specifiedCaptiveNetworkPlugins": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedBundleIdentifiers"
+      ]
+    },
+    "staffAvailabilityItem": {
+      "navigationProperties": [],
+      "properties": [
+        "availabilityItems",
+        "staffId"
+      ]
+    },
+    "standardTimeZoneOffset": {
+      "navigationProperties": [],
+      "properties": [
+        "dayOccurrence",
+        "dayOfWeek",
+        "month",
+        "time",
+        "year"
+      ]
+    },
+    "startsWithTransformation": {
+      "navigationProperties": [],
+      "properties": [
+        "output",
+        "value"
+      ]
+    },
+    "statusBase": {
+      "navigationProperties": [],
+      "properties": [
+        "status"
+      ]
+    },
+    "statusDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalDetails",
+        "errorCategory",
+        "errorCode",
+        "reason",
+        "recommendedAction"
+      ]
+    },
+    "storagePath": {
+      "navigationProperties": [],
+      "properties": [
+        "containerName",
+        "path",
+        "storageAccountName"
+      ]
+    },
+    "storagePlanInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "upgradeAvailable"
+      ]
+    },
+    "stringDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "stringKeyAttributeMappingSourceValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "stringKeyLongValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "stringKeyObjectValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "key"
+      ]
+    },
+    "stringKeyStringValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "strongAuthenticationRequirements": {
+      "navigationProperties": [],
+      "properties": [
+        "perUserMfaState"
+      ]
+    },
+    "structuredDataEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "keyEntry",
+        "valueEntry"
+      ]
+    },
+    "structuredDataEntryTypedValue": {
+      "navigationProperties": [],
+      "properties": [
+        "type",
+        "values"
+      ]
+    },
+    "subjectRightsRequestAllMailboxLocation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "subjectRightsRequestAllSiteLocation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "subjectRightsRequestDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "excludedItemCount",
+        "insightCounts",
+        "itemCount",
+        "itemNeedReview",
+        "productItemCounts",
+        "signedOffItemCount",
+        "totalItemSize"
+      ]
+    },
+    "subjectRightsRequestEnumeratedMailboxLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "upns",
+        "userPrincipalNames"
+      ]
+    },
+    "subjectRightsRequestEnumeratedSiteLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "urls"
+      ]
+    },
+    "subjectRightsRequestHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "changedBy",
+        "eventDateTime",
+        "stage",
+        "stageStatus",
+        "type"
+      ]
+    },
+    "subjectRightsRequestMailboxLocation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "subjectRightsRequestSiteLocation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "subjectRightsRequestStageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "stage",
+        "status"
+      ]
+    },
+    "subjectSet": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "subscriptionActivities": {
+      "navigationProperties": [],
+      "properties": [
+        "transcript"
+      ]
+    },
+    "substringTransformation": {
+      "navigationProperties": [],
+      "properties": [
+        "index",
+        "length"
+      ]
+    },
+    "suggestedEnrollmentLimit": {
+      "navigationProperties": [],
+      "properties": [
+        "suggestedDailyLimit"
+      ]
+    },
+    "supportedClaimConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "nameIdPolicyFormat"
+      ]
+    },
+    "synchronizationError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message",
+        "tenantActionable"
+      ]
+    },
+    "synchronizationJobApplicationParameters": {
+      "navigationProperties": [],
+      "properties": [
+        "ruleId",
+        "subjects"
+      ]
+    },
+    "synchronizationJobRestartCriteria": {
+      "navigationProperties": [],
+      "properties": [
+        "resetScope"
+      ]
+    },
+    "synchronizationJobSubject": {
+      "navigationProperties": [],
+      "properties": [
+        "links",
+        "objectId",
+        "objectTypeName"
+      ]
+    },
+    "synchronizationLinkedObjects": {
+      "navigationProperties": [],
+      "properties": [
+        "manager",
+        "members",
+        "owners"
+      ]
+    },
+    "synchronizationMetadataEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "synchronizationProgress": {
+      "navigationProperties": [],
+      "properties": [
+        "completedUnits",
+        "progressObservationDateTime",
+        "totalUnits",
+        "units"
+      ]
+    },
+    "synchronizationQuarantine": {
+      "navigationProperties": [],
+      "properties": [
+        "currentBegan",
+        "error",
+        "nextAttempt",
+        "reason",
+        "seriesBegan",
+        "seriesCount"
+      ]
+    },
+    "synchronizationRule": {
+      "navigationProperties": [],
+      "properties": [
+        "containerFilter",
+        "editable",
+        "groupFilter",
+        "id",
+        "metadata",
+        "name",
+        "objectMappings",
+        "priority",
+        "sourceDirectoryName",
+        "targetDirectoryName"
+      ]
+    },
+    "synchronizationSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "expiration",
+        "interval",
+        "state"
+      ]
+    },
+    "synchronizationSecretKeyStringValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "synchronizationStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "countSuccessiveCompleteFailures",
+        "escrowsPruned",
+        "lastExecution",
+        "lastSuccessfulExecution",
+        "lastSuccessfulExecutionWithExports",
+        "progress",
+        "quarantine",
+        "steadyStateFirstAchievedTime",
+        "steadyStateLastAchievedTime",
+        "synchronizedEntryCountByType",
+        "troubleshootingUrl"
+      ]
+    },
+    "synchronizationTaskExecution": {
+      "navigationProperties": [],
+      "properties": [
+        "activityIdentifier",
+        "countEntitled",
+        "countEntitledForProvisioning",
+        "countEscrowed",
+        "countEscrowedRaw",
+        "countExported",
+        "countExports",
+        "countImported",
+        "countImportedDeltas",
+        "countImportedReferenceDeltas",
+        "error",
+        "state",
+        "timeBegan",
+        "timeEnded"
+      ]
+    },
+    "systemCredentialPreferences": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeTargets",
+        "includeTargets",
+        "state"
+      ]
+    },
+    "systemFacet": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "tabUpdatedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "tabId"
+      ]
+    },
+    "targetAgentIdentitySponsorsOrOwners": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "targetOwners": {
+      "navigationProperties": [],
+      "properties": [
+        "notifyMembers",
+        "securityGroups"
+      ]
+    },
+    "targetPolicyEndpoints": {
+      "navigationProperties": [],
+      "properties": [
+        "platformTypes"
+      ]
+    },
+    "targetProvisionedIdentity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "targetResource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "groupType",
+        "id",
+        "modifiedProperties",
+        "type",
+        "userPrincipalName"
+      ]
+    },
+    "targetUserSponsors": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamArchivedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamId"
+      ]
+    },
+    "teamClassSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "notifyGuardiansAboutAssignments"
+      ]
+    },
+    "teamCreatedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamDescription",
+        "teamDisplayName",
+        "teamId"
+      ]
+    },
+    "teamDescriptionUpdatedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamDescription",
+        "teamId"
+      ]
+    },
+    "teamDiscoverySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "showInTeamsSearchAndSuggestions"
+      ]
+    },
+    "teamFunSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowCustomMemes",
+        "allowGiphy",
+        "allowStickersAndMemes",
+        "giphyContentRating"
+      ]
+    },
+    "teamGuestSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowCreateUpdateChannels",
+        "allowDeleteChannels"
+      ]
+    },
+    "teamJoiningDisabledEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamId"
+      ]
+    },
+    "teamJoiningEnabledEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamId"
+      ]
+    },
+    "teamMemberSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowAddRemoveApps",
+        "allowCreatePrivateChannels",
+        "allowCreateUpdateChannels",
+        "allowCreateUpdateRemoveConnectors",
+        "allowCreateUpdateRemoveTabs",
+        "allowDeleteChannels"
+      ]
+    },
+    "teamMembersNotificationRecipient": {
+      "navigationProperties": [],
+      "properties": [
+        "teamId"
+      ]
+    },
+    "teamMessagingSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowChannelMentions",
+        "allowOwnerDeleteMessages",
+        "allowTeamMentions",
+        "allowUserDeleteMessages",
+        "allowUserEditMessages"
+      ]
+    },
+    "teamRenamedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamDisplayName",
+        "teamId"
+      ]
+    },
+    "teamsAppAuthorization": {
+      "navigationProperties": [],
+      "properties": [
+        "clientAppId",
+        "requiredPermissionSet"
+      ]
+    },
+    "teamsAppDashboardCardBotConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "botId"
+      ]
+    },
+    "teamsAppDashboardCardContentSource": {
+      "navigationProperties": [],
+      "properties": [
+        "botConfiguration",
+        "sourceType"
+      ]
+    },
+    "teamsAppDashboardCardIcon": {
+      "navigationProperties": [],
+      "properties": [
+        "iconUrl",
+        "officeUIFabricIconName"
+      ]
+    },
+    "teamsAppInstallationScopeInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "scope"
+      ]
+    },
+    "teamsAppInstalledEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamsAppDisplayName",
+        "teamsAppId"
+      ]
+    },
+    "teamsAppPermissionSet": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceSpecificPermissions"
+      ]
+    },
+    "teamsAppRemovedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamsAppDisplayName",
+        "teamsAppId"
+      ]
+    },
+    "teamsAppResourceSpecificPermission": {
+      "navigationProperties": [],
+      "properties": [
+        "permissionType",
+        "permissionValue"
+      ]
+    },
+    "teamsAppUpgradedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamsAppDisplayName",
+        "teamsAppId"
+      ]
+    },
+    "teamsLicensingDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "hasTeamsLicense"
+      ]
+    },
+    "teamsTabConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "contentUrl",
+        "entityId",
+        "removeUrl",
+        "websiteUrl"
+      ]
+    },
+    "teamSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "guestsCount",
+        "membersCount",
+        "ownersCount"
+      ]
+    },
+    "teamTeamsAppInstallationScopeInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "teamId"
+      ]
+    },
+    "teamUnarchivedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamId"
+      ]
+    },
+    "teamworkAccountConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "onPremisesCalendarSyncConfiguration",
+        "supportedClient"
+      ]
+    },
+    "teamworkActivePeripherals": {
+      "navigationProperties": [
+        "communicationSpeaker",
+        "contentCamera",
+        "microphone",
+        "roomCamera",
+        "speaker"
+      ],
+      "properties": []
+    },
+    "teamworkActivityTopic": {
+      "navigationProperties": [],
+      "properties": [
+        "source",
+        "value",
+        "webUrl"
+      ]
+    },
+    "teamworkApplicationIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationIdentityType"
+      ]
+    },
+    "teamworkCameraConfiguration": {
+      "navigationProperties": [
+        "cameras",
+        "defaultContentCamera"
+      ],
+      "properties": [
+        "contentCameraConfiguration"
+      ]
+    },
+    "teamworkConfiguredPeripheral": {
+      "navigationProperties": [
+        "peripheral"
+      ],
+      "properties": [
+        "isOptional"
+      ]
+    },
+    "teamworkConnection": {
+      "navigationProperties": [],
+      "properties": [
+        "connectionStatus",
+        "lastModifiedDateTime"
+      ]
+    },
+    "teamworkContentCameraConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isContentCameraInverted",
+        "isContentCameraOptional",
+        "isContentEnhancementEnabled"
+      ]
+    },
+    "teamworkConversationIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "conversationIdentityType"
+      ]
+    },
+    "teamworkDateTimeConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "dateFormat",
+        "officeHoursEndTime",
+        "officeHoursStartTime",
+        "timeFormat",
+        "timeZone"
+      ]
+    },
+    "teamworkDeviceSoftwareVersions": {
+      "navigationProperties": [],
+      "properties": [
+        "adminAgentSoftwareVersion",
+        "firmwareSoftwareVersion",
+        "operatingSystemSoftwareVersion",
+        "partnerAgentSoftwareVersion",
+        "teamsClientSoftwareVersion"
+      ]
+    },
+    "teamworkDisplayConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "configuredDisplays",
+        "displayCount",
+        "inBuiltDisplayScreenConfiguration",
+        "isContentDuplicationAllowed",
+        "isDualDisplayModeEnabled"
+      ]
+    },
+    "teamworkDisplayScreenConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "backlightBrightness",
+        "backlightTimeout",
+        "isHighContrastEnabled",
+        "isScreensaverEnabled",
+        "screensaverTimeout"
+      ]
+    },
+    "teamworkFeaturesConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "emailToSendLogsAndFeedback",
+        "isAutoScreenShareEnabled",
+        "isBluetoothBeaconingEnabled",
+        "isHideMeetingNamesEnabled",
+        "isSendLogsAndFeedbackEnabled"
+      ]
+    },
+    "teamworkHardwareConfiguration": {
+      "navigationProperties": [
+        "compute",
+        "hdmiIngest"
+      ],
+      "properties": [
+        "processorModel"
+      ]
+    },
+    "teamworkHardwareDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "macAddresses",
+        "manufacturer",
+        "model",
+        "serialNumber",
+        "uniqueId"
+      ]
+    },
+    "teamworkHardwareHealth": {
+      "navigationProperties": [],
+      "properties": [
+        "computeHealth",
+        "hdmiIngestHealth"
+      ]
+    },
+    "teamworkLoginStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "exchangeConnection",
+        "skypeConnection",
+        "teamsConnection"
+      ]
+    },
+    "teamworkMicrophoneConfiguration": {
+      "navigationProperties": [
+        "defaultMicrophone",
+        "microphones"
+      ],
+      "properties": [
+        "isMicrophoneOptional"
+      ]
+    },
+    "teamworkNetworkConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultGateway",
+        "domainName",
+        "hostName",
+        "ipAddress",
+        "isDhcpEnabled",
+        "isPCPortEnabled",
+        "primaryDns",
+        "secondaryDns",
+        "subnetMask"
+      ]
+    },
+    "teamworkNotificationRecipient": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamworkOnlineMeetingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "calendarEventId",
+        "joinWebUrl",
+        "organizer"
+      ]
+    },
+    "teamworkOnPremisesCalendarSyncConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "domain",
+        "domainUserName",
+        "smtpAddress"
+      ]
+    },
+    "teamworkPeripheralHealth": {
+      "navigationProperties": [
+        "peripheral"
+      ],
+      "properties": [
+        "connection",
+        "isOptional"
+      ]
+    },
+    "teamworkPeripheralsHealth": {
+      "navigationProperties": [],
+      "properties": [
+        "communicationSpeakerHealth",
+        "contentCameraHealth",
+        "displayHealthCollection",
+        "microphoneHealth",
+        "roomCameraHealth",
+        "speakerHealth"
+      ]
+    },
+    "teamworkSoftwareUpdateHealth": {
+      "navigationProperties": [],
+      "properties": [
+        "adminAgentSoftwareUpdateStatus",
+        "companyPortalSoftwareUpdateStatus",
+        "firmwareSoftwareUpdateStatus",
+        "operatingSystemSoftwareUpdateStatus",
+        "partnerAgentSoftwareUpdateStatus",
+        "teamsClientSoftwareUpdateStatus"
+      ]
+    },
+    "teamworkSoftwareUpdateStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "availableVersion",
+        "currentVersion",
+        "softwareFreshness"
+      ]
+    },
+    "teamworkSpeakerConfiguration": {
+      "navigationProperties": [
+        "defaultCommunicationSpeaker",
+        "defaultSpeaker",
+        "speakers"
+      ],
+      "properties": [
+        "isCommunicationSpeakerOptional",
+        "isSpeakerOptional"
+      ]
+    },
+    "teamworkSystemConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "dateTimeConfiguration",
+        "defaultPassword",
+        "deviceLockTimeout",
+        "isDeviceLockEnabled",
+        "isLoggingEnabled",
+        "isPowerSavingEnabled",
+        "isScreenCaptureEnabled",
+        "isSilentModeEnabled",
+        "language",
+        "lockPin",
+        "loggingLevel",
+        "networkConfiguration"
+      ]
+    },
+    "teamworkTagIdentity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamworkTeamsClientConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accountConfiguration",
+        "featuresConfiguration"
+      ]
+    },
+    "teamworkUserIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "userIdentityType",
+        "userPrincipalName"
+      ]
+    },
+    "teleconferenceDeviceAudioQuality": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teleconferenceDeviceMediaQuality": {
+      "navigationProperties": [],
+      "properties": [
+        "averageInboundJitter",
+        "averageInboundPacketLossRateInPercentage",
+        "averageInboundRoundTripDelay",
+        "averageOutboundJitter",
+        "averageOutboundPacketLossRateInPercentage",
+        "averageOutboundRoundTripDelay",
+        "channelIndex",
+        "inboundPackets",
+        "localIPAddress",
+        "localPort",
+        "maximumInboundJitter",
+        "maximumInboundPacketLossRateInPercentage",
+        "maximumInboundRoundTripDelay",
+        "maximumOutboundJitter",
+        "maximumOutboundPacketLossRateInPercentage",
+        "maximumOutboundRoundTripDelay",
+        "mediaDuration",
+        "networkLinkSpeedInBytes",
+        "outboundPackets",
+        "remoteIPAddress",
+        "remotePort"
+      ]
+    },
+    "teleconferenceDeviceQuality": {
+      "navigationProperties": [],
+      "properties": [
+        "callChainId",
+        "cloudServiceDeploymentEnvironment",
+        "cloudServiceDeploymentId",
+        "cloudServiceInstanceName",
+        "cloudServiceName",
+        "deviceDescription",
+        "deviceName",
+        "mediaLegId",
+        "mediaQualityList",
+        "participantId"
+      ]
+    },
+    "teleconferenceDeviceScreenSharingQuality": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teleconferenceDeviceVideoQuality": {
+      "navigationProperties": [],
+      "properties": [
+        "averageInboundBitRate",
+        "averageInboundFrameRate",
+        "averageOutboundBitRate",
+        "averageOutboundFrameRate"
+      ]
+    },
+    "tenantAttachRBACState": {
+      "navigationProperties": [],
+      "properties": [
+        "enabled"
+      ]
+    },
+    "tenantInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultDomainName",
+        "displayName",
+        "federationBrandName",
+        "tenantId"
+      ]
+    },
+    "tenantScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "tenantSecureScore": {
+      "navigationProperties": [],
+      "properties": [
+        "createDateTime",
+        "tenantMaxScore",
+        "tenantScore"
+      ]
+    },
+    "termColumn": {
+      "navigationProperties": [
+        "parentTerm",
+        "termSet"
+      ],
+      "properties": [
+        "allowMultipleValues",
+        "showFullyQualifiedName"
+      ]
+    },
+    "termsExpiration": {
+      "navigationProperties": [],
+      "properties": [
+        "frequency",
+        "startDateTime"
+      ]
+    },
+    "textColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "allowMultipleLines",
+        "appendChangesToExistingText",
+        "linesForEditing",
+        "maxLength",
+        "textType"
+      ]
+    },
+    "textContent": {
+      "navigationProperties": [],
+      "properties": [
+        "data"
+      ]
+    },
+    "textExtractionResultBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "threatAssessmentRequestsCount": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "createdDateTime",
+        "pivotValue"
+      ]
+    },
+    "thumbnail": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "height",
+        "sourceItemId",
+        "url",
+        "width"
+      ]
+    },
+    "thumbnailColumn": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ticketInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "ticketApproverIdentityId",
+        "ticketNumber",
+        "ticketSubmitterIdentityId",
+        "ticketSystem"
+      ]
+    },
+    "timeCardBreak": {
+      "navigationProperties": [],
+      "properties": [
+        "breakId",
+        "end",
+        "notes",
+        "start"
+      ]
+    },
+    "timeCardEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "breaks",
+        "clockInEvent",
+        "clockOutEvent"
+      ]
+    },
+    "timeCardEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "atApprovedLocation",
+        "dateTime",
+        "isAtApprovedLocation",
+        "notes"
+      ]
+    },
+    "timeClockSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "approvedLocation"
+      ]
+    },
+    "timeConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "activityDomain",
+        "recurrence",
+        "timeSlots"
+      ]
+    },
+    "timeOffDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "isAllDay",
+        "subject"
+      ]
+    },
+    "timeOffItem": {
+      "navigationProperties": [],
+      "properties": [
+        "timeOffReasonId"
+      ]
+    },
+    "timePeriod": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "startDateTime"
+      ]
+    },
+    "timeRange": {
+      "navigationProperties": [],
+      "properties": [
+        "endTime",
+        "startTime"
+      ]
+    },
+    "timeSeriesParameter": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "metricName",
+        "startDateTime"
+      ]
+    },
+    "timeSlot": {
+      "navigationProperties": [],
+      "properties": [
+        "end",
+        "start"
+      ]
+    },
+    "timeSlotAvailability": {
+      "navigationProperties": [],
+      "properties": [
+        "availability"
+      ]
+    },
+    "timeZoneBase": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "timeZoneInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "alias",
+        "displayName"
+      ]
+    },
+    "titleArea": {
+      "navigationProperties": [],
+      "properties": [
+        "alternativeText",
+        "enableGradientEffect",
+        "imageWebUrl",
+        "layout",
+        "serverProcessedContent",
+        "showAuthor",
+        "showPublishedDate",
+        "showTextBlockAboveTitle",
+        "textAboveTitle",
+        "textAlignment"
+      ]
+    },
+    "todoSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isExternalJoinEnabled",
+        "isExternalShareEnabled",
+        "isPushNotificationEnabled"
+      ]
+    },
+    "tokenDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "issuedAtDateTime",
+        "uniqueTokenIdentifier"
+      ]
+    },
+    "tokenMeetingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "token"
+      ]
+    },
+    "tokenProtectionStatusDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "signInSessionStatus",
+        "signInSessionStatusCode"
+      ]
+    },
+    "toLowercaseTransformation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "toneInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "sequenceId",
+        "tone"
+      ]
+    },
+    "toUppercaseTransformation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "trainingCampaignReport": {
+      "navigationProperties": [],
+      "properties": [
+        "campaignUsers",
+        "overview"
+      ]
+    },
+    "trainingCampaignReportOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "trainingModuleCompletion",
+        "trainingNotificationDeliveryStatus",
+        "userCompletionStatus"
+      ]
+    },
+    "trainingEventsContent": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedTrainingsInfos",
+        "trainingsAssignedUserCount"
+      ]
+    },
+    "trainingNotificationDelivery": {
+      "navigationProperties": [],
+      "properties": [
+        "failedMessageDeliveryCount",
+        "resolvedTargetsCount",
+        "successfulMessageDeliveryCount"
+      ]
+    },
+    "trainingNotificationSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "trainingAssignment",
+        "trainingReminder"
+      ]
+    },
+    "trainingReminderNotification": {
+      "navigationProperties": [],
+      "properties": [
+        "deliveryFrequency"
+      ]
+    },
+    "trainingSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "settingType"
+      ]
+    },
+    "transcriptActivity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "transcriptionState": {
+      "navigationProperties": [],
+      "properties": [
+        "sequenceNumber",
+        "state"
+      ]
+    },
+    "transcriptPayload": {
+      "navigationProperties": [],
+      "properties": [
+        "audioCaptureDateTime",
+        "speaker",
+        "spokenLanguage",
+        "text"
+      ]
+    },
+    "transcriptSpeaker": {
+      "navigationProperties": [],
+      "properties": [
+        "room",
+        "user"
+      ]
+    },
+    "transformationAttribute": {
+      "navigationProperties": [],
+      "properties": [
+        "attribute",
+        "treatAsMultiValue"
+      ]
+    },
+    "translationLanguageOverride": {
+      "navigationProperties": [],
+      "properties": [
+        "languageTag",
+        "translationBehavior"
+      ]
+    },
+    "translationPreferences": {
+      "navigationProperties": [],
+      "properties": [
+        "languageOverrides",
+        "translationBehavior",
+        "untranslatedLanguages"
+      ]
+    },
+    "trimTransformation": {
+      "navigationProperties": [],
+      "properties": [
+        "type",
+        "value"
+      ]
+    },
+    "trustChainCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "certificate",
+        "displayName"
+      ]
+    },
+    "trustContainerConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "trustedSubjectNameAndIssuerConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "trustedCertificateSubjectAddition"
+      ]
+    },
+    "trustedSubjectNameAndIssuerRestriction": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeActors",
+        "isStateSetByMicrosoft",
+        "restrictForAppsCreatedAfterDateTime",
+        "state"
+      ]
+    },
+    "trustFrameworkKey": {
+      "navigationProperties": [],
+      "properties": [
+        "d",
+        "dp",
+        "dq",
+        "e",
+        "exp",
+        "k",
+        "kid",
+        "kty",
+        "n",
+        "nbf",
+        "p",
+        "q",
+        "qi",
+        "status",
+        "use",
+        "x5c",
+        "x5t"
+      ]
+    },
+    "typedEmailAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "otherLabel",
+        "type"
+      ]
+    },
+    "unavailablePlaceMode": {
+      "navigationProperties": [],
+      "properties": [
+        "reason"
+      ]
+    },
+    "unifiedRole": {
+      "navigationProperties": [],
+      "properties": [
+        "roleDefinitionId"
+      ]
+    },
+    "unifiedRoleManagementPolicyRuleTarget": {
+      "navigationProperties": [
+        "targetObjects"
+      ],
+      "properties": [
+        "caller",
+        "enforcedSettings",
+        "inheritableSettings",
+        "level",
+        "operations"
+      ]
+    },
+    "unifiedRolePermission": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedResourceActions",
+        "condition",
+        "excludedResourceActions"
+      ]
+    },
+    "unknownSource": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unmanagedDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceName",
+        "domain",
+        "ipAddress",
+        "lastLoggedOnUser",
+        "lastSeenDateTime",
+        "location",
+        "macAddress",
+        "manufacturer",
+        "model",
+        "os",
+        "osVersion"
+      ]
+    },
+    "unmatched": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "corroborativeEvidences",
+        "idMatch",
+        "length",
+        "offset"
+      ]
+    },
+    "unrestrictedAudience": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unsupportedDeviceConfigurationDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "message",
+        "propertyName"
+      ]
+    },
+    "updateAllowedCombinationsResult": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformation",
+        "conditionalAccessReferences",
+        "currentCombinations",
+        "previousCombinations"
+      ]
+    },
+    "updateWindow": {
+      "navigationProperties": [],
+      "properties": [
+        "updateWindowEndTime",
+        "updateWindowStartTime"
+      ]
+    },
+    "updateWindowsDeviceAccountActionParameter": {
+      "navigationProperties": [],
+      "properties": [
+        "calendarSyncEnabled",
+        "deviceAccount",
+        "deviceAccountEmail",
+        "exchangeServer",
+        "passwordRotationEnabled",
+        "sessionInitiationProtocalAddress"
+      ]
+    },
+    "uploadSession": {
+      "navigationProperties": [],
+      "properties": [
+        "expirationDateTime",
+        "nextExpectedRanges",
+        "uploadUrl"
+      ]
+    },
+    "uriClickSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "clickAction",
+        "clickDateTime",
+        "id",
+        "sourceId",
+        "uriDomain",
+        "verdict"
+      ]
+    },
+    "usageDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "lastAccessedDateTime",
+        "lastModifiedDateTime"
+      ]
+    },
+    "usageRightsInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "allowCopy",
+        "allowEdit",
+        "allowExport",
+        "allowPrint",
+        "allowView"
+      ]
+    },
+    "userAccount": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastSeenDateTime",
+        "riskScore",
+        "service",
+        "signinName",
+        "status"
+      ]
+    },
+    "userActionContext": {
+      "navigationProperties": [],
+      "properties": [
+        "userAction"
+      ]
+    },
+    "userAttributeValuesItem": {
+      "navigationProperties": [],
+      "properties": [
+        "isDefault",
+        "name",
+        "value"
+      ]
+    },
+    "userExperienceAnalyticsAnomalyCorrelationGroupFeature": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceFeatureType",
+        "values"
+      ]
+    },
+    "userExperienceAnalyticsAnomalySeverityOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "highSeverityAnomalyCount",
+        "informationalSeverityAnomalyCount",
+        "lowSeverityAnomalyCount",
+        "mediumSeverityAnomalyCount"
+      ]
+    },
+    "userExperienceAnalyticsAutopilotDevicesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "devicesNotAutopilotRegistered",
+        "devicesWithoutAutopilotProfileAssigned",
+        "totalWindows10DevicesWithoutTenantAttached"
+      ]
+    },
+    "userExperienceAnalyticsCloudIdentityDevicesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceWithoutCloudIdentityCount"
+      ]
+    },
+    "userExperienceAnalyticsCloudManagementDevicesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "coManagedDeviceCount",
+        "intuneDeviceCount",
+        "tenantAttachDeviceCount"
+      ]
+    },
+    "userExperienceAnalyticsDeviceBatteryDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "batteryId",
+        "fullBatteryDrainCount",
+        "maxCapacityPercentage"
+      ]
+    },
+    "userExperienceAnalyticsDeviceScopeSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDeviceScopeIds",
+        "insufficientDataDeviceScopeIds",
+        "totalDeviceScopes",
+        "totalDeviceScopesEnabled"
+      ]
+    },
+    "userExperienceAnalyticsInsight": {
+      "navigationProperties": [],
+      "properties": [
+        "insightId",
+        "severity",
+        "userExperienceAnalyticsMetricId",
+        "values"
+      ]
+    },
+    "userExperienceAnalyticsInsightValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "userExperienceAnalyticsSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationManagerDataConnectorConfigured"
+      ]
+    },
+    "userExperienceAnalyticsWindows10DevicesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "unsupportedOSversionDeviceCount"
+      ]
+    },
+    "userExperienceAnalyticsWorkFromAnywhereDevicesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "autopilotDevicesSummary",
+        "cloudIdentityDevicesSummary",
+        "cloudManagementDevicesSummary",
+        "coManagedDevices",
+        "devicesNotAutopilotRegistered",
+        "devicesWithoutAutopilotProfileAssigned",
+        "devicesWithoutCloudIdentity",
+        "intuneDevices",
+        "tenantAttachDevices",
+        "totalDevices",
+        "unsupportedOSversionDevices",
+        "windows10Devices",
+        "windows10DevicesSummary",
+        "windows10DevicesWithoutTenantAttach"
+      ]
+    },
+    "userFlowApiConnectorConfiguration": {
+      "navigationProperties": [
+        "postAttributeCollection",
+        "postFederationSignup",
+        "preTokenIssuance"
+      ],
+      "properties": []
+    },
+    "userGovernanceCriteria": {
+      "navigationProperties": [],
+      "properties": [
+        "userId"
+      ]
+    },
+    "userIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "ipAddress",
+        "userPrincipalName"
+      ]
+    },
+    "userLastSignInRecommendationInsightSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "recommendationLookBackDuration",
+        "signInScope"
+      ]
+    },
+    "userPrint": {
+      "navigationProperties": [
+        "recentPrinterShares"
+      ],
+      "properties": []
+    },
+    "userRegistrationCount": {
+      "navigationProperties": [],
+      "properties": [
+        "registrationCount",
+        "registrationStatus"
+      ]
+    },
+    "userRegistrationFeatureCount": {
+      "navigationProperties": [],
+      "properties": [
+        "feature",
+        "userCount"
+      ]
+    },
+    "userRegistrationFeatureSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "totalUserCount",
+        "userRegistrationFeatureCounts",
+        "userRoles",
+        "userTypes"
+      ]
+    },
+    "userRegistrationMethodCount": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationMethod",
+        "userCount"
+      ]
+    },
+    "userRegistrationMethodSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "totalUserCount",
+        "userRegistrationMethodCounts",
+        "userRoles",
+        "userTypes"
+      ]
+    },
+    "userScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "userSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "aadUserId",
+        "accountName",
+        "domainName",
+        "emailRole",
+        "isVpn",
+        "logonDateTime",
+        "logonId",
+        "logonIp",
+        "logonLocation",
+        "logonType",
+        "onPremisesSecurityIdentifier",
+        "riskScore",
+        "userAccountType",
+        "userPrincipalName"
+      ]
+    },
+    "userSet": {
+      "navigationProperties": [],
+      "properties": [
+        "isBackup"
+      ]
+    },
+    "userSignIn": {
+      "navigationProperties": [],
+      "properties": [
+        "externalTenantId",
+        "externalUserType",
+        "userId"
+      ]
+    },
+    "userSimulationDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedTrainingsCount",
+        "completedTrainingsCount",
+        "compromisedDateTime",
+        "inProgressTrainingsCount",
+        "isCompromised",
+        "latestSimulationActivity",
+        "reportedPhishDateTime",
+        "simulationEvents",
+        "simulationUser",
+        "trainingEvents"
+      ]
+    },
+    "userSimulationEventInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "browser",
+        "clickSource",
+        "eventDateTime",
+        "eventName",
+        "ipAddress",
+        "osPlatformDeviceDetails"
+      ]
+    },
+    "userTrainingCompletionSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "completedUsersCount",
+        "inProgressUsersCount",
+        "notCompletedUsersCount",
+        "notStartedUsersCount",
+        "previouslyAssignedUsersCount"
+      ]
+    },
+    "userTrainingContentEventInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "browser",
+        "contentDateTime",
+        "ipAddress",
+        "osPlatformDeviceDetails",
+        "potentialScoreImpact"
+      ]
+    },
+    "userTrainingEventInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "latestTrainingStatus",
+        "trainingAssignedProperties",
+        "trainingCompletedProperties",
+        "trainingUpdatedProperties"
+      ]
+    },
+    "userTrainingStatusInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedDateTime",
+        "completionDateTime",
+        "displayName",
+        "trainingStatus"
+      ]
+    },
+    "userWorkLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "placeId",
+        "source",
+        "workLocationType"
+      ]
+    },
+    "validatingDomains": {
+      "navigationProperties": [],
+      "properties": [
+        "rootDomains"
+      ]
+    },
+    "validationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "message",
+        "ruleName",
+        "validationPassed"
+      ]
+    },
+    "valueBasedAttribute": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "verifiableCredentialRequired": {
+      "navigationProperties": [],
+      "properties": [
+        "expiryDateTime",
+        "url"
+      ]
+    },
+    "verifiableCredentialRequirementStatus": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "verifiableCredentialRetrieved": {
+      "navigationProperties": [],
+      "properties": [
+        "expiryDateTime"
+      ]
+    },
+    "verifiableCredentialSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "credentialTypes"
+      ]
+    },
+    "verifiableCredentialType": {
+      "navigationProperties": [],
+      "properties": [
+        "credentialType",
+        "issuers"
+      ]
+    },
+    "verifiableCredentialVerified": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "verificationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "signatureValid"
+      ]
+    },
+    "verifiedCredentialClaims": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "verifiedCredentialData": {
+      "navigationProperties": [],
+      "properties": [
+        "authority",
+        "claims",
+        "type"
+      ]
+    },
+    "verifiedCustomDomainCertificatesMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "expiryDate",
+        "issueDate",
+        "issuerName",
+        "subjectName",
+        "thumbprint"
+      ]
+    },
+    "verifiedDomain": {
+      "navigationProperties": [],
+      "properties": [
+        "capabilities",
+        "isDefault",
+        "isInitial",
+        "name",
+        "type"
+      ]
+    },
+    "verifiedIdProfileConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "acceptedIssuer",
+        "claimBindings",
+        "claimBindingSource",
+        "type"
+      ]
+    },
+    "verifiedIdUsageConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabledForTestOnly",
+        "purpose"
+      ]
+    },
+    "verifiedPublisher": {
+      "navigationProperties": [],
+      "properties": [
+        "addedDateTime",
+        "displayName",
+        "verifiedPublisherId"
+      ]
+    },
+    "versionAction": {
+      "navigationProperties": [],
+      "properties": [
+        "newVersion"
+      ]
+    },
+    "video": {
+      "navigationProperties": [],
+      "properties": [
+        "audioBitsPerSample",
+        "audioChannels",
+        "audioFormat",
+        "audioSamplesPerSecond",
+        "bitrate",
+        "duration",
+        "fourCC",
+        "frameRate",
+        "height",
+        "width"
+      ]
+    },
+    "virtualEventExternalInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationId",
+        "externalEventId"
+      ]
+    },
+    "virtualEventExternalRegistrationInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "referrer",
+        "registrationId"
+      ]
+    },
+    "virtualEventPresenterDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "bio",
+        "company",
+        "jobTitle",
+        "linkedInProfileWebUrl",
+        "personalSiteWebUrl",
+        "photo",
+        "twitterProfileWebUrl"
+      ]
+    },
+    "virtualEventPresenterInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "presenterDetails"
+      ]
+    },
+    "virtualEventRegistrationQuestionAnswer": {
+      "navigationProperties": [],
+      "properties": [
+        "booleanValue",
+        "displayName",
+        "multiChoiceValues",
+        "questionId",
+        "value"
+      ]
+    },
+    "virtualEventSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isAttendeeEmailNotificationEnabled"
+      ]
+    },
+    "visualInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "attribution",
+        "backgroundColor",
+        "content",
+        "description",
+        "displayText"
+      ]
+    },
+    "visualProperties": {
+      "navigationProperties": [],
+      "properties": [
+        "body",
+        "title"
+      ]
+    },
+    "vpnDnsRule": {
+      "navigationProperties": [],
+      "properties": [
+        "autoTrigger",
+        "name",
+        "persistent",
+        "proxyServerUri",
+        "servers"
+      ]
+    },
+    "vpnOnDemandRule": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "dnsSearchDomains",
+        "dnsServerAddressMatch",
+        "domainAction",
+        "domains",
+        "interfaceTypeMatch",
+        "probeRequiredUrl",
+        "probeUrl",
+        "ssids"
+      ]
+    },
+    "vpnProxyServer": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "automaticConfigurationScriptUrl",
+        "port"
+      ]
+    },
+    "vpnRoute": {
+      "navigationProperties": [],
+      "properties": [
+        "destinationPrefix",
+        "prefixSize"
+      ]
+    },
+    "vpnServer": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "description",
+        "isDefaultServer"
+      ]
+    },
+    "vpnTrafficRule": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "appType",
+        "claims",
+        "localAddressRanges",
+        "localPortRanges",
+        "name",
+        "protocols",
+        "remoteAddressRanges",
+        "remotePortRanges",
+        "routingPolicyType",
+        "vpnTrafficDirection"
+      ]
+    },
+    "vppLicensingType": {
+      "navigationProperties": [],
+      "properties": [
+        "supportDeviceLicensing",
+        "supportsDeviceLicensing",
+        "supportsUserLicensing",
+        "supportUserLicensing"
+      ]
+    },
+    "vppTokenActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "actionName",
+        "actionState",
+        "lastUpdatedDateTime",
+        "startDateTime"
+      ]
+    },
+    "vppTokenLicenseSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "appleId",
+        "availableLicenseCount",
+        "organizationName",
+        "usedLicenseCount",
+        "vppTokenId"
+      ]
+    },
+    "vppTokenRevokeLicensesActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "actionFailureReason",
+        "failedLicensesCount",
+        "totalLicensesCount"
+      ]
+    },
+    "vulnerabilityState": {
+      "navigationProperties": [],
+      "properties": [
+        "cve",
+        "severity",
+        "wasRunning"
+      ]
+    },
+    "wafAllowedHeadersDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "watermarkProtectionValues": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabledForContentSharing",
+        "isEnabledForVideo"
+      ]
+    },
+    "webApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "homePageUrl",
+        "implicitGrantSettings",
+        "logoutUrl",
+        "oauth2AllowImplicitFlow",
+        "redirectUris",
+        "redirectUriSettings"
+      ]
+    },
+    "webApplicationFirewallDnsConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isDomainVerified",
+        "isProxied",
+        "name",
+        "recordType",
+        "value"
+      ]
+    },
+    "webApplicationFirewallVerificationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "errors",
+        "status",
+        "verifiedOnDateTime",
+        "warnings"
+      ]
+    },
+    "webApplicationFirewallVerifiedDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "dnsConfiguration"
+      ]
+    },
+    "webauthnAuthenticationExtensionsClientInputs": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "webauthnAuthenticationExtensionsClientOutputs": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "webauthnAuthenticatorAttestationResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "attestationObject",
+        "clientDataJSON"
+      ]
+    },
+    "webauthnAuthenticatorSelectionCriteria": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticatorAttachment",
+        "requireResidentKey",
+        "userVerification"
+      ]
+    },
+    "webauthnCredentialCreationOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "challengeTimeoutDateTime",
+        "publicKey"
+      ]
+    },
+    "webauthnPublicKeyCredential": {
+      "navigationProperties": [],
+      "properties": [
+        "clientExtensionResults",
+        "id",
+        "response"
+      ]
+    },
+    "webauthnPublicKeyCredentialCreationOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "attestation",
+        "authenticatorSelection",
+        "challenge",
+        "excludeCredentials",
+        "extensions",
+        "pubKeyCredParams",
+        "rp",
+        "timeout",
+        "user"
+      ]
+    },
+    "webauthnPublicKeyCredentialDescriptor": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "transports",
+        "type"
+      ]
+    },
+    "webauthnPublicKeyCredentialParameters": {
+      "navigationProperties": [],
+      "properties": [
+        "alg",
+        "type"
+      ]
+    },
+    "webauthnPublicKeyCredentialRpEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "name"
+      ]
+    },
+    "webauthnPublicKeyCredentialUserEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "id",
+        "name"
+      ]
+    },
+    "webPartData": {
+      "navigationProperties": [],
+      "properties": [
+        "audiences",
+        "dataVersion",
+        "description",
+        "properties",
+        "serverProcessedContent",
+        "title"
+      ]
+    },
+    "webPartPosition": {
+      "navigationProperties": [],
+      "properties": [
+        "columnId",
+        "horizontalSectionId",
+        "isInVerticalSection",
+        "webPartIndex"
+      ]
+    },
+    "webSegmentConfiguration": {
+      "navigationProperties": [
+        "applicationSegments"
+      ],
+      "properties": []
+    },
+    "website": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "displayName",
+        "type"
+      ]
+    },
+    "win32CatalogAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "win32LobAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "autoUpdateSettings",
+        "deliveryOptimizationPriority",
+        "installTimeSettings",
+        "notifications",
+        "restartSettings"
+      ]
+    },
+    "win32LobAppAutoUpdateSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "autoUpdateSupersededAppsState"
+      ]
+    },
+    "win32LobAppDetection": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "win32LobAppFileSystemDetection": {
+      "navigationProperties": [],
+      "properties": [
+        "check32BitOn64System",
+        "detectionType",
+        "detectionValue",
+        "fileOrFolderName",
+        "operator",
+        "path"
+      ]
+    },
+    "win32LobAppFileSystemRequirement": {
+      "navigationProperties": [],
+      "properties": [
+        "check32BitOn64System",
+        "detectionType",
+        "fileOrFolderName",
+        "path"
+      ]
+    },
+    "win32LobAppFileSystemRule": {
+      "navigationProperties": [],
+      "properties": [
+        "check32BitOn64System",
+        "comparisonValue",
+        "fileOrFolderName",
+        "operationType",
+        "operator",
+        "path"
+      ]
+    },
+    "win32LobAppInstallExperience": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceRestartBehavior",
+        "maxRunTimeInMinutes",
+        "runAsAccount"
+      ]
+    },
+    "win32LobAppMsiInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "packageType",
+        "productCode",
+        "productName",
+        "productVersion",
+        "publisher",
+        "requiresReboot",
+        "upgradeCode"
+      ]
+    },
+    "win32LobAppPowerShellScriptDetection": {
+      "navigationProperties": [],
+      "properties": [
+        "enforceSignatureCheck",
+        "runAs32Bit",
+        "scriptContent"
+      ]
+    },
+    "win32LobAppPowerShellScriptRequirement": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionType",
+        "displayName",
+        "enforceSignatureCheck",
+        "runAs32Bit",
+        "runAsAccount",
+        "scriptContent"
+      ]
+    },
+    "win32LobAppPowerShellScriptRule": {
+      "navigationProperties": [],
+      "properties": [
+        "comparisonValue",
+        "displayName",
+        "enforceSignatureCheck",
+        "operationType",
+        "operator",
+        "runAs32Bit",
+        "runAsAccount",
+        "scriptContent"
+      ]
+    },
+    "win32LobAppProductCodeDetection": {
+      "navigationProperties": [],
+      "properties": [
+        "productCode",
+        "productVersion",
+        "productVersionOperator"
+      ]
+    },
+    "win32LobAppProductCodeRule": {
+      "navigationProperties": [],
+      "properties": [
+        "productCode",
+        "productVersion",
+        "productVersionOperator"
+      ]
+    },
+    "win32LobAppRegistryDetection": {
+      "navigationProperties": [],
+      "properties": [
+        "check32BitOn64System",
+        "detectionType",
+        "detectionValue",
+        "keyPath",
+        "operator",
+        "valueName"
+      ]
+    },
+    "win32LobAppRegistryRequirement": {
+      "navigationProperties": [],
+      "properties": [
+        "check32BitOn64System",
+        "detectionType",
+        "keyPath",
+        "valueName"
+      ]
+    },
+    "win32LobAppRegistryRule": {
+      "navigationProperties": [],
+      "properties": [
+        "check32BitOn64System",
+        "comparisonValue",
+        "keyPath",
+        "operationType",
+        "operator",
+        "valueName"
+      ]
+    },
+    "win32LobAppRequirement": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionValue",
+        "operator"
+      ]
+    },
+    "win32LobAppRestartSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "countdownDisplayBeforeRestartInMinutes",
+        "gracePeriodInMinutes",
+        "restartNotificationSnoozeDurationInMinutes"
+      ]
+    },
+    "win32LobAppReturnCode": {
+      "navigationProperties": [],
+      "properties": [
+        "returnCode",
+        "type"
+      ]
+    },
+    "win32LobAppRule": {
+      "navigationProperties": [],
+      "properties": [
+        "ruleType"
+      ]
+    },
+    "windows10AppsForceUpdateSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "recurrence",
+        "runImmediatelyIfAfterStartDateTime",
+        "startDateTime"
+      ]
+    },
+    "windows10AssociatedApps": {
+      "navigationProperties": [],
+      "properties": [
+        "appType",
+        "identifier"
+      ]
+    },
+    "windows10NetworkProxyServer": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "exceptions",
+        "useForLocalAddresses"
+      ]
+    },
+    "windows10VpnProxyServer": {
+      "navigationProperties": [],
+      "properties": [
+        "bypassProxyServerForLocalAddress"
+      ]
+    },
+    "windows10XCustomSubjectAlternativeName": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "sanType"
+      ]
+    },
+    "windows81VpnProxyServer": {
+      "navigationProperties": [],
+      "properties": [
+        "automaticallyDetectProxySettings",
+        "bypassProxyServerForLocalAddress"
+      ]
+    },
+    "windowsAppIdentifier": {
+      "navigationProperties": [],
+      "properties": [
+        "windowsAppId"
+      ]
+    },
+    "windowsApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "packageSid",
+        "redirectUris"
+      ]
+    },
+    "windowsAppXAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "useDeviceContext"
+      ]
+    },
+    "windowsAutoUpdateCatalogAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "deliveryOptimizationPriority",
+        "installTimeSettings",
+        "notificationType",
+        "restartSettings"
+      ]
+    },
+    "windowsAutoUpdateCatalogAppInstallExperience": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceRestartBehavior",
+        "runAsAccount"
+      ]
+    },
+    "windowsAutoUpdateCatalogAppInstallTimeSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "deadlineDateTime",
+        "startDateTime",
+        "useLocalTime"
+      ]
+    },
+    "windowsAutoUpdateCatalogAppRestartSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "countdownDisplayBeforeRestartInMinutes",
+        "gracePeriodInMinutes",
+        "restartNotificationSnoozeDurationInMinutes"
+      ]
+    },
+    "windowsDefenderScanActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "scanType"
+      ]
+    },
+    "windowsDeviceAccount": {
+      "navigationProperties": [],
+      "properties": [
+        "password"
+      ]
+    },
+    "windowsDeviceADAccount": {
+      "navigationProperties": [],
+      "properties": [
+        "domainName",
+        "userName"
+      ]
+    },
+    "windowsDeviceAzureADAccount": {
+      "navigationProperties": [],
+      "properties": [
+        "userPrincipalName"
+      ]
+    },
+    "windowsDriverUpdateProfileInventorySyncStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "driverInventorySyncState",
+        "lastSuccessfulSyncDateTime"
+      ]
+    },
+    "windowsEnrollmentStatusScreenSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowDeviceUseBeforeProfileAndAppInstallComplete",
+        "allowDeviceUseOnInstallFailure",
+        "allowLogCollectionOnInstallFailure",
+        "blockDeviceSetupRetryByUser",
+        "customErrorMessage",
+        "hideInstallationProgress",
+        "installProgressTimeoutInMinutes"
+      ]
+    },
+    "windowsFirewallNetworkProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "authorizedApplicationRulesFromGroupPolicyMerged",
+        "authorizedApplicationRulesFromGroupPolicyNotMerged",
+        "connectionSecurityRulesFromGroupPolicyMerged",
+        "connectionSecurityRulesFromGroupPolicyNotMerged",
+        "firewallEnabled",
+        "globalPortRulesFromGroupPolicyMerged",
+        "globalPortRulesFromGroupPolicyNotMerged",
+        "inboundConnectionsBlocked",
+        "inboundConnectionsRequired",
+        "inboundNotificationsBlocked",
+        "inboundNotificationsRequired",
+        "incomingTrafficBlocked",
+        "incomingTrafficRequired",
+        "outboundConnectionsBlocked",
+        "outboundConnectionsRequired",
+        "policyRulesFromGroupPolicyMerged",
+        "policyRulesFromGroupPolicyNotMerged",
+        "securedPacketExemptionAllowed",
+        "securedPacketExemptionBlocked",
+        "stealthModeBlocked",
+        "stealthModeRequired",
+        "unicastResponsesToMulticastBroadcastsBlocked",
+        "unicastResponsesToMulticastBroadcastsRequired"
+      ]
+    },
+    "windowsFirewallRule": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "description",
+        "displayName",
+        "edgeTraversal",
+        "filePath",
+        "interfaceTypes",
+        "localAddressRanges",
+        "localPortRanges",
+        "localUserAuthorizations",
+        "packageFamilyName",
+        "profileTypes",
+        "protocol",
+        "remoteAddressRanges",
+        "remotePortRanges",
+        "serviceName",
+        "trafficDirection"
+      ]
+    },
+    "windowsInformationProtectionApp": {
+      "navigationProperties": [],
+      "properties": [
+        "denied",
+        "description",
+        "displayName",
+        "productName",
+        "publisherName"
+      ]
+    },
+    "windowsInformationProtectionDataRecoveryCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "certificate",
+        "description",
+        "expirationDateTime",
+        "subjectName"
+      ]
+    },
+    "windowsInformationProtectionDesktopApp": {
+      "navigationProperties": [],
+      "properties": [
+        "binaryName",
+        "binaryVersionHigh",
+        "binaryVersionLow"
+      ]
+    },
+    "windowsInformationProtectionIPRangeCollection": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "ranges"
+      ]
+    },
+    "windowsInformationProtectionProxiedDomainCollection": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "proxiedDomains"
+      ]
+    },
+    "windowsInformationProtectionResourceCollection": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "resources"
+      ]
+    },
+    "windowsInformationProtectionStoreApp": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "windowsKioskActiveDirectoryGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "groupName"
+      ]
+    },
+    "windowsKioskAppBase": {
+      "navigationProperties": [],
+      "properties": [
+        "appType",
+        "autoLaunch",
+        "name",
+        "startLayoutTileSize"
+      ]
+    },
+    "windowsKioskAppConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "windowsKioskAutologon": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "windowsKioskAzureADGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "groupId"
+      ]
+    },
+    "windowsKioskAzureADUser": {
+      "navigationProperties": [],
+      "properties": [
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "windowsKioskDesktopApp": {
+      "navigationProperties": [],
+      "properties": [
+        "desktopApplicationId",
+        "desktopApplicationLinkPath",
+        "path"
+      ]
+    },
+    "windowsKioskForceUpdateSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "dayofMonth",
+        "dayofWeek",
+        "recurrence",
+        "runImmediatelyIfAfterStartDateTime",
+        "startDateTime"
+      ]
+    },
+    "windowsKioskLocalGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "groupName"
+      ]
+    },
+    "windowsKioskLocalUser": {
+      "navigationProperties": [],
+      "properties": [
+        "userName"
+      ]
+    },
+    "windowsKioskMultipleApps": {
+      "navigationProperties": [],
+      "properties": [
+        "allowAccessToDownloadsFolder",
+        "apps",
+        "disallowDesktopApps",
+        "showTaskBar",
+        "startMenuLayoutXml"
+      ]
+    },
+    "windowsKioskProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "appConfiguration",
+        "profileId",
+        "profileName",
+        "userAccountsConfiguration"
+      ]
+    },
+    "windowsKioskSingleUWPApp": {
+      "navigationProperties": [],
+      "properties": [
+        "uwpApp"
+      ]
+    },
+    "windowsKioskSingleWin32App": {
+      "navigationProperties": [],
+      "properties": [
+        "win32App"
+      ]
+    },
+    "windowsKioskUser": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "windowsKioskUWPApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "appUserModelId",
+        "containedAppId"
+      ]
+    },
+    "windowsKioskVisitor": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "windowsKioskWin32App": {
+      "navigationProperties": [],
+      "properties": [
+        "classicAppPath",
+        "edgeKiosk",
+        "edgeKioskIdleTimeoutMinutes",
+        "edgeKioskType",
+        "edgeNoFirstRun"
+      ]
+    },
+    "windowsMalwareCategoryCount": {
+      "navigationProperties": [],
+      "properties": [
+        "activeMalwareDetectionCount",
+        "category",
+        "deviceCount",
+        "distinctActiveMalwareCount",
+        "lastUpdateDateTime"
+      ]
+    },
+    "windowsMalwareExecutionStateCount": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "executionState",
+        "lastUpdateDateTime"
+      ]
+    },
+    "windowsMalwareNameCount": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "lastUpdateDateTime",
+        "malwareIdentifier",
+        "name"
+      ]
+    },
+    "windowsMalwareOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "malwareCategorySummary",
+        "malwareDetectedDeviceCount",
+        "malwareExecutionStateSummary",
+        "malwareNameSummary",
+        "malwareSeveritySummary",
+        "malwareStateSummary",
+        "osVersionsSummary",
+        "totalDistinctMalwareCount",
+        "totalMalwareCount"
+      ]
+    },
+    "windowsMalwareSeverityCount": {
+      "navigationProperties": [],
+      "properties": [
+        "distinctMalwareCount",
+        "lastUpdateDateTime",
+        "malwareDetectionCount",
+        "severity"
+      ]
+    },
+    "windowsMalwareStateCount": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "distinctMalwareCount",
+        "lastUpdateDateTime",
+        "malwareDetectionCount",
+        "state"
+      ]
+    },
+    "windowsMinimumOperatingSystem": {
+      "navigationProperties": [],
+      "properties": [
+        "v10_0",
+        "v10_1607",
+        "v10_1703",
+        "v10_1709",
+        "v10_1803",
+        "v10_1809",
+        "v10_1903",
+        "v10_1909",
+        "v10_2004",
+        "v10_21H1",
+        "v10_2H20",
+        "v8_0",
+        "v8_1"
+      ]
+    },
+    "windowsNetworkIsolationPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "enterpriseCloudResources",
+        "enterpriseInternalProxyServers",
+        "enterpriseIPRanges",
+        "enterpriseIPRangesAreAuthoritative",
+        "enterpriseNetworkDomainNames",
+        "enterpriseProxyServers",
+        "enterpriseProxyServersAreAuthoritative",
+        "neutralDomainResources"
+      ]
+    },
+    "windowsPackageInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableArchitecture",
+        "displayName",
+        "identityName",
+        "identityPublisher",
+        "identityResourceIdentifier",
+        "identityVersion",
+        "minimumSupportedOperatingSystem"
+      ]
+    },
+    "windowsQualityUpdateApprovalSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalMethodType",
+        "deferredDeploymentInDay",
+        "windowsQualityUpdateCadence",
+        "windowsQualityUpdateCategory"
+      ]
+    },
+    "windowsQualityUpdateCatalogItemPolicyDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalStatus",
+        "catalogItemId",
+        "policyId"
+      ]
+    },
+    "windowsQualityUpdateCatalogProductRevision": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "knowledgeBaseArticle",
+        "osBuild",
+        "productName",
+        "releaseDateTime",
+        "versionName"
+      ]
+    },
+    "windowsQualityUpdateCveDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "cveInformationUrl",
+        "cveNumber"
+      ]
+    },
+    "windowsQualityUpdateCveSeverityInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "exploitedCves",
+        "maxBaseScore",
+        "maxSeverityLevel"
+      ]
+    },
+    "windowsQualityUpdateProductBuildVersionDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "buildNumber",
+        "majorVersionNumber",
+        "minorVersionNumber",
+        "updateBuildRevision"
+      ]
+    },
+    "windowsQualityUpdateProductKnowledgeBaseArticle": {
+      "navigationProperties": [],
+      "properties": [
+        "articleId",
+        "articleUrl"
+      ]
+    },
+    "windowsUniversalAppXAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "useDeviceContext"
+      ]
+    },
+    "windowsUpdateActiveHoursInstall": {
+      "navigationProperties": [],
+      "properties": [
+        "activeHoursEnd",
+        "activeHoursStart"
+      ]
+    },
+    "windowsUpdateInstallScheduleType": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "windowsUpdateRolloutSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "offerEndDateTimeInUTC",
+        "offerIntervalInDays",
+        "offerStartDateTimeInUTC"
+      ]
+    },
+    "windowsUpdateScheduledInstall": {
+      "navigationProperties": [],
+      "properties": [
+        "scheduledInstallDay",
+        "scheduledInstallTime"
+      ]
+    },
+    "windowsZtdnsExemptionRule": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "ipAddresses"
+      ]
+    },
+    "windowsZtdnsSecureDnsServer": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "dnsOverHttpsConfiguration",
+        "dnsOverTlsConfiguration",
+        "ipAddress"
+      ]
+    },
+    "windowsZtdnsSecureDnsServerDnsOverHttpsConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "httpsPort",
+        "queryUrl"
+      ]
+    },
+    "windowsZtdnsSecureDnsServerDnsOverTlsConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateSubjectName",
+        "tlsPort"
+      ]
+    },
+    "winGetAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "installTimeSettings",
+        "notifications",
+        "restartSettings"
+      ]
+    },
+    "winGetAppInstallExperience": {
+      "navigationProperties": [],
+      "properties": [
+        "runAsAccount"
+      ]
+    },
+    "winGetAppInstallTimeSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "deadlineDateTime",
+        "useLocalTime"
+      ]
+    },
+    "winGetAppRestartSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "countdownDisplayBeforeRestartInMinutes",
+        "gracePeriodInMinutes",
+        "restartNotificationSnoozeDurationInMinutes"
+      ]
+    },
+    "workbookCommentMention": {
+      "navigationProperties": [],
+      "properties": [
+        "email",
+        "id",
+        "name"
+      ]
+    },
+    "workbookDocumentTaskSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "dueDateTime",
+        "startDateTime"
+      ]
+    },
+    "workbookEmailIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "email",
+        "id"
+      ]
+    },
+    "workbookFilterCriteria": {
+      "navigationProperties": [],
+      "properties": [
+        "color",
+        "criterion1",
+        "criterion2",
+        "dynamicCriteria",
+        "filterOn",
+        "icon",
+        "operator",
+        "values"
+      ]
+    },
+    "workbookFilterDatetime": {
+      "navigationProperties": [],
+      "properties": [
+        "date",
+        "specificity"
+      ]
+    },
+    "workbookIcon": {
+      "navigationProperties": [],
+      "properties": [
+        "index",
+        "set"
+      ]
+    },
+    "workbookOperationError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "innerError",
+        "message"
+      ]
+    },
+    "workbookRangeReference": {
+      "navigationProperties": [],
+      "properties": [
+        "address"
+      ]
+    },
+    "workbookSessionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "persistChanges"
+      ]
+    },
+    "workbookSortField": {
+      "navigationProperties": [],
+      "properties": [
+        "ascending",
+        "color",
+        "dataOption",
+        "icon",
+        "key",
+        "sortOn"
+      ]
+    },
+    "workbookWorksheetProtectionOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "allowAutoFilter",
+        "allowDeleteColumns",
+        "allowDeleteRows",
+        "allowFormatCells",
+        "allowFormatColumns",
+        "allowFormatRows",
+        "allowInsertColumns",
+        "allowInsertHyperlinks",
+        "allowInsertRows",
+        "allowPivotTables",
+        "allowSort"
+      ]
+    },
+    "workforceIntegrationEncryption": {
+      "navigationProperties": [],
+      "properties": [
+        "protocol",
+        "secret"
+      ]
+    },
+    "workingHours": {
+      "navigationProperties": [],
+      "properties": [
+        "daysOfWeek",
+        "endTime",
+        "startTime",
+        "timeZone"
+      ]
+    },
+    "workplaceSensor": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "placeId",
+        "sensorId",
+        "sensorType"
+      ]
+    },
+    "workplaceSensorDeviceTelemetry": {
+      "navigationProperties": [],
+      "properties": [
+        "boolValue",
+        "deviceId",
+        "eventValue",
+        "intValue",
+        "locationHint",
+        "sensorId",
+        "sensorType",
+        "timestamp"
+      ]
+    },
+    "workplaceSensorEventValue": {
+      "navigationProperties": [],
+      "properties": [
+        "eventType",
+        "user"
+      ]
+    },
+    "writebackConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "wslDistributionConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "distribution",
+        "maximumOSVersion",
+        "minimumOSVersion"
+      ]
+    },
+    "x509CertificateAuthenticationModeConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "rules",
+        "x509CertificateAuthenticationDefaultMode",
+        "x509CertificateDefaultRequiredAffinityLevel"
+      ]
+    },
+    "x509CertificateAuthorityScope": {
+      "navigationProperties": [],
+      "properties": [
+        "includeTargets",
+        "publicKeyInfrastructureIdentifier",
+        "subjectKeyIdentifier"
+      ]
+    },
+    "x509CertificateIssuerHintsConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "state"
+      ]
+    },
+    "x509CertificateRule": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier",
+        "issuerSubjectIdentifier",
+        "policyOidIdentifier",
+        "x509CertificateAuthenticationMode",
+        "x509CertificateRequiredAffinityLevel",
+        "x509CertificateRuleType"
+      ]
+    },
+    "x509CertificateUserBinding": {
+      "navigationProperties": [],
+      "properties": [
+        "priority",
+        "trustAffinityLevel",
+        "userProperty",
+        "x509CertificateField"
+      ]
+    },
+    "zebraFotaDeploymentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "batteryRuleMinimumBatteryLevelPercentage",
+        "batteryRuleRequireCharger",
+        "deviceModel",
+        "downloadRuleNetworkType",
+        "downloadRuleStartDateTime",
+        "firmwareTargetArtifactDescription",
+        "firmwareTargetBoardSupportPackageVersion",
+        "firmwareTargetOsVersion",
+        "firmwareTargetPatch",
+        "installRuleStartDateTime",
+        "installRuleWindowEndTime",
+        "installRuleWindowStartTime",
+        "scheduleDurationInDays",
+        "scheduleMode",
+        "timeZoneOffsetInMinutes",
+        "updateType"
+      ]
+    },
+    "zebraFotaDeploymentStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "cancelRequested",
+        "completeOrCanceledDateTime",
+        "errorCode",
+        "lastUpdatedDateTime",
+        "state",
+        "totalAwaitingInstall",
+        "totalCanceled",
+        "totalCreated",
+        "totalDevices",
+        "totalDownloading",
+        "totalFailedDownload",
+        "totalFailedInstall",
+        "totalScheduled",
+        "totalSucceededInstall",
+        "totalUnknown"
+      ]
+    }
+  },
+  "microsoft.graph.agentic": {
+    "agentSignIn": {
+      "navigationProperties": [],
+      "properties": [
+        "agentSubjectParentId",
+        "agentSubjectType",
+        "agentType",
+        "parentAppId"
+      ]
+    }
+  },
+  "microsoft.graph.callRecords": {
+    "administrativeUnitInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "id"
+      ]
+    },
+    "callLogRow": {
+      "navigationProperties": [],
+      "properties": [
+        "administrativeUnitInfos",
+        "id",
+        "otherPartyCountryCode",
+        "userDisplayName",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "clientUserAgent": {
+      "navigationProperties": [],
+      "properties": [
+        "azureADAppId",
+        "communicationServiceId",
+        "platform",
+        "productFamily"
+      ]
+    },
+    "deviceInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "captureDeviceDriver",
+        "captureDeviceName",
+        "captureNotFunctioningEventRatio",
+        "cpuInsufficentEventRatio",
+        "deviceClippingEventRatio",
+        "deviceGlitchEventRatio",
+        "howlingEventCount",
+        "initialSignalLevelRootMeanSquare",
+        "lowSpeechLevelEventRatio",
+        "lowSpeechToNoiseEventRatio",
+        "micGlitchRate",
+        "receivedNoiseLevel",
+        "receivedSignalLevel",
+        "renderDeviceDriver",
+        "renderDeviceName",
+        "renderMuteEventRatio",
+        "renderNotFunctioningEventRatio",
+        "renderZeroVolumeEventRatio",
+        "sentNoiseLevel",
+        "sentSignalLevel",
+        "speakerGlitchRate"
+      ]
+    },
+    "directRoutingLogRow": {
+      "navigationProperties": [],
+      "properties": [
+        "calleeNumber",
+        "callEndSubReason",
+        "callerNumber",
+        "callType",
+        "correlationId",
+        "duration",
+        "endDateTime",
+        "failureDateTime",
+        "finalSipCode",
+        "finalSipCodePhrase",
+        "inviteDateTime",
+        "mediaBypassEnabled",
+        "mediaPathLocation",
+        "signalingLocation",
+        "startDateTime",
+        "successfulCall",
+        "transferorCorrelationId",
+        "trunkFullyQualifiedDomainName",
+        "userCountryCode"
+      ]
+    },
+    "endpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "userAgent"
+      ]
+    },
+    "failureInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "reason",
+        "stage"
+      ]
+    },
+    "feedbackTokenSet": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "media": {
+      "navigationProperties": [],
+      "properties": [
+        "calleeDevice",
+        "calleeNetwork",
+        "callerDevice",
+        "callerNetwork",
+        "label",
+        "streams"
+      ]
+    },
+    "mediaStream": {
+      "navigationProperties": [],
+      "properties": [
+        "audioCodec",
+        "averageAudioDegradation",
+        "averageAudioNetworkJitter",
+        "averageBandwidthEstimate",
+        "averageFreezeDuration",
+        "averageJitter",
+        "averagePacketLossRate",
+        "averageRatioOfConcealedSamples",
+        "averageReceivedFrameRate",
+        "averageRoundTripTime",
+        "averageVideoFrameLossPercentage",
+        "averageVideoFrameRate",
+        "averageVideoPacketLossRate",
+        "endDateTime",
+        "isAudioForwardErrorCorrectionUsed",
+        "lowFrameRateRatio",
+        "lowVideoProcessingCapabilityRatio",
+        "maxAudioNetworkJitter",
+        "maxJitter",
+        "maxPacketLossRate",
+        "maxRatioOfConcealedSamples",
+        "maxRoundTripTime",
+        "packetUtilization",
+        "postForwardErrorCorrectionPacketLossRate",
+        "rmsFreezeDuration",
+        "startDateTime",
+        "streamDirection",
+        "streamId",
+        "videoCodec",
+        "wasMediaBypassed"
+      ]
+    },
+    "networkInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "bandwidthLowEventRatio",
+        "basicServiceSetIdentifier",
+        "connectionType",
+        "delayEventRatio",
+        "dnsSuffix",
+        "ipAddress",
+        "linkSpeed",
+        "macAddress",
+        "networkTransportProtocol",
+        "port",
+        "receivedQualityEventRatio",
+        "reflexiveIPAddress",
+        "relayIPAddress",
+        "relayPort",
+        "sentQualityEventRatio",
+        "subnet",
+        "traceRouteHops",
+        "wifiBand",
+        "wifiBatteryCharge",
+        "wifiChannel",
+        "wifiMicrosoftDriver",
+        "wifiMicrosoftDriverVersion",
+        "wifiRadioType",
+        "wifiSignalStrength",
+        "wifiVendorDriver",
+        "wifiVendorDriverVersion"
+      ]
+    },
+    "participantEndpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "associatedIdentity",
+        "cpuCoresCount",
+        "cpuName",
+        "cpuProcessorSpeedInMhz",
+        "feedback",
+        "identity",
+        "name"
+      ]
+    },
+    "pstnBlockedUsersLogRow": {
+      "navigationProperties": [],
+      "properties": [
+        "blockDateTime",
+        "blockReason",
+        "remediationId",
+        "userBlockMode",
+        "userDisplayName",
+        "userId",
+        "userPrincipalName",
+        "userTelephoneNumber"
+      ]
+    },
+    "pstnCallLogRow": {
+      "navigationProperties": [],
+      "properties": [
+        "callDurationSource",
+        "calleeNumber",
+        "callerNumber",
+        "callId",
+        "callType",
+        "charge",
+        "clientLocalIpV4Address",
+        "clientLocalIpV6Address",
+        "clientPublicIpV4Address",
+        "clientPublicIpV6Address",
+        "conferenceId",
+        "connectionCharge",
+        "currency",
+        "destinationContext",
+        "destinationName",
+        "duration",
+        "endDateTime",
+        "inventoryType",
+        "licenseCapability",
+        "operator",
+        "startDateTime",
+        "tenantCountryCode",
+        "usageCountryCode"
+      ]
+    },
+    "pstnOnlineMeetingDialoutReport": {
+      "navigationProperties": [],
+      "properties": [
+        "currency",
+        "destinationContext",
+        "totalCallCharge",
+        "totalCalls",
+        "totalCallSeconds",
+        "usageLocation",
+        "userDisplayName",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "serviceEndpoint": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "serviceUserAgent": {
+      "navigationProperties": [],
+      "properties": [
+        "role"
+      ]
+    },
+    "smsLogRow": {
+      "navigationProperties": [],
+      "properties": [
+        "callCharge",
+        "currency",
+        "destinationContext",
+        "destinationName",
+        "destinationNumber",
+        "licenseCapability",
+        "sentDateTime",
+        "smsId",
+        "smsType",
+        "smsUnits",
+        "sourceNumber",
+        "tenantCountryCode",
+        "userCountryCode"
+      ]
+    },
+    "traceRouteHop": {
+      "navigationProperties": [],
+      "properties": [
+        "hopCount",
+        "ipAddress",
+        "roundTripTime"
+      ]
+    },
+    "userAgent": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationVersion",
+        "headerValue"
+      ]
+    },
+    "userFeedback": {
+      "navigationProperties": [],
+      "properties": [
+        "rating",
+        "text",
+        "tokens"
+      ]
+    },
+    "userIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "userPrincipalName"
+      ]
+    }
+  },
+  "microsoft.graph.cloudLicensing": {
+    "groupCloudLicensing": {
+      "navigationProperties": [
+        "assignments",
+        "usageRights"
+      ],
+      "properties": []
+    },
+    "service": {
+      "navigationProperties": [],
+      "properties": [
+        "assignableTo",
+        "planId",
+        "planName"
+      ]
+    },
+    "subscription": {
+      "navigationProperties": [],
+      "properties": [
+        "nextLifecycleDate",
+        "startDate",
+        "state",
+        "subscriptionId",
+        "tags"
+      ]
+    },
+    "userCloudLicensing": {
+      "navigationProperties": [
+        "assignmentErrors",
+        "assignments",
+        "usageRights",
+        "waitingMembers"
+      ],
+      "properties": []
+    }
+  },
+  "microsoft.graph.deviceManagement": {
+    "alertImpact": {
+      "navigationProperties": [],
+      "properties": [
+        "aggregationType",
+        "alertImpactDetails",
+        "value"
+      ]
+    },
+    "notificationChannel": {
+      "navigationProperties": [],
+      "properties": [
+        "notificationChannelType",
+        "notificationReceivers"
+      ]
+    },
+    "notificationReceiver": {
+      "navigationProperties": [],
+      "properties": [
+        "contactInformation",
+        "locale"
+      ]
+    },
+    "portalNotification": {
+      "navigationProperties": [],
+      "properties": [
+        "alertImpact",
+        "alertRecordId",
+        "alertRuleId",
+        "alertRuleName",
+        "alertRuleTemplate",
+        "id",
+        "isPortalNotificationSent",
+        "severity"
+      ]
+    },
+    "ruleCondition": {
+      "navigationProperties": [],
+      "properties": [
+        "aggregation",
+        "conditionCategory",
+        "operator",
+        "relationshipType",
+        "thresholdValue"
+      ]
+    },
+    "ruleThreshold": {
+      "navigationProperties": [],
+      "properties": [
+        "aggregation",
+        "operator",
+        "target"
+      ]
+    }
+  },
+  "microsoft.graph.ediscovery": {
+    "ocrSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "maxImageSize",
+        "timeout"
+      ]
+    },
+    "redundancyDetectionSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "maxWords",
+        "minWords",
+        "similarityThreshold"
+      ]
+    },
+    "topicModelingSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "dynamicallyAdjustTopicCount",
+        "ignoreNumbers",
+        "isEnabled",
+        "topicCount"
+      ]
+    }
+  },
+  "microsoft.graph.entraRecoveryServices": {
+    "entityTypeAndIds": {
+      "navigationProperties": [],
+      "properties": [
+        "entityIds",
+        "entityType"
+      ]
+    },
+    "recoveryJobEntityNameAndIdsFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "filterValues"
+      ]
+    },
+    "recoveryJobEntityNamesFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "entityTypes"
+      ]
+    },
+    "recoveryJobFilteringCriteriaBase": {
+      "navigationProperties": [],
+      "properties": []
+    }
+  },
+  "microsoft.graph.externalConnectors": {
+    "acl": {
+      "navigationProperties": [],
+      "properties": [
+        "accessType",
+        "identitySource",
+        "type",
+        "value"
+      ]
+    },
+    "activitySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "urlToItemResolvers"
+      ]
+    },
+    "complianceSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "eDiscoveryResultTemplates"
+      ]
+    },
+    "configuration": {
+      "navigationProperties": [],
+      "properties": [
+        "authorizedAppIds"
+      ]
+    },
+    "displayTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "layout",
+        "priority",
+        "rules"
+      ]
+    },
+    "externalItemContent": {
+      "navigationProperties": [],
+      "properties": [
+        "type",
+        "value"
+      ]
+    },
+    "itemIdResolver": {
+      "navigationProperties": [],
+      "properties": [
+        "itemId",
+        "urlMatchInfo"
+      ]
+    },
+    "principal": {
+      "navigationProperties": [],
+      "properties": [
+        "email",
+        "entraDisplayName",
+        "entraId",
+        "externalId",
+        "externalName",
+        "tenantId",
+        "upn"
+      ]
+    },
+    "properties": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "property": {
+      "navigationProperties": [],
+      "properties": [
+        "aliases",
+        "description",
+        "isExactMatchRequired",
+        "isQueryable",
+        "isRefinable",
+        "isRetrievable",
+        "isSearchable",
+        "labels",
+        "name",
+        "rankingHint",
+        "type"
+      ]
+    },
+    "propertyRule": {
+      "navigationProperties": [],
+      "properties": [
+        "operation",
+        "property",
+        "values",
+        "valuesJoinedBy"
+      ]
+    },
+    "rankingHint": {
+      "navigationProperties": [],
+      "properties": [
+        "importanceScore"
+      ]
+    },
+    "searchSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "searchResultTemplates"
+      ]
+    },
+    "urlMatchInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "baseUrls",
+        "urlPattern"
+      ]
+    },
+    "urlToItemResolverBase": {
+      "navigationProperties": [],
+      "properties": [
+        "priority"
+      ]
+    }
+  },
+  "microsoft.graph.healthMonitoring": {
+    "applicationImpactSummary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceImpactSummary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "Dictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "directoryObjectImpactSummary": {
+      "navigationProperties": [
+        "resourceSampling"
+      ],
+      "properties": []
+    },
+    "documentation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "emailNotificationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "groupId",
+        "isEnabled"
+      ]
+    },
+    "enrichment": {
+      "navigationProperties": [],
+      "properties": [
+        "impacts",
+        "state",
+        "supportingData"
+      ]
+    },
+    "groupImpactSummary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "healthMonitoringDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "resourceImpactSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "impactedCount",
+        "impactedCountLimitExceeded",
+        "resourceType"
+      ]
+    },
+    "servicePrincipalImpactSummary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "signals": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "supportingData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "userImpactSummary": {
+      "navigationProperties": [],
+      "properties": []
+    }
+  },
+  "microsoft.graph.identityGovernance": {
+    "activateGroupScope": {
+      "navigationProperties": [
+        "group"
+      ],
+      "properties": []
+    },
+    "activateProcessingResultScope": {
+      "navigationProperties": [
+        "processingResults"
+      ],
+      "properties": [
+        "taskScope"
+      ]
+    },
+    "activateRunScope": {
+      "navigationProperties": [
+        "run"
+      ],
+      "properties": [
+        "taskScope",
+        "userScope"
+      ]
+    },
+    "activateUserScope": {
+      "navigationProperties": [
+        "users"
+      ],
+      "properties": []
+    },
+    "activationScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "attributeChangeTrigger": {
+      "navigationProperties": [],
+      "properties": [
+        "triggerAttributes"
+      ]
+    },
+    "cancelRunsScope": {
+      "navigationProperties": [
+        "runs"
+      ],
+      "properties": []
+    },
+    "cancelScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customTaskExtensionCallbackConfiguration": {
+      "navigationProperties": [
+        "authorizedApps"
+      ],
+      "properties": []
+    },
+    "customTaskExtensionCallbackData": {
+      "navigationProperties": [],
+      "properties": [
+        "operationStatus"
+      ]
+    },
+    "customTaskExtensionCalloutData": {
+      "navigationProperties": [
+        "subject",
+        "task",
+        "taskProcessingresult",
+        "workflow"
+      ],
+      "properties": []
+    },
+    "groupBasedSubjectSet": {
+      "navigationProperties": [
+        "groups"
+      ],
+      "properties": []
+    },
+    "membershipChangeTrigger": {
+      "navigationProperties": [],
+      "properties": [
+        "changeType"
+      ]
+    },
+    "onDemandExecutionOnly": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "parameter": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "values",
+        "valueType"
+      ]
+    },
+    "previewFailedTask": {
+      "navigationProperties": [],
+      "properties": [
+        "definitionId",
+        "failureReason",
+        "name",
+        "taskId"
+      ]
+    },
+    "ruleBasedSubjectSet": {
+      "navigationProperties": [],
+      "properties": [
+        "rule"
+      ]
+    },
+    "runSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedRuns",
+        "failedTasks",
+        "successfulRuns",
+        "totalRuns",
+        "totalTasks",
+        "totalUsers"
+      ]
+    },
+    "taskReportSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedTasks",
+        "successfulTasks",
+        "totalTasks",
+        "unprocessedTasks"
+      ]
+    },
+    "timeBasedAttributeTrigger": {
+      "navigationProperties": [],
+      "properties": [
+        "offsetInDays",
+        "timeBasedAttribute"
+      ]
+    },
+    "topTasksInsightsSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedTasks",
+        "failedUsers",
+        "successfulTasks",
+        "successfulUsers",
+        "taskDefinitionDisplayName",
+        "taskDefinitionId",
+        "totalTasks",
+        "totalUsers"
+      ]
+    },
+    "topWorkflowsInsightsSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedRuns",
+        "failedUsers",
+        "successfulRuns",
+        "successfulUsers",
+        "totalRuns",
+        "totalUsers",
+        "workflowCategory",
+        "workflowDisplayName",
+        "workflowId",
+        "workflowVersion"
+      ]
+    },
+    "triggerAndScopeBasedConditions": {
+      "navigationProperties": [],
+      "properties": [
+        "scope",
+        "trigger"
+      ]
+    },
+    "triggerAttribute": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "userInactivityTrigger": {
+      "navigationProperties": [],
+      "properties": [
+        "inactivityPeriodInDays"
+      ]
+    },
+    "usersProcessingSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedTasks",
+        "failedUsers",
+        "successfulUsers",
+        "totalTasks",
+        "totalUsers"
+      ]
+    },
+    "userSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedTasks",
+        "failedUsers",
+        "successfulUsers",
+        "totalTasks",
+        "totalUsers"
+      ]
+    },
+    "workflowExecutionConditions": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "workflowExecutionTrigger": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "workflowsInsightsByCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "failedJoinerRuns",
+        "failedLeaverRuns",
+        "failedMoverRuns",
+        "successfulJoinerRuns",
+        "successfulLeaverRuns",
+        "successfulMoverRuns",
+        "totalJoinerRuns",
+        "totalLeaverRuns",
+        "totalMoverRuns"
+      ]
+    },
+    "workflowsInsightsSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedRuns",
+        "failedTasks",
+        "failedUsers",
+        "successfulRuns",
+        "successfulTasks",
+        "successfulUsers",
+        "totalRuns",
+        "totalTasks",
+        "totalUsers"
+      ]
+    }
+  },
+  "microsoft.graph.industryData": {
+    "additionalClassGroupOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "createTeam",
+        "writeDisplayNameOnCreateOnly"
+      ]
+    },
+    "additionalUserOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "allowStudentContactAssociation",
+        "markAllStudentsAsMinors",
+        "studentAgeGroup"
+      ]
+    },
+    "adminUnitCreationOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "createBasedOnOrg",
+        "createBasedOnOrgPlusRoleGroup"
+      ]
+    },
+    "aggregatedInboundStatistics": {
+      "navigationProperties": [],
+      "properties": [
+        "errors",
+        "groups",
+        "matchedPeopleByRole",
+        "memberships",
+        "organizations",
+        "people",
+        "unmatchedPeopleByRole",
+        "warnings"
+      ]
+    },
+    "basicFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "attribute",
+        "in"
+      ]
+    },
+    "classGroupConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalAttributes",
+        "additionalOptions",
+        "enrollmentMappings"
+      ]
+    },
+    "credential": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "isValid",
+        "lastValidDateTime"
+      ]
+    },
+    "enrollmentMappings": {
+      "navigationProperties": [],
+      "properties": [
+        "memberEnrollmentMappings",
+        "ownerEnrollmentMappings"
+      ]
+    },
+    "fileFormatReferenceValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "fileUploadSession": {
+      "navigationProperties": [],
+      "properties": [
+        "containerExpirationDateTime",
+        "containerId",
+        "sessionExpirationDateTime",
+        "sessionUrl"
+      ]
+    },
+    "filter": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "identifierTypeReferenceValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "inboundActivityResults": {
+      "navigationProperties": [],
+      "properties": [
+        "errors",
+        "groups",
+        "matchedPeopleByRole",
+        "memberships",
+        "organizations",
+        "people",
+        "unmatchedPeopleByRole",
+        "warnings"
+      ]
+    },
+    "industryDataActivityStatistics": {
+      "navigationProperties": [],
+      "properties": [
+        "activityId",
+        "displayName",
+        "status"
+      ]
+    },
+    "industryDataRunEntityCountMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "active",
+        "inactive",
+        "total"
+      ]
+    },
+    "industryDataRunRoleCountMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "role"
+      ]
+    },
+    "industryDataRunStatistics": {
+      "navigationProperties": [],
+      "properties": [
+        "activityStatistics",
+        "inboundTotals",
+        "runId",
+        "status"
+      ]
+    },
+    "oAuth1ClientCredential": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "oAuth2ClientCredential": {
+      "navigationProperties": [],
+      "properties": [
+        "scope",
+        "tokenUrl"
+      ]
+    },
+    "oAuthClientCredential": {
+      "navigationProperties": [],
+      "properties": [
+        "clientId",
+        "clientSecret"
+      ]
+    },
+    "passwordSettings": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "referenceValue": {
+      "navigationProperties": [
+        "value"
+      ],
+      "properties": [
+        "code"
+      ]
+    },
+    "roleReferenceValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sectionRoleReferenceValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityGroupCreationOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "createBasedOnOrgPlusRoleGroup",
+        "createBasedOnRoleGroup"
+      ]
+    },
+    "simplePasswordSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "password"
+      ]
+    },
+    "userConfiguration": {
+      "navigationProperties": [
+        "roleGroup"
+      ],
+      "properties": [
+        "defaultPasswordSettings",
+        "licenseSkus"
+      ]
+    },
+    "userCreationOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "configurations"
+      ]
+    },
+    "userManagementOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalAttributes",
+        "additionalOptions"
+      ]
+    },
+    "userMatchingSetting": {
+      "navigationProperties": [
+        "roleGroup"
+      ],
+      "properties": [
+        "matchTarget",
+        "priorityOrder",
+        "sourceIdentifier"
+      ]
+    },
+    "userMatchTargetReferenceValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "yearReferenceValue": {
+      "navigationProperties": [],
+      "properties": []
+    }
+  },
+  "microsoft.graph.internal": {
+    "notificationStatusCount": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "reason",
+        "state"
+      ]
+    },
+    "notificationSurfaceStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "isComplete",
+        "statuses",
+        "surface",
+        "surfaceContext"
+      ]
+    }
+  },
+  "microsoft.graph.managedTenants": {
+    "addLogRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "logInformation"
+      ]
+    },
+    "alertData": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "alertDataReferenceString": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "alertLogContent": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "alertRuleDefinitionTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultSeverity"
+      ]
+    },
+    "delegatedRoleAssignedUser": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "userEntityId",
+        "userPrincipalName"
+      ]
+    },
+    "email": {
+      "navigationProperties": [],
+      "properties": [
+        "emailAddress"
+      ]
+    },
+    "graphAPIErrorDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message"
+      ]
+    },
+    "managedTenantExecutionError": {
+      "navigationProperties": [],
+      "properties": [
+        "errorDetails",
+        "nodeId",
+        "rawToken",
+        "statementIndex"
+      ]
+    },
+    "managedTenantGenericError": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "managedTenantOperationError": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "tenantId"
+      ]
+    },
+    "managementActionDeploymentStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "managementActionId",
+        "managementTemplateId",
+        "managementTemplateVersion",
+        "status",
+        "workloadActionDeploymentStatuses"
+      ]
+    },
+    "managementActionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "managementActionId",
+        "managementTemplateId",
+        "managementTemplateVersion"
+      ]
+    },
+    "managementIntentInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "managementIntentDisplayName",
+        "managementIntentId",
+        "managementTemplates"
+      ]
+    },
+    "managementTemplateDetailedInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "displayName",
+        "managementTemplateId",
+        "version"
+      ]
+    },
+    "notificationTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "phone": {
+      "navigationProperties": [],
+      "properties": [
+        "phoneNumber"
+      ]
+    },
+    "roleAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentType",
+        "roles"
+      ]
+    },
+    "roleDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "templateId"
+      ]
+    },
+    "setting": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "jsonValue",
+        "overwriteAllowed",
+        "settingId",
+        "valueType"
+      ]
+    },
+    "templateAction": {
+      "navigationProperties": [
+        "licenses"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "service",
+        "settings",
+        "templateActionId"
+      ]
+    },
+    "templateParameter": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "jsonAllowedValues",
+        "jsonDefaultValue",
+        "valueType"
+      ]
+    },
+    "tenantContactInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "email",
+        "name",
+        "notes",
+        "phone",
+        "title"
+      ]
+    },
+    "tenantContract": {
+      "navigationProperties": [],
+      "properties": [
+        "contractType",
+        "defaultDomainName",
+        "displayName"
+      ]
+    },
+    "tenantInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "tenantId"
+      ]
+    },
+    "tenantStatusInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "delegatedPrivilegeStatus",
+        "lastDelegatedPrivilegeRefreshDateTime",
+        "offboardedByUserId",
+        "offboardedDateTime",
+        "onboardedByUserId",
+        "onboardedDateTime",
+        "onboardingStatus",
+        "tenantOnboardingEligibilityReason",
+        "workloadStatuses"
+      ]
+    },
+    "workloadAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actionId",
+        "category",
+        "description",
+        "displayName",
+        "licenses",
+        "service",
+        "settings"
+      ]
+    },
+    "workloadActionDeploymentStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "actionId",
+        "deployedPolicyId",
+        "error",
+        "excludeGroups",
+        "includeAllUsers",
+        "includeGroups",
+        "lastDeploymentDateTime",
+        "status"
+      ]
+    },
+    "workloadStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "offboardedDateTime",
+        "onboardedDateTime",
+        "onboardingStatus"
+      ]
+    }
+  },
+  "microsoft.graph.networkaccess": {
+    "aiAgent": {
+      "navigationProperties": [],
+      "properties": [
+        "firstAccessDateTime",
+        "id",
+        "lastAccessDateTime",
+        "name",
+        "totalBytesReceived",
+        "totalBytesSent",
+        "trafficType",
+        "transactionCount"
+      ]
+    },
+    "aiAgentDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "name"
+      ]
+    },
+    "alertAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actionLink",
+        "actionText"
+      ]
+    },
+    "alertFrequencyPoint": {
+      "navigationProperties": [],
+      "properties": [
+        "highSeverityCount",
+        "informationalSeverityCount",
+        "lowSeverityCount",
+        "mediumSeverityCount",
+        "timeStampDateTime"
+      ]
+    },
+    "alertSeveritySummary": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "severity"
+      ]
+    },
+    "alertSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "alertType",
+        "count",
+        "severity"
+      ]
+    },
+    "applicationAnalyticsUsagePoint": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudAppsCount",
+        "enterpriseAppsCount",
+        "timeStampDateTime",
+        "totalCount"
+      ]
+    },
+    "applicationSnapshot": {
+      "navigationProperties": [],
+      "properties": [
+        "appId"
+      ]
+    },
+    "associatedBranch": {
+      "navigationProperties": [],
+      "properties": [
+        "branchId"
+      ]
+    },
+    "association": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "bgpConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "asn",
+        "ipAddress",
+        "localIpAddress",
+        "peerIpAddress"
+      ]
+    },
+    "blockPageConfigurationBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudApplicationMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "categories",
+        "cloudApplicationCatalogId",
+        "complianceScore",
+        "generalScore",
+        "legalScore",
+        "loginUser",
+        "name",
+        "riskScore",
+        "securityScore",
+        "subactivity"
+      ]
+    },
+    "cloudApplicationReport": {
+      "navigationProperties": [],
+      "properties": [
+        "categories",
+        "cloudApplicationCatalogId",
+        "complianceScore",
+        "deviceCount",
+        "firstAccessDateTime",
+        "generalScore",
+        "lastAccessDateTime",
+        "legalScore",
+        "name",
+        "riskScore",
+        "securityScore",
+        "totalBytesReceived",
+        "totalBytesSent",
+        "trafficType",
+        "transactionCount",
+        "userCount"
+      ]
+    },
+    "cloudFirewallDestinationAddress": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudFirewallDestinationFqdnAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "values"
+      ]
+    },
+    "cloudFirewallDestinationIpAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "values"
+      ]
+    },
+    "cloudFirewallDestinationMatching": {
+      "navigationProperties": [],
+      "properties": [
+        "addresses",
+        "ports",
+        "protocols"
+      ]
+    },
+    "cloudFirewallMatchingConditions": {
+      "navigationProperties": [],
+      "properties": [
+        "destinations",
+        "sources"
+      ]
+    },
+    "cloudFirewallPolicySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultAction"
+      ]
+    },
+    "cloudFirewallRuleSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "status"
+      ]
+    },
+    "cloudFirewallSourceAddress": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudFirewallSourceIpAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "values"
+      ]
+    },
+    "cloudFirewallSourceMatching": {
+      "navigationProperties": [],
+      "properties": [
+        "addresses",
+        "ports"
+      ]
+    },
+    "connectionSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "totalCount",
+        "trafficType"
+      ]
+    },
+    "crossTenantAccess": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "lastAccessDateTime",
+        "resourceTenantId",
+        "resourceTenantName",
+        "resourceTenantPrimaryDomain",
+        "usageStatus",
+        "userCount"
+      ]
+    },
+    "crossTenantSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "authTransactionCount",
+        "deviceCount",
+        "newTenantCount",
+        "rarelyUsedTenantCount",
+        "tenantCount",
+        "userCount"
+      ]
+    },
+    "deploymentConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "changeType",
+        "operationName"
+      ]
+    },
+    "deploymentStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "message"
+      ]
+    },
+    "destination": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "firstAccessDateTime",
+        "fqdn",
+        "ip",
+        "lastAccessDateTime",
+        "networkingProtocol",
+        "port",
+        "threatCount",
+        "totalBytesReceived",
+        "totalBytesSent",
+        "trafficType",
+        "transactionCount",
+        "userCount"
+      ]
+    },
+    "destinationSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "destination",
+        "trafficType"
+      ]
+    },
+    "device": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "displayName",
+        "isCompliant",
+        "lastAccessDateTime",
+        "operatingSystem",
+        "trafficType"
+      ]
+    },
+    "deviceUsageSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDeviceCount",
+        "inactiveDeviceCount",
+        "totalDeviceCount"
+      ]
+    },
+    "discoveredApplicationSegmentReport": {
+      "navigationProperties": [],
+      "properties": [
+        "accessType",
+        "deviceCount",
+        "discoveredApplicationSegmentId",
+        "firstAccessDateTime",
+        "fqdn",
+        "ip",
+        "lastAccessDateTime",
+        "port",
+        "totalBytesReceived",
+        "totalBytesSent",
+        "transactionCount",
+        "transportProtocol",
+        "userCount"
+      ]
+    },
+    "enterpriseApplicationReport": {
+      "navigationProperties": [],
+      "properties": [
+        "accessType",
+        "applicationId",
+        "deviceCount",
+        "firstAccessDateTime",
+        "lastAccessDateTime",
+        "totalBytesReceived",
+        "totalBytesSent",
+        "trafficType",
+        "transactionCount",
+        "userCount"
+      ]
+    },
+    "entitiesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "trafficType",
+        "userCount",
+        "workloadCount"
+      ]
+    },
+    "extendedProperties": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "fqdn": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "headers": {
+      "navigationProperties": [],
+      "properties": [
+        "origin",
+        "referrer",
+        "xForwardedFor"
+      ]
+    },
+    "ipAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "ipDestination": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ipRange": {
+      "navigationProperties": [],
+      "properties": [
+        "beginAddress",
+        "endAddress"
+      ]
+    },
+    "ipSubnet": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "localConnectivityConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "asn",
+        "bgpAddress",
+        "endpoint",
+        "region"
+      ]
+    },
+    "markdownBlockMessageConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "body"
+      ]
+    },
+    "peerConnectivityConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "asn",
+        "bgpAddress",
+        "endpoint"
+      ]
+    },
+    "policyRuleDelta": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "ruleId"
+      ]
+    },
+    "privateAccessDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "accessType",
+        "appSegmentId",
+        "connectionStatus",
+        "connectorId",
+        "connectorIp",
+        "connectorName",
+        "processingRegion",
+        "thirdPartyTokenDetails"
+      ]
+    },
+    "redundancyConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "redundancyTier",
+        "zoneLocalIpAddress"
+      ]
+    },
+    "relatedDestination": {
+      "navigationProperties": [],
+      "properties": [
+        "fqdn",
+        "ip",
+        "networkingProtocol",
+        "port"
+      ]
+    },
+    "relatedDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId"
+      ]
+    },
+    "relatedFile": {
+      "navigationProperties": [],
+      "properties": [
+        "directory",
+        "name",
+        "sizeInBytes"
+      ]
+    },
+    "relatedFileHash": {
+      "navigationProperties": [],
+      "properties": [
+        "algorithm",
+        "value"
+      ]
+    },
+    "relatedMalware": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "name",
+        "severity"
+      ]
+    },
+    "relatedRemoteNetwork": {
+      "navigationProperties": [],
+      "properties": [
+        "remoteNetworkId"
+      ]
+    },
+    "relatedResource": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "relatedTenant": {
+      "navigationProperties": [],
+      "properties": [
+        "tenantId"
+      ]
+    },
+    "relatedThreatIntelligence": {
+      "navigationProperties": [],
+      "properties": [
+        "threatCount"
+      ]
+    },
+    "relatedToken": {
+      "navigationProperties": [],
+      "properties": [
+        "uniqueTokenIdentifier"
+      ]
+    },
+    "relatedTransaction": {
+      "navigationProperties": [],
+      "properties": [
+        "transactionId"
+      ]
+    },
+    "relatedUrl": {
+      "navigationProperties": [],
+      "properties": [
+        "url"
+      ]
+    },
+    "relatedUser": {
+      "navigationProperties": [],
+      "properties": [
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "relatedWebCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "webCategoryName"
+      ]
+    },
+    "ruleDestination": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "thirdPartyTokenDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "expirationDateTime",
+        "issuedAtDateTime",
+        "uniqueTokenIdentifier",
+        "validFromDateTime"
+      ]
+    },
+    "threatIntelligenceDestination": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "threatIntelligenceFqdnDestination": {
+      "navigationProperties": [],
+      "properties": [
+        "values"
+      ]
+    },
+    "threatIntelligenceMatchingConditions": {
+      "navigationProperties": [],
+      "properties": [
+        "destinations",
+        "severity"
+      ]
+    },
+    "threatIntelligencePolicySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultAction"
+      ]
+    },
+    "threatIntelligenceRuleSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "status"
+      ]
+    },
+    "tlsDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "policyId",
+        "policyName",
+        "ruleId",
+        "ruleName",
+        "status"
+      ]
+    },
+    "tlsInspectionDestination": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "tlsInspectionFqdnDestination": {
+      "navigationProperties": [],
+      "properties": [
+        "values"
+      ]
+    },
+    "tlsInspectionMatchingConditions": {
+      "navigationProperties": [],
+      "properties": [
+        "destinations"
+      ]
+    },
+    "tlsInspectionPolicySettings": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "tlsInspectionRuleSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "status"
+      ]
+    },
+    "tlsInspectionWebCategoryDestination": {
+      "navigationProperties": [],
+      "properties": [
+        "values"
+      ]
+    },
+    "transactionSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "blockedCount",
+        "totalCount",
+        "trafficType"
+      ]
+    },
+    "tunnelConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "preSharedKey",
+        "zoneRedundancyPreSharedKey"
+      ]
+    },
+    "tunnelConfigurationIKEv2Custom": {
+      "navigationProperties": [],
+      "properties": [
+        "dhGroup",
+        "ikeEncryption",
+        "ikeIntegrity",
+        "ipSecEncryption",
+        "ipSecIntegrity",
+        "pfsGroup",
+        "saLifeTimeSeconds"
+      ]
+    },
+    "tunnelConfigurationIKEv2Default": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "url": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "usageProfilingPoint": {
+      "navigationProperties": [],
+      "properties": [
+        "internetAccessTrafficCount",
+        "microsoft365AccessTrafficCount",
+        "privateAccessTrafficCount",
+        "timeStampDateTime",
+        "totalTrafficCount"
+      ]
+    },
+    "user": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "firstAccessDateTime",
+        "lastAccessDateTime",
+        "totalBytesReceived",
+        "totalBytesSent",
+        "trafficType",
+        "transactionCount",
+        "userId",
+        "userPrincipalName",
+        "userType"
+      ]
+    },
+    "validityDate": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "startDateTime"
+      ]
+    },
+    "webCategoriesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "deviceCount",
+        "transactionCount",
+        "userCount",
+        "webCategory"
+      ]
+    },
+    "webCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "group",
+        "name"
+      ]
+    }
+  },
+  "microsoft.graph.partner.security": {
+    "activityLog": {
+      "navigationProperties": [],
+      "properties": [
+        "statusFrom",
+        "statusTo",
+        "updatedBy",
+        "updatedDateTime"
+      ]
+    },
+    "additionalDataDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "affectedResource": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceId",
+        "resourceType"
+      ]
+    },
+    "customerMfaInsight": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantAdminsCount",
+        "compliantNonAdminsCount",
+        "legacyPerUserMfaStatus",
+        "mfaConditionalAccessPolicyStatus",
+        "securityDefaultsStatus",
+        "totalUsersCount"
+      ]
+    }
+  },
+  "microsoft.graph.partners.billing": {
+    "blob": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "partitionValue"
+      ]
+    }
+  },
+  "microsoft.graph.search": {
+    "answerKeyword": {
+      "navigationProperties": [],
+      "properties": [
+        "keywords",
+        "matchSimilarKeywords",
+        "reservedKeywords"
+      ]
+    },
+    "answerVariant": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "languageTag",
+        "platform",
+        "webUrl"
+      ]
+    },
+    "identity": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "id"
+      ]
+    },
+    "identitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "application",
+        "device",
+        "user"
+      ]
+    }
+  },
+  "microsoft.graph.security": {
+    "a365AiExecuteTool": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "a365AiInferenceCall": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "a365AiInvokeAgent": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "a365AiRunSummary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "a365SpanOutputs": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aadRiskDetectionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "account": {
+      "navigationProperties": [],
+      "properties": [
+        "actions",
+        "identifier",
+        "identityProvider"
+      ]
+    },
+    "activeDirectoryDomainEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDirectoryDomainName",
+        "trustedDomains"
+      ]
+    },
+    "addContentFooterAction": {
+      "navigationProperties": [],
+      "properties": [
+        "alignment",
+        "fontColor",
+        "fontName",
+        "fontSize",
+        "margin",
+        "text",
+        "uiElementName"
+      ]
+    },
+    "addContentHeaderAction": {
+      "navigationProperties": [],
+      "properties": [
+        "alignment",
+        "fontColor",
+        "fontName",
+        "fontSize",
+        "margin",
+        "text",
+        "uiElementName"
+      ]
+    },
+    "addWatermarkAction": {
+      "navigationProperties": [],
+      "properties": [
+        "fontColor",
+        "fontName",
+        "fontSize",
+        "layout",
+        "text",
+        "uiElementName"
+      ]
+    },
+    "aedAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "agentAdminActivityRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "agentSettingAdminActivity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aiAgentEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "agentId",
+        "agentName",
+        "hostingPlatformType",
+        "instructions"
+      ]
+    },
+    "aiAppInteractionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aiExecuteToolAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aiInteractionsChangeNotificationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aiInteractionsExportAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aiInteractionsSubscriptionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aiInvokeAgentAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aipDiscover": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aipFileDeleted": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aipHeartBeat": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aipProtectionActionLogRequest": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aipScannerDiscoverEvent": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aipSensitivityLabelActionLogRequest": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "airAdminActionInvestigationData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "airInvestigationData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "airManualInvestigationData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "alertComment": {
+      "navigationProperties": [],
+      "properties": [
+        "comment",
+        "createdByDisplayName",
+        "createdDateTime"
+      ]
+    },
+    "alertEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "detailedRoles",
+        "remediationStatus",
+        "remediationStatusDetails",
+        "roles",
+        "tags",
+        "verdict"
+      ]
+    },
+    "alertTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "description",
+        "impactedAssets",
+        "mitreTechniques",
+        "recommendedActions",
+        "severity",
+        "title"
+      ]
+    },
+    "allowFileResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceGroupNames",
+        "identifier"
+      ]
+    },
+    "amazonResourceEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "amazonAccountId",
+        "amazonResourceId",
+        "resourceName",
+        "resourceType"
+      ]
+    },
+    "analyzedEmailAttachment": {
+      "navigationProperties": [],
+      "properties": [
+        "detonationDetails",
+        "fileExtension",
+        "fileName",
+        "fileSize",
+        "fileType",
+        "malwareFamily",
+        "sha256",
+        "tenantAllowBlockListDetailInfo",
+        "threatType"
+      ]
+    },
+    "analyzedEmailAuthenticationDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "compositeAuthentication",
+        "dkim",
+        "dmarc",
+        "senderPolicyFramework"
+      ]
+    },
+    "analyzedEmailDeliveryDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "latestThreats",
+        "location",
+        "originalThreats"
+      ]
+    },
+    "analyzedEmailDlpRuleInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "ruleId"
+      ]
+    },
+    "analyzedEmailExchangeTransportRuleInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "ruleId"
+      ]
+    },
+    "analyzedEmailRecipientDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "ccRecipients",
+        "domainName"
+      ]
+    },
+    "analyzedEmailSenderDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "domainCreationDateTime",
+        "domainName",
+        "domainOwner",
+        "fromAddress",
+        "ipv4",
+        "location",
+        "mailFromAddress",
+        "mailFromDomainName"
+      ]
+    },
+    "analyzedEmailUrl": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionMethod",
+        "detonationDetails",
+        "tenantAllowBlockListDetailInfo",
+        "threatType",
+        "url"
+      ]
+    },
+    "analyzedMessageEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "antiSpamDirection",
+        "attachmentsCount",
+        "deliveryAction",
+        "deliveryLocation",
+        "internetMessageId",
+        "language",
+        "networkMessageId",
+        "p1Sender",
+        "p2Sender",
+        "receivedDateTime",
+        "recipientEmailAddress",
+        "senderIp",
+        "subject",
+        "threatDetectionMethods",
+        "threats",
+        "urlCount",
+        "urls",
+        "urn"
+      ]
+    },
+    "applyLabelAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actions",
+        "actionSource",
+        "responsibleSensitiveTypeIds",
+        "sensitivityLabelId"
+      ]
+    },
+    "attackSimAdminAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "attackSimAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "attackSimulationInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "attackSimDateTime",
+        "attackSimDurationTime",
+        "attackSimId",
+        "attackSimUserId"
+      ]
+    },
+    "auditConfigAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "auditData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "auditInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "by",
+        "dateTime"
+      ]
+    },
+    "auditSearchAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "autonomousSystem": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "number",
+        "organization",
+        "value"
+      ]
+    },
+    "azfwApplicationRuleAggregationEventRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azfwDnsQueryEventRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azfwNetworkRuleEventRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azureActiveDirectoryAccountLogonAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azureActiveDirectoryAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azureActiveDirectoryStsLogonAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azureResourceEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceId",
+        "resourceName",
+        "resourceType"
+      ]
+    },
+    "blobContainerEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "storageResource",
+        "url"
+      ]
+    },
+    "blobEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "blobContainer",
+        "etag",
+        "fileHashes",
+        "name",
+        "url"
+      ]
+    },
+    "blockFileResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceGroupNames",
+        "identifier"
+      ]
+    },
+    "bufferDecryptionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "decryptedBuffer"
+      ]
+    },
+    "bufferEncryptionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "encryptedBuffer",
+        "publishingLicense"
+      ]
+    },
+    "campaignAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ccraiPolicyViolationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cdpClassifierHealthRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cdpColdCrawlStatusRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cdpConsumptionResourceRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cdpContentExplorerAggregateRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cdpdlmaiInteractionInsightsRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cdpDlpSensitiveEndpointAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cdpLogRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cdpOcrBillingRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cdpResourceScopeChangeEventRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "classificationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "confidenceLevel",
+        "count",
+        "sensitiveTypeId"
+      ]
+    },
+    "cloudApplicationEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "displayName",
+        "instanceId",
+        "instanceName",
+        "saasAppId",
+        "stream"
+      ]
+    },
+    "cloudLogonRequestEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "requestId"
+      ]
+    },
+    "cloudLogonSessionEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "account",
+        "browser",
+        "deviceName",
+        "operatingSystem",
+        "previousLogonDateTime",
+        "protocol",
+        "sessionId",
+        "startUtcDateTime",
+        "userAgent"
+      ]
+    },
+    "cloudUpdateDeviceConfigAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudUpdateProfileConfigAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudUpdateTenantConfigAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "collectInvestigationPackageIncidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "collectInvestigationPackageResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "complianceConnectorAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLMExchangeAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLMSharePointAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLPApplicationsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLPApplicationsClassificationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLPEndpointAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLPEndpointDiscoveryAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLPEnforcementAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLPExchangeAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLPExchangeClassificationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLPExchangeClassificationCdpRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLPExchangeDiscoveryAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLPSharePointAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLPSharePointClassificationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLPSharePointClassificationCdpRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLPSharePointClassificationExtendedAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceExchangeOcrAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceManagerActionRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceSettingsChangeAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceSupervisionExchangeAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "compromiseIndicator": {
+      "navigationProperties": [],
+      "properties": [
+        "value",
+        "verdict"
+      ]
+    },
+    "connectedAIAppInteractionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "consumptionResourceAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "containerEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "args",
+        "command",
+        "containerId",
+        "image",
+        "isPrivileged",
+        "name",
+        "pod"
+      ]
+    },
+    "containerImageEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "digestImage",
+        "imageId",
+        "registry"
+      ]
+    },
+    "containerRegistryEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "registry"
+      ]
+    },
+    "contentInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "contentFormat",
+        "identifier",
+        "metadata",
+        "state"
+      ]
+    },
+    "contentLabel": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentMethod",
+        "createdDateTime",
+        "sensitivityLabelId"
+      ]
+    },
+    "contentStoreMetadataRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "copilotAgentManagementAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "copilotForSecurityLoggingAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "copilotForSecurityTriggerAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "copilotInteractionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "copilotPluginSettingAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "copilotPromptBookSettingAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "copilotSettingAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "copilotWorkspaceSettingAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "coreReportingSettingsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cortanaBriefingAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "criticalAssetManagementClassificationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "crmEntityOperationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "crossTenantAccessPolicyAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customAction": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "properties"
+      ]
+    },
+    "customerKeyServiceEncryptionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cvssSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "score",
+        "severity",
+        "vectorString"
+      ]
+    },
+    "dataCenterSecurityCmdletAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "dataGovernanceAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "dataInsightsRestApiAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "dataLakeExportOperationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "dataSecurityInvestigationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "dataShareOperationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "defaultAuditData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "defenderCaseManagementAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "defenderPreviewFeaturesRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deployFeatureActivityRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deploymentAccessKeyType": {
+      "navigationProperties": [],
+      "properties": [
+        "deploymentAccessKey"
+      ]
+    },
+    "detectionAction": {
+      "navigationProperties": [],
+      "properties": [
+        "alertTemplate",
+        "organizationalScope",
+        "responseActions"
+      ]
+    },
+    "detonationBehaviourDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "actionStatus",
+        "behaviourCapability",
+        "behaviourGroup",
+        "details",
+        "eventDateTime",
+        "operation",
+        "processId",
+        "processName",
+        "target"
+      ]
+    },
+    "detonationChain": {
+      "navigationProperties": [],
+      "properties": [
+        "childNodes",
+        "value"
+      ]
+    },
+    "detonationDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "analysisDateTime",
+        "compromiseIndicators",
+        "detonationBehaviourDetails",
+        "detonationBehaviourDetailsV2",
+        "detonationChain",
+        "detonationObservables",
+        "detonationScreenshotUri",
+        "detonationVerdict",
+        "detonationVerdictReason",
+        "entityMetadata",
+        "mitreTechniques",
+        "staticAnalysis",
+        "submissionSource"
+      ]
+    },
+    "detonationObservables": {
+      "navigationProperties": [],
+      "properties": [
+        "contactedIps",
+        "contactedUrls",
+        "droppedfiles"
+      ]
+    },
+    "deviceDiscoverySettingsAuthenticatedScansRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceDiscoverySettingsExclusionRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceDiscoverySettingsRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "azureAdDeviceId",
+        "defenderAvStatus",
+        "deviceDnsName",
+        "dnsDomain",
+        "firstSeenDateTime",
+        "healthStatus",
+        "hostName",
+        "ipInterfaces",
+        "lastExternalIpAddress",
+        "lastIpAddress",
+        "loggedOnUsers",
+        "mdeDeviceId",
+        "ntDomain",
+        "onboardingStatus",
+        "osBuild",
+        "osPlatform",
+        "rbacGroupId",
+        "rbacGroupName",
+        "resourceAccessEvents",
+        "riskScore",
+        "version",
+        "vmMetadata"
+      ]
+    },
+    "dictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "disableUserIncidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "disableUserResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "discoveryAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "dlpEndpointAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "dlpImportResultAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "dlpSensitiveInformationTypeRulePackageCmdletRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "dnsEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "dnsServerIp",
+        "domainName",
+        "hostIpAddress",
+        "ipAddresses"
+      ]
+    },
+    "downgradeJustification": {
+      "navigationProperties": [],
+      "properties": [
+        "isDowngradeJustified",
+        "justificationMessage"
+      ]
+    },
+    "dynamicColumnValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "dynamics365BusinessCentralAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ehrConnectorAuditBaseRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "emailSender": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "domainName",
+        "emailAddress"
+      ]
+    },
+    "enableUserIncidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "eventPropagationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "location",
+        "serviceName",
+        "status",
+        "statusInformation"
+      ]
+    },
+    "eventQuery": {
+      "navigationProperties": [],
+      "properties": [
+        "query",
+        "queryType"
+      ]
+    },
+    "exchangeAdminAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "exchangeAggregatedMailboxAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "exchangeAggregatedOperationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "exchangeMailboxAuditGroupRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "exchangeMailboxAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "exportFileMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "downloadUrl",
+        "fileName",
+        "size"
+      ]
+    },
+    "fabricAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "fileDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "fileName",
+        "filePath",
+        "filePublisher",
+        "fileSize",
+        "issuer",
+        "md5",
+        "sha1",
+        "sha256",
+        "sha256Ac",
+        "signer"
+      ]
+    },
+    "fileEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionStatus",
+        "fileDetails",
+        "mdeDeviceId"
+      ]
+    },
+    "fileHash": {
+      "navigationProperties": [],
+      "properties": [
+        "algorithm",
+        "value"
+      ]
+    },
+    "fileHashEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "algorithm",
+        "value"
+      ]
+    },
+    "filePlanAppliedCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "subcategory"
+      ]
+    },
+    "filePlanAuthority": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "filePlanCitation": {
+      "navigationProperties": [],
+      "properties": [
+        "citationJurisdiction",
+        "citationUrl"
+      ]
+    },
+    "filePlanDepartment": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "filePlanDescriptorBase": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "filePlanReference": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "filePlanSubcategory": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "forceUserPasswordResetIncidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "forceUserPasswordResetResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "formattedContent": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "format"
+      ]
+    },
+    "geoLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "city",
+        "countryName",
+        "latitude",
+        "longitude",
+        "state"
+      ]
+    },
+    "gitHubOrganizationEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "company",
+        "displayName",
+        "email",
+        "login",
+        "orgId",
+        "webUrl"
+      ]
+    },
+    "gitHubRepoEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "baseUrl",
+        "login",
+        "owner",
+        "ownerType",
+        "repoId"
+      ]
+    },
+    "gitHubUserEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "email",
+        "login",
+        "name",
+        "userId",
+        "webUrl"
+      ]
+    },
+    "googleCloudResourceEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "fullResourceName",
+        "location",
+        "locationType",
+        "projectId",
+        "projectNumber",
+        "resourceName",
+        "resourceType"
+      ]
+    },
+    "hardDeleteEmailIncidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "hardDeleteResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "healthcareSignalRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "hostedRpaAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "hostLogonSessionEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "account",
+        "endUtcDateTime",
+        "host",
+        "sessionId",
+        "startUtcDateTime"
+      ]
+    },
+    "hostPortBanner": {
+      "navigationProperties": [],
+      "properties": [
+        "banner",
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "scanProtocol",
+        "timesObserved"
+      ]
+    },
+    "hostPortComponent": {
+      "navigationProperties": [
+        "component"
+      ],
+      "properties": [
+        "firstSeenDateTime",
+        "isRecent",
+        "lastSeenDateTime"
+      ]
+    },
+    "hostReputationRule": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "name",
+        "relatedDetailsUrl",
+        "severity"
+      ]
+    },
+    "hostSslCertificatePort": {
+      "navigationProperties": [],
+      "properties": [
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "port"
+      ]
+    },
+    "hrSignalAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "huntingQueryResults": {
+      "navigationProperties": [],
+      "properties": [
+        "results",
+        "schema"
+      ]
+    },
+    "huntingRowResult": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "hygieneEventRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "hyperlink": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "url"
+      ]
+    },
+    "impactedAsset": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "impactedDeviceAsset": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "impactedMailboxAsset": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "impactedUserAsset": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "incidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifierValue"
+      ]
+    },
+    "informationBarrierPolicyApplicationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "informationProtectionAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "informationWorkerProtectionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "initiateInvestigationResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "insiderRiskScopedUserInsightsRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "insiderRiskScopedUsersRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "integratedAppsAppAdminActivityAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "integratedAppsAppSettingsAdminActivityAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "intelligenceProfileCountryOrRegionOfOrigin": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "label"
+      ]
+    },
+    "invokeActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "accountId",
+        "action",
+        "correlationId",
+        "identityProvider"
+      ]
+    },
+    "ioTDeviceEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "deviceName",
+        "devicePageLink",
+        "deviceSubType",
+        "deviceType",
+        "importance",
+        "ioTHub",
+        "ioTSecurityAgentId",
+        "ipAddress",
+        "isAuthorized",
+        "isProgramming",
+        "isScanner",
+        "macAddress",
+        "manufacturer",
+        "model",
+        "nics",
+        "operatingSystem",
+        "owners",
+        "protocols",
+        "purdueLayer",
+        "sensor",
+        "serialNumber",
+        "site",
+        "source",
+        "sourceRef",
+        "zone"
+      ]
+    },
+    "ipEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "countryLetterCode",
+        "ipAddress",
+        "location",
+        "stream"
+      ]
+    },
+    "irmActivityAuditTrailRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "irmUserDefinedDetectionRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "isolateDeviceIncidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "isolationType"
+      ]
+    },
+    "isolateDeviceResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier",
+        "isolationType"
+      ]
+    },
+    "justifyAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "kaizalaAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "keyValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "value"
+      ]
+    },
+    "kubernetesClusterEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudResource",
+        "distribution",
+        "name",
+        "platform",
+        "version"
+      ]
+    },
+    "kubernetesControllerEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "labels",
+        "name",
+        "namespace",
+        "type"
+      ]
+    },
+    "kubernetesNamespaceEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "cluster",
+        "labels",
+        "name"
+      ]
+    },
+    "kubernetesPodEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "containers",
+        "controller",
+        "ephemeralContainers",
+        "initContainers",
+        "labels",
+        "name",
+        "namespace",
+        "podIp",
+        "serviceAccount"
+      ]
+    },
+    "kubernetesSecretEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "namespace",
+        "secretType"
+      ]
+    },
+    "kubernetesServiceAccountEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "namespace"
+      ]
+    },
+    "kubernetesServiceEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "clusterIP",
+        "externalIPs",
+        "labels",
+        "name",
+        "namespace",
+        "selector",
+        "servicePorts",
+        "serviceType"
+      ]
+    },
+    "kubernetesServicePort": {
+      "navigationProperties": [],
+      "properties": [
+        "appProtocol",
+        "name",
+        "nodePort",
+        "port",
+        "protocol",
+        "targetPort"
+      ]
+    },
+    "labelAnalyticsAggregateAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "labelContentExplorerAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "labelingOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentMethod",
+        "downgradeJustification",
+        "extendedProperties",
+        "labelId"
+      ]
+    },
+    "largeContentMetadataAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "loggedOnUser": {
+      "navigationProperties": [],
+      "properties": [
+        "accountName",
+        "domainName"
+      ]
+    },
+    "m365ComplianceConnectorAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "m365daadAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "m365odspAssetMetadataRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "m365SearchSectionsRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mailboxConfigurationEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationId",
+        "configurationType",
+        "displayName",
+        "externalDirectoryObjectId",
+        "mailboxPrimaryAddress",
+        "upn"
+      ]
+    },
+    "mailboxEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "primaryAddress",
+        "upn",
+        "userAccount"
+      ]
+    },
+    "mailClusterEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "clusterBy",
+        "clusterByValue",
+        "emailCount",
+        "networkMessageIds",
+        "query",
+        "urn"
+      ]
+    },
+    "mailSubmissionData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "malwareEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "files",
+        "name",
+        "processes"
+      ]
+    },
+    "managedServicesAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "managedTenantsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mapgAlertsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mapgOnboardAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mapgPolicyAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mapgRemediationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "markUserAsCompromisedIncidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "markUserAsCompromisedResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "mcasAlertsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mdaAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mdaDataSecuritySignalRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mdatpAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mdcEventsRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mdiAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mergeResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "targetIncidentId"
+      ]
+    },
+    "meshWorldsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "metadataAction": {
+      "navigationProperties": [],
+      "properties": [
+        "metadataToAdd",
+        "metadataToRemove"
+      ]
+    },
+    "microsoft365BackupBackupItemAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoft365BackupBackupPolicyAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoft365BackupGranularBrowseTaskAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoft365BackupRestoreItemAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoft365BackupRestoreTaskAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoft365CopilotScheduledPromptAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftDefenderExpertsXDRAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftFlowAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftFormsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftGraphDataConnectConsent": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftGraphDataConnectOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftPurviewDataCatalogOperationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftPurviewDataMapOperationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftPurviewMetadataPolicyOperationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftPurviewPolicyOperationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftPurviewPrivacyAuditEvent": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftPurviewUnifiedCatalogOperationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftStreamAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftTeamsAdminAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftTeamsAnalyticsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftTeamsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftTeamsDeviceAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftTeamsRetentionLabelActionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftTeamsSensitivityLabelActionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "microsoftTeamsShiftsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "migrateSensorsResult": {
+      "navigationProperties": [],
+      "properties": [
+        "failedMigrationSensorIds",
+        "successfulMigrationSensorIds"
+      ]
+    },
+    "mipAutoLabelExchangeItemAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mipAutoLabelProgressFeedbackAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mipAutoLabelSharePointItemAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mipAutoLabelSharePointPolicyLocationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mipAutoLabelSimulationSharePointCompletionRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mipAutoLabelSimulationSharePointProgressRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mipAutoLabelSimulationStatisticsRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mipExactDataMatchAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mipLabelAnalyticsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mipLabelAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mosAgentInfoRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "moveToDeletedItemsResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "moveToInboxResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "moveToJunkResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "ms365dCustomDetectionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ms365dIncidentAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ms365dSuppressionRuleAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "msdeCustomCollectionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "msdeGeneralSettingsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "msdeIndicatorsSettingsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "msdeResponseActionsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "msdeRolesSettingsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "msticNationStateNotificationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "multiStageDispositionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "myAnalyticsSettingsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "networkConnectionEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "destinationAddress",
+        "destinationPort",
+        "protocol",
+        "sourceAddress",
+        "sourcePort"
+      ]
+    },
+    "nicEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "ipAddress",
+        "macAddress",
+        "vlans"
+      ]
+    },
+    "noisyAlertPolicyAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "oauthApplicationEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "displayName",
+        "objectId",
+        "publisher"
+      ]
+    },
+    "ocrSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "maxImageSize",
+        "timeout"
+      ]
+    },
+    "officeNativeAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "omePortalAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onDemandSharePointClassificationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "oneDriveAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onPremisesFileShareScannerDLPAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onPremisesSharePointScannerDLPAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "organizationalDataInM365AuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "organizationalScope": {
+      "navigationProperties": [],
+      "properties": [
+        "scopeNames",
+        "scopeType"
+      ]
+    },
+    "outlookCopilotAutomationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "owaGetAccessTokenForResourceAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "p4aiAssessmentCategoryRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "p4aiAssessmentFabricScannerRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "p4aiAssessmentLocationResultRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "p4aiAssessmentRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "peopleAdminSettingsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "physicalBadgingSignalAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "placesDirectoryAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerChatMessageAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerChatMessageListAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerCopyPlanAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerGoalAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerGoalListAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerPlanAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerPlanListAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerPlanSensitivityLabelAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerRosterAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerRosterSensitivityLabelAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerTaskAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerTaskListAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerTenantSettingsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "policyConfigChangeAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "powerAppsAuditAppRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "powerAppsAuditPlanRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "powerAppsAuditResourceRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "powerBIAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "powerBIDlpAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "powerPagesSiteAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "powerPlatformAdminDlpAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "powerPlatformAdminEnvironmentAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "powerPlatformAdministratorActivityRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "powerPlatformLockboxResourceAccessRequestAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "powerPlatformLockboxResourceCommandAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "powerPlatformServiceActivityAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "powerPlatformTenantIsolationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "privacyDataMatchAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "privacyDataMinimizationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "privacyDigestEmailRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "privacyOpenAccessAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "privacyPortalAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "privacyRemediationActionRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "privacyRemediationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "privaPrivacyAssessmentOperationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "privaPrivacyConsentOperationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "processEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionStatus",
+        "imageFile",
+        "mdeDeviceId",
+        "parentProcessCreationDateTime",
+        "parentProcessId",
+        "parentProcessImageFile",
+        "processCommandLine",
+        "processCreationDateTime",
+        "processId",
+        "userAccount"
+      ]
+    },
+    "projectAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "projectForTheWebAssignedToMeSettingsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "projectForTheWebProjectAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "projectForTheWebProjectSettingsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "projectForTheWebRoadmapAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "projectForTheWebRoadmapItemAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "projectForTheWebRoadmapSettingsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "projectForTheWebTaskAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "protectAdhocAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "protectByTemplateAction": {
+      "navigationProperties": [],
+      "properties": [
+        "templateId"
+      ]
+    },
+    "protectDoNotForwardAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "publicFolderAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "purviewInsiderRiskAlertsRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "purviewInsiderRiskCasesRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "purviewMCRecommendationRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "purviewPostureAgentAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "quarantineAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "queryCondition": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedDateTime",
+        "queryText"
+      ]
+    },
+    "recommendedHuntingQuery": {
+      "navigationProperties": [],
+      "properties": [
+        "kqlText"
+      ]
+    },
+    "recommendLabelAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actions",
+        "actionSource",
+        "responsibleSensitiveTypeIds",
+        "sensitivityLabelId"
+      ]
+    },
+    "recordsManagementAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "redundancyDetectionSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "maxWords",
+        "minWords",
+        "similarityThreshold"
+      ]
+    },
+    "registryKeyEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "registryHive",
+        "registryKey"
+      ]
+    },
+    "registryValueEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "mdeDeviceId",
+        "registryHive",
+        "registryKey",
+        "registryValue",
+        "registryValueName",
+        "registryValueType"
+      ]
+    },
+    "removeContentFooterAction": {
+      "navigationProperties": [],
+      "properties": [
+        "uiElementNames"
+      ]
+    },
+    "removeContentHeaderAction": {
+      "navigationProperties": [],
+      "properties": [
+        "uiElementNames"
+      ]
+    },
+    "removeProtectionAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "removeWatermarkAction": {
+      "navigationProperties": [],
+      "properties": [
+        "uiElementNames"
+      ]
+    },
+    "reportFileMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "downloadUrl",
+        "fileName",
+        "size"
+      ]
+    },
+    "reportSubmission": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "reportSubmissionResultDetail": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "requireSignInIncidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "resourceAccessEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "accessDateTime",
+        "accountId",
+        "ipAddress",
+        "resourceIdentifier"
+      ]
+    },
+    "responseAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "restrictAppExecutionIncidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "restrictAppExecutionResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "restrictedModeAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "retentionDuration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "retentionDurationForever": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "retentionDurationInDays": {
+      "navigationProperties": [],
+      "properties": [
+        "days"
+      ]
+    },
+    "retentionEventStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "status"
+      ]
+    },
+    "retentionPolicyAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "rtiOperationsAgentAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ruleSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "nextRunDateTime",
+        "period"
+      ]
+    },
+    "runAntivirusScanIncidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "runAntivirusScanResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "runDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "errorCode",
+        "failureReason",
+        "lastRunDateTime",
+        "status"
+      ]
+    },
+    "sasTokenEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedIpAddresses",
+        "allowedResourceTypes",
+        "allowedServices",
+        "expiryDateTime",
+        "permissions",
+        "protocol",
+        "signatureHash",
+        "signedWith",
+        "startDateTime",
+        "storageResource"
+      ]
+    },
+    "sbpConfigurationEventRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sbpUsageEventRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "scoreEvidence": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "scorePlatformGenericAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "scriptRunAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "searchAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityComplianceAlertRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityComplianceCenterEOPCmdletAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityComplianceInsightsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityComplianceRBACAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityComplianceUserChangeAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityGroupEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDirectoryObjectGuid",
+        "displayName",
+        "distinguishedName",
+        "friendlyName",
+        "securityGroupId",
+        "sid"
+      ]
+    },
+    "sensitiveInfoRemediationAgentDataRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sensitivityLabelActionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sensitivityLabeledFileActionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sensitivityLabelPolicyMatchAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sensorDeploymentPackage": {
+      "navigationProperties": [],
+      "properties": [
+        "downloadUrl",
+        "version"
+      ]
+    },
+    "sensorSettings": {
+      "navigationProperties": [
+        "networkAdapters"
+      ],
+      "properties": [
+        "description",
+        "domainControllerDnsNames",
+        "isDelayedDeploymentEnabled"
+      ]
+    },
+    "sentinelAIToolAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sentinelGraphAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sentinelJobAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sentinelKQLOnLakeAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sentinelLakeDataOnboardingAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sentinelLakeEncryptionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sentinelLakeOnboardingAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sentinelNotebookOnLakeAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sentinelPackageAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "servicePrincipalEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "appOwnerTenantId",
+        "servicePrincipalName",
+        "servicePrincipalObjectId",
+        "servicePrincipalType",
+        "tenantId"
+      ]
+    },
+    "sharePointAppPermissionOperationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointCommentOperationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointContentSecurityPolicyAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointContentTypeOperationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointESignatureAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointFieldOperationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointFileOperationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointListItemOperationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointListOperationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointSharingOperationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "signingResult": {
+      "navigationProperties": [],
+      "properties": [
+        "signature",
+        "signingKeyId"
+      ]
+    },
+    "singlePropertySchema": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "type"
+      ]
+    },
+    "skypeForBusinessCmdletsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "skypeForBusinessPSTNUsageAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "skypeForBusinessUsersBlockedAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "softDeleteIncidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "softDeleteResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "sonarDetonationContentMetadata": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sslCertificateEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "alternateNames",
+        "commonName",
+        "email",
+        "givenName",
+        "organizationName",
+        "organizationUnitName",
+        "serialNumber",
+        "surname"
+      ]
+    },
+    "stopAndQuarantineFileIncidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId"
+      ]
+    },
+    "stopAndQuarantineFileResponseAction": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier"
+      ]
+    },
+    "stream": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "stringValueDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "submissionAdminReview": {
+      "navigationProperties": [],
+      "properties": [
+        "reviewBy",
+        "reviewDateTime",
+        "reviewResult"
+      ]
+    },
+    "submissionDetectedFile": {
+      "navigationProperties": [],
+      "properties": [
+        "fileHash",
+        "fileName"
+      ]
+    },
+    "submissionMailEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "networkMessageId",
+        "recipient",
+        "reportType",
+        "sender",
+        "senderIp",
+        "subject",
+        "submissionDateTime",
+        "submissionId",
+        "submitter"
+      ]
+    },
+    "submissionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "detail",
+        "detectedFiles",
+        "detectedUrls",
+        "userMailboxSetting"
+      ]
+    },
+    "submissionUserIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "email"
+      ]
+    },
+    "supervisoryReviewDayXInsightsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "syntheticProbeAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamCopilotInteractionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamsEasyApprovalsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamsEvalDataHubAdminOperationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamsEvalDataHubDataAccessAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamsEvalDataHubPermissionChangeAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamsHealthcareAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamsMessageEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "campaignId",
+        "channelId",
+        "deliveryAction",
+        "deliveryLocation",
+        "files",
+        "groupId",
+        "isExternal",
+        "isOwned",
+        "lastModifiedDateTime",
+        "messageDirection",
+        "messageId",
+        "owningTenantId",
+        "parentMessageId",
+        "receivedDateTime",
+        "recipients",
+        "senderFromAddress",
+        "senderIP",
+        "sourceAppName",
+        "sourceId",
+        "subject",
+        "suspiciousRecipients",
+        "threadId",
+        "threadType",
+        "urls"
+      ]
+    },
+    "teamsUpdatesAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "tenantAllowBlockListAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "tenantAllowBlockListEntryResult": {
+      "navigationProperties": [],
+      "properties": [
+        "entryType",
+        "expirationDateTime",
+        "identity",
+        "status",
+        "value"
+      ]
+    },
+    "tenantAllowOrBlockListAction": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "expirationDateTime",
+        "note",
+        "results"
+      ]
+    },
+    "threatDetectionDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "confidenceLevel",
+        "priorityAccountProtection",
+        "threats"
+      ]
+    },
+    "threatFinderAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "threatIntelligenceAtpContentData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "threatIntelligenceExportAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "threatIntelligenceMailData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "threatIntelligenceObjectAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "threatIntelligenceUrlClickData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "timelineEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "eventDateTime",
+        "eventDetails",
+        "eventResult",
+        "eventSource",
+        "eventThreats",
+        "eventType"
+      ]
+    },
+    "todoAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "topicModelingSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "dynamicallyAdjustTopicCount",
+        "ignoreNumbers",
+        "isEnabled",
+        "topicCount"
+      ]
+    },
+    "trainableClassifierAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "uamOperationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unifiedGroupAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unifiedSimulationMatchedItemAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unifiedSimulationSummaryAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unIsolateDeviceIncidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "universalPrintManagementAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "universalPrintPrintJobAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unRestrictAppExecutionIncidentTaskResponseAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "urbacAssignmentAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "urbacEnableStateAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "urbacRoleAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "urlEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "url"
+      ]
+    },
+    "userAccount": {
+      "navigationProperties": [],
+      "properties": [
+        "accountName",
+        "activeDirectoryObjectGuid",
+        "azureAdUserId",
+        "displayName",
+        "domainName",
+        "resourceAccessEvents",
+        "userPrincipalName",
+        "userSid"
+      ]
+    },
+    "userEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "stream",
+        "userAccount"
+      ]
+    },
+    "userTrainingAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "usxWorkspaceOnboardingAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "verificationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "signatureValid"
+      ]
+    },
+    "vfamCreatePolicyAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vfamDeletePolicyAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vfamUpdatePolicyAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaAmplifyAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaEngageEventsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaEngageNetworkAssociationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaEngageSegmentAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaGlintAdvancedConfigurationAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaGlintFeedbackProgramAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaGlintOrganizationalDataAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaGlintPulseProgramAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaGlintPulseProgramRespondentRateAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaGlintQuestionAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaGlintRoleAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaGlintRubiconAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaGlintSupportAccessAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaGlintSystemAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaGlintUserAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaGlintUserGroupAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaGoalsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaLearningAdminAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaLearningAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaPulseAdminAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaPulseOrganizerAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaPulseReportAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vivaPulseResponseAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vmMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudProvider",
+        "resourceId",
+        "subscriptionId",
+        "vmId"
+      ]
+    },
+    "wdatpAlertsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "webContentFilteringAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "whoisContact": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "email",
+        "fax",
+        "name",
+        "organization",
+        "telephone"
+      ]
+    },
+    "whoisNameserver": {
+      "navigationProperties": [
+        "host"
+      ],
+      "properties": [
+        "firstSeenDateTime",
+        "lastSeenDateTime"
+      ]
+    },
+    "windows365CustomerLockboxAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "workplaceAnalyticsAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "yammerAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "yammerUserHidingAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    }
+  },
+  "microsoft.graph.security.dlp": {
+    "appAccessContext": {
+      "navigationProperties": [],
+      "properties": [
+        "aadSessionId",
+        "apiId",
+        "clientAppId",
+        "clientAppName",
+        "correlationId",
+        "issuedAtDate",
+        "uniqueTokenId"
+      ]
+    },
+    "attachmentInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "checksum",
+        "labelNames",
+        "labels",
+        "name",
+        "sensitiveInformationDetails",
+        "size"
+      ]
+    },
+    "attachmentSensitiveInformationDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "sensitiveInformationDetailedClassificationAttributes",
+        "sensitiveInformationDetectionIndices",
+        "sensitiveType"
+      ]
+    },
+    "conditionMatchInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "documentProperties",
+        "isConditionMatchedInNewScheme",
+        "otherConditions",
+        "sensitiveInformation"
+      ]
+    },
+    "endpointMetaDataInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "application",
+        "applicationSourceExecutableName",
+        "destinationLocationType",
+        "deviceName",
+        "dlpAuditEventMetadata",
+        "endpointOperation",
+        "enforcementMode",
+        "fileExtension",
+        "fileSize",
+        "fileType",
+        "groupId",
+        "groupName",
+        "isEaV2Enriched",
+        "isHidden",
+        "isJitTriggered",
+        "isRmseEncrypted",
+        "isViewableByExternalUsers",
+        "justification",
+        "markOfTheWebData",
+        "mdatpDeviceId",
+        "originatingDomain",
+        "parentArchiveHash",
+        "platform",
+        "policyMatchDetails",
+        "policyMatchInfo",
+        "previousFileName",
+        "removableMediaDeviceAttributes",
+        "sensitiveInfoTypeData",
+        "sensitivityLabelEventData",
+        "sensitivityLabelIds",
+        "sensitivityLabelNames",
+        "sha1",
+        "sha256",
+        "sourceLocationType",
+        "targetDomain",
+        "targetFilePath",
+        "targetPrinterName",
+        "targetUrl"
+      ]
+    },
+    "exceptionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "isFalsePositive",
+        "justification",
+        "reason",
+        "ruleIds"
+      ]
+    },
+    "exchangeMetaDataInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "attachmentDetails",
+        "bccRecipients",
+        "ccRecipients",
+        "docId",
+        "fileSize",
+        "from",
+        "immutableEntryId",
+        "isViewableByExternalUsers",
+        "messageId",
+        "recipientCount",
+        "sensitivityLabelIds",
+        "sensitivityLabelNames",
+        "sentDate",
+        "subject",
+        "toRecipients",
+        "uniqueId"
+      ]
+    },
+    "nameValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "value"
+      ]
+    },
+    "policyMatchInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "policyId",
+        "policyName",
+        "policyVersion",
+        "rules"
+      ]
+    },
+    "privacyPrimaryMatch": {
+      "navigationProperties": [],
+      "properties": [
+        "length",
+        "offset",
+        "primaryKeyName",
+        "primaryKeys"
+      ]
+    },
+    "remediationInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "alertId",
+        "bccRecipients",
+        "ccRecipients",
+        "iwUser",
+        "recipients",
+        "remediationActivity",
+        "sender",
+        "subject",
+        "templateName"
+      ]
+    },
+    "ruleMatchInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "actionParameters",
+        "actions",
+        "alertProperties",
+        "conditionsMatched",
+        "managementRuleId",
+        "matchId",
+        "matchVersion",
+        "mode",
+        "name",
+        "overriddenActions",
+        "severity"
+      ]
+    },
+    "sensitiveInformationDetailedConfidenceLevelResult": {
+      "navigationProperties": [],
+      "properties": [
+        "confidence",
+        "count",
+        "isMatch"
+      ]
+    },
+    "sensitiveInformationDetectionsInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "detectedOffsetsAndLengths",
+        "detectedValues",
+        "isResultsTruncated"
+      ]
+    },
+    "sensitiveInformationInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "classifierType",
+        "confidence",
+        "count",
+        "location",
+        "privacyPrimaryMatches",
+        "sensitiveInformationDetailedClassificationAttributes",
+        "sensitiveInformationDetections",
+        "sensitiveInformationTypeName",
+        "sensitiveType",
+        "sensitiveTypeSource",
+        "uniqueCount"
+      ]
+    },
+    "sessionMetadataInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "appHost",
+        "appHostCategories",
+        "appHostFqdn",
+        "browser",
+        "browserVersion",
+        "deviceManagementType",
+        "deviceType",
+        "enforcementPlane",
+        "osPlatform",
+        "osVersion"
+      ]
+    },
+    "sharePointMetaDataInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "aiFileActions",
+        "blockedUserForFileAccess",
+        "fileId",
+        "fileName",
+        "fileOwner",
+        "filePathUrl",
+        "fileSize",
+        "from",
+        "isJitTriggered",
+        "isViewableByExternalUsers",
+        "isVisibleOnlyToOdbOwner",
+        "itemCreatedDate",
+        "itemLastModifiedDate",
+        "itemLastSharedDate",
+        "quarantineLocationFileUrl",
+        "sensitivityLabelIds",
+        "sensitivityLabelNames",
+        "sharedBy",
+        "sharedWith",
+        "siteAdmins",
+        "siteCollectionGuid",
+        "siteCollectionUrl",
+        "uniqueId",
+        "violatingAction"
+      ]
+    },
+    "subscriptionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "dlpSubscriptionId",
+        "name"
+      ]
+    }
+  },
+  "microsoft.graph.security.securityCopilot": {
+    "collection_pluginSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "entries"
+      ]
+    },
+    "errorDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message",
+        "outerType"
+      ]
+    },
+    "evaluationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "previewState",
+        "type"
+      ]
+    },
+    "pluginAuth": {
+      "navigationProperties": [],
+      "properties": [
+        "authType"
+      ]
+    },
+    "pluginSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "acceptableValues",
+        "defaultValue",
+        "description",
+        "displayType",
+        "hintText",
+        "isRequired",
+        "label",
+        "name",
+        "settingValue",
+        "value"
+      ]
+    },
+    "skillInputDescriptor": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue",
+        "isRequired",
+        "placeholderValue"
+      ]
+    },
+    "skillTypeDescriptor": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "skillVariableDescriptor": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "name",
+        "type"
+      ]
+    }
+  },
+  "microsoft.graph.teamsAdministration": {
+    "assignedTelephoneNumber": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentCategory",
+        "telephoneNumber"
+      ]
+    },
+    "effectivePolicyAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "policyAssignment",
+        "policyType"
+      ]
+    },
+    "policyAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentType",
+        "displayName",
+        "groupId",
+        "policyId"
+      ]
+    },
+    "telephoneNumberLongRunningOperationDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceLocation",
+        "status",
+        "statusDetail"
+      ]
+    }
+  },
+  "microsoft.graph.tenantGovernanceServices": {
+    "delegatedAdministrationRoleAssignment": {
+      "navigationProperties": [
+        "group"
+      ],
+      "properties": [
+        "roleTemplates"
+      ]
+    },
+    "delegatedAdministrationRoleAssignmentSnapshot": {
+      "navigationProperties": [],
+      "properties": [
+        "groupId",
+        "roleTemplates"
+      ]
+    },
+    "multiTenantApplicationsToProvision": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "displayName",
+        "objectId",
+        "requiredResourceAccesses"
+      ]
+    },
+    "multiTenantApplicationsToProvisionSnapshot": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "displayName",
+        "objectId",
+        "requiredResourceAccesses"
+      ]
+    },
+    "relatedTenantsRefreshStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "isFirstRefresh",
+        "mostRecentRefreshRequestStatus",
+        "mostRecentRefreshTime"
+      ]
+    },
+    "relationshipPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "delegatedAdministrationRoleAssignments",
+        "governedTenantCanTerminate",
+        "multiTenantApplicationsToProvision",
+        "policyId",
+        "version"
+      ]
+    },
+    "requiredResourceAccess": {
+      "navigationProperties": [],
+      "properties": [
+        "permissions",
+        "resourceAppId"
+      ]
+    },
+    "resourcePermission": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "name",
+        "type"
+      ]
+    },
+    "roleTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "name"
+      ]
+    }
+  },
+  "microsoft.graph.termStore": {
+    "localizedDescription": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "languageTag"
+      ]
+    },
+    "localizedLabel": {
+      "navigationProperties": [],
+      "properties": [
+        "isDefault",
+        "languageTag",
+        "name"
+      ]
+    },
+    "localizedName": {
+      "navigationProperties": [],
+      "properties": [
+        "languageTag",
+        "name"
+      ]
+    }
+  },
+  "microsoft.graph.windowsUpdates": {
+    "approvalRule": {
+      "navigationProperties": [],
+      "properties": [
+        "deferralInDays"
+      ]
+    },
+    "assignedGroup": {
+      "navigationProperties": [
+        "group"
+      ],
+      "properties": [
+        "groupId"
+      ]
+    },
+    "azureADDeviceRegistrationError": {
+      "navigationProperties": [],
+      "properties": [
+        "reason"
+      ]
+    },
+    "buildVersionDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "buildNumber",
+        "majorVersion",
+        "minorVersion",
+        "updateBuildRevision"
+      ]
+    },
+    "catalogContent": {
+      "navigationProperties": [
+        "catalogEntry"
+      ],
+      "properties": []
+    },
+    "complianceChangeRule": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastEvaluatedDateTime",
+        "lastModifiedDateTime"
+      ]
+    },
+    "contentApplicabilitySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "offerWhileRecommendedBy",
+        "safeguard"
+      ]
+    },
+    "contentApprovalRule": {
+      "navigationProperties": [],
+      "properties": [
+        "contentFilter",
+        "durationBeforeDeploymentStart"
+      ]
+    },
+    "contentFilter": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "dateDrivenRolloutSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime"
+      ]
+    },
+    "deployableContent": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deploymentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "contentApplicability",
+        "expedite",
+        "monitoring",
+        "schedule",
+        "userExperience"
+      ]
+    },
+    "deploymentState": {
+      "navigationProperties": [],
+      "properties": [
+        "effectiveValue",
+        "reasons",
+        "requestedValue"
+      ]
+    },
+    "deploymentStateReason": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "driverUpdateFilter": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "durationDrivenRolloutSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "durationUntilDeploymentEnd"
+      ]
+    },
+    "excludedGroupAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "assignments"
+      ]
+    },
+    "expediteSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isExpedited",
+        "isReadinessTest"
+      ]
+    },
+    "gradualRolloutSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "durationBetweenOffers"
+      ]
+    },
+    "groupAssignment": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "includedGroupAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "assignments"
+      ]
+    },
+    "itemBody": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "contentType"
+      ]
+    },
+    "knownIssueHistoryItem": {
+      "navigationProperties": [],
+      "properties": [
+        "body",
+        "createdDateTime"
+      ]
+    },
+    "monitoringRule": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "signal",
+        "threshold"
+      ]
+    },
+    "monitoringSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "monitoringRules"
+      ]
+    },
+    "qualityUpdateApprovalRule": {
+      "navigationProperties": [],
+      "properties": [
+        "cadence",
+        "classification"
+      ]
+    },
+    "qualityUpdateCveSeverityInformation": {
+      "navigationProperties": [
+        "exploitedCves"
+      ],
+      "properties": [
+        "maxBaseScore",
+        "maxSeverity"
+      ]
+    },
+    "qualityUpdateFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "cadence",
+        "classification"
+      ]
+    },
+    "rateDrivenRolloutSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "devicesPerOffer"
+      ]
+    },
+    "recoveryApprovalRule": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "remediationUpdateFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "remediationType"
+      ]
+    },
+    "safeguardProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "category"
+      ]
+    },
+    "safeguardSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "disabledSafeguardProfiles"
+      ]
+    },
+    "scheduleSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "gradualRollout",
+        "startDateTime"
+      ]
+    },
+    "servicingPeriod": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "name",
+        "startDateTime"
+      ]
+    },
+    "softwareUpdateFilter": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "updatableAssetEnrollment": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "updatableAssetError": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "updateCategoryEnrollmentInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "enrollmentState",
+        "lastModifiedDateTime"
+      ]
+    },
+    "updateManagementEnrollment": {
+      "navigationProperties": [],
+      "properties": [
+        "driver",
+        "feature",
+        "quality"
+      ]
+    },
+    "userExperienceSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "daysUntilForcedReboot",
+        "isHotpatchEnabled",
+        "offerAsOptional"
+      ]
+    },
+    "windowsUpdateFilter": {
+      "navigationProperties": [],
+      "properties": []
+    }
+  }
+}

--- a/schemas/type-mappings/beta-entity-types.json
+++ b/schemas/type-mappings/beta-entity-types.json
@@ -229,7 +229,8 @@
         "description",
         "displayName",
         "originId",
-        "originSystem"
+        "originSystem",
+        "type"
       ]
     },
     "accessPackageResourceRoleScope": {
@@ -757,6 +758,8 @@
     },
     "agentIdentity": {
       "navigationProperties": [
+        "inheritedAppRoleAssignments",
+        "inheritedOauth2PermissionGrants",
         "sponsors"
       ],
       "properties": [
@@ -953,50 +956,6 @@
         "clientSecret",
         "clientToken",
         "hostPrefix"
-      ]
-    },
-    "alert": {
-      "navigationProperties": [],
-      "properties": [
-        "activityGroupName",
-        "alertDetections",
-        "assignedTo",
-        "azureSubscriptionId",
-        "azureTenantId",
-        "category",
-        "closedDateTime",
-        "cloudAppStates",
-        "comments",
-        "confidence",
-        "createdDateTime",
-        "description",
-        "detectionIds",
-        "eventDateTime",
-        "feedback",
-        "fileStates",
-        "historyStates",
-        "hostStates",
-        "incidentIds",
-        "investigationSecurityStates",
-        "lastEventDateTime",
-        "lastModifiedDateTime",
-        "malwareStates",
-        "messageSecurityStates",
-        "networkConnections",
-        "processes",
-        "recommendedActions",
-        "registryKeyStates",
-        "securityResources",
-        "severity",
-        "sourceMaterials",
-        "status",
-        "tags",
-        "title",
-        "triggers",
-        "uriClickSecurityStates",
-        "userStates",
-        "vendorInformation",
-        "vulnerabilityStates"
       ]
     },
     "allowedDataLocation": {
@@ -4219,28 +4178,6 @@
         "result"
       ]
     },
-    "cloudAppSecurityProfile": {
-      "navigationProperties": [],
-      "properties": [
-        "azureSubscriptionId",
-        "azureTenantId",
-        "createdDateTime",
-        "deploymentPackageUrl",
-        "destinationServiceName",
-        "isSigned",
-        "lastModifiedDateTime",
-        "manifest",
-        "name",
-        "permissionsRequired",
-        "platform",
-        "policyName",
-        "publisher",
-        "riskScore",
-        "tags",
-        "type",
-        "vendorInformation"
-      ]
-    },
     "cloudCertificationAuthority": {
       "navigationProperties": [
         "activeVersion",
@@ -5486,6 +5423,7 @@
         "lastModifiedDateTime",
         "manifestId",
         "manifestVersion",
+        "ownerId",
         "platform",
         "publisher",
         "shortDescription",
@@ -5759,11 +5697,14 @@
       ]
     },
     "customDataProvidedResourceUploadSession": {
-      "navigationProperties": [],
+      "navigationProperties": [
+        "files"
+      ],
       "properties": [
         "createdDateTime",
         "data",
         "isUploadDone",
+        "referenceId",
         "source",
         "stats",
         "status",
@@ -8205,25 +8146,6 @@
         "description"
       ]
     },
-    "domainSecurityProfile": {
-      "navigationProperties": [],
-      "properties": [
-        "activityGroupNames",
-        "azureSubscriptionId",
-        "azureTenantId",
-        "countHits",
-        "countInOrg",
-        "domainCategories",
-        "domainRegisteredDateTime",
-        "firstSeenDateTime",
-        "lastSeenDateTime",
-        "name",
-        "registrant",
-        "riskScore",
-        "tags",
-        "vendorInformation"
-      ]
-    },
     "drive": {
       "navigationProperties": [
         "activities",
@@ -9571,27 +9493,6 @@
         "sensitiveTypeIds"
       ]
     },
-    "fileSecurityProfile": {
-      "navigationProperties": [],
-      "properties": [
-        "activityGroupNames",
-        "azureSubscriptionId",
-        "azureTenantId",
-        "certificateThumbprint",
-        "extensions",
-        "fileType",
-        "firstSeenDateTime",
-        "hashes",
-        "lastSeenDateTime",
-        "malwareStates",
-        "names",
-        "riskScore",
-        "size",
-        "tags",
-        "vendorInformation",
-        "vulnerabilityStates"
-      ]
-    },
     "fileStorage": {
       "navigationProperties": [
         "containers",
@@ -9927,6 +9828,7 @@
       "properties": [
         "browseSessionId",
         "completionDateTime",
+        "destinationType",
         "restoredItemKey",
         "restoredItemPath",
         "restoredItemWebUrl",
@@ -10476,29 +10378,6 @@
       ],
       "properties": [
         "width"
-      ]
-    },
-    "hostSecurityProfile": {
-      "navigationProperties": [],
-      "properties": [
-        "azureSubscriptionId",
-        "azureTenantId",
-        "firstSeenDateTime",
-        "fqdn",
-        "isAzureAdJoined",
-        "isAzureAdRegistered",
-        "isHybridAzureDomainJoined",
-        "lastSeenDateTime",
-        "logonUsers",
-        "netBiosName",
-        "networkInterfaces",
-        "os",
-        "osVersion",
-        "parentHost",
-        "relatedHostIds",
-        "riskScore",
-        "tags",
-        "vendorInformation"
       ]
     },
     "humanSecurityFraudProtectionProvider": {
@@ -11621,24 +11500,6 @@
       "properties": [
         "ipRanges",
         "isTrusted"
-      ]
-    },
-    "ipSecurityProfile": {
-      "navigationProperties": [],
-      "properties": [
-        "activityGroupNames",
-        "address",
-        "azureSubscriptionId",
-        "azureTenantId",
-        "countHits",
-        "countHosts",
-        "firstSeenDateTime",
-        "ipCategories",
-        "ipReferenceData",
-        "lastSeenDateTime",
-        "riskScore",
-        "tags",
-        "vendorInformation"
       ]
     },
     "item": {
@@ -14447,6 +14308,7 @@
         "audioConferencing",
         "chatInfo",
         "chatRestrictions",
+        "cloudVideoInteropInfo",
         "expiryDateTime",
         "isEndToEndEncryptionEnabled",
         "isEntryExitAnnounced",
@@ -16493,16 +16355,6 @@
         "status"
       ]
     },
-    "providerTenantSetting": {
-      "navigationProperties": [],
-      "properties": [
-        "azureTenantId",
-        "enabled",
-        "lastModifiedDateTime",
-        "provider",
-        "vendor"
-      ]
-    },
     "provisioningObjectSummary": {
       "navigationProperties": [],
       "properties": [
@@ -17773,60 +17625,31 @@
     },
     "security": {
       "navigationProperties": [
-        "alerts",
         "alerts_v2",
         "attackSimulation",
         "auditLog",
         "cases",
-        "cloudAppSecurityProfiles",
         "collaboration",
         "dataDiscovery",
         "dataSecurityAndGovernance",
-        "domainSecurityProfiles",
-        "fileSecurityProfiles",
-        "hostSecurityProfiles",
         "identities",
         "incidents",
         "incidentTasks",
         "informationProtection",
-        "ipSecurityProfiles",
         "labels",
         "partner",
-        "providerTenantSettings",
         "rules",
         "secureScoreControlProfiles",
         "secureScores",
-        "securityActions",
         "securityCopilot",
         "subjectRightsRequests",
         "threatIntelligence",
         "threatSubmission",
-        "tiIndicators",
         "triggers",
         "triggerTypes",
-        "userSecurityProfiles",
         "zones"
       ],
       "properties": []
-    },
-    "securityAction": {
-      "navigationProperties": [],
-      "properties": [
-        "actionReason",
-        "appId",
-        "azureTenantId",
-        "clientContext",
-        "completedDateTime",
-        "createdDateTime",
-        "errorInfo",
-        "lastActionDateTime",
-        "name",
-        "parameters",
-        "states",
-        "status",
-        "user",
-        "vendorInformation"
-      ]
     },
     "securityBaselineCategoryStateSummary": {
       "navigationProperties": [],
@@ -19866,69 +19689,6 @@
         "source"
       ]
     },
-    "tiIndicator": {
-      "navigationProperties": [],
-      "properties": [
-        "action",
-        "activityGroupNames",
-        "additionalInformation",
-        "azureTenantId",
-        "confidence",
-        "description",
-        "diamondModel",
-        "domainName",
-        "emailEncoding",
-        "emailLanguage",
-        "emailRecipient",
-        "emailSenderAddress",
-        "emailSenderName",
-        "emailSourceDomain",
-        "emailSourceIpAddress",
-        "emailSubject",
-        "emailXMailer",
-        "expirationDateTime",
-        "externalId",
-        "fileCompileDateTime",
-        "fileCreatedDateTime",
-        "fileHashType",
-        "fileHashValue",
-        "fileMutexName",
-        "fileName",
-        "filePacker",
-        "filePath",
-        "fileSize",
-        "fileType",
-        "ingestedDateTime",
-        "isActive",
-        "killChain",
-        "knownFalsePositives",
-        "lastReportedDateTime",
-        "malwareFamilyNames",
-        "networkCidrBlock",
-        "networkDestinationAsn",
-        "networkDestinationCidrBlock",
-        "networkDestinationIPv4",
-        "networkDestinationIPv6",
-        "networkDestinationPort",
-        "networkIPv4",
-        "networkIPv6",
-        "networkPort",
-        "networkProtocol",
-        "networkSourceAsn",
-        "networkSourceCidrBlock",
-        "networkSourceIPv4",
-        "networkSourceIPv6",
-        "networkSourcePort",
-        "passiveOnly",
-        "severity",
-        "tags",
-        "targetProduct",
-        "threatType",
-        "tlpLevel",
-        "url",
-        "userAgent"
-      ]
-    },
     "timeCard": {
       "navigationProperties": [],
       "properties": [
@@ -21591,21 +21351,6 @@
       ],
       "properties": []
     },
-    "userSecurityProfile": {
-      "navigationProperties": [],
-      "properties": [
-        "accounts",
-        "azureSubscriptionId",
-        "azureTenantId",
-        "createdDateTime",
-        "displayName",
-        "lastModifiedDateTime",
-        "riskScore",
-        "tags",
-        "userPrincipalName",
-        "vendorInformation"
-      ]
-    },
     "userSettings": {
       "navigationProperties": [
         "contactMergeSuggestions",
@@ -21789,6 +21534,7 @@
         "displayName",
         "endDateTime",
         "externalEventInformation",
+        "isRegistrationEnabled",
         "settings",
         "startDateTime",
         "status"
@@ -21858,6 +21604,7 @@
         "registrations"
       ],
       "properties": [
+        "capacity",
         "endDateTime",
         "startDateTime",
         "videoOnDemandWebUrl"
@@ -21875,6 +21622,7 @@
       "navigationProperties": [],
       "properties": [
         "audience",
+        "capacity",
         "coOrganizers",
         "invitedAttendees",
         "isInviteOnly"
@@ -26495,6 +26243,10 @@
       ]
     },
     "forwardingProfile": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "forwardingProfileBase": {
       "navigationProperties": [
         "servicePrincipal"
       ],

--- a/schemas/type-mappings/beta-entity-types.json
+++ b/schemas/type-mappings/beta-entity-types.json
@@ -1,0 +1,29191 @@
+{
+  "microsoft.graph": {
+    "aadUserConversationMember": {
+      "navigationProperties": [
+        "user"
+      ],
+      "properties": [
+        "email",
+        "tenantId",
+        "userId"
+      ]
+    },
+    "accessDriftReport": {
+      "navigationProperties": [],
+      "properties": [
+        "downloadUri",
+        "expiresAt",
+        "resourceType",
+        "tenantId"
+      ]
+    },
+    "accessPackage": {
+      "navigationProperties": [
+        "accessPackageAssignmentPolicies",
+        "accessPackageCatalog",
+        "accessPackageResourceRoleScopes",
+        "accessPackagesIncompatibleWith",
+        "incompatibleAccessPackages",
+        "incompatibleGroups"
+      ],
+      "properties": [
+        "catalogId",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "isHidden",
+        "isRoleScopesVisible",
+        "modifiedBy",
+        "modifiedDateTime",
+        "uniqueName"
+      ]
+    },
+    "accessPackageAssignment": {
+      "navigationProperties": [
+        "accessPackage",
+        "accessPackageAssignmentPolicy",
+        "accessPackageAssignmentRequests",
+        "accessPackageAssignmentResourceRoles",
+        "target"
+      ],
+      "properties": [
+        "accessPackageId",
+        "assignmentPolicyId",
+        "assignmentState",
+        "assignmentStatus",
+        "catalogId",
+        "customExtensionCalloutInstances",
+        "expiredDateTime",
+        "isExtended",
+        "schedule",
+        "targetId"
+      ]
+    },
+    "accessPackageAssignmentPolicy": {
+      "navigationProperties": [
+        "accessPackage",
+        "accessPackageCatalog",
+        "customExtensionHandlers",
+        "customExtensionStageSettings"
+      ],
+      "properties": [
+        "accessPackageId",
+        "accessPackageNotificationSettings",
+        "accessReviewSettings",
+        "canExtend",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "durationInDays",
+        "expirationDateTime",
+        "modifiedBy",
+        "modifiedDateTime",
+        "questions",
+        "requestApprovalSettings",
+        "requestorSettings",
+        "verifiableCredentialSettings"
+      ]
+    },
+    "accessPackageAssignmentRequest": {
+      "navigationProperties": [
+        "accessPackage",
+        "accessPackageAssignment",
+        "requestor"
+      ],
+      "properties": [
+        "answers",
+        "completedDate",
+        "createdDateTime",
+        "customExtensionCalloutInstances",
+        "customExtensionHandlerInstances",
+        "expirationDateTime",
+        "history",
+        "isValidationOnly",
+        "justification",
+        "requestState",
+        "requestStatus",
+        "requestType",
+        "schedule",
+        "verifiedCredentialsData"
+      ]
+    },
+    "accessPackageAssignmentRequestWorkflowExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "callbackConfiguration",
+        "createdBy",
+        "createdDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "accessPackageAssignmentResourceRole": {
+      "navigationProperties": [
+        "accessPackageAssignments",
+        "accessPackageResourceRole",
+        "accessPackageResourceScope",
+        "accessPackageSubject"
+      ],
+      "properties": [
+        "originId",
+        "originSystem",
+        "status"
+      ]
+    },
+    "accessPackageAssignmentWorkflowExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "callbackConfiguration",
+        "createdBy",
+        "createdDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "accessPackageCatalog": {
+      "navigationProperties": [
+        "accessPackageCustomWorkflowExtensions",
+        "accessPackageResourceRoles",
+        "accessPackageResources",
+        "accessPackageResourceScopes",
+        "accessPackages",
+        "customAccessPackageWorkflowExtensions"
+      ],
+      "properties": [
+        "catalogStatus",
+        "catalogType",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "isExternallyVisible",
+        "modifiedBy",
+        "modifiedDateTime",
+        "privilegeLevel",
+        "uniqueName"
+      ]
+    },
+    "accessPackageResource": {
+      "navigationProperties": [
+        "accessPackageResourceEnvironment",
+        "accessPackageResourceRoles",
+        "accessPackageResourceScopes",
+        "externalOriginResourceConnector",
+        "uploadSessions"
+      ],
+      "properties": [
+        "addedBy",
+        "addedOn",
+        "attributes",
+        "description",
+        "displayName",
+        "isPendingOnboarding",
+        "originId",
+        "originSystem",
+        "resourceType",
+        "url"
+      ]
+    },
+    "accessPackageResourceEnvironment": {
+      "navigationProperties": [
+        "accessPackageResources"
+      ],
+      "properties": [
+        "connectionInfo",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "isDefaultEnvironment",
+        "modifiedBy",
+        "modifiedDateTime",
+        "originId",
+        "originSystem"
+      ]
+    },
+    "accessPackageResourceRequest": {
+      "navigationProperties": [
+        "accessPackageResource",
+        "requestor"
+      ],
+      "properties": [
+        "catalogId",
+        "executeImmediately",
+        "expirationDateTime",
+        "isValidationOnly",
+        "justification",
+        "requestState",
+        "requestStatus",
+        "requestType"
+      ]
+    },
+    "accessPackageResourceRole": {
+      "navigationProperties": [
+        "accessPackageResource"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "originId",
+        "originSystem"
+      ]
+    },
+    "accessPackageResourceRoleScope": {
+      "navigationProperties": [
+        "accessPackageResourceRole",
+        "accessPackageResourceScope"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "modifiedBy",
+        "modifiedDateTime"
+      ]
+    },
+    "accessPackageResourceScope": {
+      "navigationProperties": [
+        "accessPackageResource"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "isRootScope",
+        "originId",
+        "originSystem",
+        "roleOriginId",
+        "url"
+      ]
+    },
+    "accessPackageSubject": {
+      "navigationProperties": [
+        "connectedOrganization"
+      ],
+      "properties": [
+        "altSecId",
+        "cleanupScheduledDateTime",
+        "connectedOrganizationId",
+        "displayName",
+        "email",
+        "objectId",
+        "onPremisesSecurityIdentifier",
+        "principalName",
+        "subjectLifecycle",
+        "type"
+      ]
+    },
+    "accessPackageSuggestion": {
+      "navigationProperties": [
+        "accessPackage"
+      ],
+      "properties": [
+        "reasons"
+      ]
+    },
+    "accessReview": {
+      "navigationProperties": [
+        "decisions",
+        "instances",
+        "myDecisions",
+        "reviewers"
+      ],
+      "properties": [
+        "businessFlowTemplateId",
+        "createdBy",
+        "description",
+        "displayName",
+        "endDateTime",
+        "reviewedEntity",
+        "reviewerType",
+        "settings",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "accessReviewDecision": {
+      "navigationProperties": [],
+      "properties": [
+        "accessRecommendation",
+        "accessReviewId",
+        "appliedBy",
+        "appliedDateTime",
+        "applyResult",
+        "justification",
+        "reviewedBy",
+        "reviewedDateTime",
+        "reviewResult"
+      ]
+    },
+    "accessReviewHistoryDefinition": {
+      "navigationProperties": [
+        "instances"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "decisions",
+        "displayName",
+        "downloadUri",
+        "fulfilledDateTime",
+        "reviewHistoryPeriodEndDateTime",
+        "reviewHistoryPeriodStartDateTime",
+        "scheduleSettings",
+        "scopes",
+        "status"
+      ]
+    },
+    "accessReviewHistoryInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "downloadUri",
+        "expirationDateTime",
+        "fulfilledDateTime",
+        "reviewHistoryPeriodEndDateTime",
+        "reviewHistoryPeriodStartDateTime",
+        "runDateTime",
+        "status"
+      ]
+    },
+    "accessReviewInstance": {
+      "navigationProperties": [
+        "contactedReviewers",
+        "decisions",
+        "definition",
+        "stages"
+      ],
+      "properties": [
+        "endDateTime",
+        "errors",
+        "fallbackReviewers",
+        "reviewers",
+        "scope",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "accessReviewInstanceDecisionItem": {
+      "navigationProperties": [
+        "insights",
+        "instance"
+      ],
+      "properties": [
+        "accessReviewId",
+        "appliedBy",
+        "appliedDateTime",
+        "applyDescription",
+        "applyResult",
+        "decision",
+        "justification",
+        "permission",
+        "principal",
+        "principalLink",
+        "principalResourceMembership",
+        "recommendation",
+        "resource",
+        "resourceLink",
+        "reviewedBy",
+        "reviewedDateTime",
+        "target"
+      ]
+    },
+    "accessReviewPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "isGroupOwnerManagementEnabled"
+      ]
+    },
+    "accessReviewReviewer": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "userPrincipalName"
+      ]
+    },
+    "accessReviewScheduleDefinition": {
+      "navigationProperties": [
+        "instances"
+      ],
+      "properties": [
+        "additionalNotificationRecipients",
+        "backupReviewers",
+        "createdBy",
+        "createdDateTime",
+        "descriptionForAdmins",
+        "descriptionForReviewers",
+        "displayName",
+        "fallbackReviewers",
+        "instanceEnumerationScope",
+        "lastModifiedDateTime",
+        "reviewers",
+        "scope",
+        "settings",
+        "stageSettings",
+        "status"
+      ]
+    },
+    "accessReviewSet": {
+      "navigationProperties": [
+        "decisions",
+        "definitions",
+        "historyDefinitions",
+        "instances",
+        "policy"
+      ],
+      "properties": []
+    },
+    "accessReviewStage": {
+      "navigationProperties": [
+        "decisions"
+      ],
+      "properties": [
+        "endDateTime",
+        "fallbackReviewers",
+        "reviewers",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "account": {
+      "navigationProperties": [],
+      "properties": [
+        "blocked",
+        "category",
+        "displayName",
+        "id",
+        "lastModifiedDateTime",
+        "number",
+        "subCategory"
+      ]
+    },
+    "activeDirectoryWindowsAutopilotDeploymentProfile": {
+      "navigationProperties": [
+        "domainJoinConfiguration"
+      ],
+      "properties": [
+        "hybridAzureADJoinSkipConnectivityCheck"
+      ]
+    },
+    "activeUsersMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "appName",
+        "count",
+        "country",
+        "factDate",
+        "language",
+        "os"
+      ]
+    },
+    "activitiesContainer": {
+      "navigationProperties": [
+        "contentActivities"
+      ],
+      "properties": []
+    },
+    "activityBasedTimeoutPolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "activityHistoryItem": {
+      "navigationProperties": [
+        "activity"
+      ],
+      "properties": [
+        "activeDurationSeconds",
+        "createdDateTime",
+        "expirationDateTime",
+        "lastActiveDateTime",
+        "lastModifiedDateTime",
+        "startedDateTime",
+        "status",
+        "userTimezone"
+      ]
+    },
+    "activityLogBase": {
+      "navigationProperties": [],
+      "properties": [
+        "activityType",
+        "error",
+        "eventDateTime",
+        "performedBy",
+        "resultStatus",
+        "serviceType",
+        "severity"
+      ]
+    },
+    "activityStatistics": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "duration",
+        "endDate",
+        "startDate",
+        "timeZoneUsed"
+      ]
+    },
+    "addLargeGalleryViewOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "adhocCall": {
+      "navigationProperties": [
+        "recordings",
+        "transcripts"
+      ],
+      "properties": []
+    },
+    "admin": {
+      "navigationProperties": [
+        "appsAndServices",
+        "cloudLicensing",
+        "configurationManagement",
+        "dynamics",
+        "edge",
+        "entra",
+        "exchange",
+        "forms",
+        "microsoft365Apps",
+        "people",
+        "reportSettings",
+        "serviceAnnouncement",
+        "sharepoint",
+        "teams",
+        "todo",
+        "windows"
+      ],
+      "properties": []
+    },
+    "adminAppsAndServices": {
+      "navigationProperties": [],
+      "properties": [
+        "settings"
+      ]
+    },
+    "adminConsentRequestPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "notifyReviewers",
+        "remindersEnabled",
+        "requestDurationInDays",
+        "reviewers",
+        "version"
+      ]
+    },
+    "adminDynamics": {
+      "navigationProperties": [],
+      "properties": [
+        "customerVoice"
+      ]
+    },
+    "adminForms": {
+      "navigationProperties": [],
+      "properties": [
+        "settings"
+      ]
+    },
+    "administrativeUnit": {
+      "navigationProperties": [
+        "deletedMembers",
+        "extensions",
+        "members",
+        "scopedRoleMembers"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "isMemberManagementRestricted",
+        "membershipRule",
+        "membershipRuleProcessingState",
+        "membershipType",
+        "visibility"
+      ]
+    },
+    "adminMicrosoft365Apps": {
+      "navigationProperties": [
+        "installationOptions"
+      ],
+      "properties": []
+    },
+    "adminReportSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "displayConcealedNames"
+      ]
+    },
+    "adminTodo": {
+      "navigationProperties": [],
+      "properties": [
+        "settings"
+      ]
+    },
+    "adminWindows": {
+      "navigationProperties": [
+        "updates"
+      ],
+      "properties": []
+    },
+    "adminWindowsUpdates": {
+      "navigationProperties": [
+        "catalog",
+        "deploymentAudiences",
+        "deployments",
+        "policies",
+        "products",
+        "resourceConnections",
+        "updatableAssets",
+        "updatePolicies"
+      ],
+      "properties": []
+    },
+    "advancedThreatProtectionOnboardingDeviceSettingState": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceGracePeriodExpirationDateTime",
+        "deviceId",
+        "deviceModel",
+        "deviceName",
+        "platformType",
+        "setting",
+        "settingName",
+        "state",
+        "userEmail",
+        "userId",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "advancedThreatProtectionOnboardingStateSummary": {
+      "navigationProperties": [
+        "advancedThreatProtectionOnboardingDeviceSettingStates"
+      ],
+      "properties": [
+        "compliantDeviceCount",
+        "conflictDeviceCount",
+        "errorDeviceCount",
+        "nonCompliantDeviceCount",
+        "notApplicableDeviceCount",
+        "notAssignedDeviceCount",
+        "remediatedDeviceCount",
+        "unknownDeviceCount"
+      ]
+    },
+    "agedAccountsPayable": {
+      "navigationProperties": [],
+      "properties": [
+        "agedAsOfDate",
+        "balanceDue",
+        "currencyCode",
+        "currentAmount",
+        "id",
+        "name",
+        "period1Amount",
+        "period2Amount",
+        "period3Amount",
+        "periodLengthFilter",
+        "vendorId",
+        "vendorNumber"
+      ]
+    },
+    "agedAccountsReceivable": {
+      "navigationProperties": [],
+      "properties": [
+        "agedAsOfDate",
+        "balanceDue",
+        "currencyCode",
+        "currentAmount",
+        "customerId",
+        "customerNumber",
+        "id",
+        "name",
+        "period1Amount",
+        "period2Amount",
+        "period3Amount",
+        "periodLengthFilter"
+      ]
+    },
+    "agent": {
+      "navigationProperties": [
+        "copilotTools"
+      ],
+      "properties": []
+    },
+    "agentCardManifest": {
+      "navigationProperties": [],
+      "properties": [
+        "capabilities",
+        "createdBy",
+        "createdDateTime",
+        "defaultInputModes",
+        "defaultOutputModes",
+        "description",
+        "displayName",
+        "documentationUrl",
+        "iconUrl",
+        "lastModifiedDateTime",
+        "managedBy",
+        "originatingStore",
+        "ownerIds",
+        "protocolVersion",
+        "provider",
+        "security",
+        "securitySchemes",
+        "skills",
+        "supportsAuthenticatedExtendedCard",
+        "version"
+      ]
+    },
+    "agentCollection": {
+      "navigationProperties": [
+        "members"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "managedBy",
+        "originatingStore",
+        "ownerIds"
+      ]
+    },
+    "agentIdentity": {
+      "navigationProperties": [
+        "sponsors"
+      ],
+      "properties": [
+        "agentIdentityBlueprintId",
+        "createdDateTime"
+      ]
+    },
+    "agentIdentityBlueprint": {
+      "navigationProperties": [
+        "inheritablePermissions",
+        "sponsors"
+      ],
+      "properties": []
+    },
+    "agentIdentityBlueprintPrincipal": {
+      "navigationProperties": [
+        "sponsors"
+      ],
+      "properties": []
+    },
+    "agentInstance": {
+      "navigationProperties": [
+        "agentCardManifest",
+        "collections"
+      ],
+      "properties": [
+        "additionalInterfaces",
+        "agentIdentityBlueprintId",
+        "agentIdentityId",
+        "agentUserId",
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "lastModifiedDateTime",
+        "managedBy",
+        "originatingStore",
+        "ownerIds",
+        "preferredTransport",
+        "signatures",
+        "sourceAgentId",
+        "url"
+      ]
+    },
+    "agentRegistration": {
+      "navigationProperties": [],
+      "properties": [
+        "agentCard",
+        "agentIdentityBlueprintId",
+        "agentIdentityId",
+        "createdBy",
+        "description",
+        "displayName",
+        "lastPublishedBy",
+        "managedByAppId",
+        "originatingStore",
+        "ownerIds",
+        "sourceAgentId",
+        "sourceCreatedDateTime",
+        "sourceLastModifiedDateTime"
+      ]
+    },
+    "agentRegistry": {
+      "navigationProperties": [
+        "agentCardManifests",
+        "agentCollections",
+        "agentInstances"
+      ],
+      "properties": []
+    },
+    "agentRiskDetection": {
+      "navigationProperties": [],
+      "properties": [
+        "activityDateTime",
+        "additionalInfo",
+        "agentDisplayName",
+        "agentId",
+        "blueprintId",
+        "detectedDateTime",
+        "detectionTimingType",
+        "identityType",
+        "lastModifiedDateTime",
+        "riskDetail",
+        "riskEventType",
+        "riskEvidence",
+        "riskLevel",
+        "riskState",
+        "source"
+      ]
+    },
+    "agentUser": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "agreement": {
+      "navigationProperties": [
+        "acceptances",
+        "file",
+        "files"
+      ],
+      "properties": [
+        "displayName",
+        "isPerDeviceAcceptanceRequired",
+        "isViewingBeforeAcceptanceRequired",
+        "termsExpiration",
+        "userReacceptRequiredFrequency"
+      ]
+    },
+    "agreementAcceptance": {
+      "navigationProperties": [],
+      "properties": [
+        "agreementFileId",
+        "agreementId",
+        "deviceDisplayName",
+        "deviceId",
+        "deviceOSType",
+        "deviceOSVersion",
+        "expirationDateTime",
+        "recordedDateTime",
+        "state",
+        "userDisplayName",
+        "userEmail",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "agreementFile": {
+      "navigationProperties": [
+        "localizations"
+      ],
+      "properties": []
+    },
+    "agreementFileLocalization": {
+      "navigationProperties": [
+        "versions"
+      ],
+      "properties": []
+    },
+    "agreementFileProperties": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "fileData",
+        "fileName",
+        "isDefault",
+        "isMajorVersion",
+        "language"
+      ]
+    },
+    "agreementFileVersion": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aiInteraction": {
+      "navigationProperties": [],
+      "properties": [
+        "appClass",
+        "attachments",
+        "body",
+        "contexts",
+        "conversationType",
+        "createdDateTime",
+        "etag",
+        "from",
+        "interactionType",
+        "links",
+        "locale",
+        "mentions",
+        "requestId",
+        "sessionId"
+      ]
+    },
+    "aiInteractionHistory": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aiOnlineMeeting": {
+      "navigationProperties": [
+        "aiInsights"
+      ],
+      "properties": []
+    },
+    "aiUser": {
+      "navigationProperties": [
+        "interactionHistory",
+        "onlineMeetings"
+      ],
+      "properties": []
+    },
+    "akamaiWebApplicationFirewallProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "accessToken",
+        "clientSecret",
+        "clientToken",
+        "hostPrefix"
+      ]
+    },
+    "alert": {
+      "navigationProperties": [],
+      "properties": [
+        "activityGroupName",
+        "alertDetections",
+        "assignedTo",
+        "azureSubscriptionId",
+        "azureTenantId",
+        "category",
+        "closedDateTime",
+        "cloudAppStates",
+        "comments",
+        "confidence",
+        "createdDateTime",
+        "description",
+        "detectionIds",
+        "eventDateTime",
+        "feedback",
+        "fileStates",
+        "historyStates",
+        "hostStates",
+        "incidentIds",
+        "investigationSecurityStates",
+        "lastEventDateTime",
+        "lastModifiedDateTime",
+        "malwareStates",
+        "messageSecurityStates",
+        "networkConnections",
+        "processes",
+        "recommendedActions",
+        "registryKeyStates",
+        "securityResources",
+        "severity",
+        "sourceMaterials",
+        "status",
+        "tags",
+        "title",
+        "triggers",
+        "uriClickSecurityStates",
+        "userStates",
+        "vendorInformation",
+        "vulnerabilityStates"
+      ]
+    },
+    "allowedDataLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "domain",
+        "isDefault",
+        "location"
+      ]
+    },
+    "allowedValue": {
+      "navigationProperties": [],
+      "properties": [
+        "isActive"
+      ]
+    },
+    "androidAppConfigurationSchema": {
+      "navigationProperties": [],
+      "properties": [
+        "exampleJson",
+        "nestedSchemaItems",
+        "schemaItems"
+      ]
+    },
+    "androidCertificateProfileBase": {
+      "navigationProperties": [
+        "rootCertificate"
+      ],
+      "properties": [
+        "certificateValidityPeriodScale",
+        "certificateValidityPeriodValue",
+        "extendedKeyUsages",
+        "renewalThresholdPercentage",
+        "subjectAlternativeNameType",
+        "subjectNameFormat"
+      ]
+    },
+    "androidCompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "advancedThreatProtectionRequiredSecurityLevel",
+        "conditionStatementId",
+        "deviceThreatProtectionEnabled",
+        "deviceThreatProtectionRequiredSecurityLevel",
+        "minAndroidSecurityPatchLevel",
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordExpirationDays",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "requiredPasswordComplexity",
+        "restrictedApps",
+        "securityBlockDeviceAdministratorManagedDevices",
+        "securityBlockJailbrokenDevices",
+        "securityDisableUsbDebugging",
+        "securityPreventInstallAppsFromUnknownSources",
+        "securityRequireCompanyPortalAppIntegrity",
+        "securityRequireGooglePlayServices",
+        "securityRequireSafetyNetAttestationBasicIntegrity",
+        "securityRequireSafetyNetAttestationCertifiedDevice",
+        "securityRequireUpToDateSecurityProviders",
+        "securityRequireVerifyApps",
+        "storageRequireEncryption"
+      ]
+    },
+    "androidCustomConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "omaSettings"
+      ]
+    },
+    "androidDeviceComplianceLocalActionBase": {
+      "navigationProperties": [],
+      "properties": [
+        "gracePeriodInMinutes"
+      ]
+    },
+    "androidDeviceComplianceLocalActionLockDevice": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "androidDeviceComplianceLocalActionLockDeviceWithPasscode": {
+      "navigationProperties": [],
+      "properties": [
+        "passcode",
+        "passcodeSignInFailureCountBeforeWipe"
+      ]
+    },
+    "androidDeviceOwnerCertificateProfileBase": {
+      "navigationProperties": [
+        "rootCertificate"
+      ],
+      "properties": [
+        "certificateValidityPeriodScale",
+        "certificateValidityPeriodValue",
+        "extendedKeyUsages",
+        "renewalThresholdPercentage",
+        "subjectAlternativeNameType",
+        "subjectNameFormat"
+      ]
+    },
+    "androidDeviceOwnerCompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "advancedThreatProtectionRequiredSecurityLevel",
+        "deviceThreatProtectionEnabled",
+        "deviceThreatProtectionRequiredSecurityLevel",
+        "minAndroidSecurityPatchLevel",
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordExpirationDays",
+        "passwordMinimumLength",
+        "passwordMinimumLetterCharacters",
+        "passwordMinimumLowerCaseCharacters",
+        "passwordMinimumNonLetterCharacters",
+        "passwordMinimumNumericCharacters",
+        "passwordMinimumSymbolCharacters",
+        "passwordMinimumUpperCaseCharacters",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordCountToBlock",
+        "passwordRequired",
+        "passwordRequiredType",
+        "requireNoPendingSystemUpdates",
+        "securityBlockJailbrokenDevices",
+        "securityRequiredAndroidSafetyNetEvaluationType",
+        "securityRequireIntuneAppIntegrity",
+        "securityRequireSafetyNetAttestationBasicIntegrity",
+        "securityRequireSafetyNetAttestationCertifiedDevice",
+        "storageRequireEncryption"
+      ]
+    },
+    "androidDeviceOwnerDerivedCredentialAuthenticationConfiguration": {
+      "navigationProperties": [
+        "derivedCredentialSettings"
+      ],
+      "properties": [
+        "certificateAccessType",
+        "silentCertificateAccessDetails"
+      ]
+    },
+    "androidDeviceOwnerEnrollmentProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "accountId",
+        "configureWifi",
+        "createdDateTime",
+        "description",
+        "deviceNameTemplate",
+        "displayName",
+        "enrolledDeviceCount",
+        "enrollmentMode",
+        "enrollmentTokenType",
+        "enrollmentTokenUsageCount",
+        "isTeamsDeviceProfile",
+        "lastModifiedDateTime",
+        "qrCodeContent",
+        "qrCodeImage",
+        "roleScopeTagIds",
+        "tokenCreationDateTime",
+        "tokenExpirationDateTime",
+        "tokenValue",
+        "wifiHidden",
+        "wifiPassword",
+        "wifiSecurityType",
+        "wifiSsid"
+      ]
+    },
+    "androidDeviceOwnerEnterpriseWiFiConfiguration": {
+      "navigationProperties": [
+        "derivedCredentialSettings",
+        "identityCertificateForClientAuthentication",
+        "rootCertificateForServerValidation",
+        "rootCertificatesForServerValidation"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "eapType",
+        "innerAuthenticationProtocolForEapTtls",
+        "innerAuthenticationProtocolForPeap",
+        "outerIdentityPrivacyTemporaryValue",
+        "trustedServerCertificateNames"
+      ]
+    },
+    "androidDeviceOwnerGeneralDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accountsBlockModification",
+        "androidDeviceOwnerDelegatedScopeAppSettings",
+        "appsAllowInstallFromUnknownSources",
+        "appsAutoUpdatePolicy",
+        "appsDefaultPermissionPolicy",
+        "appsRecommendSkippingFirstUseHints",
+        "azureAdSharedDeviceDataClearApps",
+        "bluetoothBlockConfiguration",
+        "bluetoothBlockContactSharing",
+        "cameraBlocked",
+        "cellularBlockWiFiTethering",
+        "certificateCredentialConfigurationDisabled",
+        "crossProfilePoliciesAllowCopyPaste",
+        "crossProfilePoliciesAllowDataSharing",
+        "crossProfilePoliciesShowWorkContactsInPersonalProfile",
+        "dataRoamingBlocked",
+        "dateTimeConfigurationBlocked",
+        "detailedHelpText",
+        "deviceLocationMode",
+        "deviceOwnerLockScreenMessage",
+        "enrollmentProfile",
+        "factoryResetBlocked",
+        "factoryResetDeviceAdministratorEmails",
+        "globalProxy",
+        "googleAccountsBlocked",
+        "isKioskModeExitCodeSet",
+        "kioskCustomizationDeviceSettingsBlocked",
+        "kioskCustomizationPowerButtonActionsBlocked",
+        "kioskCustomizationStatusBar",
+        "kioskCustomizationSystemErrorWarnings",
+        "kioskCustomizationSystemNavigation",
+        "kioskModeAppOrderEnabled",
+        "kioskModeAppPositions",
+        "kioskModeApps",
+        "kioskModeAppsInFolderOrderedByName",
+        "kioskModeBluetoothConfigurationEnabled",
+        "kioskModeDebugMenuEasyAccessEnabled",
+        "kioskModeExitCode",
+        "kioskModeFlashlightConfigurationEnabled",
+        "kioskModeFolderIcon",
+        "kioskModeGridHeight",
+        "kioskModeGridWidth",
+        "kioskModeIconSize",
+        "kioskModeLockHomeScreen",
+        "kioskModeManagedFolders",
+        "kioskModeManagedHomeScreenAppSettings",
+        "kioskModeManagedHomeScreenAutoSignout",
+        "kioskModeManagedHomeScreenInactiveSignOutDelayInSeconds",
+        "kioskModeManagedHomeScreenInactiveSignOutNoticeInSeconds",
+        "kioskModeManagedHomeScreenPinComplexity",
+        "kioskModeManagedHomeScreenPinRequired",
+        "kioskModeManagedHomeScreenPinRequiredToResume",
+        "kioskModeManagedHomeScreenSignInBackground",
+        "kioskModeManagedHomeScreenSignInBrandingLogo",
+        "kioskModeManagedHomeScreenSignInEnabled",
+        "kioskModeManagedSettingsEntryDisabled",
+        "kioskModeMediaVolumeConfigurationEnabled",
+        "kioskModeScreenOrientation",
+        "kioskModeScreenSaverConfigurationEnabled",
+        "kioskModeScreenSaverDetectMediaDisabled",
+        "kioskModeScreenSaverDisplayTimeInSeconds",
+        "kioskModeScreenSaverImageUrl",
+        "kioskModeScreenSaverStartDelayInSeconds",
+        "kioskModeShowAppNotificationBadge",
+        "kioskModeShowDeviceInfo",
+        "kioskModeUseManagedHomeScreenApp",
+        "kioskModeVirtualHomeButtonEnabled",
+        "kioskModeVirtualHomeButtonType",
+        "kioskModeWallpaperUrl",
+        "kioskModeWifiAllowedSsids",
+        "kioskModeWiFiConfigurationEnabled",
+        "locateDeviceLostModeEnabled",
+        "locateDeviceUserlessDisabled",
+        "microphoneForceMute",
+        "microsoftLauncherConfigurationEnabled",
+        "microsoftLauncherCustomWallpaperAllowUserModification",
+        "microsoftLauncherCustomWallpaperEnabled",
+        "microsoftLauncherCustomWallpaperImageUrl",
+        "microsoftLauncherDockPresenceAllowUserModification",
+        "microsoftLauncherDockPresenceConfiguration",
+        "microsoftLauncherFeedAllowUserModification",
+        "microsoftLauncherFeedEnabled",
+        "microsoftLauncherSearchBarPlacementConfiguration",
+        "networkEscapeHatchAllowed",
+        "nfcBlockOutgoingBeam",
+        "passwordBlockKeyguard",
+        "passwordBlockKeyguardFeatures",
+        "passwordExpirationDays",
+        "passwordMinimumLength",
+        "passwordMinimumLetterCharacters",
+        "passwordMinimumLowerCaseCharacters",
+        "passwordMinimumNonLetterCharacters",
+        "passwordMinimumNumericCharacters",
+        "passwordMinimumSymbolCharacters",
+        "passwordMinimumUpperCaseCharacters",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordPreviousPasswordCountToBlock",
+        "passwordRequiredType",
+        "passwordRequireUnlock",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "personalProfileAppsAllowInstallFromUnknownSources",
+        "personalProfileCameraBlocked",
+        "personalProfilePersonalApplications",
+        "personalProfilePlayStoreMode",
+        "personalProfileScreenCaptureBlocked",
+        "playStoreMode",
+        "screenCaptureBlocked",
+        "securityCommonCriteriaModeEnabled",
+        "securityDeveloperSettingsEnabled",
+        "securityRequireVerifyApps",
+        "shareDeviceLocationDisabled",
+        "shortHelpText",
+        "statusBarBlocked",
+        "stayOnModes",
+        "storageAllowUsb",
+        "storageBlockExternalMedia",
+        "storageBlockUsbFileTransfer",
+        "systemUpdateFreezePeriods",
+        "systemUpdateInstallType",
+        "systemUpdateWindowEndMinutesAfterMidnight",
+        "systemUpdateWindowStartMinutesAfterMidnight",
+        "systemWindowsBlocked",
+        "usersBlockAdd",
+        "usersBlockRemove",
+        "volumeBlockAdjustment",
+        "vpnAlwaysOnLockdownMode",
+        "vpnAlwaysOnPackageIdentifier",
+        "wifiBlockEditConfigurations",
+        "wifiBlockEditPolicyDefinedConfigurations",
+        "workProfilePasswordExpirationDays",
+        "workProfilePasswordMinimumLength",
+        "workProfilePasswordMinimumLetterCharacters",
+        "workProfilePasswordMinimumLowerCaseCharacters",
+        "workProfilePasswordMinimumNonLetterCharacters",
+        "workProfilePasswordMinimumNumericCharacters",
+        "workProfilePasswordMinimumSymbolCharacters",
+        "workProfilePasswordMinimumUpperCaseCharacters",
+        "workProfilePasswordPreviousPasswordCountToBlock",
+        "workProfilePasswordRequiredType",
+        "workProfilePasswordRequireUnlock",
+        "workProfilePasswordSignInFailureCountBeforeFactoryReset"
+      ]
+    },
+    "androidDeviceOwnerImportedPFXCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "certificateAccessType",
+        "intendedPurpose",
+        "silentCertificateAccessDetails"
+      ]
+    },
+    "androidDeviceOwnerPkcsCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "certificateAccessType",
+        "certificateStore",
+        "certificateTemplateName",
+        "certificationAuthority",
+        "certificationAuthorityName",
+        "certificationAuthorityType",
+        "customSubjectAlternativeNames",
+        "silentCertificateAccessDetails",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "androidDeviceOwnerScepCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "certificateAccessType",
+        "certificateStore",
+        "customSubjectAlternativeNames",
+        "hashAlgorithm",
+        "keySize",
+        "keyUsage",
+        "scepServerUrls",
+        "silentCertificateAccessDetails",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "androidDeviceOwnerTrustedRootCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "certFileName",
+        "trustedRootCertificate"
+      ]
+    },
+    "androidDeviceOwnerVpnConfiguration": {
+      "navigationProperties": [
+        "derivedCredentialSettings",
+        "identityCertificate"
+      ],
+      "properties": [
+        "alwaysOn",
+        "alwaysOnLockdown",
+        "connectionType",
+        "customData",
+        "customKeyValueData",
+        "lockdownExclusionList",
+        "microsoftTunnelSiteId",
+        "proxyExclusionList",
+        "proxyServer",
+        "targetedMobileApps",
+        "targetedPackageIds"
+      ]
+    },
+    "androidDeviceOwnerWiFiConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "connectAutomatically",
+        "connectWhenNetworkNameIsHidden",
+        "macAddressRandomizationMode",
+        "networkName",
+        "preSharedKey",
+        "preSharedKeyIsSet",
+        "proxyAutomaticConfigurationUrl",
+        "proxyExclusionList",
+        "proxyManualAddress",
+        "proxyManualPort",
+        "proxySettings",
+        "ssid",
+        "wiFiSecurityType"
+      ]
+    },
+    "androidEasEmailProfileConfiguration": {
+      "navigationProperties": [
+        "identityCertificate",
+        "smimeSigningCertificate"
+      ],
+      "properties": [
+        "accountName",
+        "authenticationMethod",
+        "customDomainName",
+        "durationOfEmailToSync",
+        "emailAddressSource",
+        "emailSyncSchedule",
+        "hostName",
+        "requireSmime",
+        "requireSsl",
+        "syncCalendar",
+        "syncContacts",
+        "syncNotes",
+        "syncTasks",
+        "userDomainNameSource",
+        "usernameSource"
+      ]
+    },
+    "androidEnterpriseWiFiConfiguration": {
+      "navigationProperties": [
+        "identityCertificateForClientAuthentication",
+        "rootCertificateForServerValidation"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "eapType",
+        "innerAuthenticationProtocolForEapTtls",
+        "innerAuthenticationProtocolForPeap",
+        "outerIdentityPrivacyTemporaryValue",
+        "passwordFormatString",
+        "preSharedKey",
+        "trustedServerCertificateNames",
+        "usernameFormatString"
+      ]
+    },
+    "androidForWorkApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appIdentifier",
+        "appStoreUrl",
+        "packageId",
+        "totalLicenseCount",
+        "usedLicenseCount"
+      ]
+    },
+    "androidForWorkAppConfigurationSchema": {
+      "navigationProperties": [],
+      "properties": [
+        "exampleJson",
+        "schemaItems"
+      ]
+    },
+    "androidForWorkCertificateProfileBase": {
+      "navigationProperties": [
+        "rootCertificate"
+      ],
+      "properties": [
+        "certificateValidityPeriodScale",
+        "certificateValidityPeriodValue",
+        "extendedKeyUsages",
+        "renewalThresholdPercentage",
+        "subjectAlternativeNameType",
+        "subjectNameFormat"
+      ]
+    },
+    "androidForWorkCompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceThreatProtectionEnabled",
+        "deviceThreatProtectionRequiredSecurityLevel",
+        "minAndroidSecurityPatchLevel",
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordExpirationDays",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "requiredPasswordComplexity",
+        "securityBlockJailbrokenDevices",
+        "securityDisableUsbDebugging",
+        "securityPreventInstallAppsFromUnknownSources",
+        "securityRequireCompanyPortalAppIntegrity",
+        "securityRequiredAndroidSafetyNetEvaluationType",
+        "securityRequireGooglePlayServices",
+        "securityRequireSafetyNetAttestationBasicIntegrity",
+        "securityRequireSafetyNetAttestationCertifiedDevice",
+        "securityRequireUpToDateSecurityProviders",
+        "securityRequireVerifyApps",
+        "storageRequireEncryption",
+        "workProfileInactiveBeforeScreenLockInMinutes",
+        "workProfilePasswordExpirationInDays",
+        "workProfilePasswordMinimumLength",
+        "workProfilePasswordRequiredType",
+        "workProfilePreviousPasswordBlockCount",
+        "workProfileRequiredPasswordComplexity",
+        "workProfileRequirePassword"
+      ]
+    },
+    "androidForWorkCustomConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "omaSettings"
+      ]
+    },
+    "androidForWorkEasEmailProfileBase": {
+      "navigationProperties": [
+        "identityCertificate"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "durationOfEmailToSync",
+        "emailAddressSource",
+        "hostName",
+        "requireSsl",
+        "usernameSource"
+      ]
+    },
+    "androidForWorkEnrollmentProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "accountId",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "enrolledDeviceCount",
+        "lastModifiedDateTime",
+        "qrCodeContent",
+        "qrCodeImage",
+        "tokenExpirationDateTime",
+        "tokenValue"
+      ]
+    },
+    "androidForWorkEnterpriseWiFiConfiguration": {
+      "navigationProperties": [
+        "identityCertificateForClientAuthentication",
+        "rootCertificateForServerValidation"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "eapType",
+        "innerAuthenticationProtocolForEapTtls",
+        "innerAuthenticationProtocolForPeap",
+        "outerIdentityPrivacyTemporaryValue",
+        "trustedServerCertificateNames"
+      ]
+    },
+    "androidForWorkGeneralDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedGoogleAccountDomains",
+        "blockUnifiedPasswordForWorkProfile",
+        "passwordBlockFaceUnlock",
+        "passwordBlockFingerprintUnlock",
+        "passwordBlockIrisUnlock",
+        "passwordBlockTrustAgents",
+        "passwordExpirationDays",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequiredType",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "requiredPasswordComplexity",
+        "securityRequireVerifyApps",
+        "vpnAlwaysOnPackageIdentifier",
+        "vpnEnableAlwaysOnLockdownMode",
+        "workProfileAccountUse",
+        "workProfileAllowWidgets",
+        "workProfileBlockAddingAccounts",
+        "workProfileBlockCamera",
+        "workProfileBlockCrossProfileCallerId",
+        "workProfileBlockCrossProfileContactsSearch",
+        "workProfileBlockCrossProfileCopyPaste",
+        "workProfileBlockNotificationsWhileDeviceLocked",
+        "workProfileBlockPersonalAppInstallsFromUnknownSources",
+        "workProfileBlockScreenCapture",
+        "workProfileBluetoothEnableContactSharing",
+        "workProfileDataSharingType",
+        "workProfileDefaultAppPermissionPolicy",
+        "workProfilePasswordBlockFaceUnlock",
+        "workProfilePasswordBlockFingerprintUnlock",
+        "workProfilePasswordBlockIrisUnlock",
+        "workProfilePasswordBlockTrustAgents",
+        "workProfilePasswordExpirationDays",
+        "workProfilePasswordMinimumLength",
+        "workProfilePasswordMinLetterCharacters",
+        "workProfilePasswordMinLowerCaseCharacters",
+        "workProfilePasswordMinNonLetterCharacters",
+        "workProfilePasswordMinNumericCharacters",
+        "workProfilePasswordMinSymbolCharacters",
+        "workProfilePasswordMinUpperCaseCharacters",
+        "workProfilePasswordMinutesOfInactivityBeforeScreenTimeout",
+        "workProfilePasswordPreviousPasswordBlockCount",
+        "workProfilePasswordRequiredType",
+        "workProfilePasswordSignInFailureCountBeforeFactoryReset",
+        "workProfileRequiredPasswordComplexity",
+        "workProfileRequirePassword"
+      ]
+    },
+    "androidForWorkGmailEasConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "androidForWorkImportedPFXCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "intendedPurpose"
+      ]
+    },
+    "androidForWorkMobileAppConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "connectedAppsEnabled",
+        "credentialProviderRoleState",
+        "packageId",
+        "payloadJson",
+        "permissionActions",
+        "profileApplicability"
+      ]
+    },
+    "androidForWorkNineWorkEasConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "syncCalendar",
+        "syncContacts",
+        "syncTasks"
+      ]
+    },
+    "androidForWorkPkcsCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "certificateTemplateName",
+        "certificationAuthority",
+        "certificationAuthorityName",
+        "subjectAlternativeNameFormatString"
+      ]
+    },
+    "androidForWorkScepCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "certificateStore",
+        "customSubjectAlternativeNames",
+        "hashAlgorithm",
+        "keySize",
+        "keyUsage",
+        "scepServerUrls",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "androidForWorkSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "bindStatus",
+        "deviceOwnerManagementEnabled",
+        "enrollmentTarget",
+        "lastAppSyncDateTime",
+        "lastAppSyncStatus",
+        "lastModifiedDateTime",
+        "ownerOrganizationName",
+        "ownerUserPrincipalName",
+        "targetGroupIds"
+      ]
+    },
+    "androidForWorkTrustedRootCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "certFileName",
+        "trustedRootCertificate"
+      ]
+    },
+    "androidForWorkVpnConfiguration": {
+      "navigationProperties": [
+        "identityCertificate"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "connectionName",
+        "connectionType",
+        "customData",
+        "customKeyValueData",
+        "fingerprint",
+        "realm",
+        "role",
+        "servers"
+      ]
+    },
+    "androidForWorkWiFiConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "connectAutomatically",
+        "connectWhenNetworkNameIsHidden",
+        "networkName",
+        "ssid",
+        "wiFiSecurityType"
+      ]
+    },
+    "androidGeneralDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "appsBlockClipboardSharing",
+        "appsBlockCopyPaste",
+        "appsBlockYouTube",
+        "appsHideList",
+        "appsInstallAllowList",
+        "appsLaunchBlockList",
+        "bluetoothBlocked",
+        "cameraBlocked",
+        "cellularBlockDataRoaming",
+        "cellularBlockMessaging",
+        "cellularBlockVoiceRoaming",
+        "cellularBlockWiFiTethering",
+        "compliantAppListType",
+        "compliantAppsList",
+        "dateAndTimeBlockChanges",
+        "deviceSharingAllowed",
+        "diagnosticDataBlockSubmission",
+        "factoryResetBlocked",
+        "googleAccountBlockAutoSync",
+        "googlePlayStoreBlocked",
+        "kioskModeApps",
+        "kioskModeBlockSleepButton",
+        "kioskModeBlockVolumeButtons",
+        "locationServicesBlocked",
+        "nfcBlocked",
+        "passwordBlockFingerprintUnlock",
+        "passwordBlockTrustAgents",
+        "passwordExpirationDays",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "powerOffBlocked",
+        "requiredPasswordComplexity",
+        "screenCaptureBlocked",
+        "securityRequireVerifyApps",
+        "storageBlockGoogleBackup",
+        "storageBlockRemovableStorage",
+        "storageRequireDeviceEncryption",
+        "storageRequireRemovableStorageEncryption",
+        "voiceAssistantBlocked",
+        "voiceDialingBlocked",
+        "webBrowserBlockAutofill",
+        "webBrowserBlocked",
+        "webBrowserBlockJavaScript",
+        "webBrowserBlockPopups",
+        "webBrowserCookieSettings",
+        "wiFiBlocked"
+      ]
+    },
+    "androidImportedPFXCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "intendedPurpose"
+      ]
+    },
+    "androidLobApp": {
+      "navigationProperties": [],
+      "properties": [
+        "minimumSupportedOperatingSystem",
+        "packageId",
+        "targetedPlatforms",
+        "versionCode",
+        "versionName"
+      ]
+    },
+    "androidManagedAppProtection": {
+      "navigationProperties": [
+        "apps",
+        "deploymentSummary"
+      ],
+      "properties": [
+        "allowedAndroidDeviceManufacturers",
+        "allowedAndroidDeviceModels",
+        "appActionIfAccountIsClockedOut",
+        "appActionIfAndroidDeviceManufacturerNotAllowed",
+        "appActionIfAndroidDeviceModelNotAllowed",
+        "appActionIfAndroidSafetyNetAppsVerificationFailed",
+        "appActionIfAndroidSafetyNetDeviceAttestationFailed",
+        "appActionIfDeviceLockNotSet",
+        "appActionIfDevicePasscodeComplexityLessThanHigh",
+        "appActionIfDevicePasscodeComplexityLessThanLow",
+        "appActionIfDevicePasscodeComplexityLessThanMedium",
+        "appActionIfSamsungKnoxAttestationRequired",
+        "approvedKeyboards",
+        "biometricAuthenticationBlocked",
+        "blockAfterCompanyPortalUpdateDeferralInDays",
+        "connectToVpnOnLaunch",
+        "customBrowserDisplayName",
+        "customBrowserPackageId",
+        "customDialerAppDisplayName",
+        "customDialerAppPackageId",
+        "deployedAppCount",
+        "deviceLockRequired",
+        "disableAppEncryptionIfDeviceEncryptionIsEnabled",
+        "encryptAppData",
+        "exemptedAppPackages",
+        "fingerprintAndBiometricEnabled",
+        "keyboardsRestricted",
+        "messagingRedirectAppDisplayName",
+        "messagingRedirectAppPackageId",
+        "minimumRequiredCompanyPortalVersion",
+        "minimumRequiredPatchVersion",
+        "minimumWarningCompanyPortalVersion",
+        "minimumWarningPatchVersion",
+        "minimumWipeCompanyPortalVersion",
+        "minimumWipePatchVersion",
+        "requireClass3Biometrics",
+        "requiredAndroidSafetyNetAppsVerificationType",
+        "requiredAndroidSafetyNetDeviceAttestationType",
+        "requiredAndroidSafetyNetEvaluationType",
+        "requirePinAfterBiometricChange",
+        "screenCaptureBlocked",
+        "warnAfterCompanyPortalUpdateDeferralInDays",
+        "wipeAfterCompanyPortalUpdateDeferralInDays"
+      ]
+    },
+    "androidManagedAppRegistration": {
+      "navigationProperties": [],
+      "properties": [
+        "patchVersion"
+      ]
+    },
+    "androidManagedStoreAccountEnterpriseSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "androidDeviceOwnerFullyManagedEnrollmentEnabled",
+        "bindStatus",
+        "companyCodes",
+        "deviceOwnerManagementEnabled",
+        "enrollmentTarget",
+        "lastAppSyncDateTime",
+        "lastAppSyncStatus",
+        "lastModifiedDateTime",
+        "managedGooglePlayEnterpriseType",
+        "managedGooglePlayInitialScopeTagIds",
+        "ownerOrganizationName",
+        "ownerUserPrincipalName",
+        "targetGroupIds"
+      ]
+    },
+    "androidManagedStoreApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appIdentifier",
+        "appStoreUrl",
+        "appTracks",
+        "isPrivate",
+        "isSystemApp",
+        "packageId",
+        "supportsOemConfig",
+        "totalLicenseCount",
+        "usedLicenseCount"
+      ]
+    },
+    "androidManagedStoreAppConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "appSupportsOemConfig",
+        "connectedAppsEnabled",
+        "credentialProviderRoleState",
+        "packageId",
+        "payloadJson",
+        "permissionActions",
+        "profileApplicability"
+      ]
+    },
+    "androidManagedStoreAppConfigurationSchema": {
+      "navigationProperties": [],
+      "properties": [
+        "exampleJson",
+        "nestedSchemaItems",
+        "schemaItems"
+      ]
+    },
+    "androidManagedStoreWebApp": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "androidOmaCpConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationXml"
+      ]
+    },
+    "androidPkcsCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "certificateTemplateName",
+        "certificationAuthority",
+        "certificationAuthorityName",
+        "subjectAlternativeNameFormatString"
+      ]
+    },
+    "androidScepCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "hashAlgorithm",
+        "keySize",
+        "keyUsage",
+        "scepServerUrls",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "androidStoreApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appStoreUrl",
+        "minimumSupportedOperatingSystem",
+        "packageId"
+      ]
+    },
+    "androidTrustedRootCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "certFileName",
+        "trustedRootCertificate"
+      ]
+    },
+    "androidVpnConfiguration": {
+      "navigationProperties": [
+        "identityCertificate"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "connectionName",
+        "connectionType",
+        "customData",
+        "customKeyValueData",
+        "fingerprint",
+        "realm",
+        "role",
+        "servers"
+      ]
+    },
+    "androidWiFiConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "connectAutomatically",
+        "connectWhenNetworkNameIsHidden",
+        "networkName",
+        "ssid",
+        "wiFiSecurityType"
+      ]
+    },
+    "androidWorkProfileCertificateProfileBase": {
+      "navigationProperties": [
+        "rootCertificate"
+      ],
+      "properties": [
+        "certificateValidityPeriodScale",
+        "certificateValidityPeriodValue",
+        "extendedKeyUsages",
+        "renewalThresholdPercentage",
+        "subjectAlternativeNameType",
+        "subjectNameFormat"
+      ]
+    },
+    "androidWorkProfileCompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "advancedThreatProtectionRequiredSecurityLevel",
+        "deviceThreatProtectionEnabled",
+        "deviceThreatProtectionRequiredSecurityLevel",
+        "minAndroidSecurityPatchLevel",
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordExpirationDays",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "requiredPasswordComplexity",
+        "securityBlockJailbrokenDevices",
+        "securityDisableUsbDebugging",
+        "securityPreventInstallAppsFromUnknownSources",
+        "securityRequireCompanyPortalAppIntegrity",
+        "securityRequiredAndroidSafetyNetEvaluationType",
+        "securityRequireGooglePlayServices",
+        "securityRequireSafetyNetAttestationBasicIntegrity",
+        "securityRequireSafetyNetAttestationCertifiedDevice",
+        "securityRequireUpToDateSecurityProviders",
+        "securityRequireVerifyApps",
+        "storageRequireEncryption",
+        "workProfileInactiveBeforeScreenLockInMinutes",
+        "workProfilePasswordExpirationInDays",
+        "workProfilePasswordMinimumLength",
+        "workProfilePasswordRequiredType",
+        "workProfilePreviousPasswordBlockCount",
+        "workProfileRequiredPasswordComplexity",
+        "workProfileRequirePassword"
+      ]
+    },
+    "androidWorkProfileCustomConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "omaSettings"
+      ]
+    },
+    "androidWorkProfileEasEmailProfileBase": {
+      "navigationProperties": [
+        "identityCertificate"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "durationOfEmailToSync",
+        "emailAddressSource",
+        "hostName",
+        "requireSsl",
+        "usernameSource"
+      ]
+    },
+    "androidWorkProfileEnterpriseWiFiConfiguration": {
+      "navigationProperties": [
+        "identityCertificateForClientAuthentication",
+        "rootCertificateForServerValidation"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "eapType",
+        "innerAuthenticationProtocolForEapTtls",
+        "innerAuthenticationProtocolForPeap",
+        "outerIdentityPrivacyTemporaryValue",
+        "trustedServerCertificateNames"
+      ]
+    },
+    "androidWorkProfileGeneralDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedGoogleAccountDomains",
+        "blockUnifiedPasswordForWorkProfile",
+        "passwordBlockFaceUnlock",
+        "passwordBlockFingerprintUnlock",
+        "passwordBlockIrisUnlock",
+        "passwordBlockTrustAgents",
+        "passwordExpirationDays",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequiredType",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "requiredPasswordComplexity",
+        "securityRequireVerifyApps",
+        "vpnAlwaysOnPackageIdentifier",
+        "vpnEnableAlwaysOnLockdownMode",
+        "workProfileAccountUse",
+        "workProfileAllowAppInstallsFromUnknownSources",
+        "workProfileAllowWidgets",
+        "workProfileBlockAddingAccounts",
+        "workProfileBlockCamera",
+        "workProfileBlockCrossProfileCallerId",
+        "workProfileBlockCrossProfileContactsSearch",
+        "workProfileBlockCrossProfileCopyPaste",
+        "workProfileBlockNotificationsWhileDeviceLocked",
+        "workProfileBlockPersonalAppInstallsFromUnknownSources",
+        "workProfileBlockScreenCapture",
+        "workProfileBluetoothEnableContactSharing",
+        "workProfileDataSharingType",
+        "workProfileDefaultAppPermissionPolicy",
+        "workProfilePasswordBlockFaceUnlock",
+        "workProfilePasswordBlockFingerprintUnlock",
+        "workProfilePasswordBlockIrisUnlock",
+        "workProfilePasswordBlockTrustAgents",
+        "workProfilePasswordExpirationDays",
+        "workProfilePasswordMinimumLength",
+        "workProfilePasswordMinLetterCharacters",
+        "workProfilePasswordMinLowerCaseCharacters",
+        "workProfilePasswordMinNonLetterCharacters",
+        "workProfilePasswordMinNumericCharacters",
+        "workProfilePasswordMinSymbolCharacters",
+        "workProfilePasswordMinUpperCaseCharacters",
+        "workProfilePasswordMinutesOfInactivityBeforeScreenTimeout",
+        "workProfilePasswordPreviousPasswordBlockCount",
+        "workProfilePasswordRequiredType",
+        "workProfilePasswordSignInFailureCountBeforeFactoryReset",
+        "workProfileRequiredPasswordComplexity",
+        "workProfileRequirePassword"
+      ]
+    },
+    "androidWorkProfileGmailEasConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "androidWorkProfileNineWorkEasConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "syncCalendar",
+        "syncContacts",
+        "syncTasks"
+      ]
+    },
+    "androidWorkProfilePkcsCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "certificateStore",
+        "certificateTemplateName",
+        "certificationAuthority",
+        "certificationAuthorityName",
+        "customSubjectAlternativeNames",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "androidWorkProfileScepCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "certificateStore",
+        "customSubjectAlternativeNames",
+        "hashAlgorithm",
+        "keySize",
+        "keyUsage",
+        "scepServerUrls",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "androidWorkProfileTrustedRootCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "certFileName",
+        "trustedRootCertificate"
+      ]
+    },
+    "androidWorkProfileVpnConfiguration": {
+      "navigationProperties": [
+        "identityCertificate"
+      ],
+      "properties": [
+        "alwaysOn",
+        "alwaysOnLockdown",
+        "authenticationMethod",
+        "connectionName",
+        "connectionType",
+        "customData",
+        "customKeyValueData",
+        "fingerprint",
+        "microsoftTunnelSiteId",
+        "proxyExclusionList",
+        "proxyServer",
+        "realm",
+        "role",
+        "servers",
+        "targetedMobileApps",
+        "targetedPackageIds"
+      ]
+    },
+    "androidWorkProfileWiFiConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "connectAutomatically",
+        "connectWhenNetworkNameIsHidden",
+        "networkName",
+        "preSharedKey",
+        "preSharedKeyIsSet",
+        "proxyAutomaticConfigurationUrl",
+        "proxySettings",
+        "ssid",
+        "wiFiSecurityType"
+      ]
+    },
+    "anonymousGuestConversationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "anonymousGuestId"
+      ]
+    },
+    "aospDeviceOwnerCertificateProfileBase": {
+      "navigationProperties": [
+        "rootCertificate"
+      ],
+      "properties": [
+        "certificateValidityPeriodScale",
+        "certificateValidityPeriodValue",
+        "extendedKeyUsages",
+        "renewalThresholdPercentage",
+        "subjectAlternativeNameType",
+        "subjectNameFormat"
+      ]
+    },
+    "aospDeviceOwnerCompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "minAndroidSecurityPatchLevel",
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordRequired",
+        "passwordRequiredType",
+        "securityBlockJailbrokenDevices",
+        "storageRequireEncryption"
+      ]
+    },
+    "aospDeviceOwnerDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "appsBlockInstallFromUnknownSources",
+        "bluetoothBlockConfiguration",
+        "bluetoothBlocked",
+        "cameraBlocked",
+        "factoryResetBlocked",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordRequiredType",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "screenCaptureBlocked",
+        "securityAllowDebuggingFeatures",
+        "storageBlockExternalMedia",
+        "storageBlockUsbFileTransfer",
+        "wifiBlockEditConfigurations"
+      ]
+    },
+    "aospDeviceOwnerEnterpriseWiFiConfiguration": {
+      "navigationProperties": [
+        "identityCertificateForClientAuthentication",
+        "rootCertificateForServerValidation"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "eapType",
+        "innerAuthenticationProtocolForEapTtls",
+        "innerAuthenticationProtocolForPeap",
+        "outerIdentityPrivacyTemporaryValue",
+        "trustedServerCertificateNames"
+      ]
+    },
+    "aospDeviceOwnerPkcsCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "certificateStore",
+        "certificateTemplateName",
+        "certificationAuthority",
+        "certificationAuthorityName",
+        "certificationAuthorityType",
+        "customSubjectAlternativeNames",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "aospDeviceOwnerScepCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "certificateStore",
+        "customSubjectAlternativeNames",
+        "hashAlgorithm",
+        "keySize",
+        "keyUsage",
+        "scepServerUrls",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "aospDeviceOwnerTrustedRootCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "certFileName",
+        "trustedRootCertificate"
+      ]
+    },
+    "aospDeviceOwnerWiFiConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "connectAutomatically",
+        "connectWhenNetworkNameIsHidden",
+        "networkName",
+        "preSharedKey",
+        "preSharedKeyIsSet",
+        "proxyAutomaticConfigurationUrl",
+        "proxyExclusionList",
+        "proxyManualAddress",
+        "proxyManualPort",
+        "proxySetting",
+        "ssid",
+        "wiFiSecurityType"
+      ]
+    },
+    "appCatalogs": {
+      "navigationProperties": [
+        "teamsApps"
+      ],
+      "properties": []
+    },
+    "appConsentApprovalRoute": {
+      "navigationProperties": [
+        "appConsentRequests"
+      ],
+      "properties": []
+    },
+    "appConsentRequest": {
+      "navigationProperties": [
+        "userConsentRequests"
+      ],
+      "properties": [
+        "appDisplayName",
+        "appId",
+        "consentType",
+        "pendingScopes"
+      ]
+    },
+    "appCredentialSignInActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "appObjectId",
+        "createdDateTime",
+        "credentialOrigin",
+        "expirationDateTime",
+        "keyId",
+        "keyType",
+        "keyUsage",
+        "resourceId",
+        "servicePrincipalObjectId",
+        "signInActivity"
+      ]
+    },
+    "appleDeviceFeaturesConfigurationBase": {
+      "navigationProperties": [],
+      "properties": [
+        "airPrintDestinations"
+      ]
+    },
+    "appleEnrollmentProfileAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "appleExpeditedCheckinConfigurationBase": {
+      "navigationProperties": [],
+      "properties": [
+        "enableExpeditedCheckin"
+      ]
+    },
+    "appleManagedIdentityProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateData",
+        "developerId",
+        "keyId",
+        "serviceId"
+      ]
+    },
+    "applePushNotificationCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "appleIdentifier",
+        "certificate",
+        "certificateSerialNumber",
+        "certificateUploadFailureReason",
+        "certificateUploadStatus",
+        "expirationDateTime",
+        "lastModifiedDateTime",
+        "topicIdentifier"
+      ]
+    },
+    "appleUserInitiatedEnrollmentProfile": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "availableEnrollmentTypeOptions",
+        "createdDateTime",
+        "defaultEnrollmentType",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "platform",
+        "priority"
+      ]
+    },
+    "appleVpnConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "associatedDomains",
+        "authenticationMethod",
+        "connectionName",
+        "connectionType",
+        "customData",
+        "customKeyValueData",
+        "disableOnDemandUserOverride",
+        "disconnectOnIdle",
+        "disconnectOnIdleTimerInSeconds",
+        "enablePerApp",
+        "enableSplitTunneling",
+        "excludedDomains",
+        "identifier",
+        "loginGroupOrDomain",
+        "onDemandRules",
+        "optInToDeviceIdSharing",
+        "providerType",
+        "proxyServer",
+        "realm",
+        "role",
+        "safariDomains",
+        "server"
+      ]
+    },
+    "appleVppTokenTroubleshootingEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "tokenId"
+      ]
+    },
+    "application": {
+      "navigationProperties": [
+        "appManagementPolicies",
+        "connectorGroup",
+        "createdOnBehalfOf",
+        "extensionProperties",
+        "federatedIdentityCredentials",
+        "homeRealmDiscoveryPolicies",
+        "owners",
+        "synchronization",
+        "tokenIssuancePolicies",
+        "tokenLifetimePolicies"
+      ],
+      "properties": [
+        "api",
+        "appId",
+        "appRoles",
+        "authenticationBehaviors",
+        "certification",
+        "createdByAppId",
+        "createdDateTime",
+        "defaultRedirectUri",
+        "description",
+        "disabledByMicrosoftStatus",
+        "displayName",
+        "groupMembershipClaims",
+        "identifierUris",
+        "info",
+        "isDeviceOnlyAuthSupported",
+        "isDisabled",
+        "isFallbackPublicClient",
+        "keyCredentials",
+        "logo",
+        "managerApplications",
+        "nativeAuthenticationApisEnabled",
+        "notes",
+        "onPremisesPublishing",
+        "optionalClaims",
+        "parentalControlSettings",
+        "passwordCredentials",
+        "publicClient",
+        "publisherDomain",
+        "requestSignatureVerification",
+        "requiredResourceAccess",
+        "samlMetadataUrl",
+        "serviceManagementReference",
+        "servicePrincipalLockConfiguration",
+        "signInAudience",
+        "signInAudienceRestrictions",
+        "spa",
+        "tags",
+        "tokenEncryptionKeyId",
+        "uniqueName",
+        "verifiedPublisher",
+        "web",
+        "windows"
+      ]
+    },
+    "applicationSegment": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "applicationSignInDetailedSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "aggregatedEventDateTime",
+        "appDisplayName",
+        "appId",
+        "signInCount",
+        "status"
+      ]
+    },
+    "applicationSignInSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "appDisplayName",
+        "failedSignInCount",
+        "successfulSignInCount",
+        "successPercentage"
+      ]
+    },
+    "applicationTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "categories",
+        "configurationUris",
+        "deprecationDate",
+        "description",
+        "displayName",
+        "endpoints",
+        "homePageUrl",
+        "informationalUrls",
+        "isEntraIntegrated",
+        "lastModifiedDateTime",
+        "logoUrl",
+        "publisher",
+        "riskFactors",
+        "riskScore",
+        "supportedClaimConfiguration",
+        "supportedProvisioningTypes",
+        "supportedSingleSignOnModes"
+      ]
+    },
+    "appLogCollectionRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "customLogFolders",
+        "errorMessage",
+        "status"
+      ]
+    },
+    "appManagementPolicy": {
+      "navigationProperties": [
+        "appliesTo"
+      ],
+      "properties": [
+        "isEnabled",
+        "restrictions"
+      ]
+    },
+    "appRoleAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "appRoleId",
+        "creationTimestamp",
+        "principalDisplayName",
+        "principalId",
+        "principalType",
+        "resourceDisplayName",
+        "resourceId"
+      ]
+    },
+    "approval": {
+      "navigationProperties": [
+        "request",
+        "steps"
+      ],
+      "properties": []
+    },
+    "approvalItem": {
+      "navigationProperties": [
+        "requests",
+        "responses"
+      ],
+      "properties": [
+        "allowCancel",
+        "allowEmailNotification",
+        "approvalType",
+        "approvers",
+        "completedDateTime",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "owner",
+        "responsePrompts",
+        "result",
+        "state",
+        "viewPoint"
+      ]
+    },
+    "approvalItemRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "approver",
+        "createdDateTime",
+        "isReassigned",
+        "reassignedFrom"
+      ]
+    },
+    "approvalItemResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "comments",
+        "createdBy",
+        "createdDateTime",
+        "owners",
+        "response"
+      ]
+    },
+    "approvalOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "error",
+        "lastActionDateTime",
+        "resourceLocation",
+        "status"
+      ]
+    },
+    "approvalSolution": {
+      "navigationProperties": [
+        "approvalItems",
+        "operations"
+      ],
+      "properties": [
+        "provisioningStatus"
+      ]
+    },
+    "approvalStep": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedToMe",
+        "displayName",
+        "justification",
+        "reviewedBy",
+        "reviewedDateTime",
+        "reviewResult",
+        "status"
+      ]
+    },
+    "approvalWorkflowProvider": {
+      "navigationProperties": [
+        "businessFlows",
+        "businessFlowsWithRequestsAwaitingMyDecision",
+        "policyTemplates"
+      ],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "approvedClientApp": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "appScope": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "type"
+      ]
+    },
+    "appVulnerabilityManagedDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastSyncDateTime",
+        "managedDeviceId"
+      ]
+    },
+    "appVulnerabilityMobileApp": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "lastModifiedDateTime",
+        "mobileAppId",
+        "mobileAppType",
+        "version"
+      ]
+    },
+    "appVulnerabilityTask": {
+      "navigationProperties": [
+        "managedDevices",
+        "mobileApps"
+      ],
+      "properties": [
+        "appName",
+        "appPublisher",
+        "appVersion",
+        "insights",
+        "managedDeviceCount",
+        "mitigationType",
+        "mobileAppCount",
+        "remediation"
+      ]
+    },
+    "arkoseFraudProtectionProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "clientSubDomain",
+        "privateKey",
+        "publicKey",
+        "verifySubDomain"
+      ]
+    },
+    "assignedComputeInstanceDetails": {
+      "navigationProperties": [
+        "accessedStorageBuckets",
+        "assignedComputeInstance"
+      ],
+      "properties": []
+    },
+    "assignmentFilterEvaluationStatusDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "payloadId"
+      ]
+    },
+    "associatedTeamInfo": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "attachment": {
+      "navigationProperties": [],
+      "properties": [
+        "contentType",
+        "isInline",
+        "lastModifiedDateTime",
+        "name",
+        "size"
+      ]
+    },
+    "attachmentBase": {
+      "navigationProperties": [],
+      "properties": [
+        "contentType",
+        "lastModifiedDateTime",
+        "name",
+        "size"
+      ]
+    },
+    "attachmentSession": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "expirationDateTime",
+        "nextExpectedRanges"
+      ]
+    },
+    "attackSimulationOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "percentageCompleted",
+        "tenantId",
+        "type"
+      ]
+    },
+    "attackSimulationRoot": {
+      "navigationProperties": [
+        "endUserNotifications",
+        "landingPages",
+        "loginPages",
+        "operations",
+        "payloads",
+        "simulationAutomations",
+        "simulations",
+        "trainingCampaigns",
+        "trainings"
+      ],
+      "properties": []
+    },
+    "attendanceRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "attendanceIntervals",
+        "emailAddress",
+        "externalRegistrationInformation",
+        "identity",
+        "registrantId",
+        "registrationId",
+        "role",
+        "totalAttendanceInSeconds"
+      ]
+    },
+    "attributeMappingFunctionSchema": {
+      "navigationProperties": [],
+      "properties": [
+        "parameters"
+      ]
+    },
+    "attributeSet": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "maxAttributesPerSet"
+      ]
+    },
+    "audioRoutingGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "receivers",
+        "routingMode",
+        "sources"
+      ]
+    },
+    "auditActivityType": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "category",
+        "service"
+      ]
+    },
+    "auditEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "activityDateTime",
+        "activityOperationType",
+        "activityResult",
+        "activityType",
+        "actor",
+        "category",
+        "componentName",
+        "correlationId",
+        "displayName",
+        "resources"
+      ]
+    },
+    "auditLogRoot": {
+      "navigationProperties": [
+        "auditActivityTypes",
+        "customSecurityAttributeAudits",
+        "directoryAudits",
+        "directoryProvisioning",
+        "provisioning",
+        "signInEventsAppSummary",
+        "signInEventsSummary",
+        "signIns",
+        "signUps"
+      ],
+      "properties": []
+    },
+    "authentication": {
+      "navigationProperties": [
+        "emailMethods",
+        "externalAuthenticationMethods",
+        "fido2Methods",
+        "hardwareOathMethods",
+        "methods",
+        "microsoftAuthenticatorMethods",
+        "operations",
+        "passwordlessMicrosoftAuthenticatorMethods",
+        "passwordMethods",
+        "phoneMethods",
+        "platformCredentialMethods",
+        "qrCodePinMethod",
+        "softwareOathMethods",
+        "temporaryAccessPassMethods",
+        "windowsHelloForBusinessMethods"
+      ],
+      "properties": [
+        "requirements",
+        "signInPreferences"
+      ]
+    },
+    "authenticationCombinationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "appliesToCombinations"
+      ]
+    },
+    "authenticationConditionApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "appId"
+      ]
+    },
+    "authenticationContextClassReference": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "isAvailable"
+      ]
+    },
+    "authenticationEventListener": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationEventsFlowId",
+        "conditions",
+        "displayName",
+        "priority"
+      ]
+    },
+    "authenticationEventsFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "conditions",
+        "description",
+        "displayName",
+        "priority"
+      ]
+    },
+    "authenticationEventsPolicy": {
+      "navigationProperties": [
+        "onSignupStart"
+      ],
+      "properties": []
+    },
+    "authenticationFailure": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "reason",
+        "reasonCode"
+      ]
+    },
+    "authenticationFlowsPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "selfServiceSignUp"
+      ]
+    },
+    "authenticationListener": {
+      "navigationProperties": [],
+      "properties": [
+        "priority",
+        "sourceFilter"
+      ]
+    },
+    "authenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastUsedDateTime"
+      ]
+    },
+    "authenticationMethodConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeTargets",
+        "state"
+      ]
+    },
+    "authenticationMethodDevice": {
+      "navigationProperties": [
+        "hardwareOathDevices"
+      ],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "authenticationMethodModeDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationMethod",
+        "displayName"
+      ]
+    },
+    "authenticationMethodsPolicy": {
+      "navigationProperties": [
+        "authenticationMethodConfigurations"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "microsoftAuthenticatorPlatformSettings",
+        "policyMigrationState",
+        "policyVersion",
+        "reconfirmationInDays",
+        "registrationEnforcement",
+        "reportSuspiciousActivitySettings",
+        "systemCredentialPreferences"
+      ]
+    },
+    "authenticationMethodsRoot": {
+      "navigationProperties": [
+        "userEventsSummary",
+        "userMfaSignInSummary",
+        "userPasswordResetsAndChangesSummary",
+        "userRegistrationDetails"
+      ],
+      "properties": []
+    },
+    "authenticationMethodTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "isRegistrationRequired",
+        "targetType"
+      ]
+    },
+    "authenticationsMetric": {
+      "navigationProperties": [
+        "failures"
+      ],
+      "properties": [
+        "appid",
+        "attemptsCount",
+        "authFlow",
+        "browser",
+        "country",
+        "factDate",
+        "identityProvider",
+        "language",
+        "os",
+        "successCount"
+      ]
+    },
+    "authenticationStrengthPolicy": {
+      "navigationProperties": [
+        "combinationConfigurations"
+      ],
+      "properties": [
+        "allowedCombinations",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "modifiedDateTime",
+        "policyType",
+        "requirementsSatisfied"
+      ]
+    },
+    "authenticationStrengthRoot": {
+      "navigationProperties": [
+        "authenticationMethodModes",
+        "policies"
+      ],
+      "properties": [
+        "authenticationCombinations",
+        "combinations"
+      ]
+    },
+    "authoredNote": {
+      "navigationProperties": [],
+      "properties": [
+        "author",
+        "content",
+        "createdDateTime"
+      ]
+    },
+    "authorizationPolicy": {
+      "navigationProperties": [
+        "defaultUserRoleOverrides"
+      ],
+      "properties": [
+        "allowedToSignUpEmailBasedSubscriptions",
+        "allowedToUseSSPR",
+        "allowEmailVerifiedUsersToJoinOrganization",
+        "allowInvitesFrom",
+        "allowUserConsentForRiskyApps",
+        "blockMsolPowerShell",
+        "defaultUserRolePermissions",
+        "enabledPreviewFeatures",
+        "guestUserRoleId",
+        "permissionGrantPolicyIdsAssignedToDefaultUserRole"
+      ]
+    },
+    "authorizationSystem": {
+      "navigationProperties": [
+        "dataCollectionInfo"
+      ],
+      "properties": [
+        "authorizationSystemId",
+        "authorizationSystemName",
+        "authorizationSystemType"
+      ]
+    },
+    "authorizationSystemIdentity": {
+      "navigationProperties": [
+        "authorizationSystem"
+      ],
+      "properties": [
+        "displayName",
+        "externalId",
+        "source"
+      ]
+    },
+    "authorizationSystemResource": {
+      "navigationProperties": [
+        "authorizationSystem"
+      ],
+      "properties": [
+        "displayName",
+        "externalId",
+        "resourceType"
+      ]
+    },
+    "authorizationSystemTypeAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actionType",
+        "externalId",
+        "resourceTypes",
+        "severity"
+      ]
+    },
+    "authorizationSystemTypeService": {
+      "navigationProperties": [
+        "actions"
+      ],
+      "properties": []
+    },
+    "availableAccessPackage": {
+      "navigationProperties": [
+        "resourceRoleScopes"
+      ],
+      "properties": [
+        "description",
+        "displayName"
+      ]
+    },
+    "awsAccessKey": {
+      "navigationProperties": [
+        "owner"
+      ],
+      "properties": []
+    },
+    "awsAuthorizationSystem": {
+      "navigationProperties": [
+        "actions",
+        "policies",
+        "resources",
+        "services"
+      ],
+      "properties": [
+        "associatedIdentities"
+      ]
+    },
+    "awsAuthorizationSystemResource": {
+      "navigationProperties": [
+        "service"
+      ],
+      "properties": []
+    },
+    "awsAuthorizationSystemTypeAction": {
+      "navigationProperties": [
+        "service"
+      ],
+      "properties": []
+    },
+    "awsEc2Instance": {
+      "navigationProperties": [
+        "resource"
+      ],
+      "properties": []
+    },
+    "awsExternalSystemAccessFinding": {
+      "navigationProperties": [
+        "affectedSystem"
+      ],
+      "properties": [
+        "accessMethods",
+        "systemWithAccess",
+        "trustedIdentityCount",
+        "trustsAllIdentities"
+      ]
+    },
+    "awsExternalSystemAccessRoleFinding": {
+      "navigationProperties": [
+        "role"
+      ],
+      "properties": [
+        "accessibleSystemIds",
+        "permissionsCreepIndex"
+      ]
+    },
+    "awsGroup": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "awsIdentity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "awsIdentityAccessManagementKeyAgeFinding": {
+      "navigationProperties": [
+        "accessKey"
+      ],
+      "properties": [
+        "actionSummary",
+        "awsAccessKeyDetails",
+        "permissionsCreepIndex",
+        "status"
+      ]
+    },
+    "awsIdentityAccessManagementKeyUsageFinding": {
+      "navigationProperties": [
+        "accessKey"
+      ],
+      "properties": [
+        "actionSummary",
+        "awsAccessKeyDetails",
+        "permissionsCreepIndex",
+        "status"
+      ]
+    },
+    "awsLambda": {
+      "navigationProperties": [
+        "resource"
+      ],
+      "properties": []
+    },
+    "awsPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "awsPolicyType",
+        "displayName",
+        "externalId"
+      ]
+    },
+    "awsRole": {
+      "navigationProperties": [],
+      "properties": [
+        "roleType",
+        "trustEntityType"
+      ]
+    },
+    "awsSecretInformationAccessFinding": {
+      "navigationProperties": [
+        "identity"
+      ],
+      "properties": [
+        "identityDetails",
+        "permissionsCreepIndex",
+        "secretInformationWebServices"
+      ]
+    },
+    "awsSecurityToolAdministrationFinding": {
+      "navigationProperties": [
+        "identity"
+      ],
+      "properties": [
+        "identityDetails",
+        "permissionsCreepIndex",
+        "securityTools"
+      ]
+    },
+    "awsStatement": {
+      "navigationProperties": [],
+      "properties": [
+        "actions",
+        "condition",
+        "effect",
+        "notActions",
+        "notResources",
+        "resources",
+        "statementId"
+      ]
+    },
+    "awsUser": {
+      "navigationProperties": [
+        "assumableRoles"
+      ],
+      "properties": []
+    },
+    "azureADAuthentication": {
+      "navigationProperties": [],
+      "properties": [
+        "attainments"
+      ]
+    },
+    "azureADPremiumLicenseInsight": {
+      "navigationProperties": [],
+      "properties": [
+        "entitledP1LicenseCount",
+        "entitledP2LicenseCount",
+        "entitledTotalLicenseCount",
+        "internetAccessFeatureUtilizations",
+        "p1FeatureUtilizations",
+        "p2FeatureUtilizations",
+        "privateAccessFeatureUtilizations"
+      ]
+    },
+    "azureADWindowsAutopilotDeploymentProfile": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azureAuthorizationSystem": {
+      "navigationProperties": [
+        "actions",
+        "resources",
+        "roleDefinitions",
+        "services"
+      ],
+      "properties": [
+        "associatedIdentities"
+      ]
+    },
+    "azureAuthorizationSystemResource": {
+      "navigationProperties": [
+        "service"
+      ],
+      "properties": []
+    },
+    "azureAuthorizationSystemTypeAction": {
+      "navigationProperties": [
+        "service"
+      ],
+      "properties": []
+    },
+    "azureCommunicationServicesUserConversationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "azureCommunicationServicesId"
+      ]
+    },
+    "azureGroup": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azureIdentity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azureManagedIdentity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azureRoleDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "assignableScopes",
+        "azureRoleDefinitionType",
+        "displayName",
+        "externalId"
+      ]
+    },
+    "azureServerlessFunction": {
+      "navigationProperties": [
+        "resource"
+      ],
+      "properties": []
+    },
+    "azureServicePrincipal": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azureUser": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "b2bManagementPolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "b2cAuthenticationMethodsPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "isEmailPasswordAuthenticationEnabled",
+        "isPhoneOneTimePasswordAuthenticationEnabled",
+        "isUserNameAuthenticationEnabled"
+      ]
+    },
+    "b2cIdentityUserFlow": {
+      "navigationProperties": [
+        "identityProviders",
+        "languages",
+        "userAttributeAssignments",
+        "userFlowIdentityProviders"
+      ],
+      "properties": [
+        "apiConnectorConfiguration",
+        "defaultLanguageTag",
+        "isLanguageCustomizationEnabled"
+      ]
+    },
+    "b2xIdentityUserFlow": {
+      "navigationProperties": [
+        "identityProviders",
+        "languages",
+        "userAttributeAssignments",
+        "userFlowIdentityProviders"
+      ],
+      "properties": [
+        "apiConnectorConfiguration"
+      ]
+    },
+    "backupPolicyActivityLog": {
+      "navigationProperties": [],
+      "properties": [
+        "oldPolicyName",
+        "policyId",
+        "policyName",
+        "policyStatus",
+        "protectionUnitDetails",
+        "retentionPeriod"
+      ]
+    },
+    "backupReport": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "backupRestoreRoot": {
+      "navigationProperties": [
+        "activityLogs",
+        "browseSessions",
+        "driveExclusionUnits",
+        "driveExclusionUnitsBulkAdditionJobs",
+        "driveInclusionRules",
+        "driveProtectionUnits",
+        "driveProtectionUnitsBulkAdditionJobs",
+        "emailNotificationsSetting",
+        "exchangeProtectionPolicies",
+        "exchangeRestoreSessions",
+        "exclusionUnits",
+        "mailboxExclusionUnits",
+        "mailboxExclusionUnitsBulkAdditionJobs",
+        "mailboxInclusionRules",
+        "mailboxProtectionUnits",
+        "mailboxProtectionUnitsBulkAdditionJobs",
+        "oneDriveForBusinessBrowseSessions",
+        "oneDriveForBusinessProtectionPolicies",
+        "oneDriveForBusinessRestoreSessions",
+        "protectionPolicies",
+        "protectionUnits",
+        "reports",
+        "restorePoints",
+        "restoreSessions",
+        "serviceApps",
+        "sharePointBrowseSessions",
+        "sharePointProtectionPolicies",
+        "sharePointRestoreSessions",
+        "siteExclusionUnits",
+        "siteExclusionUnitsBulkAdditionJobs",
+        "siteInclusionRules",
+        "siteProtectionUnits",
+        "siteProtectionUnitsBulkAdditionJobs"
+      ],
+      "properties": [
+        "serviceStatus"
+      ]
+    },
+    "baseItem": {
+      "navigationProperties": [
+        "createdByUser",
+        "lastModifiedByUser"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "eTag",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "name",
+        "parentReference",
+        "webUrl"
+      ]
+    },
+    "baseItemVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "publication"
+      ]
+    },
+    "baseMapFeature": {
+      "navigationProperties": [],
+      "properties": [
+        "properties"
+      ]
+    },
+    "baseSitePage": {
+      "navigationProperties": [],
+      "properties": [
+        "pageLayout",
+        "publishingState",
+        "title"
+      ]
+    },
+    "bitlocker": {
+      "navigationProperties": [
+        "recoveryKeys"
+      ],
+      "properties": []
+    },
+    "bitlockerRecoveryKey": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "deviceId",
+        "key",
+        "volumeType"
+      ]
+    },
+    "bookingAppointment": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformation",
+        "anonymousJoinWebUrl",
+        "appointmentLabel",
+        "createdDateTime",
+        "customerEmailAddress",
+        "customerId",
+        "customerLocation",
+        "customerName",
+        "customerNotes",
+        "customerPhone",
+        "customers",
+        "customerTimeZone",
+        "duration",
+        "end",
+        "filledAttendeesCount",
+        "invoiceAmount",
+        "invoiceDate",
+        "invoiceId",
+        "invoiceStatus",
+        "invoiceUrl",
+        "isCustomerAllowedToManageBooking",
+        "isLocationOnline",
+        "joinWebUrl",
+        "lastUpdatedDateTime",
+        "maximumAttendeesCount",
+        "onlineMeetingUrl",
+        "optOutOfCustomerEmail",
+        "postBuffer",
+        "preBuffer",
+        "price",
+        "priceType",
+        "reminders",
+        "selfServiceAppointmentId",
+        "serviceId",
+        "serviceLocation",
+        "serviceName",
+        "serviceNotes",
+        "smsNotificationsEnabled",
+        "staffMemberIds",
+        "start"
+      ]
+    },
+    "bookingBusiness": {
+      "navigationProperties": [
+        "appointments",
+        "calendarView",
+        "customers",
+        "customQuestions",
+        "services",
+        "staffMembers"
+      ],
+      "properties": [
+        "address",
+        "bookingPageSettings",
+        "businessHours",
+        "businessType",
+        "createdDateTime",
+        "defaultCurrencyIso",
+        "email",
+        "isPublished",
+        "languageTag",
+        "lastUpdatedDateTime",
+        "phone",
+        "publicUrl",
+        "schedulingPolicy",
+        "webSiteUrl"
+      ]
+    },
+    "bookingCurrency": {
+      "navigationProperties": [],
+      "properties": [
+        "symbol"
+      ]
+    },
+    "bookingCustomer": {
+      "navigationProperties": [],
+      "properties": [
+        "addresses",
+        "createdDateTime",
+        "lastUpdatedDateTime",
+        "phones"
+      ]
+    },
+    "bookingCustomQuestion": {
+      "navigationProperties": [],
+      "properties": [
+        "answerInputType",
+        "answerOptions",
+        "createdDateTime",
+        "displayName",
+        "lastUpdatedDateTime"
+      ]
+    },
+    "bookingNamedEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "bookingPerson": {
+      "navigationProperties": [],
+      "properties": [
+        "emailAddress"
+      ]
+    },
+    "bookingService": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformation",
+        "createdDateTime",
+        "customQuestions",
+        "defaultDuration",
+        "defaultLocation",
+        "defaultPrice",
+        "defaultPriceType",
+        "defaultReminders",
+        "description",
+        "isAnonymousJoinEnabled",
+        "isCustomerAllowedToManageBooking",
+        "isHiddenFromCustomers",
+        "isLocationOnline",
+        "languageTag",
+        "lastUpdatedDateTime",
+        "maximumAttendeesCount",
+        "notes",
+        "postBuffer",
+        "preBuffer",
+        "schedulingPolicy",
+        "smsNotificationsEnabled",
+        "staffMemberIds",
+        "webUrl"
+      ]
+    },
+    "bookingStaffMember": {
+      "navigationProperties": [],
+      "properties": [
+        "availabilityIsAffectedByPersonalCalendar",
+        "colorIndex",
+        "createdDateTime",
+        "isEmailNotificationEnabled",
+        "lastUpdatedDateTime",
+        "membershipStatus",
+        "role",
+        "timeZone",
+        "useBusinessHours",
+        "workingHours"
+      ]
+    },
+    "browserSharedCookie": {
+      "navigationProperties": [],
+      "properties": [
+        "comment",
+        "createdDateTime",
+        "deletedDateTime",
+        "displayName",
+        "history",
+        "hostOnly",
+        "hostOrDomain",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "path",
+        "sourceEnvironment",
+        "status"
+      ]
+    },
+    "browserSite": {
+      "navigationProperties": [],
+      "properties": [
+        "allowRedirect",
+        "comment",
+        "compatibilityMode",
+        "createdDateTime",
+        "deletedDateTime",
+        "history",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "mergeType",
+        "status",
+        "targetEnvironment",
+        "webUrl"
+      ]
+    },
+    "browserSiteList": {
+      "navigationProperties": [
+        "sharedCookies",
+        "sites"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "publishedBy",
+        "publishedDateTime",
+        "revision",
+        "status"
+      ]
+    },
+    "browseSessionBase": {
+      "navigationProperties": [],
+      "properties": [
+        "backupSizeInBytes",
+        "createdDateTime",
+        "error",
+        "expirationDateTime",
+        "restorePointDateTime",
+        "restorePointId",
+        "status"
+      ]
+    },
+    "building": {
+      "navigationProperties": [
+        "map"
+      ],
+      "properties": [
+        "hasWiFi",
+        "resourceLinks",
+        "wifiState"
+      ]
+    },
+    "buildingMap": {
+      "navigationProperties": [
+        "footprints",
+        "levels"
+      ],
+      "properties": [
+        "placeId"
+      ]
+    },
+    "builtInIdentityProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "identityProviderType",
+        "state"
+      ]
+    },
+    "bulkUpload": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "businessFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "customData",
+        "deDuplicationId",
+        "description",
+        "displayName",
+        "policy",
+        "policyTemplateId",
+        "recordVersion",
+        "schemaId",
+        "settings"
+      ]
+    },
+    "businessFlowTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "businessScenario": {
+      "navigationProperties": [
+        "planner"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "ownerAppIds",
+        "uniqueName"
+      ]
+    },
+    "businessScenarioPlanner": {
+      "navigationProperties": [
+        "planConfiguration",
+        "taskConfiguration",
+        "tasks"
+      ],
+      "properties": []
+    },
+    "businessScenarioPlanReference": {
+      "navigationProperties": [],
+      "properties": [
+        "title"
+      ]
+    },
+    "businessScenarioTask": {
+      "navigationProperties": [],
+      "properties": [
+        "businessScenarioProperties",
+        "target"
+      ]
+    },
+    "calendar": {
+      "navigationProperties": [
+        "calendarPermissions",
+        "calendarView",
+        "events",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "allowedOnlineMeetingProviders",
+        "calendarGroupId",
+        "canEdit",
+        "canShare",
+        "canViewPrivateItems",
+        "changeKey",
+        "color",
+        "defaultOnlineMeetingProvider",
+        "hexColor",
+        "isDefaultCalendar",
+        "isRemovable",
+        "isShared",
+        "isSharedWithMe",
+        "isTallyingResponses",
+        "name",
+        "owner"
+      ]
+    },
+    "calendarGroup": {
+      "navigationProperties": [
+        "calendars"
+      ],
+      "properties": [
+        "changeKey",
+        "classId",
+        "name"
+      ]
+    },
+    "calendarPermission": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedRoles",
+        "emailAddress",
+        "isInsideOrganization",
+        "isRemovable",
+        "role"
+      ]
+    },
+    "calendarSharingMessage": {
+      "navigationProperties": [],
+      "properties": [
+        "canAccept",
+        "sharingMessageAction",
+        "sharingMessageActions",
+        "suggestedCalendarName"
+      ]
+    },
+    "call": {
+      "navigationProperties": [
+        "audioRoutingGroups",
+        "contentSharingSessions",
+        "operations",
+        "participants"
+      ],
+      "properties": [
+        "activeModalities",
+        "answeredBy",
+        "callbackUri",
+        "callChainId",
+        "callOptions",
+        "callRoutes",
+        "chatInfo",
+        "direction",
+        "incomingContext",
+        "mediaConfig",
+        "mediaState",
+        "meetingCapability",
+        "meetingInfo",
+        "myParticipantId",
+        "requestedModalities",
+        "resultInfo",
+        "ringingTimeoutInSeconds",
+        "routingPolicies",
+        "source",
+        "state",
+        "subject",
+        "targets",
+        "tenantId",
+        "terminationReason",
+        "toneInfo",
+        "transcription"
+      ]
+    },
+    "callActivityStatistics": {
+      "navigationProperties": [],
+      "properties": [
+        "afterHours"
+      ]
+    },
+    "callAiInsight": {
+      "navigationProperties": [],
+      "properties": [
+        "actionItems",
+        "callId",
+        "contentCorrelationId",
+        "createdDateTime",
+        "endDateTime",
+        "meetingNotes",
+        "viewpoint"
+      ]
+    },
+    "callEvent": {
+      "navigationProperties": [
+        "participants"
+      ],
+      "properties": [
+        "callConversationId",
+        "callEventType",
+        "eventDateTime",
+        "recordingState",
+        "transcriptionState"
+      ]
+    },
+    "callRecording": {
+      "navigationProperties": [],
+      "properties": [
+        "callId",
+        "content",
+        "contentCorrelationId",
+        "createdDateTime",
+        "endDateTime",
+        "meetingId",
+        "meetingOrganizer",
+        "recordingContentUrl"
+      ]
+    },
+    "callSettings": {
+      "navigationProperties": [
+        "delegates",
+        "delegators"
+      ],
+      "properties": []
+    },
+    "callTranscript": {
+      "navigationProperties": [],
+      "properties": [
+        "callId",
+        "content",
+        "contentCorrelationId",
+        "createdDateTime",
+        "endDateTime",
+        "meetingId",
+        "meetingOrganizer",
+        "metadataContent",
+        "transcriptContentUrl"
+      ]
+    },
+    "cancelMediaProcessingOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "canvasLayout": {
+      "navigationProperties": [
+        "horizontalSections",
+        "verticalSection"
+      ],
+      "properties": []
+    },
+    "caPoliciesDeletableRoot": {
+      "navigationProperties": [
+        "namedLocations",
+        "policies"
+      ],
+      "properties": []
+    },
+    "cartToClassAssociation": {
+      "navigationProperties": [],
+      "properties": [
+        "classroomIds",
+        "createdDateTime",
+        "description",
+        "deviceCartIds",
+        "displayName",
+        "lastModifiedDateTime",
+        "version"
+      ]
+    },
+    "certificateAuthorityAsEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "certificate",
+        "isRootAuthority",
+        "issuer",
+        "issuerSubjectKeyIdentifier"
+      ]
+    },
+    "certificateAuthorityDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "certificate",
+        "certificateAuthorityType",
+        "certificateRevocationListUrl",
+        "createdDateTime",
+        "deltaCertificateRevocationListUrl",
+        "displayName",
+        "expirationDateTime",
+        "isIssuerHintEnabled",
+        "issuer",
+        "issuerSubjectKeyIdentifier",
+        "thumbprint"
+      ]
+    },
+    "certificateAuthorityPath": {
+      "navigationProperties": [
+        "certificateBasedApplicationConfigurations",
+        "mutualTlsOauthConfigurations"
+      ],
+      "properties": []
+    },
+    "certificateBasedApplicationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName"
+      ]
+    },
+    "certificateBasedAuthConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateAuthorities"
+      ]
+    },
+    "certificateBasedAuthPki": {
+      "navigationProperties": [
+        "certificateAuthorities"
+      ],
+      "properties": [
+        "displayName",
+        "lastModifiedDateTime",
+        "status",
+        "statusDetails"
+      ]
+    },
+    "certificateConnectorDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "connectorName",
+        "connectorVersion",
+        "enrollmentDateTime",
+        "lastCheckinDateTime",
+        "machineName"
+      ]
+    },
+    "changeTrackedEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "channel": {
+      "navigationProperties": [
+        "allMembers",
+        "enabledApps",
+        "filesFolder",
+        "members",
+        "messages",
+        "planner",
+        "sharedWithTeams",
+        "tabs"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "email",
+        "isArchived",
+        "isFavoriteByDefault",
+        "layoutType",
+        "membershipType",
+        "migrationMode",
+        "moderationSettings",
+        "originalCreatedDateTime",
+        "summary",
+        "tenantId",
+        "webUrl"
+      ]
+    },
+    "chat": {
+      "navigationProperties": [
+        "installedApps",
+        "lastMessagePreview",
+        "members",
+        "messages",
+        "operations",
+        "permissionGrants",
+        "pinnedMessages",
+        "tabs",
+        "targetedMessages"
+      ],
+      "properties": [
+        "chatType",
+        "createdBy",
+        "createdDateTime",
+        "isHiddenForAllMembers",
+        "lastUpdatedDateTime",
+        "migrationMode",
+        "onlineMeetingInfo",
+        "originalCreatedDateTime",
+        "tenantId",
+        "topic",
+        "viewpoint",
+        "webUrl"
+      ]
+    },
+    "chatActivityStatistics": {
+      "navigationProperties": [],
+      "properties": [
+        "afterHours"
+      ]
+    },
+    "chatMessage": {
+      "navigationProperties": [
+        "hostedContents",
+        "replies"
+      ],
+      "properties": [
+        "attachments",
+        "body",
+        "channelIdentity",
+        "chatId",
+        "createdDateTime",
+        "deletedDateTime",
+        "etag",
+        "eventDetail",
+        "from",
+        "importance",
+        "lastEditedDateTime",
+        "lastModifiedDateTime",
+        "locale",
+        "mentions",
+        "messageHistory",
+        "messageType",
+        "onBehalfOf",
+        "policyViolation",
+        "reactions",
+        "replyToId",
+        "subject",
+        "summary",
+        "webUrl"
+      ]
+    },
+    "chatMessageHostedContent": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "chatMessageInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "body",
+        "createdDateTime",
+        "eventDetail",
+        "from",
+        "isDeleted",
+        "messageType"
+      ]
+    },
+    "checkInClaim": {
+      "navigationProperties": [],
+      "properties": [
+        "calendarEventId",
+        "checkInMethod",
+        "createdDateTime"
+      ]
+    },
+    "checklistItem": {
+      "navigationProperties": [],
+      "properties": [
+        "checkedDateTime",
+        "createdDateTime",
+        "displayName",
+        "isChecked"
+      ]
+    },
+    "chromeOSOnboardingSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "lastDirectorySyncDateTime",
+        "lastModifiedDateTime",
+        "onboardingStatus",
+        "ownerUserPrincipalName"
+      ]
+    },
+    "claimsMappingPolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "classificationJobResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "result"
+      ]
+    },
+    "cloudAppSecurityProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "azureSubscriptionId",
+        "azureTenantId",
+        "createdDateTime",
+        "deploymentPackageUrl",
+        "destinationServiceName",
+        "isSigned",
+        "lastModifiedDateTime",
+        "manifest",
+        "name",
+        "permissionsRequired",
+        "platform",
+        "policyName",
+        "publisher",
+        "riskScore",
+        "tags",
+        "type",
+        "vendorInformation"
+      ]
+    },
+    "cloudCertificationAuthority": {
+      "navigationProperties": [
+        "activeVersion",
+        "cloudCertificationAuthorityLeafCertificate",
+        "versions"
+      ],
+      "properties": [
+        "certificateDownloadUrl",
+        "certificateKeySize",
+        "certificateRevocationListUrl",
+        "certificateSigningRequest",
+        "certificationAuthorityIssuerId",
+        "certificationAuthorityIssuerUri",
+        "certificationAuthorityStatus",
+        "cloudCertificationAuthorityHashingAlgorithm",
+        "cloudCertificationAuthorityType",
+        "commonName",
+        "countryName",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "eTag",
+        "extendedKeyUsages",
+        "issuerCommonName",
+        "keyPlatform",
+        "lastModifiedDateTime",
+        "localityName",
+        "ocspResponderUri",
+        "organizationName",
+        "organizationUnit",
+        "roleScopeTagIds",
+        "rootCertificateCommonName",
+        "scepServerUrl",
+        "serialNumber",
+        "stateName",
+        "subjectName",
+        "thumbprint",
+        "validityEndDateTime",
+        "validityPeriodInYears",
+        "validityStartDateTime",
+        "versionNumber"
+      ]
+    },
+    "cloudCertificationAuthorityLeafCertificate": {
+      "navigationProperties": [
+        "cloudCertificationAuthorityVersion"
+      ],
+      "properties": [
+        "certificateStatus",
+        "certificationAuthorityIssuerUri",
+        "certificationAuthorityVersionNumber",
+        "crlDistributionPointUrl",
+        "deviceId",
+        "deviceName",
+        "devicePlatform",
+        "extendedKeyUsages",
+        "issuerId",
+        "issuerName",
+        "keyUsages",
+        "ocspResponderUri",
+        "revocationDateTime",
+        "serialNumber",
+        "subjectName",
+        "thumbprint",
+        "userId",
+        "userPrincipalName",
+        "validityEndDateTime",
+        "validityStartDateTime"
+      ]
+    },
+    "cloudCertificationAuthorityVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateDownloadUrl",
+        "certificateRevocationListUrl",
+        "certificateSigningRequest",
+        "certificationAuthorityId",
+        "certificationAuthorityIssuerUri",
+        "certificationAuthorityVersionStatus",
+        "decommissionDateTime",
+        "keyPlatform",
+        "lastModifiedDateTime",
+        "ocspResponderUri",
+        "scepServerUrl",
+        "serialNumber",
+        "subjectName",
+        "thumbprint",
+        "usage",
+        "validityEndDateTime",
+        "validityStartDateTime",
+        "versionNumber"
+      ]
+    },
+    "cloudClipboardItem": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "expirationDateTime",
+        "lastModifiedDateTime",
+        "payloads"
+      ]
+    },
+    "cloudClipboardRoot": {
+      "navigationProperties": [
+        "items"
+      ],
+      "properties": []
+    },
+    "cloudCommunications": {
+      "navigationProperties": [
+        "adhocCalls",
+        "callRecords",
+        "calls",
+        "onlineMeetingConversations",
+        "onlineMeetings",
+        "presences"
+      ],
+      "properties": []
+    },
+    "cloudFlareWebApplicationFirewallProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "apiToken",
+        "zoneId"
+      ]
+    },
+    "cloudPC": {
+      "navigationProperties": [],
+      "properties": [
+        "aadDeviceId",
+        "allotmentDisplayName",
+        "connectionSetting",
+        "connectionSettings",
+        "connectivityResult",
+        "deviceRegionName",
+        "disasterRecoveryCapability",
+        "diskEncryptionState",
+        "displayName",
+        "frontlineCloudPcAvailability",
+        "gracePeriodEndDateTime",
+        "groupDetail",
+        "imageDisplayName",
+        "lastLoginResult",
+        "lastModifiedDateTime",
+        "lastRemoteActionResult",
+        "managedDeviceId",
+        "managedDeviceName",
+        "onPremisesConnectionName",
+        "osVersion",
+        "partnerAgentInstallResults",
+        "powerState",
+        "productType",
+        "provisionedDateTime",
+        "provisioningPolicyId",
+        "provisioningPolicyName",
+        "provisioningType",
+        "scopeIds",
+        "servicePlanId",
+        "servicePlanName",
+        "servicePlanType",
+        "sharedDeviceDetail",
+        "status",
+        "statusDetail",
+        "statusDetails",
+        "userAccountType",
+        "userDetail",
+        "userExperienceType",
+        "userPrincipalName"
+      ]
+    },
+    "cloudPcAgentPool": {
+      "navigationProperties": [],
+      "properties": [
+        "billingConfiguration",
+        "poolUrl",
+        "scalingPolicy",
+        "sessionUsage"
+      ]
+    },
+    "cloudPcAgentPoolUserAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "userPrincipalId"
+      ]
+    },
+    "cloudPcAuditEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "activityDateTime",
+        "activityOperationType",
+        "activityResult",
+        "activityType",
+        "actor",
+        "category",
+        "componentName",
+        "correlationId",
+        "displayName",
+        "resources"
+      ]
+    },
+    "cloudPcBulkAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actionSummary",
+        "cloudPcIds",
+        "createdDateTime",
+        "displayName",
+        "initiatedByUserPrincipalName",
+        "scheduledDuringMaintenanceWindow",
+        "status"
+      ]
+    },
+    "cloudPcBulkCreateSnapshot": {
+      "navigationProperties": [],
+      "properties": [
+        "accessTier",
+        "storageAccountId"
+      ]
+    },
+    "cloudPcBulkDisasterRecovery": {
+      "navigationProperties": [],
+      "properties": [
+        "capabilityType",
+        "licenseType"
+      ]
+    },
+    "cloudPcBulkDisasterRecoveryFailback": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcBulkDisasterRecoveryFailover": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcBulkModifyDiskEncryptionType": {
+      "navigationProperties": [],
+      "properties": [
+        "diskEncryptionType"
+      ]
+    },
+    "cloudPcBulkMove": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcBulkPowerOff": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcBulkPowerOn": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcBulkReinstallAgent": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcBulkReprovision": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcBulkResize": {
+      "navigationProperties": [],
+      "properties": [
+        "targetServicePlanId"
+      ]
+    },
+    "cloudPcBulkRestart": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcBulkRestore": {
+      "navigationProperties": [],
+      "properties": [
+        "ignoreUnhealthySnapshots",
+        "restorePointDateTime",
+        "timeRange"
+      ]
+    },
+    "cloudPcBulkSetReviewStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "reviewStatus"
+      ]
+    },
+    "cloudPcBulkTroubleshoot": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcCloudApp": {
+      "navigationProperties": [],
+      "properties": [
+        "actionFailedErrorCode",
+        "actionFailedErrorMessage",
+        "addedDateTime",
+        "appDetail",
+        "appStatus",
+        "availableToUser",
+        "description",
+        "discoveredAppName",
+        "displayName",
+        "lastPublishedDateTime",
+        "provisioningPolicyId",
+        "scopeIds"
+      ]
+    },
+    "cloudPCConnectivityIssue": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "errorCode",
+        "errorDateTime",
+        "errorDescription",
+        "recommendedAction",
+        "userId"
+      ]
+    },
+    "cloudPcCrossCloudGovernmentOrganizationMapping": {
+      "navigationProperties": [],
+      "properties": [
+        "organizationIdsInUSGovCloud"
+      ]
+    },
+    "cloudPcDeviceImage": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "errorCode",
+        "expirationDate",
+        "lastModifiedDateTime",
+        "operatingSystem",
+        "osBuildNumber",
+        "osStatus",
+        "osVersionNumber",
+        "scopeIds",
+        "sizeInGB",
+        "sourceImageResourceId",
+        "status",
+        "statusDetails",
+        "version"
+      ]
+    },
+    "cloudPcExportJob": {
+      "navigationProperties": [],
+      "properties": [
+        "expirationDateTime",
+        "exportJobStatus",
+        "exportUrl",
+        "filter",
+        "format",
+        "reportName",
+        "requestDateTime",
+        "select"
+      ]
+    },
+    "cloudPcExternalPartner": {
+      "navigationProperties": [],
+      "properties": [
+        "agentSetting",
+        "connectionStatus",
+        "enableConnection",
+        "lastSyncDateTime",
+        "partnerId",
+        "statusDetails"
+      ]
+    },
+    "cloudPcExternalPartnerSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "enableConnection",
+        "lastSyncDateTime",
+        "partnerId",
+        "status",
+        "statusDetails"
+      ]
+    },
+    "cloudPcFrontLineServicePlan": {
+      "navigationProperties": [],
+      "properties": [
+        "allotmentLicensesCount",
+        "displayName",
+        "totalCount",
+        "usedCount"
+      ]
+    },
+    "cloudPcGalleryImage": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "endDate",
+        "expirationDate",
+        "offer",
+        "offerDisplayName",
+        "offerName",
+        "osVersionNumber",
+        "publisher",
+        "publisherName",
+        "recommendedSku",
+        "sizeInGB",
+        "sku",
+        "skuDisplayName",
+        "skuName",
+        "startDate",
+        "status"
+      ]
+    },
+    "cloudPcManagedLicense": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDateTime",
+        "allotmentLicensesCount",
+        "assignedCount",
+        "displayName",
+        "expirationDateTime",
+        "latestLicenseStartDateTime",
+        "licensesCount",
+        "licenseType",
+        "nextBillingDateTime",
+        "servicePlanId",
+        "status",
+        "subscriptionId"
+      ]
+    },
+    "cloudPcOnPremisesConnection": {
+      "navigationProperties": [],
+      "properties": [
+        "adDomainName",
+        "adDomainPassword",
+        "adDomainUsername",
+        "alternateResourceUrl",
+        "connectionType",
+        "displayName",
+        "healthCheckPaused",
+        "healthCheckStatus",
+        "healthCheckStatusDetail",
+        "healthCheckStatusDetails",
+        "inUse",
+        "inUseByCloudPc",
+        "managedBy",
+        "organizationalUnit",
+        "resourceGroupId",
+        "scopeIds",
+        "subnetId",
+        "subnetPrivateIpDetail",
+        "subscriptionId",
+        "subscriptionName",
+        "type",
+        "virtualNetworkId",
+        "virtualNetworkLocation"
+      ]
+    },
+    "cloudPcOrganizationSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "enableMEMAutoEnroll",
+        "enableSingleSignOn",
+        "osVersion",
+        "userAccountType",
+        "windowsSettings"
+      ]
+    },
+    "cloudPcPool": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "capabilities",
+        "cloudPcConfiguration",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "networkConfiguration"
+      ]
+    },
+    "cloudPcPoolAssignment": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcProvisioningPolicy": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "alternateResourceUrl",
+        "autopatch",
+        "autopilotConfiguration",
+        "cloudPcGroupDisplayName",
+        "cloudPcNamingTemplate",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "domainJoinConfigurations",
+        "enableSingleSignOn",
+        "gracePeriodInHours",
+        "imageDisplayName",
+        "imageId",
+        "imageType",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "localAdminEnabled",
+        "managedBy",
+        "microsoftManagedDesktop",
+        "provisioningType",
+        "scopeIds",
+        "userExperienceType",
+        "userSettingsPersistenceConfiguration",
+        "windowsSetting",
+        "windowsSettings"
+      ]
+    },
+    "cloudPcProvisioningPolicyAssignment": {
+      "navigationProperties": [
+        "assignedUsers",
+        "userSettingsPersistenceDetail"
+      ],
+      "properties": [
+        "target"
+      ]
+    },
+    "cloudPcReport": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcReports": {
+      "navigationProperties": [
+        "exportJobs"
+      ],
+      "properties": []
+    },
+    "cloudPcServicePlan": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "provisioningType",
+        "ramInGB",
+        "storageInGB",
+        "supportedSolution",
+        "type",
+        "userProfileInGB",
+        "vCpuCount"
+      ]
+    },
+    "cloudPcSnapshot": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudPcId",
+        "createdDateTime",
+        "expirationDateTime",
+        "healthCheckStatus",
+        "lastRestoredDateTime",
+        "snapshotType",
+        "status"
+      ]
+    },
+    "cloudPcSupportedRegion": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "geographicLocationType",
+        "regionGroup",
+        "regionRestrictionDetail",
+        "regionStatus",
+        "supportedSolution"
+      ]
+    },
+    "cloudPcUserSetting": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "createdDateTime",
+        "crossRegionDisasterRecoverySetting",
+        "displayName",
+        "lastModifiedDateTime",
+        "localAdminEnabled",
+        "notificationSetting",
+        "provisioningSourceType",
+        "resetEnabled",
+        "restorePointSetting",
+        "selfServiceEnabled"
+      ]
+    },
+    "cloudPcUserSettingAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "target"
+      ]
+    },
+    "cloudPCUserSettingsPersistenceDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "gracePeriodEndDateTime"
+      ]
+    },
+    "columnDefinition": {
+      "navigationProperties": [
+        "sourceColumn"
+      ],
+      "properties": [
+        "boolean",
+        "calculated",
+        "choice",
+        "columnGroup",
+        "contentApprovalStatus",
+        "currency",
+        "dateTime",
+        "defaultValue",
+        "description",
+        "displayName",
+        "enforceUniqueValues",
+        "geolocation",
+        "hidden",
+        "hyperlinkOrPicture",
+        "indexed",
+        "isDeletable",
+        "isReorderable",
+        "isSealed",
+        "lookup",
+        "name",
+        "number",
+        "personOrGroup",
+        "propagateChanges",
+        "readOnly",
+        "required",
+        "sourceContentType",
+        "term",
+        "text",
+        "thumbnail",
+        "type",
+        "validation"
+      ]
+    },
+    "columnLink": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "comanagementEligibleDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "clientRegistrationStatus",
+        "deviceName",
+        "deviceType",
+        "entitySource",
+        "managementAgents",
+        "managementState",
+        "manufacturer",
+        "mdmStatus",
+        "model",
+        "osDescription",
+        "osVersion",
+        "ownerType",
+        "referenceId",
+        "serialNumber",
+        "status",
+        "upn",
+        "userEmail",
+        "userId",
+        "userName"
+      ]
+    },
+    "command": {
+      "navigationProperties": [
+        "responsepayload"
+      ],
+      "properties": [
+        "appServiceName",
+        "error",
+        "packageFamilyName",
+        "payload",
+        "permissionTicket",
+        "postBackUri",
+        "status",
+        "type"
+      ]
+    },
+    "commsApplication": {
+      "navigationProperties": [
+        "calls",
+        "onlineMeetings"
+      ],
+      "properties": []
+    },
+    "commsOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "clientContext",
+        "resultInfo",
+        "status"
+      ]
+    },
+    "community": {
+      "navigationProperties": [
+        "group",
+        "owners"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "groupId",
+        "privacy"
+      ]
+    },
+    "company": {
+      "navigationProperties": [
+        "accounts",
+        "agedAccountsPayable",
+        "agedAccountsReceivable",
+        "companyInformation",
+        "countriesRegions",
+        "currencies",
+        "customerPaymentJournals",
+        "customerPayments",
+        "customers",
+        "dimensions",
+        "dimensionValues",
+        "employees",
+        "generalLedgerEntries",
+        "itemCategories",
+        "items",
+        "journalLines",
+        "journals",
+        "paymentMethods",
+        "paymentTerms",
+        "picture",
+        "purchaseInvoiceLines",
+        "purchaseInvoices",
+        "salesCreditMemoLines",
+        "salesCreditMemos",
+        "salesInvoiceLines",
+        "salesInvoices",
+        "salesOrderLines",
+        "salesOrders",
+        "salesQuoteLines",
+        "salesQuotes",
+        "shipmentMethods",
+        "taxAreas",
+        "taxGroups",
+        "unitsOfMeasure",
+        "vendors"
+      ],
+      "properties": [
+        "businessProfileId",
+        "displayName",
+        "id",
+        "name",
+        "systemVersion"
+      ]
+    },
+    "companyInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "currencyCode",
+        "currentFiscalYearStartDate",
+        "displayName",
+        "email",
+        "faxNumber",
+        "id",
+        "industry",
+        "lastModifiedDateTime",
+        "phoneNumber",
+        "picture",
+        "taxRegistrationNumber",
+        "website"
+      ]
+    },
+    "companySubscription": {
+      "navigationProperties": [],
+      "properties": [
+        "commerceSubscriptionId",
+        "createdDateTime",
+        "isTrial",
+        "nextLifecycleDateTime",
+        "ocpSubscriptionId",
+        "ownerId",
+        "ownerTenantId",
+        "ownerType",
+        "serviceStatus",
+        "skuId",
+        "skuPartNumber",
+        "status",
+        "totalLicenses"
+      ]
+    },
+    "compliance": {
+      "navigationProperties": [
+        "ediscovery"
+      ],
+      "properties": []
+    },
+    "complianceManagementPartner": {
+      "navigationProperties": [],
+      "properties": [
+        "androidEnrollmentAssignments",
+        "androidOnboarded",
+        "displayName",
+        "iosEnrollmentAssignments",
+        "iosOnboarded",
+        "lastHeartbeatDateTime",
+        "linuxEnrollmentAssignments",
+        "linuxOnboarded",
+        "macOsEnrollmentAssignments",
+        "macOsOnboarded",
+        "partnerState"
+      ]
+    },
+    "compliantNetworkNamedLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantNetworkType",
+        "isTrusted"
+      ]
+    },
+    "conditionalAccessPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "conditions",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "grantControls",
+        "id",
+        "modifiedDateTime",
+        "sessionControls",
+        "state"
+      ]
+    },
+    "conditionalAccessRoot": {
+      "navigationProperties": [
+        "authenticationContextClassReferences",
+        "authenticationStrength",
+        "authenticationStrengths",
+        "deletedItems",
+        "namedLocations",
+        "policies",
+        "templates"
+      ],
+      "properties": []
+    },
+    "conditionalAccessTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "details",
+        "name",
+        "scenarios"
+      ]
+    },
+    "configManagerCollection": {
+      "navigationProperties": [],
+      "properties": [
+        "collectionIdentifier",
+        "createdDateTime",
+        "displayName",
+        "hierarchyIdentifier",
+        "hierarchyName",
+        "lastModifiedDateTime"
+      ]
+    },
+    "configurationBaseline": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "parameters",
+        "resources"
+      ]
+    },
+    "configurationDrift": {
+      "navigationProperties": [],
+      "properties": [
+        "baselineResourceDisplayName",
+        "driftedProperties",
+        "firstReportedDateTime",
+        "monitorId",
+        "resourceInstanceIdentifier",
+        "resourceType",
+        "status",
+        "tenantId"
+      ]
+    },
+    "configurationManagement": {
+      "navigationProperties": [
+        "configurationDrifts",
+        "configurationMonitoringResults",
+        "configurationMonitors",
+        "configurationSnapshotJobs",
+        "configurationSnapshots"
+      ],
+      "properties": []
+    },
+    "configurationMonitor": {
+      "navigationProperties": [
+        "baseline"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "inactivationReason",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "mode",
+        "monitorRunFrequencyInHours",
+        "parameters",
+        "status",
+        "tenantId"
+      ]
+    },
+    "configurationMonitoringResult": {
+      "navigationProperties": [],
+      "properties": [
+        "driftsCount",
+        "errorDetails",
+        "monitorId",
+        "runCompletionDateTime",
+        "runInitiationDateTime",
+        "runStatus",
+        "tenantId"
+      ]
+    },
+    "configurationSnapshotJob": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "errorDetails",
+        "resourceLocation",
+        "resources",
+        "status",
+        "tenantId"
+      ]
+    },
+    "connectedOrganization": {
+      "navigationProperties": [
+        "externalSponsors",
+        "internalSponsors"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "identitySources",
+        "modifiedBy",
+        "modifiedDateTime",
+        "state"
+      ]
+    },
+    "connectionOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "status"
+      ]
+    },
+    "connector": {
+      "navigationProperties": [
+        "memberOf"
+      ],
+      "properties": [
+        "externalIp",
+        "machineName",
+        "status",
+        "version"
+      ]
+    },
+    "connectorGroup": {
+      "navigationProperties": [
+        "applications",
+        "members"
+      ],
+      "properties": [
+        "connectorGroupType",
+        "isDefault",
+        "name",
+        "region"
+      ]
+    },
+    "contact": {
+      "navigationProperties": [
+        "extensions",
+        "multiValueExtendedProperties",
+        "photo",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "assistantName",
+        "birthday",
+        "children",
+        "companyName",
+        "department",
+        "displayName",
+        "emailAddresses",
+        "fileAs",
+        "flag",
+        "gender",
+        "generation",
+        "givenName",
+        "imAddresses",
+        "initials",
+        "isFavorite",
+        "jobTitle",
+        "manager",
+        "middleName",
+        "nickName",
+        "officeLocation",
+        "parentFolderId",
+        "personalNotes",
+        "phones",
+        "postalAddresses",
+        "primaryEmailAddress",
+        "profession",
+        "secondaryEmailAddress",
+        "spouseName",
+        "surname",
+        "tertiaryEmailAddress",
+        "title",
+        "websites",
+        "weddingAnniversary",
+        "yomiCompanyName",
+        "yomiGivenName",
+        "yomiSurname"
+      ]
+    },
+    "contactFolder": {
+      "navigationProperties": [
+        "childFolders",
+        "contacts",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "displayName",
+        "parentFolderId",
+        "wellKnownName"
+      ]
+    },
+    "contactMergeSuggestions": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "contentActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "contentMetadata",
+        "scopeIdentifier",
+        "userId"
+      ]
+    },
+    "contentModel": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "modelType",
+        "name"
+      ]
+    },
+    "contentSharingSession": {
+      "navigationProperties": [],
+      "properties": [
+        "pngOfCurrentSlide",
+        "presenterParticipantId"
+      ]
+    },
+    "contentType": {
+      "navigationProperties": [
+        "base",
+        "baseTypes",
+        "columnLinks",
+        "columnPositions",
+        "columns"
+      ],
+      "properties": [
+        "associatedHubsUrls",
+        "description",
+        "documentSet",
+        "documentTemplate",
+        "group",
+        "hidden",
+        "inheritedFrom",
+        "isBuiltIn",
+        "name",
+        "order",
+        "parentId",
+        "propagateChanges",
+        "readOnly",
+        "sealed"
+      ]
+    },
+    "continuousAccessEvaluationPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "groups",
+        "isEnabled",
+        "migrate",
+        "users"
+      ]
+    },
+    "contract": {
+      "navigationProperties": [],
+      "properties": [
+        "contractType",
+        "customerId",
+        "defaultDomainName",
+        "displayName"
+      ]
+    },
+    "controlConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "isEnabled",
+        "modifiedBy",
+        "modifiedDateTime"
+      ]
+    },
+    "conversation": {
+      "navigationProperties": [
+        "threads"
+      ],
+      "properties": [
+        "hasAttachments",
+        "lastDeliveredDateTime",
+        "preview",
+        "topic",
+        "uniqueSenders"
+      ]
+    },
+    "conversationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "roles",
+        "visibleHistoryStartDateTime"
+      ]
+    },
+    "conversationThread": {
+      "navigationProperties": [
+        "posts"
+      ],
+      "properties": [
+        "ccRecipients",
+        "hasAttachments",
+        "isLocked",
+        "lastDeliveredDateTime",
+        "preview",
+        "topic",
+        "toRecipients",
+        "uniqueSenders"
+      ]
+    },
+    "copilotAdmin": {
+      "navigationProperties": [
+        "catalog",
+        "policySettings",
+        "settings"
+      ],
+      "properties": []
+    },
+    "copilotAdminCatalog": {
+      "navigationProperties": [
+        "packages"
+      ],
+      "properties": []
+    },
+    "copilotAdminLimitedMode": {
+      "navigationProperties": [],
+      "properties": [
+        "groupId",
+        "isEnabledForGroup"
+      ]
+    },
+    "copilotAdminSetting": {
+      "navigationProperties": [
+        "limitedMode"
+      ],
+      "properties": []
+    },
+    "copilotCommunicationsRoot": {
+      "navigationProperties": [
+        "realtimeActivityFeed"
+      ],
+      "properties": []
+    },
+    "copilotConversation": {
+      "navigationProperties": [
+        "messages"
+      ],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "state",
+        "turnCount"
+      ]
+    },
+    "copilotConversationMessage": {
+      "navigationProperties": [],
+      "properties": [
+        "text"
+      ]
+    },
+    "copilotConversationRequestMessage": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "copilotConversationResponseMessage": {
+      "navigationProperties": [],
+      "properties": [
+        "adaptiveCards",
+        "attributions",
+        "createdDateTime",
+        "sensitivityLabel"
+      ]
+    },
+    "copilotPackage": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "assetId",
+        "availableTo",
+        "deployedTo",
+        "displayName",
+        "elementTypes",
+        "isBlocked",
+        "lastModifiedDateTime",
+        "manifestId",
+        "manifestVersion",
+        "platform",
+        "publisher",
+        "shortDescription",
+        "supportedHosts",
+        "type",
+        "version",
+        "zipFile"
+      ]
+    },
+    "copilotPackageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "acquireUsersAndGroups",
+        "allowedUsersAndGroups",
+        "categories",
+        "elementDetails",
+        "longDescription",
+        "sensitivity"
+      ]
+    },
+    "copilotPeopleAdminSetting": {
+      "navigationProperties": [
+        "enhancedPersonalization"
+      ],
+      "properties": []
+    },
+    "copilotPolicySetting": {
+      "navigationProperties": [],
+      "properties": [
+        "policyId",
+        "value"
+      ]
+    },
+    "copilotReportRoot": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "copilotRoot": {
+      "navigationProperties": [
+        "admin",
+        "agentRegistrations",
+        "agents",
+        "communications",
+        "conversations",
+        "interactionHistory",
+        "reports",
+        "settings",
+        "users"
+      ],
+      "properties": []
+    },
+    "copilotSetting": {
+      "navigationProperties": [
+        "people"
+      ],
+      "properties": []
+    },
+    "copilotTool": {
+      "navigationProperties": [],
+      "properties": [
+        "copilotToolName",
+        "url"
+      ]
+    },
+    "corsConfiguration_v2": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedHeaders",
+        "allowedMethods",
+        "allowedOrigins",
+        "maxAgeInSeconds",
+        "resource"
+      ]
+    },
+    "countryNamedLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "countriesAndRegions",
+        "countryLookupMethod",
+        "includeUnknownCountriesAndRegions"
+      ]
+    },
+    "countryRegion": {
+      "navigationProperties": [],
+      "properties": [
+        "addressFormat",
+        "code",
+        "displayName",
+        "id",
+        "lastModifiedDateTime"
+      ]
+    },
+    "credentialUsageSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "authMethod",
+        "failureActivityCount",
+        "feature",
+        "successfulActivityCount"
+      ]
+    },
+    "credentialUserRegistrationCount": {
+      "navigationProperties": [],
+      "properties": [
+        "totalUserCount",
+        "userRegistrationCounts"
+      ]
+    },
+    "credentialUserRegistrationDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "authMethods",
+        "isCapable",
+        "isEnabled",
+        "isMfaRegistered",
+        "isRegistered",
+        "userDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "crossTenantAccessPolicy": {
+      "navigationProperties": [
+        "default",
+        "partners",
+        "templates"
+      ],
+      "properties": [
+        "allowedCloudEndpoints"
+      ]
+    },
+    "crossTenantAccessPolicyConfigurationDefault": {
+      "navigationProperties": [],
+      "properties": [
+        "appServiceConnectInbound",
+        "automaticUserConsentSettings",
+        "b2bCollaborationInbound",
+        "b2bCollaborationOutbound",
+        "b2bDirectConnectInbound",
+        "b2bDirectConnectOutbound",
+        "blockServiceProviderOutboundAccess",
+        "inboundTrust",
+        "invitationRedemptionIdentityProviderConfiguration",
+        "isServiceDefault",
+        "m365CollaborationInbound",
+        "m365CollaborationOutbound",
+        "tenantRestrictions"
+      ]
+    },
+    "crossTenantAccessPolicyConfigurationPartner": {
+      "navigationProperties": [
+        "identitySynchronization"
+      ],
+      "properties": [
+        "appServiceConnectInbound",
+        "automaticUserConsentSettings",
+        "b2bCollaborationInbound",
+        "b2bCollaborationOutbound",
+        "b2bDirectConnectInbound",
+        "b2bDirectConnectOutbound",
+        "blockServiceProviderOutboundAccess",
+        "inboundTrust",
+        "isInMultiTenantOrganization",
+        "isServiceProvider",
+        "m365CollaborationInbound",
+        "m365CollaborationOutbound",
+        "tenantId",
+        "tenantRestrictions"
+      ]
+    },
+    "crossTenantIdentitySyncPolicyPartner": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "externalCloudAuthorizedApplicationId",
+        "groupSyncInbound",
+        "tenantId",
+        "userSyncInbound"
+      ]
+    },
+    "crossTenantMigrationJob": {
+      "navigationProperties": [
+        "users"
+      ],
+      "properties": [
+        "completeAfterDateTime",
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "exchangeSettings",
+        "jobType",
+        "lastUpdatedDateTime",
+        "message",
+        "resources",
+        "resourceType",
+        "sourceTenantId",
+        "status",
+        "targetTenantId",
+        "workloads"
+      ]
+    },
+    "crossTenantMigrationTask": {
+      "navigationProperties": [],
+      "properties": [
+        "currentStatus",
+        "lastUpdatedDateTime",
+        "taskType"
+      ]
+    },
+    "currency": {
+      "navigationProperties": [],
+      "properties": [
+        "amountDecimalPlaces",
+        "amountRoundingPrecision",
+        "code",
+        "displayName",
+        "id",
+        "lastModifiedDateTime",
+        "symbol"
+      ]
+    },
+    "customAccessPackageWorkflowExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastModifiedDateTime"
+      ]
+    },
+    "customAppScope": {
+      "navigationProperties": [],
+      "properties": [
+        "customAttributes"
+      ]
+    },
+    "customAuthenticationExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "behaviorOnError"
+      ]
+    },
+    "customCalloutExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationConfiguration",
+        "clientConfiguration",
+        "description",
+        "displayName",
+        "endpointConfiguration"
+      ]
+    },
+    "customClaimsPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "audienceOverride",
+        "claims",
+        "includeApplicationIdInIssuer",
+        "includeBasicClaimSet"
+      ]
+    },
+    "customDataProvidedResource": {
+      "navigationProperties": [],
+      "properties": [
+        "notificationEndpointConfiguration"
+      ]
+    },
+    "customDataProvidedResourceFile": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "size",
+        "uploadedDateTime"
+      ]
+    },
+    "customDataProvidedResourceUploadSession": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "data",
+        "isUploadDone",
+        "source",
+        "stats",
+        "status",
+        "type"
+      ]
+    },
+    "customer": {
+      "navigationProperties": [
+        "currency",
+        "paymentMethod",
+        "paymentTerm",
+        "picture",
+        "shipmentMethod"
+      ],
+      "properties": [
+        "address",
+        "blocked",
+        "currencyCode",
+        "currencyId",
+        "displayName",
+        "email",
+        "id",
+        "lastModifiedDateTime",
+        "number",
+        "paymentMethodId",
+        "paymentTermsId",
+        "phoneNumber",
+        "shipmentMethodId",
+        "taxAreaDisplayName",
+        "taxAreaId",
+        "taxLiable",
+        "taxRegistrationNumber",
+        "type",
+        "website"
+      ]
+    },
+    "customerPayment": {
+      "navigationProperties": [
+        "customer"
+      ],
+      "properties": [
+        "amount",
+        "appliesToInvoiceId",
+        "appliesToInvoiceNumber",
+        "comment",
+        "contactId",
+        "customerId",
+        "customerNumber",
+        "description",
+        "documentNumber",
+        "externalDocumentNumber",
+        "id",
+        "journalDisplayName",
+        "lastModifiedDateTime",
+        "lineNumber",
+        "postingDate"
+      ]
+    },
+    "customerPaymentJournal": {
+      "navigationProperties": [
+        "account",
+        "customerPayments"
+      ],
+      "properties": [
+        "balancingAccountId",
+        "balancingAccountNumber",
+        "code",
+        "displayName",
+        "id",
+        "lastModifiedDateTime"
+      ]
+    },
+    "customExtensionHandler": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "stage"
+      ]
+    },
+    "customExtensionStageSetting": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "stage"
+      ]
+    },
+    "customSecurityAttributeAudit": {
+      "navigationProperties": [],
+      "properties": [
+        "activityDateTime",
+        "activityDisplayName",
+        "additionalDetails",
+        "category",
+        "correlationId",
+        "initiatedBy",
+        "loggedByService",
+        "operationType",
+        "result",
+        "resultReason",
+        "targetResources",
+        "userAgent"
+      ]
+    },
+    "customSecurityAttributeDefinition": {
+      "navigationProperties": [
+        "allowedValues"
+      ],
+      "properties": [
+        "attributeSet",
+        "description",
+        "isCollection",
+        "isSearchable",
+        "name",
+        "status",
+        "type",
+        "usePreDefinedValuesOnly"
+      ]
+    },
+    "customUsernameSignInIdentifier": {
+      "navigationProperties": [],
+      "properties": [
+        "validationRegEx"
+      ]
+    },
+    "dailyInactiveUsersByApplicationMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "inactive1DayCount"
+      ]
+    },
+    "dailyInactiveUsersMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "inactive1DayCount"
+      ]
+    },
+    "dailyUserInsightMetricsRoot": {
+      "navigationProperties": [
+        "activeUsers",
+        "authentications",
+        "inactiveUsers",
+        "inactiveUsersByApplication",
+        "mfaCompletions",
+        "mfaTelecomFraud",
+        "signUps",
+        "summary",
+        "userCount"
+      ],
+      "properties": []
+    },
+    "dataClassificationService": {
+      "navigationProperties": [
+        "classifyFileJobs",
+        "classifyTextJobs",
+        "evaluateDlpPoliciesJobs",
+        "evaluateLabelJobs",
+        "exactMatchDataStores",
+        "exactMatchUploadAgents",
+        "jobs",
+        "sensitiveTypes",
+        "sensitivityLabels"
+      ],
+      "properties": []
+    },
+    "dataCollectionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "entitlements"
+      ]
+    },
+    "dataLossPreventionPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "dataPolicyOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "progress",
+        "status",
+        "storageLocation",
+        "submittedDateTime",
+        "userId"
+      ]
+    },
+    "dataSecurityAndGovernance": {
+      "navigationProperties": [
+        "sensitivityLabels"
+      ],
+      "properties": []
+    },
+    "dataSharingConsent": {
+      "navigationProperties": [],
+      "properties": [
+        "grantDateTime",
+        "granted",
+        "grantedByUpn",
+        "grantedByUserId",
+        "serviceDisplayName",
+        "termsUrl"
+      ]
+    },
+    "dayNote": {
+      "navigationProperties": [],
+      "properties": [
+        "dayNoteDate",
+        "draftDayNote",
+        "sharedDayNote"
+      ]
+    },
+    "defaultDeviceCompliancePolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "defaultManagedAppProtection": {
+      "navigationProperties": [
+        "apps",
+        "deploymentSummary"
+      ],
+      "properties": [
+        "allowedAndroidDeviceManufacturers",
+        "allowedAndroidDeviceModels",
+        "allowedIosDeviceModels",
+        "allowWidgetContentSync",
+        "appActionIfAccountIsClockedOut",
+        "appActionIfAndroidDeviceManufacturerNotAllowed",
+        "appActionIfAndroidDeviceModelNotAllowed",
+        "appActionIfAndroidSafetyNetAppsVerificationFailed",
+        "appActionIfAndroidSafetyNetDeviceAttestationFailed",
+        "appActionIfDeviceLockNotSet",
+        "appActionIfDevicePasscodeComplexityLessThanHigh",
+        "appActionIfDevicePasscodeComplexityLessThanLow",
+        "appActionIfDevicePasscodeComplexityLessThanMedium",
+        "appActionIfIosDeviceModelNotAllowed",
+        "appDataEncryptionType",
+        "biometricAuthenticationBlocked",
+        "blockAfterCompanyPortalUpdateDeferralInDays",
+        "connectToVpnOnLaunch",
+        "customBrowserDisplayName",
+        "customBrowserPackageId",
+        "customBrowserProtocol",
+        "customDialerAppDisplayName",
+        "customDialerAppPackageId",
+        "customDialerAppProtocol",
+        "customSettings",
+        "deployedAppCount",
+        "deviceLockRequired",
+        "disableAppEncryptionIfDeviceEncryptionIsEnabled",
+        "disableProtectionOfManagedOutboundOpenInData",
+        "encryptAppData",
+        "exemptedAppPackages",
+        "exemptedAppProtocols",
+        "faceIdBlocked",
+        "filterOpenInToOnlyManagedApps",
+        "fingerprintAndBiometricEnabled",
+        "messagingRedirectAppDisplayName",
+        "messagingRedirectAppPackageId",
+        "messagingRedirectAppUrlScheme",
+        "minimumRequiredCompanyPortalVersion",
+        "minimumRequiredPatchVersion",
+        "minimumRequiredSdkVersion",
+        "minimumWarningCompanyPortalVersion",
+        "minimumWarningPatchVersion",
+        "minimumWarningSdkVersion",
+        "minimumWipeCompanyPortalVersion",
+        "minimumWipePatchVersion",
+        "minimumWipeSdkVersion",
+        "protectInboundDataFromUnknownSources",
+        "requireClass3Biometrics",
+        "requiredAndroidSafetyNetAppsVerificationType",
+        "requiredAndroidSafetyNetDeviceAttestationType",
+        "requiredAndroidSafetyNetEvaluationType",
+        "requirePinAfterBiometricChange",
+        "screenCaptureBlocked",
+        "thirdPartyKeyboardsBlocked",
+        "warnAfterCompanyPortalUpdateDeferralInDays",
+        "wipeAfterCompanyPortalUpdateDeferralInDays"
+      ]
+    },
+    "defaultUserRoleOverride": {
+      "navigationProperties": [],
+      "properties": [
+        "isDefault",
+        "rolePermissions"
+      ]
+    },
+    "delegatedAdminAccessAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "accessContainer",
+        "accessDetails",
+        "createdDateTime",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "delegatedAdminCustomer": {
+      "navigationProperties": [
+        "serviceManagementDetails"
+      ],
+      "properties": [
+        "displayName",
+        "tenantId"
+      ]
+    },
+    "delegatedAdminRelationship": {
+      "navigationProperties": [
+        "accessAssignments",
+        "operations",
+        "requests"
+      ],
+      "properties": [
+        "accessDetails",
+        "activatedDateTime",
+        "autoExtendDuration",
+        "createdDateTime",
+        "customer",
+        "displayName",
+        "duration",
+        "endDateTime",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "delegatedAdminRelationshipOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "data",
+        "lastModifiedDateTime",
+        "operationType",
+        "status"
+      ]
+    },
+    "delegatedAdminRelationshipRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "createdDateTime",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "delegatedAdminServiceManagementDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "serviceManagementUrl",
+        "serviceName"
+      ]
+    },
+    "delegatedPermissionClassification": {
+      "navigationProperties": [],
+      "properties": [
+        "classification",
+        "permissionId",
+        "permissionName"
+      ]
+    },
+    "delegationSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedActions",
+        "createdDateTime",
+        "isActive"
+      ]
+    },
+    "deletedChat": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deletedItemContainer": {
+      "navigationProperties": [
+        "workflows"
+      ],
+      "properties": []
+    },
+    "deletedTeam": {
+      "navigationProperties": [
+        "channels"
+      ],
+      "properties": []
+    },
+    "deltaParticipants": {
+      "navigationProperties": [
+        "participants"
+      ],
+      "properties": [
+        "sequenceNumber"
+      ]
+    },
+    "depEnrollmentBaseProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "appleIdDisabled",
+        "applePayDisabled",
+        "configurationWebUrl",
+        "deviceNameTemplate",
+        "diagnosticsDisabled",
+        "displayToneSetupDisabled",
+        "enabledSkipKeys",
+        "enrollmentTimeAzureAdGroupIds",
+        "isDefault",
+        "isMandatory",
+        "locationDisabled",
+        "privacyPaneDisabled",
+        "profileRemovalDisabled",
+        "restoreBlocked",
+        "screenTimeScreenDisabled",
+        "siriDisabled",
+        "supervisedModeEnabled",
+        "supportDepartment",
+        "supportPhoneNumber",
+        "termsAndConditionsDisabled",
+        "touchIdDisabled",
+        "waitForDeviceConfiguredConfirmation"
+      ]
+    },
+    "depEnrollmentProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "appleIdDisabled",
+        "applePayDisabled",
+        "awaitDeviceConfiguredConfirmation",
+        "diagnosticsDisabled",
+        "enableSharedIPad",
+        "isDefault",
+        "isMandatory",
+        "iTunesPairingMode",
+        "locationDisabled",
+        "macOSFileVaultDisabled",
+        "macOSRegistrationDisabled",
+        "managementCertificates",
+        "passCodeDisabled",
+        "profileRemovalDisabled",
+        "restoreBlocked",
+        "restoreFromAndroidDisabled",
+        "sharedIPadMaximumUserCount",
+        "siriDisabled",
+        "supervisedModeEnabled",
+        "supportDepartment",
+        "supportPhoneNumber",
+        "termsAndConditionsDisabled",
+        "touchIdDisabled",
+        "zoomDisabled"
+      ]
+    },
+    "depIOSEnrollmentProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "appearanceScreenDisabled",
+        "awaitDeviceConfiguredConfirmation",
+        "carrierActivationUrl",
+        "companyPortalVppTokenId",
+        "deviceToDeviceMigrationDisabled",
+        "enableSharedIPad",
+        "enableSingleAppEnrollmentMode",
+        "expressLanguageScreenDisabled",
+        "forceTemporarySession",
+        "homeButtonScreenDisabled",
+        "iMessageAndFaceTimeScreenDisabled",
+        "iTunesPairingMode",
+        "managementCertificates",
+        "onBoardingScreenDisabled",
+        "passCodeDisabled",
+        "passcodeLockGracePeriodInSeconds",
+        "preferredLanguageScreenDisabled",
+        "restoreCompletedScreenDisabled",
+        "restoreFromAndroidDisabled",
+        "sharedIPadMaximumUserCount",
+        "simSetupScreenDisabled",
+        "softwareUpdateScreenDisabled",
+        "temporarySessionTimeoutInSeconds",
+        "updateCompleteScreenDisabled",
+        "userlessSharedAadModeEnabled",
+        "userSessionTimeoutInSeconds",
+        "watchMigrationScreenDisabled",
+        "welcomeScreenDisabled",
+        "zoomDisabled"
+      ]
+    },
+    "depMacOSEnrollmentProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "accessibilityScreenDisabled",
+        "adminAccountFullName",
+        "adminAccountPassword",
+        "adminAccountUserName",
+        "autoAdvanceSetupEnabled",
+        "autoUnlockWithWatchDisabled",
+        "chooseYourLockScreenDisabled",
+        "depProfileAdminAccountPasswordRotationSetting",
+        "dontAutoPopulatePrimaryAccountInfo",
+        "enableRestrictEditing",
+        "fileVaultDisabled",
+        "hideAdminAccount",
+        "iCloudDiagnosticsDisabled",
+        "iCloudStorageDisabled",
+        "passCodeDisabled",
+        "primaryAccountFullName",
+        "primaryAccountUserName",
+        "registrationDisabled",
+        "requestRequiresNetworkTether",
+        "setPrimarySetupAccountAsRegularUser",
+        "skipPrimarySetupAccountCreation",
+        "usePlatformSSODuringSetupAssistant",
+        "zoomDisabled"
+      ]
+    },
+    "depOnboardingSetting": {
+      "navigationProperties": [
+        "defaultIosEnrollmentProfile",
+        "defaultMacOsEnrollmentProfile",
+        "defaultTvOSEnrollmentProfile",
+        "defaultVisionOSEnrollmentProfile",
+        "enrollmentProfiles",
+        "importedAppleDeviceIdentities"
+      ],
+      "properties": [
+        "appleIdentifier",
+        "dataSharingConsentGranted",
+        "lastModifiedDateTime",
+        "lastSuccessfulSyncDateTime",
+        "lastSyncErrorCode",
+        "lastSyncTriggeredDateTime",
+        "roleScopeTagIds",
+        "shareTokenWithSchoolDataSyncService",
+        "syncedDeviceCount",
+        "tokenExpirationDateTime",
+        "tokenName",
+        "tokenType"
+      ]
+    },
+    "depTvOSEnrollmentProfile": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "depVisionOSEnrollmentProfile": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "desk": {
+      "navigationProperties": [],
+      "properties": [
+        "displayDeviceName",
+        "heightAdjustableState",
+        "mailboxDetails",
+        "mode"
+      ]
+    },
+    "detectedApp": {
+      "navigationProperties": [
+        "managedDevices"
+      ],
+      "properties": [
+        "deviceCount",
+        "displayName",
+        "platform",
+        "publisher",
+        "sizeInByte",
+        "version"
+      ]
+    },
+    "device": {
+      "navigationProperties": [
+        "commands",
+        "deviceTemplate",
+        "extensions",
+        "memberOf",
+        "registeredOwners",
+        "registeredUsers",
+        "transitiveMemberOf",
+        "usageRights"
+      ],
+      "properties": [
+        "accountEnabled",
+        "alternativeNames",
+        "alternativeSecurityIds",
+        "approximateLastSignInDateTime",
+        "complianceExpirationDateTime",
+        "deviceCategory",
+        "deviceId",
+        "deviceMetadata",
+        "deviceOwnership",
+        "deviceVersion",
+        "displayName",
+        "domainName",
+        "enrollmentProfileName",
+        "enrollmentType",
+        "extensionAttributes",
+        "hostnames",
+        "isCompliant",
+        "isManaged",
+        "isManagementRestricted",
+        "isRooted",
+        "kind",
+        "managementType",
+        "manufacturer",
+        "mdmAppId",
+        "model",
+        "name",
+        "onPremisesLastSyncDateTime",
+        "onPremisesSecurityIdentifier",
+        "onPremisesSyncEnabled",
+        "operatingSystem",
+        "operatingSystemVersion",
+        "physicalIds",
+        "platform",
+        "profileType",
+        "registrationDateTime",
+        "status",
+        "systemLabels",
+        "trustType"
+      ]
+    },
+    "deviceAndAppManagementAssignmentFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentFilterManagementType",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "payloads",
+        "platform",
+        "roleScopeTags",
+        "rule"
+      ]
+    },
+    "deviceAndAppManagementRoleAssignment": {
+      "navigationProperties": [
+        "roleScopeTags"
+      ],
+      "properties": [
+        "members",
+        "roleScopeTagIds"
+      ]
+    },
+    "deviceAndAppManagementRoleDefinition": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceAppManagement": {
+      "navigationProperties": [
+        "androidManagedAppProtections",
+        "defaultManagedAppProtections",
+        "deviceAppManagementTasks",
+        "enterpriseCodeSigningCertificates",
+        "iosLobAppProvisioningConfigurations",
+        "iosManagedAppProtections",
+        "managedAppPolicies",
+        "managedAppRegistrations",
+        "managedAppStatuses",
+        "managedEBookCategories",
+        "managedEBooks",
+        "mdmWindowsInformationProtectionPolicies",
+        "mobileAppCatalogPackages",
+        "mobileAppCategories",
+        "mobileAppConfigurations",
+        "mobileAppRelationships",
+        "mobileApps",
+        "policySets",
+        "symantecCodeSigningCertificate",
+        "targetedManagedAppConfigurations",
+        "vppTokens",
+        "wdacSupplementalPolicies",
+        "windowsInformationProtectionDeviceRegistrations",
+        "windowsInformationProtectionPolicies",
+        "windowsInformationProtectionWipeActions",
+        "windowsManagedAppProtections",
+        "windowsManagementApp"
+      ],
+      "properties": [
+        "isEnabledForMicrosoftStoreForBusiness",
+        "microsoftStoreForBusinessLanguage",
+        "microsoftStoreForBusinessLastCompletedApplicationSyncTime",
+        "microsoftStoreForBusinessLastSuccessfulSyncDateTime",
+        "microsoftStoreForBusinessPortalSelection"
+      ]
+    },
+    "deviceAppManagementTask": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedTo",
+        "category",
+        "createdDateTime",
+        "creator",
+        "creatorNotes",
+        "description",
+        "displayName",
+        "dueDateTime",
+        "priority",
+        "status"
+      ]
+    },
+    "deviceCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "roleScopeTagIds"
+      ]
+    },
+    "deviceComanagementAuthorityConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationManagerAgentCommandLineArgument",
+        "installConfigurationManagerAgent",
+        "managedDeviceAuthority"
+      ]
+    },
+    "deviceComplianceActionItem": {
+      "navigationProperties": [],
+      "properties": [
+        "actionType",
+        "gracePeriodHours",
+        "notificationMessageCCList",
+        "notificationTemplateId"
+      ]
+    },
+    "deviceComplianceDeviceOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationVersion",
+        "conflictCount",
+        "errorCount",
+        "failedCount",
+        "lastUpdateDateTime",
+        "notApplicableCount",
+        "notApplicablePlatformCount",
+        "pendingCount",
+        "successCount"
+      ]
+    },
+    "deviceComplianceDeviceStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceGracePeriodExpirationDateTime",
+        "deviceDisplayName",
+        "deviceModel",
+        "lastReportedDateTime",
+        "platform",
+        "status",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceCompliancePolicy": {
+      "navigationProperties": [
+        "assignments",
+        "deviceSettingStateSummaries",
+        "deviceStatuses",
+        "deviceStatusOverview",
+        "scheduledActionsForRule",
+        "userStatuses",
+        "userStatusOverview"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "roleScopeTagIds",
+        "version"
+      ]
+    },
+    "deviceCompliancePolicyAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "source",
+        "sourceId",
+        "target"
+      ]
+    },
+    "deviceCompliancePolicyDeviceStateSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantDeviceCount",
+        "configManagerCount",
+        "conflictDeviceCount",
+        "errorDeviceCount",
+        "inGracePeriodCount",
+        "nonCompliantDeviceCount",
+        "notApplicableDeviceCount",
+        "remediatedDeviceCount",
+        "unknownDeviceCount"
+      ]
+    },
+    "deviceCompliancePolicyGroupAssignment": {
+      "navigationProperties": [
+        "deviceCompliancePolicy"
+      ],
+      "properties": [
+        "excludeGroup",
+        "targetGroupId"
+      ]
+    },
+    "deviceCompliancePolicyPolicySetItem": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceCompliancePolicySettingStateSummary": {
+      "navigationProperties": [
+        "deviceComplianceSettingStates"
+      ],
+      "properties": [
+        "compliantDeviceCount",
+        "conflictDeviceCount",
+        "errorDeviceCount",
+        "nonCompliantDeviceCount",
+        "notApplicableDeviceCount",
+        "platformType",
+        "remediatedDeviceCount",
+        "setting",
+        "settingName",
+        "unknownDeviceCount"
+      ]
+    },
+    "deviceCompliancePolicyState": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "platformType",
+        "settingCount",
+        "settingStates",
+        "state",
+        "userId",
+        "userPrincipalName",
+        "version"
+      ]
+    },
+    "deviceComplianceScheduledActionForRule": {
+      "navigationProperties": [
+        "scheduledActionConfigurations"
+      ],
+      "properties": [
+        "ruleName"
+      ]
+    },
+    "deviceComplianceScript": {
+      "navigationProperties": [
+        "assignments",
+        "deviceRunStates",
+        "runSummary"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "detectionScriptContent",
+        "displayName",
+        "enforceSignatureCheck",
+        "lastModifiedDateTime",
+        "publisher",
+        "roleScopeTagIds",
+        "runAs32Bit",
+        "runAsAccount",
+        "version"
+      ]
+    },
+    "deviceComplianceScriptDeviceState": {
+      "navigationProperties": [
+        "managedDevice"
+      ],
+      "properties": [
+        "detectionState",
+        "expectedStateUpdateDateTime",
+        "lastStateUpdateDateTime",
+        "lastSyncDateTime",
+        "scriptError",
+        "scriptOutput"
+      ]
+    },
+    "deviceComplianceScriptRunSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionScriptErrorDeviceCount",
+        "detectionScriptPendingDeviceCount",
+        "issueDetectedDeviceCount",
+        "lastScriptRunDateTime",
+        "noIssueDetectedDeviceCount"
+      ]
+    },
+    "deviceComplianceSettingState": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceGracePeriodExpirationDateTime",
+        "deviceId",
+        "deviceModel",
+        "deviceName",
+        "platformType",
+        "setting",
+        "settingName",
+        "state",
+        "userEmail",
+        "userId",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceComplianceUserOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationVersion",
+        "conflictCount",
+        "errorCount",
+        "failedCount",
+        "lastUpdateDateTime",
+        "notApplicableCount",
+        "pendingCount",
+        "successCount"
+      ]
+    },
+    "deviceComplianceUserStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "devicesCount",
+        "lastReportedDateTime",
+        "status",
+        "userDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceConfiguration": {
+      "navigationProperties": [
+        "assignments",
+        "deviceSettingStateSummaries",
+        "deviceStatuses",
+        "deviceStatusOverview",
+        "groupAssignments",
+        "userStatuses",
+        "userStatusOverview"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "deviceManagementApplicabilityRuleDeviceMode",
+        "deviceManagementApplicabilityRuleOsEdition",
+        "deviceManagementApplicabilityRuleOsVersion",
+        "displayName",
+        "lastModifiedDateTime",
+        "roleScopeTagIds",
+        "supportsScopeTags",
+        "version"
+      ]
+    },
+    "deviceConfigurationAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "intent",
+        "source",
+        "sourceId",
+        "target"
+      ]
+    },
+    "deviceConfigurationConflictSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "conflictingDeviceConfigurations",
+        "contributingSettings",
+        "deviceCheckinsImpacted"
+      ]
+    },
+    "deviceConfigurationDeviceOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationVersion",
+        "conflictCount",
+        "errorCount",
+        "failedCount",
+        "lastUpdateDateTime",
+        "notApplicableCount",
+        "notApplicablePlatformCount",
+        "pendingCount",
+        "successCount"
+      ]
+    },
+    "deviceConfigurationDeviceStateSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantDeviceCount",
+        "conflictDeviceCount",
+        "errorDeviceCount",
+        "nonCompliantDeviceCount",
+        "notApplicableDeviceCount",
+        "remediatedDeviceCount",
+        "unknownDeviceCount"
+      ]
+    },
+    "deviceConfigurationDeviceStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceGracePeriodExpirationDateTime",
+        "deviceDisplayName",
+        "deviceModel",
+        "lastReportedDateTime",
+        "platform",
+        "status",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceConfigurationGroupAssignment": {
+      "navigationProperties": [
+        "deviceConfiguration"
+      ],
+      "properties": [
+        "excludeGroup",
+        "targetGroupId"
+      ]
+    },
+    "deviceConfigurationPolicySetItem": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceConfigurationState": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "platformType",
+        "settingCount",
+        "settingStates",
+        "state",
+        "userId",
+        "userPrincipalName",
+        "version"
+      ]
+    },
+    "deviceConfigurationUserOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationVersion",
+        "conflictCount",
+        "errorCount",
+        "failedCount",
+        "lastUpdateDateTime",
+        "notApplicableCount",
+        "pendingCount",
+        "successCount"
+      ]
+    },
+    "deviceConfigurationUserStateSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantUserCount",
+        "conflictUserCount",
+        "errorUserCount",
+        "nonCompliantUserCount",
+        "notApplicableUserCount",
+        "remediatedUserCount",
+        "unknownUserCount"
+      ]
+    },
+    "deviceConfigurationUserStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "devicesCount",
+        "lastReportedDateTime",
+        "status",
+        "userDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceCustomAttributeShellScript": {
+      "navigationProperties": [
+        "assignments",
+        "deviceRunStates",
+        "groupAssignments",
+        "runSummary",
+        "userRunStates"
+      ],
+      "properties": [
+        "createdDateTime",
+        "customAttributeName",
+        "customAttributeType",
+        "description",
+        "displayName",
+        "fileName",
+        "lastModifiedDateTime",
+        "roleScopeTagIds",
+        "runAsAccount",
+        "scriptContent"
+      ]
+    },
+    "deviceEnrollmentConfiguration": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "deviceEnrollmentConfigurationType",
+        "displayName",
+        "lastModifiedDateTime",
+        "priority",
+        "roleScopeTagIds",
+        "version"
+      ]
+    },
+    "deviceEnrollmentLimitConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "limit"
+      ]
+    },
+    "deviceEnrollmentNotificationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "brandingOptions",
+        "defaultLocale",
+        "notificationMessageTemplateId",
+        "notificationTemplates",
+        "platformType",
+        "templateType"
+      ]
+    },
+    "deviceEnrollmentPlatformRestrictionConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "platformRestriction",
+        "platformType"
+      ]
+    },
+    "deviceEnrollmentPlatformRestrictionsConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "androidForWorkRestriction",
+        "androidRestriction",
+        "iosRestriction",
+        "macOSRestriction",
+        "macRestriction",
+        "tvosRestriction",
+        "visionOSRestriction",
+        "windowsHomeSkuRestriction",
+        "windowsMobileRestriction",
+        "windowsRestriction"
+      ]
+    },
+    "deviceEnrollmentWindowsHelloForBusinessConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "enhancedBiometricsState",
+        "enhancedSignInSecurity",
+        "pinExpirationInDays",
+        "pinLowercaseCharactersUsage",
+        "pinMaximumLength",
+        "pinMinimumLength",
+        "pinPreviousBlockCount",
+        "pinSpecialCharactersUsage",
+        "pinUppercaseCharactersUsage",
+        "remotePassportEnabled",
+        "securityDeviceRequired",
+        "securityKeyForSignIn",
+        "state",
+        "unlockWithBiometricsEnabled"
+      ]
+    },
+    "deviceHealthScript": {
+      "navigationProperties": [
+        "assignments",
+        "deviceRunStates",
+        "runSummary"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "detectionScriptContent",
+        "detectionScriptParameters",
+        "deviceHealthScriptType",
+        "displayName",
+        "enforceSignatureCheck",
+        "highestAvailableVersion",
+        "isGlobalScript",
+        "lastModifiedDateTime",
+        "publisher",
+        "remediationScriptContent",
+        "remediationScriptParameters",
+        "roleScopeTagIds",
+        "runAs32Bit",
+        "runAsAccount",
+        "version"
+      ]
+    },
+    "deviceHealthScriptAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "runRemediationScript",
+        "runSchedule",
+        "target"
+      ]
+    },
+    "deviceHealthScriptDeviceState": {
+      "navigationProperties": [
+        "managedDevice"
+      ],
+      "properties": [
+        "assignmentFilterIds",
+        "detectionState",
+        "expectedStateUpdateDateTime",
+        "lastStateUpdateDateTime",
+        "lastSyncDateTime",
+        "postRemediationDetectionScriptError",
+        "postRemediationDetectionScriptOutput",
+        "preRemediationDetectionScriptError",
+        "preRemediationDetectionScriptOutput",
+        "remediationScriptError",
+        "remediationState"
+      ]
+    },
+    "deviceHealthScriptPolicyState": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentFilterIds",
+        "detectionState",
+        "deviceId",
+        "deviceName",
+        "expectedStateUpdateDateTime",
+        "id",
+        "lastStateUpdateDateTime",
+        "lastSyncDateTime",
+        "osVersion",
+        "policyId",
+        "policyName",
+        "postRemediationDetectionScriptError",
+        "postRemediationDetectionScriptOutput",
+        "preRemediationDetectionScriptError",
+        "preRemediationDetectionScriptOutput",
+        "remediationScriptError",
+        "remediationState",
+        "userName"
+      ]
+    },
+    "deviceHealthScriptRunSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionScriptErrorDeviceCount",
+        "detectionScriptNotApplicableDeviceCount",
+        "detectionScriptPendingDeviceCount",
+        "issueDetectedDeviceCount",
+        "issueRemediatedCumulativeDeviceCount",
+        "issueRemediatedDeviceCount",
+        "issueReoccurredDeviceCount",
+        "lastScriptRunDateTime",
+        "noIssueDetectedDeviceCount",
+        "remediationScriptErrorDeviceCount",
+        "remediationSkippedDeviceCount"
+      ]
+    },
+    "deviceInstallState": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "deviceName",
+        "errorCode",
+        "installState",
+        "lastSyncDateTime",
+        "osDescription",
+        "osVersion",
+        "userName"
+      ]
+    },
+    "deviceLocalCredentialInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "credentials",
+        "deviceName",
+        "lastBackupDateTime",
+        "refreshDateTime"
+      ]
+    },
+    "deviceLogCollectionResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "enrolledByUser",
+        "errorCode",
+        "expirationDateTimeUTC",
+        "initiatedByUserPrincipalName",
+        "managedDeviceId",
+        "receivedDateTimeUTC",
+        "requestedDateTimeUTC",
+        "size",
+        "sizeInKB",
+        "status"
+      ]
+    },
+    "deviceManagement": {
+      "navigationProperties": [
+        "advancedThreatProtectionOnboardingStateSummary",
+        "androidAppConfigurationSchema",
+        "androidDeviceOwnerEnrollmentProfiles",
+        "androidForWorkAppConfigurationSchemas",
+        "androidForWorkEnrollmentProfiles",
+        "androidForWorkSettings",
+        "androidManagedStoreAccountEnterpriseSettings",
+        "androidManagedStoreAppConfigurationSchemas",
+        "applePushNotificationCertificate",
+        "appleUserInitiatedEnrollmentProfiles",
+        "assignmentFilters",
+        "auditEvents",
+        "autopilotEvents",
+        "cartToClassAssociations",
+        "categories",
+        "certificateConnectorDetails",
+        "chromeOSOnboardingSettings",
+        "cloudCertificationAuthority",
+        "cloudCertificationAuthorityLeafCertificate",
+        "cloudPCConnectivityIssues",
+        "comanagedDevices",
+        "comanagementEligibleDevices",
+        "complianceCategories",
+        "complianceManagementPartners",
+        "compliancePolicies",
+        "complianceSettings",
+        "conditionalAccessSettings",
+        "configManagerCollections",
+        "configurationCategories",
+        "configurationPolicies",
+        "configurationPolicyTemplates",
+        "configurationSettings",
+        "dataSharingConsents",
+        "depOnboardingSettings",
+        "derivedCredentials",
+        "detectedApps",
+        "deviceCategories",
+        "deviceCompliancePolicies",
+        "deviceCompliancePolicyDeviceStateSummary",
+        "deviceCompliancePolicySettingStateSummaries",
+        "deviceComplianceScripts",
+        "deviceConfigurationConflictSummary",
+        "deviceConfigurationDeviceStateSummaries",
+        "deviceConfigurationRestrictedAppsViolations",
+        "deviceConfigurations",
+        "deviceConfigurationsAllManagedDeviceCertificateStates",
+        "deviceConfigurationUserStateSummaries",
+        "deviceCustomAttributeShellScripts",
+        "deviceEnrollmentConfigurations",
+        "deviceHealthScripts",
+        "deviceManagementPartners",
+        "deviceManagementScripts",
+        "deviceShellScripts",
+        "domainJoinConnectors",
+        "elevationRequests",
+        "embeddedSIMActivationCodePools",
+        "endpointPrivilegeManagementProvisioningStatus",
+        "exchangeConnectors",
+        "exchangeOnPremisesPolicies",
+        "exchangeOnPremisesPolicy",
+        "groupPolicyCategories",
+        "groupPolicyConfigurations",
+        "groupPolicyDefinitionFiles",
+        "groupPolicyDefinitions",
+        "groupPolicyMigrationReports",
+        "groupPolicyObjectFiles",
+        "groupPolicyUploadedDefinitionFiles",
+        "hardwareConfigurations",
+        "hardwarePasswordDetails",
+        "hardwarePasswordInfo",
+        "importedDeviceIdentities",
+        "importedWindowsAutopilotDeviceIdentities",
+        "intents",
+        "intuneBrandingProfiles",
+        "iosUpdateStatuses",
+        "macOSSoftwareUpdateAccountSummaries",
+        "managedDeviceCleanupRules",
+        "managedDeviceEncryptionStates",
+        "managedDeviceOverview",
+        "managedDevices",
+        "managedDeviceWindowsOSImages",
+        "microsoftTunnelConfigurations",
+        "microsoftTunnelHealthThresholds",
+        "microsoftTunnelServerLogCollectionResponses",
+        "microsoftTunnelSites",
+        "mobileAppTroubleshootingEvents",
+        "mobileThreatDefenseConnectors",
+        "monitoring",
+        "ndesConnectors",
+        "notificationMessageTemplates",
+        "operationApprovalPolicies",
+        "operationApprovalRequests",
+        "privilegeManagementElevations",
+        "remoteActionAudits",
+        "remoteAssistancePartners",
+        "remoteAssistanceSettings",
+        "reports",
+        "resourceAccessProfiles",
+        "resourceOperations",
+        "reusablePolicySettings",
+        "reusableSettings",
+        "roleAssignments",
+        "roleDefinitions",
+        "roleScopeTags",
+        "serviceNowConnections",
+        "settingDefinitions",
+        "softwareUpdateStatusSummary",
+        "templateInsights",
+        "templates",
+        "templateSettings",
+        "tenantAttachRBAC",
+        "termsAndConditions",
+        "troubleshootingEvents",
+        "userExperienceAnalyticsAnomaly",
+        "userExperienceAnalyticsAnomalyCorrelationGroupOverview",
+        "userExperienceAnalyticsAnomalyDevice",
+        "userExperienceAnalyticsAppHealthApplicationPerformance",
+        "userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersion",
+        "userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersionDetails",
+        "userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersionDeviceId",
+        "userExperienceAnalyticsAppHealthApplicationPerformanceByOSVersion",
+        "userExperienceAnalyticsAppHealthDeviceModelPerformance",
+        "userExperienceAnalyticsAppHealthDevicePerformance",
+        "userExperienceAnalyticsAppHealthDevicePerformanceDetails",
+        "userExperienceAnalyticsAppHealthOSVersionPerformance",
+        "userExperienceAnalyticsAppHealthOverview",
+        "userExperienceAnalyticsBaselines",
+        "userExperienceAnalyticsBatteryHealthAppImpact",
+        "userExperienceAnalyticsBatteryHealthCapacityDetails",
+        "userExperienceAnalyticsBatteryHealthDeviceAppImpact",
+        "userExperienceAnalyticsBatteryHealthDevicePerformance",
+        "userExperienceAnalyticsBatteryHealthDeviceRuntimeHistory",
+        "userExperienceAnalyticsBatteryHealthModelPerformance",
+        "userExperienceAnalyticsBatteryHealthOsPerformance",
+        "userExperienceAnalyticsBatteryHealthRuntimeDetails",
+        "userExperienceAnalyticsCategories",
+        "userExperienceAnalyticsDeviceMetricHistory",
+        "userExperienceAnalyticsDevicePerformance",
+        "userExperienceAnalyticsDeviceScope",
+        "userExperienceAnalyticsDeviceScopes",
+        "userExperienceAnalyticsDeviceScores",
+        "userExperienceAnalyticsDeviceStartupHistory",
+        "userExperienceAnalyticsDeviceStartupProcesses",
+        "userExperienceAnalyticsDeviceStartupProcessPerformance",
+        "userExperienceAnalyticsDevicesWithoutCloudIdentity",
+        "userExperienceAnalyticsDeviceTimelineEvent",
+        "userExperienceAnalyticsImpactingProcess",
+        "userExperienceAnalyticsMetricHistory",
+        "userExperienceAnalyticsModelScores",
+        "userExperienceAnalyticsNotAutopilotReadyDevice",
+        "userExperienceAnalyticsOverview",
+        "userExperienceAnalyticsRemoteConnection",
+        "userExperienceAnalyticsResourcePerformance",
+        "userExperienceAnalyticsScoreHistory",
+        "userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric",
+        "userExperienceAnalyticsWorkFromAnywhereMetrics",
+        "userExperienceAnalyticsWorkFromAnywhereModelPerformance",
+        "userPfxCertificates",
+        "virtualEndpoint",
+        "windowsAutopilotDeploymentProfiles",
+        "windowsAutopilotDeviceIdentities",
+        "windowsAutopilotSettings",
+        "windowsDriverUpdateProfiles",
+        "windowsFeatureUpdateProfiles",
+        "windowsInformationProtectionAppLearningSummaries",
+        "windowsInformationProtectionNetworkLearningSummaries",
+        "windowsMalwareInformation",
+        "windowsQualityUpdatePolicies",
+        "windowsQualityUpdateProfiles",
+        "windowsUpdateCatalogItems",
+        "zebraFotaArtifacts",
+        "zebraFotaConnector",
+        "zebraFotaDeployments"
+      ],
+      "properties": [
+        "accountMoveCompletionDateTime",
+        "adminConsent",
+        "connectorStatus",
+        "dataProcessorServiceForWindowsFeaturesOnboarding",
+        "deviceComplianceReportSummarizationDateTime",
+        "deviceProtectionOverview",
+        "intuneAccountId",
+        "intuneBrand",
+        "lastReportAggregationDateTime",
+        "legacyPcManangementEnabled",
+        "managedDeviceCleanupSettings",
+        "maximumDepTokens",
+        "samsungEFotaFirmwareVersions",
+        "settings",
+        "subscriptions",
+        "subscriptionState",
+        "unlicensedAdminstratorsEnabled",
+        "userExperienceAnalyticsAnomalySeverityOverview",
+        "userExperienceAnalyticsSettings",
+        "windowsMalwareOverview"
+      ]
+    },
+    "deviceManagementAbstractComplexSettingDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "implementations"
+      ]
+    },
+    "deviceManagementAbstractComplexSettingInstance": {
+      "navigationProperties": [
+        "value"
+      ],
+      "properties": [
+        "implementationId"
+      ]
+    },
+    "deviceManagementAutopilotEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "accountSetupDuration",
+        "accountSetupStatus",
+        "deploymentDuration",
+        "deploymentEndDateTime",
+        "deploymentStartDateTime",
+        "deploymentState",
+        "deploymentTotalDuration",
+        "deviceId",
+        "deviceRegisteredDateTime",
+        "deviceSerialNumber",
+        "deviceSetupDuration",
+        "deviceSetupStatus",
+        "enrollmentFailureDetails",
+        "enrollmentStartDateTime",
+        "enrollmentState",
+        "enrollmentType",
+        "eventDateTime",
+        "managedDeviceName",
+        "osVersion",
+        "userId",
+        "userPrincipalName",
+        "windows10EnrollmentCompletionPageConfigurationDisplayName",
+        "windows10EnrollmentCompletionPageConfigurationId",
+        "windowsAutopilotDeploymentProfileDisplayName"
+      ]
+    },
+    "deviceManagementAutopilotPolicyStatusDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceStatus",
+        "displayName",
+        "errorCode",
+        "lastReportedDateTime",
+        "policyType",
+        "trackedOnEnrollmentStatus"
+      ]
+    },
+    "deviceManagementBooleanSettingInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "deviceManagementCachedReportConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "expirationDateTime",
+        "filter",
+        "lastRefreshDateTime",
+        "metadata",
+        "orderBy",
+        "reportName",
+        "select",
+        "status"
+      ]
+    },
+    "deviceManagementCollectionSettingDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "elementDefinitionId"
+      ]
+    },
+    "deviceManagementCollectionSettingInstance": {
+      "navigationProperties": [
+        "value"
+      ],
+      "properties": []
+    },
+    "deviceManagementComplexSettingDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "propertyDefinitionIds"
+      ]
+    },
+    "deviceManagementComplexSettingInstance": {
+      "navigationProperties": [
+        "value"
+      ],
+      "properties": []
+    },
+    "deviceManagementComplianceActionItem": {
+      "navigationProperties": [],
+      "properties": [
+        "actionType",
+        "gracePeriodHours",
+        "notificationMessageCCList",
+        "notificationTemplateId"
+      ]
+    },
+    "deviceManagementCompliancePolicy": {
+      "navigationProperties": [
+        "assignments",
+        "scheduledActionsForRule",
+        "settings"
+      ],
+      "properties": [
+        "createdDateTime",
+        "creationSource",
+        "description",
+        "isAssigned",
+        "lastModifiedDateTime",
+        "name",
+        "platforms",
+        "roleScopeTagIds",
+        "settingCount",
+        "technologies"
+      ]
+    },
+    "deviceManagementComplianceScheduledActionForRule": {
+      "navigationProperties": [
+        "scheduledActionConfigurations"
+      ],
+      "properties": [
+        "ruleName"
+      ]
+    },
+    "deviceManagementConfigurationCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "categoryDescription",
+        "childCategoryIds",
+        "description",
+        "displayName",
+        "helpText",
+        "name",
+        "parentCategoryId",
+        "platforms",
+        "rootCategoryId",
+        "settingUsage",
+        "technologies"
+      ]
+    },
+    "deviceManagementConfigurationChoiceSettingCollectionDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumCount",
+        "minimumCount"
+      ]
+    },
+    "deviceManagementConfigurationChoiceSettingDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultOptionId",
+        "options"
+      ]
+    },
+    "deviceManagementConfigurationPolicy": {
+      "navigationProperties": [
+        "assignments",
+        "settings"
+      ],
+      "properties": [
+        "createdDateTime",
+        "creationSource",
+        "description",
+        "disableEntraGroupPolicyAssignment",
+        "isAssigned",
+        "lastModifiedDateTime",
+        "name",
+        "platforms",
+        "priorityMetaData",
+        "roleScopeTagIds",
+        "settingCount",
+        "technologies",
+        "templateReference"
+      ]
+    },
+    "deviceManagementConfigurationPolicyAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "source",
+        "sourceId",
+        "target"
+      ]
+    },
+    "deviceManagementConfigurationPolicyPolicySetItem": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementConfigurationPolicyTemplate": {
+      "navigationProperties": [
+        "settingTemplates"
+      ],
+      "properties": [
+        "allowUnmanagedSettings",
+        "baseId",
+        "description",
+        "disableEntraGroupPolicyAssignment",
+        "displayName",
+        "displayVersion",
+        "lifecycleState",
+        "platforms",
+        "settingTemplateCount",
+        "technologies",
+        "templateFamily",
+        "version"
+      ]
+    },
+    "deviceManagementConfigurationRedirectSettingDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "deepLink",
+        "redirectMessage",
+        "redirectReason"
+      ]
+    },
+    "deviceManagementConfigurationSetting": {
+      "navigationProperties": [
+        "settingDefinitions"
+      ],
+      "properties": [
+        "settingInstance"
+      ]
+    },
+    "deviceManagementConfigurationSettingDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "accessTypes",
+        "applicability",
+        "baseUri",
+        "categoryId",
+        "description",
+        "displayName",
+        "helpText",
+        "infoUrls",
+        "keywords",
+        "name",
+        "occurrence",
+        "offsetUri",
+        "referredSettingInformationList",
+        "riskLevel",
+        "rootDefinitionId",
+        "settingUsage",
+        "uxBehavior",
+        "version",
+        "visibility"
+      ]
+    },
+    "deviceManagementConfigurationSettingGroupCollectionDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumCount",
+        "minimumCount"
+      ]
+    },
+    "deviceManagementConfigurationSettingGroupDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "childIds",
+        "dependedOnBy",
+        "dependentOn"
+      ]
+    },
+    "deviceManagementConfigurationSettingTemplate": {
+      "navigationProperties": [
+        "settingDefinitions"
+      ],
+      "properties": [
+        "settingInstanceTemplate"
+      ]
+    },
+    "deviceManagementConfigurationSimpleSettingCollectionDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumCount",
+        "minimumCount"
+      ]
+    },
+    "deviceManagementConfigurationSimpleSettingDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue",
+        "dependedOnBy",
+        "dependentOn",
+        "valueDefinition"
+      ]
+    },
+    "deviceManagementDerivedCredentialSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "helpUrl",
+        "issuer",
+        "notificationType",
+        "renewalThresholdPercentage"
+      ]
+    },
+    "deviceManagementDomainJoinConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastConnectionDateTime",
+        "state",
+        "version"
+      ]
+    },
+    "deviceManagementExchangeConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "connectorServerName",
+        "exchangeAlias",
+        "exchangeConnectorType",
+        "exchangeOrganization",
+        "lastSyncDateTime",
+        "primarySmtpAddress",
+        "serverName",
+        "status",
+        "version"
+      ]
+    },
+    "deviceManagementExchangeOnPremisesPolicy": {
+      "navigationProperties": [
+        "conditionalAccessSettings"
+      ],
+      "properties": [
+        "accessRules",
+        "defaultAccessLevel",
+        "knownDeviceClasses",
+        "notificationContent"
+      ]
+    },
+    "deviceManagementExportJob": {
+      "navigationProperties": [],
+      "properties": [
+        "expirationDateTime",
+        "filter",
+        "format",
+        "localizationType",
+        "reportName",
+        "requestDateTime",
+        "search",
+        "select",
+        "snapshotId",
+        "status",
+        "url"
+      ]
+    },
+    "deviceManagementIntegerSettingInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "deviceManagementIntent": {
+      "navigationProperties": [
+        "assignments",
+        "categories",
+        "deviceSettingStateSummaries",
+        "deviceStates",
+        "deviceStateSummary",
+        "settings",
+        "userStates",
+        "userStateSummary"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "isAssigned",
+        "isMigratingToConfigurationPolicy",
+        "lastModifiedDateTime",
+        "roleScopeTagIds",
+        "templateId"
+      ]
+    },
+    "deviceManagementIntentAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "deviceManagementIntentDeviceSettingStateSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantCount",
+        "conflictCount",
+        "errorCount",
+        "nonCompliantCount",
+        "notApplicableCount",
+        "remediatedCount",
+        "settingName"
+      ]
+    },
+    "deviceManagementIntentDeviceState": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceDisplayName",
+        "deviceId",
+        "lastReportedDateTime",
+        "state",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceManagementIntentDeviceStateSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "conflictCount",
+        "errorCount",
+        "failedCount",
+        "notApplicableCount",
+        "notApplicablePlatformCount",
+        "successCount"
+      ]
+    },
+    "deviceManagementIntentSettingCategory": {
+      "navigationProperties": [
+        "settings"
+      ],
+      "properties": []
+    },
+    "deviceManagementIntentUserState": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "lastReportedDateTime",
+        "state",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceManagementIntentUserStateSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "conflictCount",
+        "errorCount",
+        "failedCount",
+        "notApplicableCount",
+        "successCount"
+      ]
+    },
+    "deviceManagementPartner": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "groupsRequiringPartnerEnrollment",
+        "isConfigured",
+        "lastHeartbeatDateTime",
+        "partnerAppType",
+        "partnerState",
+        "singleTenantAppId",
+        "whenPartnerDevicesWillBeMarkedAsNonCompliantDateTime",
+        "whenPartnerDevicesWillBeRemovedDateTime"
+      ]
+    },
+    "deviceManagementReports": {
+      "navigationProperties": [
+        "cachedReportConfigurations",
+        "exportJobs"
+      ],
+      "properties": []
+    },
+    "deviceManagementResourceAccessProfileAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "intent",
+        "sourceId",
+        "target"
+      ]
+    },
+    "deviceManagementResourceAccessProfileBase": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "creationDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "roleScopeTagIds",
+        "version"
+      ]
+    },
+    "deviceManagementReusablePolicySetting": {
+      "navigationProperties": [
+        "referencingConfigurationPolicies"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "referencingConfigurationPolicyCount",
+        "settingDefinitionId",
+        "settingInstance",
+        "version"
+      ]
+    },
+    "deviceManagementScript": {
+      "navigationProperties": [
+        "assignments",
+        "deviceRunStates",
+        "groupAssignments",
+        "runSummary",
+        "userRunStates"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "enforceSignatureCheck",
+        "fileName",
+        "lastModifiedDateTime",
+        "roleScopeTagIds",
+        "runAs32Bit",
+        "runAsAccount",
+        "scriptContent"
+      ]
+    },
+    "deviceManagementScriptAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "deviceManagementScriptDeviceState": {
+      "navigationProperties": [
+        "managedDevice"
+      ],
+      "properties": [
+        "errorCode",
+        "errorDescription",
+        "lastStateUpdateDateTime",
+        "resultMessage",
+        "runState"
+      ]
+    },
+    "deviceManagementScriptGroupAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "targetGroupId"
+      ]
+    },
+    "deviceManagementScriptPolicySetItem": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementScriptRunSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "errorDeviceCount",
+        "errorUserCount",
+        "successDeviceCount",
+        "successUserCount"
+      ]
+    },
+    "deviceManagementScriptUserState": {
+      "navigationProperties": [
+        "deviceRunStates"
+      ],
+      "properties": [
+        "errorDeviceCount",
+        "successDeviceCount",
+        "userPrincipalName"
+      ]
+    },
+    "deviceManagementSettingCategory": {
+      "navigationProperties": [
+        "settingDefinitions"
+      ],
+      "properties": [
+        "displayName",
+        "hasRequiredSetting"
+      ]
+    },
+    "deviceManagementSettingDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "constraints",
+        "dependencies",
+        "description",
+        "displayName",
+        "documentationUrl",
+        "headerSubtitle",
+        "headerTitle",
+        "isTopLevel",
+        "keywords",
+        "placeholderText",
+        "valueType"
+      ]
+    },
+    "deviceManagementSettingInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "definitionId",
+        "valueJson"
+      ]
+    },
+    "deviceManagementStringSettingInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "deviceManagementTemplate": {
+      "navigationProperties": [
+        "categories",
+        "migratableTo",
+        "settings"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "intentCount",
+        "isDeprecated",
+        "platformType",
+        "publishedDateTime",
+        "templateSubtype",
+        "templateType",
+        "versionInfo"
+      ]
+    },
+    "deviceManagementTemplateInsightsDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "settingInsights"
+      ]
+    },
+    "deviceManagementTemplateSettingCategory": {
+      "navigationProperties": [
+        "recommendedSettings"
+      ],
+      "properties": []
+    },
+    "deviceManagementTroubleshootingEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformation",
+        "correlationId",
+        "eventDateTime",
+        "eventName",
+        "troubleshootingErrorDetails"
+      ]
+    },
+    "deviceRegistrationPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "azureADJoin",
+        "azureADRegistration",
+        "description",
+        "displayName",
+        "localAdminPassword",
+        "multiFactorAuthConfiguration",
+        "userDeviceQuota"
+      ]
+    },
+    "deviceSetupConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "version"
+      ]
+    },
+    "deviceShellScript": {
+      "navigationProperties": [
+        "assignments",
+        "deviceRunStates",
+        "groupAssignments",
+        "runSummary",
+        "userRunStates"
+      ],
+      "properties": [
+        "blockExecutionNotifications",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "executionFrequency",
+        "fileName",
+        "lastModifiedDateTime",
+        "retryCount",
+        "roleScopeTagIds",
+        "runAsAccount",
+        "scriptContent"
+      ]
+    },
+    "deviceTemplate": {
+      "navigationProperties": [
+        "deviceInstances",
+        "owners"
+      ],
+      "properties": [
+        "deviceAuthority",
+        "manufacturer",
+        "model",
+        "mutualTlsOauthConfigurationId",
+        "mutualTlsOauthConfigurationTenantId",
+        "operatingSystem"
+      ]
+    },
+    "dimension": {
+      "navigationProperties": [
+        "dimensionValues"
+      ],
+      "properties": [
+        "code",
+        "displayName",
+        "id",
+        "lastModifiedDateTime"
+      ]
+    },
+    "dimensionValue": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "displayName",
+        "id",
+        "lastModifiedDateTime"
+      ]
+    },
+    "directory": {
+      "navigationProperties": [
+        "administrativeUnits",
+        "attributeSets",
+        "authenticationMethodDevices",
+        "certificateAuthorities",
+        "customSecurityAttributeDefinitions",
+        "deletedItems",
+        "deviceLocalCredentials",
+        "externalUserProfiles",
+        "featureRolloutPolicies",
+        "federationConfigurations",
+        "impactedResources",
+        "inboundSharedUserProfiles",
+        "onPremisesSynchronization",
+        "outboundSharedUserProfiles",
+        "pendingExternalUserProfiles",
+        "publicKeyInfrastructure",
+        "recommendationConfiguration",
+        "recommendations",
+        "recovery",
+        "sharedEmailDomains",
+        "subscriptions",
+        "templates",
+        "tenantGovernance"
+      ],
+      "properties": []
+    },
+    "directoryAudit": {
+      "navigationProperties": [],
+      "properties": [
+        "activityDateTime",
+        "activityDisplayName",
+        "additionalDetails",
+        "category",
+        "correlationId",
+        "initiatedBy",
+        "loggedByService",
+        "operationType",
+        "performedBy",
+        "result",
+        "resultReason",
+        "targetResources",
+        "userAgent"
+      ]
+    },
+    "directoryDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "discoverabilities",
+        "discoveryDateTime",
+        "name",
+        "objects",
+        "readOnly",
+        "version"
+      ]
+    },
+    "directoryObject": {
+      "navigationProperties": [],
+      "properties": [
+        "deletedDateTime"
+      ]
+    },
+    "directoryObjectPartnerReference": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "externalPartnerTenantId",
+        "objectType"
+      ]
+    },
+    "directoryRole": {
+      "navigationProperties": [
+        "members",
+        "scopedMembers"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "roleTemplateId"
+      ]
+    },
+    "directoryRoleAccessReviewPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "settings"
+      ]
+    },
+    "directoryRoleTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName"
+      ]
+    },
+    "directorySetting": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "templateId",
+        "values"
+      ]
+    },
+    "directorySettingTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "values"
+      ]
+    },
+    "dlpEvaluatePoliciesJobResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "result"
+      ]
+    },
+    "document": {
+      "navigationProperties": [
+        "comments"
+      ],
+      "properties": []
+    },
+    "documentComment": {
+      "navigationProperties": [
+        "replies"
+      ],
+      "properties": [
+        "content"
+      ]
+    },
+    "documentCommentReply": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "location"
+      ]
+    },
+    "documentProcessingJob": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "jobType",
+        "listItemUniqueId",
+        "status"
+      ]
+    },
+    "documentSetVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "comment",
+        "createdBy",
+        "createdDateTime",
+        "items",
+        "shouldCaptureMinorVersion"
+      ]
+    },
+    "domain": {
+      "navigationProperties": [
+        "domainNameReferences",
+        "federationConfiguration",
+        "rootDomain",
+        "serviceConfigurationRecords",
+        "sharedEmailDomainInvitations",
+        "verificationDnsRecords"
+      ],
+      "properties": [
+        "authenticationType",
+        "availabilityStatus",
+        "isAdminManaged",
+        "isDefault",
+        "isInitial",
+        "isRoot",
+        "isVerified",
+        "passwordNotificationWindowInDays",
+        "passwordValidityPeriodInDays",
+        "state",
+        "supportedServices"
+      ]
+    },
+    "domainDnsCnameRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "canonicalName"
+      ]
+    },
+    "domainDnsMxRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "mailExchange",
+        "preference"
+      ]
+    },
+    "domainDnsRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "isOptional",
+        "label",
+        "recordType",
+        "supportedService",
+        "ttl"
+      ]
+    },
+    "domainDnsSrvRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "nameTarget",
+        "port",
+        "priority",
+        "protocol",
+        "service",
+        "weight"
+      ]
+    },
+    "domainDnsTxtRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "text"
+      ]
+    },
+    "domainDnsUnavailableRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "description"
+      ]
+    },
+    "domainSecurityProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "activityGroupNames",
+        "azureSubscriptionId",
+        "azureTenantId",
+        "countHits",
+        "countInOrg",
+        "domainCategories",
+        "domainRegisteredDateTime",
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "name",
+        "registrant",
+        "riskScore",
+        "tags",
+        "vendorInformation"
+      ]
+    },
+    "drive": {
+      "navigationProperties": [
+        "activities",
+        "bundles",
+        "following",
+        "items",
+        "list",
+        "root",
+        "special"
+      ],
+      "properties": [
+        "driveType",
+        "owner",
+        "quota",
+        "sharePointIds",
+        "system"
+      ]
+    },
+    "driveExclusionUnit": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectId",
+        "displayName",
+        "email"
+      ]
+    },
+    "driveExclusionUnitsBulkAdditionJob": {
+      "navigationProperties": [],
+      "properties": [
+        "drives"
+      ]
+    },
+    "driveItem": {
+      "navigationProperties": [
+        "activities",
+        "analytics",
+        "children",
+        "extensions",
+        "listItem",
+        "permissions",
+        "retentionLabel",
+        "subscriptions",
+        "thumbnails",
+        "versions",
+        "workbook"
+      ],
+      "properties": [
+        "audio",
+        "bundle",
+        "content",
+        "contentStream",
+        "cTag",
+        "deleted",
+        "file",
+        "fileSystemInfo",
+        "folder",
+        "image",
+        "location",
+        "malware",
+        "media",
+        "package",
+        "pendingOperations",
+        "photo",
+        "publication",
+        "remoteItem",
+        "root",
+        "searchResult",
+        "shared",
+        "sharepointIds",
+        "size",
+        "source",
+        "specialFolder",
+        "video",
+        "viewpoint",
+        "webDavUrl"
+      ]
+    },
+    "driveItemVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "size"
+      ]
+    },
+    "driveProtectionRule": {
+      "navigationProperties": [],
+      "properties": [
+        "driveExpression"
+      ]
+    },
+    "driveProtectionUnit": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectId",
+        "displayName",
+        "email"
+      ]
+    },
+    "driveProtectionUnitsBulkAdditionJob": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectIds",
+        "drives"
+      ]
+    },
+    "driveRestoreArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "restoredSiteId",
+        "restoredSiteName",
+        "restoredSiteWebUrl"
+      ]
+    },
+    "driveRestoreArtifactsBulkAdditionRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectIds",
+        "drives"
+      ]
+    },
+    "dynamicRuleActivityLog": {
+      "navigationProperties": [],
+      "properties": [
+        "policyId",
+        "policyName",
+        "protectionUnitDetails"
+      ]
+    },
+    "easEmailProfileConfigurationBase": {
+      "navigationProperties": [],
+      "properties": [
+        "customDomainName",
+        "userDomainNameSource",
+        "usernameAADSource",
+        "usernameSource"
+      ]
+    },
+    "eBookInstallSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedDeviceCount",
+        "failedUserCount",
+        "installedDeviceCount",
+        "installedUserCount",
+        "notInstalledDeviceCount",
+        "notInstalledUserCount"
+      ]
+    },
+    "edge": {
+      "navigationProperties": [
+        "internetExplorerMode"
+      ],
+      "properties": []
+    },
+    "editionUpgradeConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "license",
+        "licenseType",
+        "productKey",
+        "targetEdition",
+        "windowsSMode"
+      ]
+    },
+    "educationalActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "completionMonthYear",
+        "endMonthYear",
+        "institution",
+        "program",
+        "startMonthYear"
+      ]
+    },
+    "educationAssignment": {
+      "navigationProperties": [
+        "categories",
+        "gradingCategory",
+        "gradingScheme",
+        "resources",
+        "rubric",
+        "submissions"
+      ],
+      "properties": [
+        "addedStudentAction",
+        "addToCalendarAction",
+        "allowLateSubmissions",
+        "allowStudentsToAddResourcesToSubmission",
+        "assignDateTime",
+        "assignedDateTime",
+        "assignTo",
+        "classId",
+        "closeDateTime",
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "dueDateTime",
+        "feedbackResourcesFolderUrl",
+        "grading",
+        "instructions",
+        "languageTag",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "moduleUrl",
+        "notificationChannelUrl",
+        "resourcesFolderUrl",
+        "status",
+        "webUrl"
+      ]
+    },
+    "educationAssignmentDefaults": {
+      "navigationProperties": [],
+      "properties": [
+        "addedStudentAction",
+        "addToCalendarAction",
+        "dueTime",
+        "notificationChannelUrl"
+      ]
+    },
+    "educationAssignmentResource": {
+      "navigationProperties": [
+        "dependentResources"
+      ],
+      "properties": [
+        "distributeForStudentWork",
+        "resource"
+      ]
+    },
+    "educationAssignmentSettings": {
+      "navigationProperties": [
+        "defaultGradingScheme",
+        "gradingCategories",
+        "gradingSchemes"
+      ],
+      "properties": [
+        "submissionAnimationDisabled"
+      ]
+    },
+    "educationCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "educationClass": {
+      "navigationProperties": [
+        "assignmentCategories",
+        "assignmentDefaults",
+        "assignments",
+        "assignmentSettings",
+        "group",
+        "members",
+        "modules",
+        "schools",
+        "teachers"
+      ],
+      "properties": [
+        "classCode",
+        "course",
+        "createdBy",
+        "description",
+        "displayName",
+        "externalId",
+        "externalName",
+        "externalSource",
+        "externalSourceDetail",
+        "grade",
+        "mailNickname",
+        "term"
+      ]
+    },
+    "educationFeedbackOutcome": {
+      "navigationProperties": [],
+      "properties": [
+        "feedback",
+        "publishedFeedback"
+      ]
+    },
+    "educationFeedbackResourceOutcome": {
+      "navigationProperties": [],
+      "properties": [
+        "feedbackResource",
+        "resourceStatus"
+      ]
+    },
+    "educationGradingCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "percentageWeight"
+      ]
+    },
+    "educationGradingScheme": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "grades",
+        "hidePointsDuringGrading"
+      ]
+    },
+    "educationModule": {
+      "navigationProperties": [
+        "resources"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "isPinned",
+        "languageTag",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "resourcesFolderUrl",
+        "status"
+      ]
+    },
+    "educationModuleResource": {
+      "navigationProperties": [],
+      "properties": [
+        "resource"
+      ]
+    },
+    "educationOrganization": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "externalSource",
+        "externalSourceDetail"
+      ]
+    },
+    "educationOutcome": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "educationPointsOutcome": {
+      "navigationProperties": [],
+      "properties": [
+        "points",
+        "publishedPoints"
+      ]
+    },
+    "educationRoot": {
+      "navigationProperties": [
+        "classes",
+        "me",
+        "reports",
+        "schools",
+        "users"
+      ],
+      "properties": []
+    },
+    "educationRubric": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "grading",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "levels",
+        "qualities"
+      ]
+    },
+    "educationRubricOutcome": {
+      "navigationProperties": [],
+      "properties": [
+        "publishedRubricQualityFeedback",
+        "publishedRubricQualitySelectedLevels",
+        "rubricQualityFeedback",
+        "rubricQualitySelectedLevels"
+      ]
+    },
+    "educationSchool": {
+      "navigationProperties": [
+        "administrativeUnit",
+        "classes",
+        "users"
+      ],
+      "properties": [
+        "address",
+        "createdBy",
+        "externalId",
+        "externalPrincipalId",
+        "fax",
+        "highestGrade",
+        "lowestGrade",
+        "phone",
+        "principalEmail",
+        "principalName",
+        "schoolNumber"
+      ]
+    },
+    "educationSubmission": {
+      "navigationProperties": [
+        "outcomes",
+        "resources",
+        "submittedResources"
+      ],
+      "properties": [
+        "assignmentId",
+        "excusedBy",
+        "excusedDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "reassignedBy",
+        "reassignedDateTime",
+        "recipient",
+        "resourcesFolderUrl",
+        "returnedBy",
+        "returnedDateTime",
+        "status",
+        "submittedBy",
+        "submittedDateTime",
+        "unsubmittedBy",
+        "unsubmittedDateTime",
+        "webUrl"
+      ]
+    },
+    "educationSubmissionResource": {
+      "navigationProperties": [
+        "dependentResources"
+      ],
+      "properties": [
+        "assignmentResourceUrl",
+        "resource"
+      ]
+    },
+    "educationUser": {
+      "navigationProperties": [
+        "assignments",
+        "classes",
+        "rubrics",
+        "schools",
+        "taughtClasses",
+        "user"
+      ],
+      "properties": [
+        "accountEnabled",
+        "assignedLicenses",
+        "assignedPlans",
+        "businessPhones",
+        "createdBy",
+        "department",
+        "displayName",
+        "externalSource",
+        "externalSourceDetail",
+        "givenName",
+        "mail",
+        "mailingAddress",
+        "mailNickname",
+        "middleName",
+        "mobilePhone",
+        "officeLocation",
+        "onPremisesInfo",
+        "passwordPolicies",
+        "passwordProfile",
+        "preferredLanguage",
+        "primaryRole",
+        "provisionedPlans",
+        "refreshTokensValidFromDateTime",
+        "relatedContacts",
+        "residenceAddress",
+        "showInAddressList",
+        "student",
+        "surname",
+        "teacher",
+        "usageLocation",
+        "userPrincipalName",
+        "userType"
+      ]
+    },
+    "emailActivityStatistics": {
+      "navigationProperties": [],
+      "properties": [
+        "afterHours",
+        "readEmail",
+        "sentEmail"
+      ]
+    },
+    "emailAuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "emailAddress"
+      ]
+    },
+    "emailAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": [
+        "allowExternalIdToUseEmailOtp"
+      ]
+    },
+    "emailFileAssessmentRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "contentData",
+        "destinationRoutingReason",
+        "recipientEmail"
+      ]
+    },
+    "emailNotificationsSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalEvents",
+        "isEnabled",
+        "recipients"
+      ]
+    },
+    "emailSignInIdentifier": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "embeddedSIMActivationCodePool": {
+      "navigationProperties": [
+        "assignments",
+        "deviceStates"
+      ],
+      "properties": [
+        "activationCodeCount",
+        "activationCodes",
+        "createdDateTime",
+        "displayName",
+        "modifiedDateTime"
+      ]
+    },
+    "embeddedSIMActivationCodePoolAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "embeddedSIMDeviceState": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "deviceName",
+        "lastSyncDateTime",
+        "modifiedDateTime",
+        "state",
+        "stateDetails",
+        "universalIntegratedCircuitCardIdentifier",
+        "userName"
+      ]
+    },
+    "emergencyCallEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "callerInfo",
+        "emergencyNumberDialed",
+        "policyName"
+      ]
+    },
+    "employee": {
+      "navigationProperties": [
+        "picture"
+      ],
+      "properties": [
+        "address",
+        "birthDate",
+        "displayName",
+        "email",
+        "employmentDate",
+        "givenName",
+        "id",
+        "jobTitle",
+        "lastModifiedDateTime",
+        "middleName",
+        "mobilePhone",
+        "number",
+        "personalEmail",
+        "phoneNumber",
+        "statisticsGroupCode",
+        "status",
+        "surname",
+        "terminationDate"
+      ]
+    },
+    "employeeExperience": {
+      "navigationProperties": [
+        "communities",
+        "engagementAsyncOperations",
+        "goals",
+        "learningCourseActivities",
+        "learningProviders",
+        "roles"
+      ],
+      "properties": []
+    },
+    "employeeExperienceUser": {
+      "navigationProperties": [
+        "assignedRoles",
+        "learningCourseActivities",
+        "storyline"
+      ],
+      "properties": []
+    },
+    "encryptedAwsStorageBucketFinding": {
+      "navigationProperties": [
+        "storageBucket"
+      ],
+      "properties": [
+        "accessibility"
+      ]
+    },
+    "encryptedAzureStorageAccountFinding": {
+      "navigationProperties": [
+        "storageAccount"
+      ],
+      "properties": [
+        "encryptionManagedBy"
+      ]
+    },
+    "encryptedGcpStorageBucketFinding": {
+      "navigationProperties": [
+        "storageBucket"
+      ],
+      "properties": [
+        "accessibility",
+        "encryptionManagedBy"
+      ]
+    },
+    "endpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "capability",
+        "providerId",
+        "providerName",
+        "providerResourceId",
+        "uri"
+      ]
+    },
+    "endpointPrivilegeManagementProvisioningStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "licenseType",
+        "onboardedToMicrosoftManagedPlatform"
+      ]
+    },
+    "endUserNotification": {
+      "navigationProperties": [
+        "details"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "notificationType",
+        "source",
+        "status",
+        "supportedLocales"
+      ]
+    },
+    "endUserNotificationDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "emailContent",
+        "isDefaultLangauge",
+        "language",
+        "locale",
+        "sentFrom",
+        "subject"
+      ]
+    },
+    "endUserSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "relatedPeopleInsightLevel",
+        "showApproverDetailsToMembers"
+      ]
+    },
+    "engagementAsyncOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "operationType",
+        "resourceId"
+      ]
+    },
+    "engagementConversation": {
+      "navigationProperties": [
+        "messages",
+        "starter"
+      ],
+      "properties": [
+        "creationMode",
+        "starterId"
+      ]
+    },
+    "engagementConversationDiscussionMessage": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "engagementConversationMessage": {
+      "navigationProperties": [
+        "conversation",
+        "reactions",
+        "replies",
+        "replyTo"
+      ],
+      "properties": [
+        "body",
+        "createdDateTime",
+        "creationMode",
+        "from",
+        "lastModifiedDateTime",
+        "replyToId"
+      ]
+    },
+    "engagementConversationMessageReaction": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "reactionBy",
+        "reactionType"
+      ]
+    },
+    "engagementConversationQuestionMessage": {
+      "navigationProperties": [],
+      "properties": [
+        "title"
+      ]
+    },
+    "engagementConversationSystemMessage": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "engagementRole": {
+      "navigationProperties": [
+        "members"
+      ],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "engagementRoleMember": {
+      "navigationProperties": [
+        "user"
+      ],
+      "properties": [
+        "createdDateTime",
+        "userId"
+      ]
+    },
+    "enhancedPersonalizationSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "disabledForGroup",
+        "isEnabledInOrganization"
+      ]
+    },
+    "enrollmentConfigurationAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "source",
+        "sourceId",
+        "target"
+      ]
+    },
+    "enrollmentProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationEndpointUrl",
+        "description",
+        "displayName",
+        "enableAuthenticationViaCompanyPortal",
+        "requireCompanyPortalOnSetupAssistantEnrolledDevices",
+        "requiresUserAuthentication"
+      ]
+    },
+    "enrollmentRestrictionsConfigurationPolicySetItem": {
+      "navigationProperties": [],
+      "properties": [
+        "limit",
+        "priority"
+      ]
+    },
+    "enrollmentTroubleshootingEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "enrollmentType",
+        "failureCategory",
+        "failureReason",
+        "managedDeviceIdentifier",
+        "operatingSystem",
+        "osVersion",
+        "userId"
+      ]
+    },
+    "enterpriseCodeSigningCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "expirationDateTime",
+        "issuer",
+        "issuerName",
+        "status",
+        "subject",
+        "subjectName",
+        "uploadDateTime"
+      ]
+    },
+    "entitlementManagement": {
+      "navigationProperties": [
+        "accessPackageAssignmentApprovals",
+        "accessPackageAssignmentPolicies",
+        "accessPackageAssignmentRequests",
+        "accessPackageAssignmentResourceRoles",
+        "accessPackageAssignments",
+        "accessPackageCatalogs",
+        "accessPackageResourceEnvironments",
+        "accessPackageResourceRequests",
+        "accessPackageResourceRoleScopes",
+        "accessPackageResources",
+        "accessPackages",
+        "accessPackageSuggestions",
+        "assignmentRequests",
+        "availableAccessPackages",
+        "connectedOrganizations",
+        "controlConfigurations",
+        "externalOriginResourceConnectors",
+        "settings",
+        "subjects"
+      ],
+      "properties": []
+    },
+    "entitlementManagementSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "daysUntilExternalUserDeletedAfterBlocked",
+        "externalUserLifecycleAction"
+      ]
+    },
+    "entity": {
+      "navigationProperties": [],
+      "properties": [
+        "id"
+      ]
+    },
+    "entra": {
+      "navigationProperties": [
+        "uxSetting"
+      ],
+      "properties": []
+    },
+    "entraIdProtectionRiskyUserApproval": {
+      "navigationProperties": [],
+      "properties": [
+        "isApprovalRequired",
+        "minimumRiskLevel"
+      ]
+    },
+    "evaluateLabelJobResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "result"
+      ]
+    },
+    "event": {
+      "navigationProperties": [
+        "attachments",
+        "calendar",
+        "exceptionOccurrences",
+        "extensions",
+        "instances",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "allowNewTimeProposals",
+        "attendees",
+        "body",
+        "bodyPreview",
+        "cancelledOccurrences",
+        "end",
+        "hasAttachments",
+        "hideAttendees",
+        "iCalUId",
+        "importance",
+        "isAllDay",
+        "isCancelled",
+        "isDraft",
+        "isOnlineMeeting",
+        "isOrganizer",
+        "isReminderOn",
+        "location",
+        "locations",
+        "occurrenceId",
+        "onlineMeeting",
+        "onlineMeetingProvider",
+        "onlineMeetingUrl",
+        "organizer",
+        "originalEndTimeZone",
+        "originalStart",
+        "originalStartTimeZone",
+        "recurrence",
+        "reminderMinutesBeforeStart",
+        "responseRequested",
+        "responseStatus",
+        "sensitivity",
+        "seriesMasterId",
+        "showAs",
+        "start",
+        "subject",
+        "transactionId",
+        "type",
+        "uid",
+        "webLink"
+      ]
+    },
+    "eventMessage": {
+      "navigationProperties": [
+        "event"
+      ],
+      "properties": [
+        "endDateTime",
+        "isAllDay",
+        "isDelegated",
+        "isOutOfDate",
+        "location",
+        "meetingMessageType",
+        "recurrence",
+        "startDateTime",
+        "type"
+      ]
+    },
+    "eventMessageRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "allowNewTimeProposals",
+        "meetingRequestType",
+        "previousEndDateTime",
+        "previousLocation",
+        "previousStartDateTime",
+        "responseRequested"
+      ]
+    },
+    "eventMessageResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "proposedNewTime",
+        "responseType"
+      ]
+    },
+    "exactMatchDataStore": {
+      "navigationProperties": [
+        "sessions"
+      ],
+      "properties": []
+    },
+    "exactMatchDataStoreBase": {
+      "navigationProperties": [],
+      "properties": [
+        "columns",
+        "dataLastUpdatedDateTime",
+        "description",
+        "displayName"
+      ]
+    },
+    "exactMatchJobBase": {
+      "navigationProperties": [],
+      "properties": [
+        "completionDateTime",
+        "creationDateTime",
+        "error",
+        "lastUpdatedDateTime",
+        "startDateTime"
+      ]
+    },
+    "exactMatchLookupJob": {
+      "navigationProperties": [
+        "matchingRows"
+      ],
+      "properties": [
+        "state"
+      ]
+    },
+    "exactMatchSession": {
+      "navigationProperties": [
+        "uploadAgent"
+      ],
+      "properties": [
+        "checksum",
+        "dataUploadURI",
+        "fields",
+        "fileName",
+        "rowsPerBlock",
+        "salt",
+        "uploadAgentId"
+      ]
+    },
+    "exactMatchSessionBase": {
+      "navigationProperties": [],
+      "properties": [
+        "dataStoreId",
+        "processingCompletionDateTime",
+        "remainingBlockCount",
+        "remainingJobCount",
+        "state",
+        "totalBlockCount",
+        "totalJobCount",
+        "uploadCompletionDateTime"
+      ]
+    },
+    "exactMatchUploadAgent": {
+      "navigationProperties": [],
+      "properties": [
+        "creationDateTime",
+        "description"
+      ]
+    },
+    "exchangeAdmin": {
+      "navigationProperties": [
+        "mailboxes",
+        "messageTraces",
+        "tracing"
+      ],
+      "properties": []
+    },
+    "exchangeMessageTrace": {
+      "navigationProperties": [],
+      "properties": [
+        "fromIP",
+        "messageId",
+        "receivedDateTime",
+        "recipientAddress",
+        "senderAddress",
+        "size",
+        "status",
+        "subject",
+        "toIP"
+      ]
+    },
+    "exchangeMessageTraceDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "data",
+        "dateTime",
+        "description",
+        "event",
+        "messageId"
+      ]
+    },
+    "exchangeProtectionPolicy": {
+      "navigationProperties": [
+        "mailboxExclusionUnits",
+        "mailboxExclusionUnitsBulkAdditionJobs",
+        "mailboxInclusionRules",
+        "mailboxProtectionUnits",
+        "mailboxProtectionUnitsBulkAdditionJobs"
+      ],
+      "properties": []
+    },
+    "exchangeRestoreSession": {
+      "navigationProperties": [
+        "granularMailboxRestoreArtifacts",
+        "mailboxRestoreArtifacts",
+        "mailboxRestoreArtifactsBulkAdditionRequests"
+      ],
+      "properties": []
+    },
+    "exchangeSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "inPlaceArchiveMailboxId",
+        "primaryMailboxId"
+      ]
+    },
+    "exclusionUnitBase": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "error",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "policyId"
+      ]
+    },
+    "exclusionUnitBulkAdditionJob": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "error",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "extension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "extensionProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "appDisplayName",
+        "dataType",
+        "isMultiValued",
+        "isSyncedFromOnPremises",
+        "name",
+        "targetObjects"
+      ]
+    },
+    "external": {
+      "navigationProperties": [
+        "connections"
+      ],
+      "properties": []
+    },
+    "externalAuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationId",
+        "displayName"
+      ]
+    },
+    "externalAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": [
+        "appId",
+        "displayName",
+        "openIdConnectSetting"
+      ]
+    },
+    "externalConnection": {
+      "navigationProperties": [
+        "groups",
+        "items",
+        "operations",
+        "schema"
+      ],
+      "properties": [
+        "configuration",
+        "description",
+        "name",
+        "state"
+      ]
+    },
+    "externalDomainName": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "externalGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName"
+      ]
+    },
+    "externalIdentitiesPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "allowDeletedIdentitiesDataRemoval",
+        "allowExternalIdentitiesToLeave"
+      ]
+    },
+    "externalItem": {
+      "navigationProperties": [],
+      "properties": [
+        "acl",
+        "content",
+        "properties"
+      ]
+    },
+    "externallyAccessibleAwsStorageBucketFinding": {
+      "navigationProperties": [
+        "storageBucket"
+      ],
+      "properties": [
+        "accessibility",
+        "accountsWithAccess"
+      ]
+    },
+    "externallyAccessibleAzureBlobContainerFinding": {
+      "navigationProperties": [
+        "storageAccount"
+      ],
+      "properties": [
+        "accessibility",
+        "encryptionManagedBy"
+      ]
+    },
+    "externallyAccessibleGcpStorageBucketFinding": {
+      "navigationProperties": [
+        "storageBucket"
+      ],
+      "properties": [
+        "accessibility",
+        "encryptionManagedBy"
+      ]
+    },
+    "externalMeetingRegistrant": {
+      "navigationProperties": [],
+      "properties": [
+        "tenantId",
+        "userId"
+      ]
+    },
+    "externalMeetingRegistration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "externalOriginResourceConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "connectionInfo",
+        "connectorType",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "modifiedBy",
+        "modifiedDateTime"
+      ]
+    },
+    "externalProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "companyName",
+        "createdBy",
+        "createdDateTime",
+        "department",
+        "displayName",
+        "isDiscoverable",
+        "isEnabled",
+        "jobTitle",
+        "phoneNumber",
+        "supervisorId"
+      ]
+    },
+    "externalUserProfile": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "externalUsersSelfServiceSignUpEventsFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "onAttributeCollection",
+        "onAttributeCollectionStart",
+        "onAttributeCollectionSubmit",
+        "onAuthenticationMethodLoadStart",
+        "onInteractiveAuthFlowStart",
+        "onUserCreateStart"
+      ]
+    },
+    "featureRolloutPolicy": {
+      "navigationProperties": [
+        "appliesTo"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "feature",
+        "isAppliedToOrganization",
+        "isEnabled"
+      ]
+    },
+    "federatedIdentityCredential": {
+      "navigationProperties": [],
+      "properties": [
+        "audiences",
+        "claimsMatchingExpression",
+        "description",
+        "issuer",
+        "name",
+        "subject"
+      ]
+    },
+    "federatedTokenValidationPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "validatingDomains"
+      ]
+    },
+    "fido2AuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "aaGuid",
+        "attestationCertificates",
+        "attestationLevel",
+        "displayName",
+        "model",
+        "passkeyType",
+        "publicKeyCredential"
+      ]
+    },
+    "fido2AuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets",
+        "passkeyProfiles"
+      ],
+      "properties": [
+        "defaultPasskeyProfile",
+        "isAttestationEnforced",
+        "isSelfServiceRegistrationAllowed",
+        "keyRestrictions"
+      ]
+    },
+    "fido2CombinationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedAAGUIDs"
+      ]
+    },
+    "fieldValueSet": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "fileAssessmentRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "contentData",
+        "fileName"
+      ]
+    },
+    "fileAttachment": {
+      "navigationProperties": [],
+      "properties": [
+        "contentBytes",
+        "contentId",
+        "contentLocation"
+      ]
+    },
+    "fileClassificationRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "file",
+        "sensitiveTypeIds"
+      ]
+    },
+    "fileSecurityProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "activityGroupNames",
+        "azureSubscriptionId",
+        "azureTenantId",
+        "certificateThumbprint",
+        "extensions",
+        "fileType",
+        "firstSeenDateTime",
+        "hashes",
+        "lastSeenDateTime",
+        "malwareStates",
+        "names",
+        "riskScore",
+        "size",
+        "tags",
+        "vendorInformation",
+        "vulnerabilityStates"
+      ]
+    },
+    "fileStorage": {
+      "navigationProperties": [
+        "containers",
+        "containerTypeRegistrations",
+        "containerTypes",
+        "deletedContainers"
+      ],
+      "properties": []
+    },
+    "fileStorageContainer": {
+      "navigationProperties": [
+        "columns",
+        "drive",
+        "migrationJobs",
+        "permissions",
+        "recycleBin",
+        "sharePointGroups"
+      ],
+      "properties": [
+        "archivalDetails",
+        "assignedSensitivityLabel",
+        "containerTypeId",
+        "createdDateTime",
+        "customProperties",
+        "description",
+        "displayName",
+        "externalGroupId",
+        "informationBarrier",
+        "lockState",
+        "owners",
+        "ownershipType",
+        "settings",
+        "status",
+        "storageUsedInBytes",
+        "viewpoint"
+      ]
+    },
+    "fileStorageContainerType": {
+      "navigationProperties": [
+        "permissions"
+      ],
+      "properties": [
+        "billingClassification",
+        "billingStatus",
+        "createdDateTime",
+        "etag",
+        "expirationDateTime",
+        "name",
+        "owningAppId",
+        "settings"
+      ]
+    },
+    "fileStorageContainerTypeAppPermissionGrant": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "applicationPermissions",
+        "delegatedPermissions"
+      ]
+    },
+    "fileStorageContainerTypeRegistration": {
+      "navigationProperties": [
+        "applicationPermissionGrants"
+      ],
+      "properties": [
+        "billingClassification",
+        "billingStatus",
+        "etag",
+        "expirationDateTime",
+        "name",
+        "owningAppId",
+        "registeredDateTime",
+        "settings"
+      ]
+    },
+    "filterOperatorSchema": {
+      "navigationProperties": [],
+      "properties": [
+        "arity",
+        "multivaluedComparisonType",
+        "supportedAttributeTypes"
+      ]
+    },
+    "financials": {
+      "navigationProperties": [
+        "companies"
+      ],
+      "properties": [
+        "id"
+      ]
+    },
+    "finding": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime"
+      ]
+    },
+    "fixtureMap": {
+      "navigationProperties": [],
+      "properties": [
+        "placeId"
+      ]
+    },
+    "floor": {
+      "navigationProperties": [],
+      "properties": [
+        "sortOrder"
+      ]
+    },
+    "focusActivityStatistics": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "footprintMap": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "fraudProtectionProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "gcpAuthorizationSystem": {
+      "navigationProperties": [
+        "actions",
+        "resources",
+        "roles",
+        "services"
+      ],
+      "properties": [
+        "associatedIdentities"
+      ]
+    },
+    "gcpAuthorizationSystemResource": {
+      "navigationProperties": [
+        "service"
+      ],
+      "properties": []
+    },
+    "gcpAuthorizationSystemTypeAction": {
+      "navigationProperties": [
+        "service"
+      ],
+      "properties": []
+    },
+    "gcpCloudFunction": {
+      "navigationProperties": [
+        "resource"
+      ],
+      "properties": []
+    },
+    "gcpGroup": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "gcpIdentity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "gcpRole": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "externalId",
+        "gcpRoleType",
+        "scopes"
+      ]
+    },
+    "gcpServiceAccount": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "gcpUser": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "generalLedgerEntry": {
+      "navigationProperties": [
+        "account"
+      ],
+      "properties": [
+        "accountId",
+        "accountNumber",
+        "creditAmount",
+        "debitAmount",
+        "description",
+        "documentNumber",
+        "documentType",
+        "id",
+        "lastModifiedDateTime",
+        "postingDate"
+      ]
+    },
+    "goals": {
+      "navigationProperties": [
+        "exportJobs"
+      ],
+      "properties": []
+    },
+    "goalsExportJob": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "expirationDateTime",
+        "explorerViewId",
+        "goalsOrganizationId"
+      ]
+    },
+    "governanceInsight": {
+      "navigationProperties": [],
+      "properties": [
+        "insightCreatedDateTime"
+      ]
+    },
+    "governancePolicyTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "policy",
+        "settings"
+      ]
+    },
+    "governanceResource": {
+      "navigationProperties": [
+        "parent",
+        "roleAssignmentRequests",
+        "roleAssignments",
+        "roleDefinitions",
+        "roleSettings"
+      ],
+      "properties": [
+        "displayName",
+        "externalId",
+        "registeredDateTime",
+        "registeredRoot",
+        "status",
+        "type"
+      ]
+    },
+    "governanceRoleAssignment": {
+      "navigationProperties": [
+        "linkedEligibleRoleAssignment",
+        "resource",
+        "roleDefinition",
+        "subject"
+      ],
+      "properties": [
+        "assignmentState",
+        "endDateTime",
+        "externalId",
+        "linkedEligibleRoleAssignmentId",
+        "memberType",
+        "resourceId",
+        "roleDefinitionId",
+        "startDateTime",
+        "status",
+        "subjectId"
+      ]
+    },
+    "governanceRoleAssignmentRequest": {
+      "navigationProperties": [
+        "resource",
+        "roleDefinition",
+        "subject"
+      ],
+      "properties": [
+        "assignmentState",
+        "linkedEligibleRoleAssignmentId",
+        "reason",
+        "requestedDateTime",
+        "resourceId",
+        "roleDefinitionId",
+        "schedule",
+        "status",
+        "subjectId",
+        "type"
+      ]
+    },
+    "governanceRoleDefinition": {
+      "navigationProperties": [
+        "resource",
+        "roleSetting"
+      ],
+      "properties": [
+        "displayName",
+        "externalId",
+        "resourceId",
+        "templateId"
+      ]
+    },
+    "governanceRoleSetting": {
+      "navigationProperties": [
+        "resource",
+        "roleDefinition"
+      ],
+      "properties": [
+        "adminEligibleSettings",
+        "adminMemberSettings",
+        "isDefault",
+        "lastUpdatedBy",
+        "lastUpdatedDateTime",
+        "resourceId",
+        "roleDefinitionId",
+        "userEligibleSettings",
+        "userMemberSettings"
+      ]
+    },
+    "governanceSubject": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "email",
+        "principalName",
+        "type"
+      ]
+    },
+    "granularDriveRestoreArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectId"
+      ]
+    },
+    "granularMailboxRestoreArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "artifactCount",
+        "searchResponseId"
+      ]
+    },
+    "granularRestoreArtifactBase": {
+      "navigationProperties": [],
+      "properties": [
+        "browseSessionId",
+        "completionDateTime",
+        "restoredItemKey",
+        "restoredItemPath",
+        "restoredItemWebUrl",
+        "restorePointDateTime",
+        "startDateTime",
+        "status",
+        "webUrl"
+      ]
+    },
+    "granularSiteRestoreArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "siteId"
+      ]
+    },
+    "group": {
+      "navigationProperties": [
+        "acceptedSenders",
+        "appRoleAssignments",
+        "calendar",
+        "calendarView",
+        "conversations",
+        "createdOnBehalfOf",
+        "drive",
+        "drives",
+        "endpoints",
+        "events",
+        "extensions",
+        "groupLifecyclePolicies",
+        "memberOf",
+        "members",
+        "membersWithLicenseErrors",
+        "onenote",
+        "onPremisesSyncBehavior",
+        "owners",
+        "permissionGrants",
+        "photo",
+        "photos",
+        "planner",
+        "rejectedSenders",
+        "settings",
+        "sites",
+        "team",
+        "threads",
+        "transitiveMemberOf",
+        "transitiveMembers"
+      ],
+      "properties": [
+        "accessType",
+        "allowExternalSenders",
+        "assignedLabels",
+        "assignedLicenses",
+        "autoSubscribeNewMembers",
+        "classification",
+        "cloudLicensing",
+        "createdByAppId",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "expirationDateTime",
+        "groupTypes",
+        "hasMembersWithLicenseErrors",
+        "hideFromAddressLists",
+        "hideFromOutlookClients",
+        "infoCatalogs",
+        "isArchived",
+        "isAssignableToRole",
+        "isFavorite",
+        "isManagementRestricted",
+        "isSubscribedByMail",
+        "licenseProcessingState",
+        "mail",
+        "mailEnabled",
+        "mailNickname",
+        "membershipRule",
+        "membershipRuleProcessingState",
+        "membershipRuleProcessingStatus",
+        "onPremisesDomainName",
+        "onPremisesExtensionAttributes",
+        "onPremisesLastSyncDateTime",
+        "onPremisesNetBiosName",
+        "onPremisesProvisioningErrors",
+        "onPremisesSamAccountName",
+        "onPremisesSecurityIdentifier",
+        "onPremisesSyncEnabled",
+        "organizationId",
+        "preferredDataLocation",
+        "preferredLanguage",
+        "proxyAddresses",
+        "renewedDateTime",
+        "resourceBehaviorOptions",
+        "resourceProvisioningOptions",
+        "securityEnabled",
+        "securityIdentifier",
+        "serviceProvisioningErrors",
+        "theme",
+        "uniqueName",
+        "unseenConversationsCount",
+        "unseenCount",
+        "unseenMessagesCount",
+        "visibility",
+        "welcomeMessageEnabled",
+        "writebackConfiguration"
+      ]
+    },
+    "groupLifecyclePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "alternateNotificationEmails",
+        "groupLifetimeInDays",
+        "managedGroupTypes"
+      ]
+    },
+    "groupPolicyCategory": {
+      "navigationProperties": [
+        "children",
+        "definitionFile",
+        "definitions",
+        "parent"
+      ],
+      "properties": [
+        "displayName",
+        "ingestionSource",
+        "isRoot",
+        "lastModifiedDateTime"
+      ]
+    },
+    "groupPolicyConfiguration": {
+      "navigationProperties": [
+        "assignments",
+        "definitionValues"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "policyConfigurationIngestionType",
+        "roleScopeTagIds"
+      ]
+    },
+    "groupPolicyConfigurationAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedDateTime",
+        "target"
+      ]
+    },
+    "groupPolicyDefinition": {
+      "navigationProperties": [
+        "category",
+        "definitionFile",
+        "nextVersionDefinition",
+        "presentations",
+        "previousVersionDefinition"
+      ],
+      "properties": [
+        "categoryPath",
+        "classType",
+        "displayName",
+        "explainText",
+        "groupPolicyCategoryId",
+        "hasRelatedDefinitions",
+        "lastModifiedDateTime",
+        "minDeviceCspVersion",
+        "minUserCspVersion",
+        "policyType",
+        "supportedOn",
+        "version"
+      ]
+    },
+    "groupPolicyDefinitionFile": {
+      "navigationProperties": [
+        "definitions"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "fileName",
+        "languageCodes",
+        "lastModifiedDateTime",
+        "policyType",
+        "revision",
+        "targetNamespace",
+        "targetPrefix"
+      ]
+    },
+    "groupPolicyDefinitionValue": {
+      "navigationProperties": [
+        "definition",
+        "presentationValues"
+      ],
+      "properties": [
+        "configurationType",
+        "createdDateTime",
+        "enabled",
+        "lastModifiedDateTime"
+      ]
+    },
+    "groupPolicyMigrationReport": {
+      "navigationProperties": [
+        "groupPolicySettingMappings",
+        "unsupportedGroupPolicyExtensions"
+      ],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "groupPolicyCreatedDateTime",
+        "groupPolicyLastModifiedDateTime",
+        "groupPolicyObjectId",
+        "lastModifiedDateTime",
+        "migrationReadiness",
+        "ouDistinguishedName",
+        "roleScopeTagIds",
+        "supportedSettingsCount",
+        "supportedSettingsPercent",
+        "targetedInActiveDirectory",
+        "totalSettingsCount"
+      ]
+    },
+    "groupPolicyObjectFile": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "createdDateTime",
+        "groupPolicyObjectId",
+        "lastModifiedDateTime",
+        "ouDistinguishedName",
+        "roleScopeTagIds"
+      ]
+    },
+    "groupPolicyOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedDateTime",
+        "operationStatus",
+        "operationType",
+        "statusDetails"
+      ]
+    },
+    "groupPolicyPresentation": {
+      "navigationProperties": [
+        "definition"
+      ],
+      "properties": [
+        "label",
+        "lastModifiedDateTime"
+      ]
+    },
+    "groupPolicyPresentationCheckBox": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultChecked"
+      ]
+    },
+    "groupPolicyPresentationComboBox": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue",
+        "maxLength",
+        "required",
+        "suggestions"
+      ]
+    },
+    "groupPolicyPresentationDecimalTextBox": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue",
+        "maxValue",
+        "minValue",
+        "required",
+        "spin",
+        "spinStep"
+      ]
+    },
+    "groupPolicyPresentationDropdownList": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultItem",
+        "items",
+        "required"
+      ]
+    },
+    "groupPolicyPresentationListBox": {
+      "navigationProperties": [],
+      "properties": [
+        "explicitValue",
+        "valuePrefix"
+      ]
+    },
+    "groupPolicyPresentationLongDecimalTextBox": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue",
+        "maxValue",
+        "minValue",
+        "required",
+        "spin",
+        "spinStep"
+      ]
+    },
+    "groupPolicyPresentationMultiTextBox": {
+      "navigationProperties": [],
+      "properties": [
+        "maxLength",
+        "maxStrings",
+        "required"
+      ]
+    },
+    "groupPolicyPresentationText": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "groupPolicyPresentationTextBox": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue",
+        "maxLength",
+        "required"
+      ]
+    },
+    "groupPolicyPresentationValue": {
+      "navigationProperties": [
+        "definitionValue",
+        "presentation"
+      ],
+      "properties": [
+        "createdDateTime",
+        "lastModifiedDateTime"
+      ]
+    },
+    "groupPolicyPresentationValueBoolean": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "groupPolicyPresentationValueDecimal": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "groupPolicyPresentationValueList": {
+      "navigationProperties": [],
+      "properties": [
+        "values"
+      ]
+    },
+    "groupPolicyPresentationValueLongDecimal": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "groupPolicyPresentationValueMultiText": {
+      "navigationProperties": [],
+      "properties": [
+        "values"
+      ]
+    },
+    "groupPolicyPresentationValueText": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "groupPolicySettingMapping": {
+      "navigationProperties": [],
+      "properties": [
+        "admxSettingDefinitionId",
+        "childIdList",
+        "intuneSettingDefinitionId",
+        "intuneSettingUriList",
+        "isMdmSupported",
+        "mdmCspName",
+        "mdmMinimumOSVersion",
+        "mdmSettingUri",
+        "mdmSupportedState",
+        "parentId",
+        "settingCategory",
+        "settingDisplayName",
+        "settingDisplayValue",
+        "settingDisplayValueType",
+        "settingName",
+        "settingScope",
+        "settingType",
+        "settingValue",
+        "settingValueDisplayUnits",
+        "settingValueType"
+      ]
+    },
+    "groupPolicyUploadedDefinitionFile": {
+      "navigationProperties": [
+        "groupPolicyOperations"
+      ],
+      "properties": [
+        "content",
+        "defaultLanguageCode",
+        "groupPolicyUploadedLanguageFiles",
+        "status",
+        "uploadDateTime"
+      ]
+    },
+    "groupPolicyUploadedPresentation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "groupResource": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "hardwareConfiguration": {
+      "navigationProperties": [
+        "assignments",
+        "deviceRunStates",
+        "runSummary",
+        "userRunStates"
+      ],
+      "properties": [
+        "configurationFileContent",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "fileName",
+        "hardwareConfigurationFormat",
+        "lastModifiedDateTime",
+        "perDevicePasswordDisabled",
+        "roleScopeTagIds",
+        "version"
+      ]
+    },
+    "hardwareConfigurationAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "hardwareConfigurationDeviceState": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentFilterIds",
+        "configurationError",
+        "configurationOutput",
+        "configurationState",
+        "deviceName",
+        "internalVersion",
+        "lastStateUpdateDateTime",
+        "osVersion",
+        "upn",
+        "userId"
+      ]
+    },
+    "hardwareConfigurationRunSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "errorDeviceCount",
+        "errorUserCount",
+        "failedDeviceCount",
+        "failedUserCount",
+        "lastRunDateTime",
+        "notApplicableDeviceCount",
+        "notApplicableUserCount",
+        "pendingDeviceCount",
+        "pendingUserCount",
+        "successfulDeviceCount",
+        "successfulUserCount",
+        "unknownDeviceCount",
+        "unknownUserCount"
+      ]
+    },
+    "hardwareConfigurationUserState": {
+      "navigationProperties": [],
+      "properties": [
+        "errorDeviceCount",
+        "failedDeviceCount",
+        "lastStateUpdateDateTime",
+        "notApplicableDeviceCount",
+        "pendingDeviceCount",
+        "successfulDeviceCount",
+        "unknownDeviceCount",
+        "upn",
+        "userEmail",
+        "userName"
+      ]
+    },
+    "hardwareOathAuthenticationMethod": {
+      "navigationProperties": [
+        "device"
+      ],
+      "properties": []
+    },
+    "hardwareOathAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": []
+    },
+    "hardwareOathTokenAuthenticationMethodDevice": {
+      "navigationProperties": [
+        "assignTo"
+      ],
+      "properties": [
+        "assignedTo",
+        "hashFunction",
+        "lastUsedDateTime",
+        "manufacturer",
+        "model",
+        "secretKey",
+        "serialNumber",
+        "status",
+        "timeIntervalInSeconds"
+      ]
+    },
+    "hardwarePasswordDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "currentPassword",
+        "previousPasswords",
+        "serialNumber"
+      ]
+    },
+    "hardwarePasswordInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "currentPassword",
+        "previousPasswords",
+        "serialNumber"
+      ]
+    },
+    "homeRealmDiscoveryPolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "horizontalSection": {
+      "navigationProperties": [
+        "columns"
+      ],
+      "properties": [
+        "emphasis",
+        "layout"
+      ]
+    },
+    "horizontalSectionColumn": {
+      "navigationProperties": [
+        "webparts"
+      ],
+      "properties": [
+        "width"
+      ]
+    },
+    "hostSecurityProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "azureSubscriptionId",
+        "azureTenantId",
+        "firstSeenDateTime",
+        "fqdn",
+        "isAzureAdJoined",
+        "isAzureAdRegistered",
+        "isHybridAzureDomainJoined",
+        "lastSeenDateTime",
+        "logonUsers",
+        "netBiosName",
+        "networkInterfaces",
+        "os",
+        "osVersion",
+        "parentHost",
+        "relatedHostIds",
+        "riskScore",
+        "tags",
+        "vendorInformation"
+      ]
+    },
+    "humanSecurityFraudProtectionProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "serverToken"
+      ]
+    },
+    "identityApiConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationConfiguration",
+        "displayName",
+        "targetUrl"
+      ]
+    },
+    "identityBuiltInUserFlowAttribute": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "identityContainer": {
+      "navigationProperties": [
+        "apiConnectors",
+        "authenticationEventListeners",
+        "authenticationEventsFlows",
+        "b2cUserFlows",
+        "b2xUserFlows",
+        "conditionalAccess",
+        "continuousAccessEvaluationPolicy",
+        "customAuthenticationExtensions",
+        "identityProviders",
+        "riskPrevention",
+        "signInIdentifiers",
+        "userFlowAttributes",
+        "userFlows",
+        "verifiedId"
+      ],
+      "properties": []
+    },
+    "identityCustomUserFlowAttribute": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "identityFinding": {
+      "navigationProperties": [
+        "identity"
+      ],
+      "properties": [
+        "actionSummary",
+        "identityDetails",
+        "permissionsCreepIndex"
+      ]
+    },
+    "identityGovernance": {
+      "navigationProperties": [
+        "accessReviews",
+        "appConsent",
+        "catalogs",
+        "entitlementManagement",
+        "lifecycleWorkflows",
+        "permissionsAnalytics",
+        "permissionsManagement",
+        "privilegedAccess",
+        "roleManagementAlerts",
+        "termsOfUse"
+      ],
+      "properties": []
+    },
+    "identityProtectionRoot": {
+      "navigationProperties": [
+        "agentRiskDetections",
+        "riskDetections",
+        "riskyAgents",
+        "riskyServicePrincipals",
+        "riskyUsers",
+        "servicePrincipalRiskDetections"
+      ],
+      "properties": []
+    },
+    "identityProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "clientId",
+        "clientSecret",
+        "name",
+        "type"
+      ]
+    },
+    "identityProviderBase": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "identitySecurityDefaultsEnforcementPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "identityUserFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "userFlowType",
+        "userFlowTypeVersion"
+      ]
+    },
+    "identityUserFlowAttribute": {
+      "navigationProperties": [],
+      "properties": [
+        "dataType",
+        "description",
+        "displayName",
+        "userFlowAttributeType"
+      ]
+    },
+    "identityUserFlowAttributeAssignment": {
+      "navigationProperties": [
+        "userAttribute"
+      ],
+      "properties": [
+        "displayName",
+        "isOptional",
+        "requiresVerification",
+        "userAttributeValues",
+        "userInputType"
+      ]
+    },
+    "identityVerifiedIdRoot": {
+      "navigationProperties": [
+        "profiles"
+      ],
+      "properties": []
+    },
+    "impactedResource": {
+      "navigationProperties": [],
+      "properties": [
+        "addedDateTime",
+        "additionalDetails",
+        "apiUrl",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "owner",
+        "portalUrl",
+        "postponeUntilDateTime",
+        "rank",
+        "recommendationId",
+        "resourceType",
+        "status",
+        "subjectId"
+      ]
+    },
+    "importedAppleDeviceIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "discoverySource",
+        "enrollmentState",
+        "isDeleted",
+        "isSupervised",
+        "lastContactedDateTime",
+        "platform",
+        "requestedEnrollmentProfileAssignmentDateTime",
+        "requestedEnrollmentProfileId",
+        "serialNumber"
+      ]
+    },
+    "importedAppleDeviceIdentityResult": {
+      "navigationProperties": [],
+      "properties": [
+        "status"
+      ]
+    },
+    "importedDeviceIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "enrollmentState",
+        "importedDeviceIdentifier",
+        "importedDeviceIdentityType",
+        "lastContactedDateTime",
+        "lastModifiedDateTime",
+        "platform"
+      ]
+    },
+    "importedDeviceIdentityResult": {
+      "navigationProperties": [],
+      "properties": [
+        "status"
+      ]
+    },
+    "importedWindowsAutopilotDeviceIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedUserPrincipalName",
+        "groupTag",
+        "hardwareIdentifier",
+        "importId",
+        "productKey",
+        "serialNumber",
+        "state"
+      ]
+    },
+    "importedWindowsAutopilotDeviceIdentityUpload": {
+      "navigationProperties": [
+        "deviceIdentities"
+      ],
+      "properties": [
+        "createdDateTimeUtc",
+        "status"
+      ]
+    },
+    "inactiveAwsResourceFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "inactiveAwsRoleFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "inactiveAzureServicePrincipalFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "inactiveGcpServiceAccountFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "inactiveGroupFinding": {
+      "navigationProperties": [
+        "group"
+      ],
+      "properties": [
+        "actionSummary",
+        "permissionsCreepIndex"
+      ]
+    },
+    "inactiveServerlessFunctionFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "inactiveUserFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "inactiveUsersByApplicationMetricBase": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "factDate",
+        "inactive30DayCount",
+        "inactive60DayCount",
+        "inactive90DayCount"
+      ]
+    },
+    "inactiveUsersMetricBase": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "factDate",
+        "inactive30DayCount",
+        "inactive60DayCount",
+        "inactive90DayCount"
+      ]
+    },
+    "inboundSharedUserProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "homeTenantId",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "inferenceClassification": {
+      "navigationProperties": [
+        "overrides"
+      ],
+      "properties": []
+    },
+    "inferenceClassificationOverride": {
+      "navigationProperties": [],
+      "properties": [
+        "classifyAs",
+        "senderEmailAddress"
+      ]
+    },
+    "informationProtection": {
+      "navigationProperties": [
+        "bitlocker",
+        "dataLossPreventionPolicies",
+        "policy",
+        "sensitivityLabels",
+        "sensitivityPolicySettings",
+        "threatAssessmentRequests"
+      ],
+      "properties": []
+    },
+    "informationProtectionLabel": {
+      "navigationProperties": [],
+      "properties": [
+        "color",
+        "description",
+        "isActive",
+        "name",
+        "parent",
+        "sensitivity",
+        "tooltip"
+      ]
+    },
+    "informationProtectionPolicy": {
+      "navigationProperties": [
+        "labels"
+      ],
+      "properties": []
+    },
+    "inheritablePermission": {
+      "navigationProperties": [],
+      "properties": [
+        "inheritableScopes",
+        "resourceAppId"
+      ]
+    },
+    "insiderRiskyUserApproval": {
+      "navigationProperties": [],
+      "properties": [
+        "isApprovalRequired",
+        "minimumRiskLevel"
+      ]
+    },
+    "insightsSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "disabledForGroup",
+        "isEnabledInOrganization"
+      ]
+    },
+    "insightSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "activeUsers",
+        "appId",
+        "authenticationCompletions",
+        "authenticationRequests",
+        "factDate",
+        "os",
+        "securityTextCompletions",
+        "securityTextRequests",
+        "securityVoiceCompletions",
+        "securityVoiceRequests"
+      ]
+    },
+    "internalDomainFederation": {
+      "navigationProperties": [],
+      "properties": [
+        "activeSignInUri",
+        "defaultInteractiveAuthenticationMethod",
+        "federatedIdpMfaBehavior",
+        "isSignedAuthenticationRequestRequired",
+        "nextSigningCertificate",
+        "openIdConnectDiscoveryEndpoint",
+        "passwordChangeUri",
+        "passwordResetUri",
+        "promptLoginBehavior",
+        "signingCertificateUpdateStatus",
+        "signOutUri"
+      ]
+    },
+    "internetExplorerMode": {
+      "navigationProperties": [
+        "siteLists"
+      ],
+      "properties": []
+    },
+    "intuneBrandingProfile": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "companyPortalBlockedActions",
+        "contactITEmailAddress",
+        "contactITName",
+        "contactITNotes",
+        "contactITPhoneNumber",
+        "createdDateTime",
+        "customCanSeePrivacyMessage",
+        "customCantSeePrivacyMessage",
+        "customPrivacyMessage",
+        "disableClientTelemetry",
+        "disableDeviceCategorySelection",
+        "displayName",
+        "enrollmentAvailability",
+        "isDefaultProfile",
+        "isFactoryResetDisabled",
+        "isRemoveDeviceDisabled",
+        "landingPageCustomizedImage",
+        "lastModifiedDateTime",
+        "lightBackgroundLogo",
+        "onlineSupportSiteName",
+        "onlineSupportSiteUrl",
+        "privacyUrl",
+        "profileDescription",
+        "profileName",
+        "roleScopeTagIds",
+        "showAzureADEnterpriseApps",
+        "showConfigurationManagerApps",
+        "showDisplayNameNextToLogo",
+        "showLogo",
+        "showOfficeWebApps",
+        "themeColor",
+        "themeColorLogo"
+      ]
+    },
+    "intuneBrandingProfileAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "invalidLicenseAlertConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "invalidLicenseAlertIncident": {
+      "navigationProperties": [],
+      "properties": [
+        "tenantLicenseStatus"
+      ]
+    },
+    "invitation": {
+      "navigationProperties": [
+        "invitedUser",
+        "invitedUserSponsors"
+      ],
+      "properties": [
+        "invitedUserDisplayName",
+        "invitedUserEmailAddress",
+        "invitedUserMessageInfo",
+        "invitedUserType",
+        "inviteRedeemUrl",
+        "inviteRedirectUrl",
+        "resetRedemption",
+        "sendInvitationMessage",
+        "status"
+      ]
+    },
+    "inviteParticipantsOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "participants"
+      ]
+    },
+    "invokeUserFlowListener": {
+      "navigationProperties": [
+        "userFlow"
+      ],
+      "properties": []
+    },
+    "iosCertificateProfile": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "iosCertificateProfileBase": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateValidityPeriodScale",
+        "certificateValidityPeriodValue",
+        "renewalThresholdPercentage",
+        "subjectAlternativeNameType",
+        "subjectNameFormat"
+      ]
+    },
+    "iosCompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "advancedThreatProtectionRequiredSecurityLevel",
+        "deviceThreatProtectionEnabled",
+        "deviceThreatProtectionRequiredSecurityLevel",
+        "managedEmailProfileRequired",
+        "osMaximumBuildVersion",
+        "osMaximumVersion",
+        "osMinimumBuildVersion",
+        "osMinimumVersion",
+        "passcodeBlockSimple",
+        "passcodeExpirationDays",
+        "passcodeMinimumCharacterSetCount",
+        "passcodeMinimumLength",
+        "passcodeMinutesOfInactivityBeforeLock",
+        "passcodeMinutesOfInactivityBeforeScreenTimeout",
+        "passcodePreviousPasscodeBlockCount",
+        "passcodeRequired",
+        "passcodeRequiredType",
+        "restrictedApps",
+        "securityBlockJailbrokenDevices"
+      ]
+    },
+    "iosCustomConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "payload",
+        "payloadFileName",
+        "payloadName"
+      ]
+    },
+    "iosDerivedCredentialAuthenticationConfiguration": {
+      "navigationProperties": [
+        "derivedCredentialSettings"
+      ],
+      "properties": []
+    },
+    "iosDeviceFeaturesConfiguration": {
+      "navigationProperties": [
+        "identityCertificateForClientAuthentication",
+        "singleSignOnExtensionPkinitCertificate"
+      ],
+      "properties": [
+        "assetTagTemplate",
+        "contentFilterSettings",
+        "homeScreenDockIcons",
+        "homeScreenGridHeight",
+        "homeScreenGridWidth",
+        "homeScreenPages",
+        "iosSingleSignOnExtension",
+        "lockScreenFootnote",
+        "notificationSettings",
+        "singleSignOnExtension",
+        "singleSignOnSettings",
+        "wallpaperDisplayLocation",
+        "wallpaperImage"
+      ]
+    },
+    "iosEasEmailProfileConfiguration": {
+      "navigationProperties": [
+        "derivedCredentialSettings",
+        "identityCertificate",
+        "smimeEncryptionCertificate",
+        "smimeSigningCertificate"
+      ],
+      "properties": [
+        "accountName",
+        "authenticationMethod",
+        "blockMovingMessagesToOtherEmailAccounts",
+        "blockSendingEmailFromThirdPartyApps",
+        "blockSyncingRecentlyUsedEmailAddresses",
+        "durationOfEmailToSync",
+        "easServices",
+        "easServicesUserOverrideEnabled",
+        "emailAddressSource",
+        "encryptionCertificateType",
+        "hostName",
+        "perAppVPNProfileId",
+        "requireSmime",
+        "requireSsl",
+        "signingCertificateType",
+        "smimeEnablePerMessageSwitch",
+        "smimeEncryptByDefaultEnabled",
+        "smimeEncryptByDefaultUserOverrideEnabled",
+        "smimeEncryptionCertificateUserOverrideEnabled",
+        "smimeSigningCertificateUserOverrideEnabled",
+        "smimeSigningEnabled",
+        "smimeSigningUserOverrideEnabled",
+        "useOAuth"
+      ]
+    },
+    "iosEducationDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "iosEduDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCertificateSettings",
+        "studentCertificateSettings",
+        "teacherCertificateSettings"
+      ]
+    },
+    "iosEnterpriseWiFiConfiguration": {
+      "navigationProperties": [
+        "derivedCredentialSettings",
+        "identityCertificateForClientAuthentication",
+        "rootCertificatesForServerValidation"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "eapFastConfiguration",
+        "eapType",
+        "innerAuthenticationProtocolForEapTtls",
+        "outerIdentityPrivacyTemporaryValue",
+        "passwordFormatString",
+        "trustedServerCertificateNames",
+        "usernameFormatString"
+      ]
+    },
+    "iosExpeditedCheckinConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "iosGeneralDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accountBlockModification",
+        "activationLockAllowWhenSupervised",
+        "airDropBlocked",
+        "airDropForceUnmanagedDropTarget",
+        "airPlayForcePairingPasswordForOutgoingRequests",
+        "airPrintBlockCredentialsStorage",
+        "airPrintBlocked",
+        "airPrintBlockiBeaconDiscovery",
+        "airPrintForceTrustedTLS",
+        "appClipsBlocked",
+        "appleNewsBlocked",
+        "applePersonalizedAdsBlocked",
+        "appleWatchBlockPairing",
+        "appleWatchForceWristDetection",
+        "appRemovalBlocked",
+        "appsSingleAppModeList",
+        "appStoreBlockAutomaticDownloads",
+        "appStoreBlocked",
+        "appStoreBlockInAppPurchases",
+        "appStoreBlockUIAppInstallation",
+        "appStoreRequirePassword",
+        "appsVisibilityList",
+        "appsVisibilityListType",
+        "autoFillForceAuthentication",
+        "autoUnlockBlocked",
+        "blockSystemAppRemoval",
+        "bluetoothBlockModification",
+        "cameraBlocked",
+        "cellularBlockDataRoaming",
+        "cellularBlockGlobalBackgroundFetchWhileRoaming",
+        "cellularBlockPerAppDataModification",
+        "cellularBlockPersonalHotspot",
+        "cellularBlockPersonalHotspotModification",
+        "cellularBlockPlanModification",
+        "cellularBlockVoiceRoaming",
+        "certificatesBlockUntrustedTlsCertificates",
+        "classroomAppBlockRemoteScreenObservation",
+        "classroomAppForceUnpromptedScreenObservation",
+        "classroomForceAutomaticallyJoinClasses",
+        "classroomForceRequestPermissionToLeaveClasses",
+        "classroomForceUnpromptedAppAndDeviceLock",
+        "compliantAppListType",
+        "compliantAppsList",
+        "configurationProfileBlockChanges",
+        "contactsAllowManagedToUnmanagedWrite",
+        "contactsAllowUnmanagedToManagedRead",
+        "continuousPathKeyboardBlocked",
+        "dateAndTimeForceSetAutomatically",
+        "definitionLookupBlocked",
+        "deviceBlockEnableRestrictions",
+        "deviceBlockEraseContentAndSettings",
+        "deviceBlockNameModification",
+        "diagnosticDataBlockSubmission",
+        "diagnosticDataBlockSubmissionModification",
+        "documentsBlockManagedDocumentsInUnmanagedApps",
+        "documentsBlockUnmanagedDocumentsInManagedApps",
+        "emailInDomainSuffixes",
+        "enterpriseAppBlockTrust",
+        "enterpriseAppBlockTrustModification",
+        "enterpriseBookBlockBackup",
+        "enterpriseBookBlockMetadataSync",
+        "esimBlockModification",
+        "faceTimeBlocked",
+        "filesNetworkDriveAccessBlocked",
+        "filesUsbDriveAccessBlocked",
+        "findMyDeviceInFindMyAppBlocked",
+        "findMyFriendsBlocked",
+        "findMyFriendsInFindMyAppBlocked",
+        "gameCenterBlocked",
+        "gamingBlockGameCenterFriends",
+        "gamingBlockMultiplayer",
+        "hostPairingBlocked",
+        "iBooksStoreBlocked",
+        "iBooksStoreBlockErotica",
+        "iCloudBlockActivityContinuation",
+        "iCloudBlockBackup",
+        "iCloudBlockDocumentSync",
+        "iCloudBlockManagedAppsSync",
+        "iCloudBlockPhotoLibrary",
+        "iCloudBlockPhotoStreamSync",
+        "iCloudBlockSharedPhotoStream",
+        "iCloudPrivateRelayBlocked",
+        "iCloudRequireEncryptedBackup",
+        "iTunesBlocked",
+        "iTunesBlockExplicitContent",
+        "iTunesBlockMusicService",
+        "iTunesBlockRadio",
+        "keyboardBlockAutoCorrect",
+        "keyboardBlockDictation",
+        "keyboardBlockPredictive",
+        "keyboardBlockShortcuts",
+        "keyboardBlockSpellCheck",
+        "keychainBlockCloudSync",
+        "kioskModeAllowAssistiveSpeak",
+        "kioskModeAllowAssistiveTouchSettings",
+        "kioskModeAllowAutoLock",
+        "kioskModeAllowColorInversionSettings",
+        "kioskModeAllowRingerSwitch",
+        "kioskModeAllowScreenRotation",
+        "kioskModeAllowSleepButton",
+        "kioskModeAllowTouchscreen",
+        "kioskModeAllowVoiceControlModification",
+        "kioskModeAllowVoiceOverSettings",
+        "kioskModeAllowVolumeButtons",
+        "kioskModeAllowZoomSettings",
+        "kioskModeAppStoreUrl",
+        "kioskModeAppType",
+        "kioskModeBlockAutoLock",
+        "kioskModeBlockRingerSwitch",
+        "kioskModeBlockScreenRotation",
+        "kioskModeBlockSleepButton",
+        "kioskModeBlockTouchscreen",
+        "kioskModeBlockVolumeButtons",
+        "kioskModeBuiltInAppId",
+        "kioskModeEnableVoiceControl",
+        "kioskModeManagedAppId",
+        "kioskModeRequireAssistiveTouch",
+        "kioskModeRequireColorInversion",
+        "kioskModeRequireMonoAudio",
+        "kioskModeRequireVoiceOver",
+        "kioskModeRequireZoom",
+        "lockScreenBlockControlCenter",
+        "lockScreenBlockNotificationView",
+        "lockScreenBlockPassbook",
+        "lockScreenBlockTodayView",
+        "managedPasteboardRequired",
+        "mediaContentRatingApps",
+        "mediaContentRatingAustralia",
+        "mediaContentRatingCanada",
+        "mediaContentRatingFrance",
+        "mediaContentRatingGermany",
+        "mediaContentRatingIreland",
+        "mediaContentRatingJapan",
+        "mediaContentRatingNewZealand",
+        "mediaContentRatingUnitedKingdom",
+        "mediaContentRatingUnitedStates",
+        "messagesBlocked",
+        "networkUsageRules",
+        "nfcBlocked",
+        "notificationsBlockSettingsModification",
+        "onDeviceOnlyDictationForced",
+        "onDeviceOnlyTranslationForced",
+        "passcodeBlockFingerprintModification",
+        "passcodeBlockFingerprintUnlock",
+        "passcodeBlockModification",
+        "passcodeBlockSimple",
+        "passcodeExpirationDays",
+        "passcodeMinimumCharacterSetCount",
+        "passcodeMinimumLength",
+        "passcodeMinutesOfInactivityBeforeLock",
+        "passcodeMinutesOfInactivityBeforeScreenTimeout",
+        "passcodePreviousPasscodeBlockCount",
+        "passcodeRequired",
+        "passcodeRequiredType",
+        "passcodeSignInFailureCountBeforeWipe",
+        "passwordBlockAirDropSharing",
+        "passwordBlockAutoFill",
+        "passwordBlockProximityRequests",
+        "pkiBlockOTAUpdates",
+        "podcastsBlocked",
+        "privacyForceLimitAdTracking",
+        "proximityBlockSetupToNewDevice",
+        "safariBlockAutofill",
+        "safariBlocked",
+        "safariBlockJavaScript",
+        "safariBlockPopups",
+        "safariCookieSettings",
+        "safariManagedDomains",
+        "safariPasswordAutoFillDomains",
+        "safariRequireFraudWarning",
+        "screenCaptureBlocked",
+        "sharedDeviceBlockTemporarySessions",
+        "siriBlocked",
+        "siriBlockedWhenLocked",
+        "siriBlockUserGeneratedContent",
+        "siriRequireProfanityFilter",
+        "softwareUpdatesEnforcedDelayInDays",
+        "softwareUpdatesForceDelayed",
+        "spotlightBlockInternetResults",
+        "unpairedExternalBootToRecoveryAllowed",
+        "usbRestrictedModeBlocked",
+        "voiceDialingBlocked",
+        "vpnBlockCreation",
+        "wallpaperBlockModification",
+        "wiFiConnectOnlyToConfiguredNetworks",
+        "wiFiConnectToAllowedNetworksOnlyForced",
+        "wifiPowerOnForced"
+      ]
+    },
+    "iosikEv2VpnConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowDefaultChildSecurityAssociationParameters",
+        "allowDefaultSecurityAssociationParameters",
+        "alwaysOnConfiguration",
+        "childSecurityAssociationParameters",
+        "clientAuthenticationType",
+        "deadPeerDetectionRate",
+        "disableMobilityAndMultihoming",
+        "disableRedirect",
+        "enableAlwaysOnConfiguration",
+        "enableCertificateRevocationCheck",
+        "enableEAP",
+        "enablePerfectForwardSecrecy",
+        "enableUseInternalSubnetAttributes",
+        "localIdentifier",
+        "mtuSizeInBytes",
+        "remoteIdentifier",
+        "securityAssociationParameters",
+        "serverCertificateCommonName",
+        "serverCertificateIssuerCommonName",
+        "serverCertificateType",
+        "sharedSecret",
+        "tlsMaximumVersion",
+        "tlsMinimumVersion"
+      ]
+    },
+    "iosImportedPFXCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "intendedPurpose"
+      ]
+    },
+    "iosiPadOSWebClip": {
+      "navigationProperties": [],
+      "properties": [
+        "appUrl",
+        "fullScreenEnabled",
+        "ignoreManifestScope",
+        "preComposedIconEnabled",
+        "targetApplicationBundleIdentifier",
+        "useManagedBrowser"
+      ]
+    },
+    "iosLobApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appleDeviceAppDeliveryProtocolType",
+        "applicableDeviceType",
+        "buildNumber",
+        "bundleId",
+        "expirationDateTime",
+        "minimumSupportedOperatingSystem",
+        "versionNumber"
+      ]
+    },
+    "iosLobAppProvisioningConfiguration": {
+      "navigationProperties": [
+        "assignments",
+        "deviceStatuses",
+        "groupAssignments",
+        "userStatuses"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "expirationDateTime",
+        "lastModifiedDateTime",
+        "payload",
+        "payloadFileName",
+        "roleScopeTagIds",
+        "version"
+      ]
+    },
+    "iosLobAppProvisioningConfigurationAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "iosLobAppProvisioningConfigurationPolicySetItem": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "iosManagedAppProtection": {
+      "navigationProperties": [
+        "apps",
+        "deploymentSummary"
+      ],
+      "properties": [
+        "allowedIosDeviceModels",
+        "allowWidgetContentSync",
+        "appActionIfAccountIsClockedOut",
+        "appActionIfIosDeviceModelNotAllowed",
+        "appDataEncryptionType",
+        "customBrowserProtocol",
+        "customDialerAppProtocol",
+        "deployedAppCount",
+        "disableProtectionOfManagedOutboundOpenInData",
+        "exemptedAppProtocols",
+        "exemptedUniversalLinks",
+        "faceIdBlocked",
+        "filterOpenInToOnlyManagedApps",
+        "genmojiConfigurationState",
+        "managedUniversalLinks",
+        "messagingRedirectAppUrlScheme",
+        "minimumRequiredSdkVersion",
+        "minimumWarningSdkVersion",
+        "minimumWipeSdkVersion",
+        "protectInboundDataFromUnknownSources",
+        "screenCaptureConfigurationState",
+        "thirdPartyKeyboardsBlocked",
+        "writingToolsConfigurationState"
+      ]
+    },
+    "iosManagedAppRegistration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "iosMobileAppConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "encodedSettingXml",
+        "settings"
+      ]
+    },
+    "iosPkcsCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "certificateStore",
+        "certificateTemplateName",
+        "certificationAuthority",
+        "certificationAuthorityName",
+        "customSubjectAlternativeNames",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "iosScepCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates",
+        "rootCertificate"
+      ],
+      "properties": [
+        "certificateStore",
+        "customSubjectAlternativeNames",
+        "extendedKeyUsages",
+        "keySize",
+        "keyUsage",
+        "scepServerUrls",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "iosStoreApp": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableDeviceType",
+        "appStoreUrl",
+        "bundleId",
+        "minimumSupportedOperatingSystem"
+      ]
+    },
+    "iosTrustedRootCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "certFileName",
+        "trustedRootCertificate"
+      ]
+    },
+    "iosUpdateConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "activeHoursEnd",
+        "activeHoursStart",
+        "customUpdateTimeWindows",
+        "desiredOsVersion",
+        "enforcedSoftwareUpdateDelayInDays",
+        "isEnabled",
+        "scheduledInstallDays",
+        "updateScheduleType",
+        "utcTimeOffsetInMinutes"
+      ]
+    },
+    "iosUpdateDeviceStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceGracePeriodExpirationDateTime",
+        "deviceDisplayName",
+        "deviceId",
+        "deviceModel",
+        "installStatus",
+        "lastReportedDateTime",
+        "osVersion",
+        "platform",
+        "status",
+        "userId",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "iosVpnConfiguration": {
+      "navigationProperties": [
+        "derivedCredentialSettings",
+        "identityCertificate"
+      ],
+      "properties": [
+        "cloudName",
+        "excludeList",
+        "microsoftTunnelSiteId",
+        "strictEnforcement",
+        "targetedMobileApps",
+        "userDomain"
+      ]
+    },
+    "iosVppApp": {
+      "navigationProperties": [
+        "assignedLicenses"
+      ],
+      "properties": [
+        "applicableDeviceType",
+        "appStoreUrl",
+        "bundleId",
+        "licensingType",
+        "releaseDateTime",
+        "revokeLicenseActionResults",
+        "totalLicenseCount",
+        "usedLicenseCount",
+        "vppTokenAccountType",
+        "vppTokenAppleId",
+        "vppTokenDisplayName",
+        "vppTokenId",
+        "vppTokenOrganizationName"
+      ]
+    },
+    "iosVppAppAssignedDeviceLicense": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceName",
+        "managedDeviceId"
+      ]
+    },
+    "iosVppAppAssignedLicense": {
+      "navigationProperties": [],
+      "properties": [
+        "userEmailAddress",
+        "userId",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "iosVppAppAssignedUserLicense": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "iosVppEBook": {
+      "navigationProperties": [],
+      "properties": [
+        "appleId",
+        "genres",
+        "language",
+        "roleScopeTagIds",
+        "seller",
+        "totalLicenseCount",
+        "usedLicenseCount",
+        "vppOrganizationName",
+        "vppTokenId"
+      ]
+    },
+    "iosVppEBookAssignment": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "iosWiFiConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "connectAutomatically",
+        "connectWhenNetworkNameIsHidden",
+        "disableMacAddressRandomization",
+        "networkName",
+        "preSharedKey",
+        "proxyAutomaticConfigurationUrl",
+        "proxyManualAddress",
+        "proxyManualPort",
+        "proxySettings",
+        "ssid",
+        "wiFiSecurityType"
+      ]
+    },
+    "iosWiredNetworkConfiguration": {
+      "navigationProperties": [
+        "identityCertificateForClientAuthentication",
+        "rootCertificateForServerValidation"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "eapFastConfiguration",
+        "eapType",
+        "networkInterface",
+        "networkName",
+        "nonEapAuthenticationMethodForEapTtls",
+        "outerIdentityPrivacyMaskValue",
+        "trustedServerCertificateNames"
+      ]
+    },
+    "ipApplicationSegment": {
+      "navigationProperties": [
+        "application"
+      ],
+      "properties": [
+        "action",
+        "destinationHost",
+        "destinationType",
+        "port",
+        "ports",
+        "protocol"
+      ]
+    },
+    "ipNamedLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "ipRanges",
+        "isTrusted"
+      ]
+    },
+    "ipSecurityProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "activityGroupNames",
+        "address",
+        "azureSubscriptionId",
+        "azureTenantId",
+        "countHits",
+        "countHosts",
+        "firstSeenDateTime",
+        "ipCategories",
+        "ipReferenceData",
+        "lastSeenDateTime",
+        "riskScore",
+        "tags",
+        "vendorInformation"
+      ]
+    },
+    "item": {
+      "navigationProperties": [
+        "itemCategory",
+        "picture"
+      ],
+      "properties": [
+        "baseUnitOfMeasureId",
+        "blocked",
+        "displayName",
+        "gtin",
+        "id",
+        "inventory",
+        "itemCategoryCode",
+        "itemCategoryId",
+        "lastModifiedDateTime",
+        "number",
+        "priceIncludesTax",
+        "taxGroupCode",
+        "taxGroupId",
+        "type",
+        "unitCost",
+        "unitPrice"
+      ]
+    },
+    "itemActivity": {
+      "navigationProperties": [
+        "driveItem"
+      ],
+      "properties": [
+        "access",
+        "activityDateTime",
+        "actor"
+      ]
+    },
+    "itemActivityOLD": {
+      "navigationProperties": [
+        "driveItem",
+        "listItem"
+      ],
+      "properties": [
+        "action",
+        "actor",
+        "times"
+      ]
+    },
+    "itemActivityStat": {
+      "navigationProperties": [
+        "activities"
+      ],
+      "properties": [
+        "access",
+        "create",
+        "delete",
+        "edit",
+        "endDateTime",
+        "incompleteData",
+        "isTrending",
+        "move",
+        "startDateTime"
+      ]
+    },
+    "itemAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "detail",
+        "displayName",
+        "geoCoordinates"
+      ]
+    },
+    "itemAnalytics": {
+      "navigationProperties": [
+        "allTime",
+        "itemActivityStats",
+        "lastSevenDays"
+      ],
+      "properties": []
+    },
+    "itemAttachment": {
+      "navigationProperties": [
+        "item"
+      ],
+      "properties": []
+    },
+    "itemCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "displayName",
+        "id",
+        "lastModifiedDateTime"
+      ]
+    },
+    "itemEmail": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "displayName",
+        "type"
+      ]
+    },
+    "itemFacet": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedAudiences",
+        "createdBy",
+        "createdDateTime",
+        "inference",
+        "isSearchable",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "source",
+        "sources"
+      ]
+    },
+    "itemInsights": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "itemPatent": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "isPending",
+        "issuedDate",
+        "issuingAuthority",
+        "number",
+        "webUrl"
+      ]
+    },
+    "itemPhone": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "number",
+        "type"
+      ]
+    },
+    "itemPublication": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "publishedDate",
+        "publisher",
+        "thumbnailUrl",
+        "webUrl"
+      ]
+    },
+    "itemRetentionLabel": {
+      "navigationProperties": [],
+      "properties": [
+        "isLabelAppliedExplicitly",
+        "labelAppliedBy",
+        "labelAppliedDateTime",
+        "name",
+        "retentionSettings"
+      ]
+    },
+    "jobResponseBase": {
+      "navigationProperties": [],
+      "properties": [
+        "creationDateTime",
+        "endDateTime",
+        "error",
+        "startDateTime",
+        "status",
+        "tenantId",
+        "type",
+        "userId"
+      ]
+    },
+    "journal": {
+      "navigationProperties": [
+        "account",
+        "journalLines"
+      ],
+      "properties": [
+        "balancingAccountId",
+        "balancingAccountNumber",
+        "code",
+        "displayName",
+        "id",
+        "lastModifiedDateTime"
+      ]
+    },
+    "journalLine": {
+      "navigationProperties": [
+        "account"
+      ],
+      "properties": [
+        "accountId",
+        "accountNumber",
+        "amount",
+        "comment",
+        "description",
+        "documentNumber",
+        "externalDocumentNumber",
+        "id",
+        "journalDisplayName",
+        "lastModifiedDateTime",
+        "lineNumber",
+        "postingDate"
+      ]
+    },
+    "labelContentRight": {
+      "navigationProperties": [
+        "label"
+      ],
+      "properties": [
+        "cid",
+        "format",
+        "rights"
+      ]
+    },
+    "landingPage": {
+      "navigationProperties": [
+        "details"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "locale",
+        "source",
+        "status",
+        "supportedLocales"
+      ]
+    },
+    "landingPageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "isDefaultLangauge",
+        "language"
+      ]
+    },
+    "languageProficiency": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "proficiency",
+        "reading",
+        "spoken",
+        "tag",
+        "thumbnailUrl",
+        "written"
+      ]
+    },
+    "learningAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedDateTime",
+        "assignerUserId",
+        "assignmentType",
+        "dueDateTime",
+        "notes"
+      ]
+    },
+    "learningContent": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalTags",
+        "contentWebUrl",
+        "contributors",
+        "createdDateTime",
+        "description",
+        "duration",
+        "externalId",
+        "format",
+        "isActive",
+        "isPremium",
+        "isSearchable",
+        "languageTag",
+        "lastModifiedDateTime",
+        "level",
+        "numberOfPages",
+        "skillTags",
+        "sourceName",
+        "thumbnailWebUrl",
+        "title"
+      ]
+    },
+    "learningCourseActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "completionPercentage",
+        "externalcourseActivityId",
+        "learnerUserId",
+        "learningContentId",
+        "learningProviderId",
+        "status"
+      ]
+    },
+    "learningProvider": {
+      "navigationProperties": [
+        "learningContents",
+        "learningCourseActivities"
+      ],
+      "properties": [
+        "displayName",
+        "isCourseActivitySyncEnabled",
+        "loginWebUrl",
+        "longLogoWebUrlForDarkTheme",
+        "longLogoWebUrlForLightTheme",
+        "squareLogoWebUrlForDarkTheme",
+        "squareLogoWebUrlForLightTheme"
+      ]
+    },
+    "learningSelfInitiatedCourse": {
+      "navigationProperties": [],
+      "properties": [
+        "startedDateTime"
+      ]
+    },
+    "levelMap": {
+      "navigationProperties": [
+        "fixtures",
+        "sections",
+        "units"
+      ],
+      "properties": [
+        "placeId"
+      ]
+    },
+    "licenseDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "servicePlans",
+        "skuId",
+        "skuPartNumber"
+      ]
+    },
+    "linkedResource": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationName",
+        "displayName",
+        "externalId",
+        "webUrl"
+      ]
+    },
+    "list": {
+      "navigationProperties": [
+        "activities",
+        "columns",
+        "contentTypes",
+        "drive",
+        "items",
+        "operations",
+        "permissions",
+        "subscriptions"
+      ],
+      "properties": [
+        "displayName",
+        "itemCount",
+        "list",
+        "sharepointIds",
+        "system"
+      ]
+    },
+    "listItem": {
+      "navigationProperties": [
+        "activities",
+        "analytics",
+        "documentSetVersions",
+        "driveItem",
+        "fields",
+        "permissions",
+        "versions"
+      ],
+      "properties": [
+        "contentType",
+        "deleted",
+        "sharepointIds"
+      ]
+    },
+    "listItemVersion": {
+      "navigationProperties": [
+        "fields"
+      ],
+      "properties": []
+    },
+    "localizedNotificationMessage": {
+      "navigationProperties": [],
+      "properties": [
+        "isDefault",
+        "lastModifiedDateTime",
+        "locale",
+        "messageTemplate",
+        "subject"
+      ]
+    },
+    "loginPage": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "language",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "source",
+        "status"
+      ]
+    },
+    "longRunningOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastActionDateTime",
+        "resourceLocation",
+        "status",
+        "statusDetail"
+      ]
+    },
+    "lookupResultRow": {
+      "navigationProperties": [],
+      "properties": [
+        "row"
+      ]
+    },
+    "m365AppsInstallationOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "appsForMac",
+        "appsForWindows",
+        "updateChannel"
+      ]
+    },
+    "m365CapabilityBase": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedDateTime",
+        "name"
+      ]
+    },
+    "macOSCertificateProfileBase": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateValidityPeriodScale",
+        "certificateValidityPeriodValue",
+        "renewalThresholdPercentage",
+        "subjectAlternativeNameType",
+        "subjectNameFormat"
+      ]
+    },
+    "macOSCompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "advancedThreatProtectionRequiredSecurityLevel",
+        "deviceCompliancePolicyScript",
+        "deviceThreatProtectionEnabled",
+        "deviceThreatProtectionRequiredSecurityLevel",
+        "firewallBlockAllIncoming",
+        "firewallEnabled",
+        "firewallEnableStealthMode",
+        "gatekeeperAllowedAppSource",
+        "osMaximumBuildVersion",
+        "osMaximumVersion",
+        "osMinimumBuildVersion",
+        "osMinimumVersion",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "storageRequireEncryption",
+        "systemIntegrityProtectionEnabled"
+      ]
+    },
+    "macOSCustomAppConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "bundleId",
+        "configurationXml",
+        "fileName"
+      ]
+    },
+    "macOSCustomConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "deploymentChannel",
+        "payload",
+        "payloadFileName",
+        "payloadName"
+      ]
+    },
+    "macOSDeviceFeaturesConfiguration": {
+      "navigationProperties": [
+        "singleSignOnExtensionPkinitCertificate"
+      ],
+      "properties": [
+        "adminShowHostInfo",
+        "appAssociatedDomains",
+        "associatedDomains",
+        "authorizedUsersListHidden",
+        "authorizedUsersListHideAdminUsers",
+        "authorizedUsersListHideLocalUsers",
+        "authorizedUsersListHideMobileAccounts",
+        "authorizedUsersListIncludeNetworkUsers",
+        "authorizedUsersListShowOtherManagedUsers",
+        "autoLaunchItems",
+        "consoleAccessDisabled",
+        "contentCachingBlockDeletion",
+        "contentCachingClientListenRanges",
+        "contentCachingClientPolicy",
+        "contentCachingDataPath",
+        "contentCachingDisableConnectionSharing",
+        "contentCachingEnabled",
+        "contentCachingForceConnectionSharing",
+        "contentCachingKeepAwake",
+        "contentCachingLogClientIdentities",
+        "contentCachingMaxSizeBytes",
+        "contentCachingParents",
+        "contentCachingParentSelectionPolicy",
+        "contentCachingPeerFilterRanges",
+        "contentCachingPeerListenRanges",
+        "contentCachingPeerPolicy",
+        "contentCachingPort",
+        "contentCachingPublicRanges",
+        "contentCachingShowAlerts",
+        "contentCachingType",
+        "loginWindowText",
+        "logOutDisabledWhileLoggedIn",
+        "macOSSingleSignOnExtension",
+        "powerOffDisabledWhileLoggedIn",
+        "restartDisabled",
+        "restartDisabledWhileLoggedIn",
+        "screenLockDisableImmediate",
+        "shutDownDisabled",
+        "shutDownDisabledWhileLoggedIn",
+        "singleSignOnExtension",
+        "sleepDisabled"
+      ]
+    },
+    "macOSDmgApp": {
+      "navigationProperties": [],
+      "properties": [
+        "ignoreVersionDetection",
+        "includedApps",
+        "minimumSupportedOperatingSystem",
+        "primaryBundleId",
+        "primaryBundleVersion"
+      ]
+    },
+    "macOSEndpointProtectionConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "advancedThreatProtectionAutomaticSampleSubmission",
+        "advancedThreatProtectionCloudDelivered",
+        "advancedThreatProtectionDiagnosticDataCollection",
+        "advancedThreatProtectionExcludedExtensions",
+        "advancedThreatProtectionExcludedFiles",
+        "advancedThreatProtectionExcludedFolders",
+        "advancedThreatProtectionExcludedProcesses",
+        "advancedThreatProtectionRealTime",
+        "fileVaultAllowDeferralUntilSignOut",
+        "fileVaultDisablePromptAtSignOut",
+        "fileVaultEnabled",
+        "fileVaultHidePersonalRecoveryKey",
+        "fileVaultInstitutionalRecoveryKeyCertificate",
+        "fileVaultInstitutionalRecoveryKeyCertificateFileName",
+        "fileVaultNumberOfTimesUserCanIgnore",
+        "fileVaultPersonalRecoveryKeyHelpMessage",
+        "fileVaultPersonalRecoveryKeyRotationInMonths",
+        "fileVaultSelectedRecoveryKeyTypes",
+        "firewallApplications",
+        "firewallBlockAllIncoming",
+        "firewallEnabled",
+        "firewallEnableStealthMode",
+        "gatekeeperAllowedAppSource",
+        "gatekeeperBlockOverride"
+      ]
+    },
+    "macOSEnterpriseWiFiConfiguration": {
+      "navigationProperties": [
+        "identityCertificateForClientAuthentication",
+        "rootCertificateForServerValidation",
+        "rootCertificatesForServerValidation"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "eapFastConfiguration",
+        "eapType",
+        "innerAuthenticationProtocolForEapTtls",
+        "outerIdentityPrivacyTemporaryValue",
+        "trustedServerCertificateNames"
+      ]
+    },
+    "macOSExtensionsConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "kernelExtensionAllowedTeamIdentifiers",
+        "kernelExtensionOverridesAllowed",
+        "kernelExtensionsAllowed",
+        "systemExtensionsAllowed",
+        "systemExtensionsAllowedTeamIdentifiers",
+        "systemExtensionsAllowedTypes",
+        "systemExtensionsBlockOverride"
+      ]
+    },
+    "macOSGeneralDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "activationLockWhenSupervisedAllowed",
+        "addingGameCenterFriendsBlocked",
+        "airDropBlocked",
+        "appleWatchBlockAutoUnlock",
+        "cameraBlocked",
+        "classroomAppBlockRemoteScreenObservation",
+        "classroomAppForceUnpromptedScreenObservation",
+        "classroomForceAutomaticallyJoinClasses",
+        "classroomForceRequestPermissionToLeaveClasses",
+        "classroomForceUnpromptedAppAndDeviceLock",
+        "compliantAppListType",
+        "compliantAppsList",
+        "contentCachingBlocked",
+        "definitionLookupBlocked",
+        "emailInDomainSuffixes",
+        "eraseContentAndSettingsBlocked",
+        "gameCenterBlocked",
+        "iCloudBlockActivityContinuation",
+        "iCloudBlockAddressBook",
+        "iCloudBlockBookmarks",
+        "iCloudBlockCalendar",
+        "iCloudBlockDocumentSync",
+        "iCloudBlockMail",
+        "iCloudBlockNotes",
+        "iCloudBlockPhotoLibrary",
+        "iCloudBlockReminders",
+        "iCloudDesktopAndDocumentsBlocked",
+        "iCloudPrivateRelayBlocked",
+        "iTunesBlockFileSharing",
+        "iTunesBlockMusicService",
+        "keyboardBlockDictation",
+        "keychainBlockCloudSync",
+        "multiplayerGamingBlocked",
+        "passwordBlockAirDropSharing",
+        "passwordBlockAutoFill",
+        "passwordBlockFingerprintUnlock",
+        "passwordBlockModification",
+        "passwordBlockProximityRequests",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMaximumAttemptCount",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordMinutesUntilFailedLoginReset",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "privacyAccessControls",
+        "safariBlockAutofill",
+        "screenCaptureBlocked",
+        "softwareUpdateMajorOSDeferredInstallDelayInDays",
+        "softwareUpdateMinorOSDeferredInstallDelayInDays",
+        "softwareUpdateNonOSDeferredInstallDelayInDays",
+        "softwareUpdatesEnforcedDelayInDays",
+        "spotlightBlockInternetResults",
+        "touchIdTimeoutInHours",
+        "updateDelayPolicy",
+        "wallpaperModificationBlocked"
+      ]
+    },
+    "macOSImportedPFXCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "deploymentChannel",
+        "intendedPurpose"
+      ]
+    },
+    "macOSLobApp": {
+      "navigationProperties": [],
+      "properties": [
+        "buildNumber",
+        "bundleId",
+        "childApps",
+        "ignoreVersionDetection",
+        "installAsManaged",
+        "md5Hash",
+        "md5HashChunkSize",
+        "minimumSupportedOperatingSystem",
+        "versionNumber"
+      ]
+    },
+    "macOSMicrosoftDefenderApp": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "macOSMicrosoftEdgeApp": {
+      "navigationProperties": [],
+      "properties": [
+        "channel"
+      ]
+    },
+    "macOSOfficeSuiteApp": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "macOSPkcsCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "allowAllAppsAccess",
+        "certificateStore",
+        "certificateTemplateName",
+        "certificationAuthority",
+        "certificationAuthorityName",
+        "customSubjectAlternativeNames",
+        "deploymentChannel",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "macOSPkgApp": {
+      "navigationProperties": [],
+      "properties": [
+        "ignoreVersionDetection",
+        "includedApps",
+        "minimumSupportedOperatingSystem",
+        "postInstallScript",
+        "preInstallScript",
+        "primaryBundleId",
+        "primaryBundleVersion"
+      ]
+    },
+    "macOSScepCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates",
+        "rootCertificate"
+      ],
+      "properties": [
+        "allowAllAppsAccess",
+        "certificateStore",
+        "customSubjectAlternativeNames",
+        "deploymentChannel",
+        "extendedKeyUsages",
+        "hashAlgorithm",
+        "keySize",
+        "keyUsage",
+        "scepServerUrls",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "macOSSoftwareUpdateAccountSummary": {
+      "navigationProperties": [
+        "categorySummaries"
+      ],
+      "properties": [
+        "deviceId",
+        "deviceName",
+        "displayName",
+        "failedUpdateCount",
+        "lastUpdatedDateTime",
+        "osVersion",
+        "successfulUpdateCount",
+        "totalUpdateCount",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "macOSSoftwareUpdateCategorySummary": {
+      "navigationProperties": [
+        "updateStateSummaries"
+      ],
+      "properties": [
+        "deviceId",
+        "displayName",
+        "failedUpdateCount",
+        "lastUpdatedDateTime",
+        "successfulUpdateCount",
+        "totalUpdateCount",
+        "updateCategory",
+        "userId"
+      ]
+    },
+    "macOSSoftwareUpdateConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allOtherUpdateBehavior",
+        "configDataUpdateBehavior",
+        "criticalUpdateBehavior",
+        "customUpdateTimeWindows",
+        "firmwareUpdateBehavior",
+        "maxUserDeferralsCount",
+        "priority",
+        "updateScheduleType",
+        "updateTimeWindowUtcOffsetInMinutes"
+      ]
+    },
+    "macOSSoftwareUpdateStateSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastUpdatedDateTime",
+        "productKey",
+        "state",
+        "updateCategory",
+        "updateVersion"
+      ]
+    },
+    "macOSTrustedRootCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "certFileName",
+        "deploymentChannel",
+        "trustedRootCertificate"
+      ]
+    },
+    "macOSVpnConfiguration": {
+      "navigationProperties": [
+        "identityCertificate"
+      ],
+      "properties": [
+        "deploymentChannel"
+      ]
+    },
+    "macOsVppApp": {
+      "navigationProperties": [
+        "assignedLicenses"
+      ],
+      "properties": [
+        "appStoreUrl",
+        "bundleId",
+        "licensingType",
+        "releaseDateTime",
+        "revokeLicenseActionResults",
+        "totalLicenseCount",
+        "usedLicenseCount",
+        "vppTokenAccountType",
+        "vppTokenAppleId",
+        "vppTokenDisplayName",
+        "vppTokenId",
+        "vppTokenOrganizationName"
+      ]
+    },
+    "macOsVppAppAssignedLicense": {
+      "navigationProperties": [],
+      "properties": [
+        "userEmailAddress",
+        "userId",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "macOSWebClip": {
+      "navigationProperties": [],
+      "properties": [
+        "appUrl",
+        "fullScreenEnabled",
+        "preComposedIconEnabled"
+      ]
+    },
+    "macOSWiFiConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "connectAutomatically",
+        "connectWhenNetworkNameIsHidden",
+        "deploymentChannel",
+        "networkName",
+        "preSharedKey",
+        "proxyAutomaticConfigurationUrl",
+        "proxyManualAddress",
+        "proxyManualPort",
+        "proxySettings",
+        "ssid",
+        "wiFiSecurityType"
+      ]
+    },
+    "macOSWiredNetworkConfiguration": {
+      "navigationProperties": [
+        "identityCertificateForClientAuthentication",
+        "rootCertificateForServerValidation"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "deploymentChannel",
+        "eapFastConfiguration",
+        "eapType",
+        "enableOuterIdentityPrivacy",
+        "networkInterface",
+        "networkName",
+        "nonEapAuthenticationMethodForEapTtls",
+        "trustedServerCertificateNames"
+      ]
+    },
+    "mailAssessmentRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "destinationRoutingReason",
+        "messageUri",
+        "recipientEmail"
+      ]
+    },
+    "mailbox": {
+      "navigationProperties": [
+        "folders"
+      ],
+      "properties": []
+    },
+    "mailboxExclusionUnit": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectId",
+        "displayName",
+        "email",
+        "mailboxType"
+      ]
+    },
+    "mailboxExclusionUnitsBulkAdditionJob": {
+      "navigationProperties": [],
+      "properties": [
+        "mailboxes"
+      ]
+    },
+    "mailboxFolder": {
+      "navigationProperties": [
+        "childFolders",
+        "items",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "childFolderCount",
+        "displayName",
+        "parentFolderId",
+        "parentMailboxUrl",
+        "totalItemCount",
+        "type"
+      ]
+    },
+    "mailboxItem": {
+      "navigationProperties": [
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "size",
+        "type"
+      ]
+    },
+    "mailboxProtectionRule": {
+      "navigationProperties": [],
+      "properties": [
+        "mailboxExpression"
+      ]
+    },
+    "mailboxProtectionUnit": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectId",
+        "displayName",
+        "email",
+        "mailboxType"
+      ]
+    },
+    "mailboxProtectionUnitsBulkAdditionJob": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectIds",
+        "mailboxes"
+      ]
+    },
+    "mailboxRestoreArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "restoredFolderId",
+        "restoredFolderName",
+        "restoredItemCount"
+      ]
+    },
+    "mailboxRestoreArtifactsBulkAdditionRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectIds",
+        "mailboxes"
+      ]
+    },
+    "mailFolder": {
+      "navigationProperties": [
+        "childFolders",
+        "messageRules",
+        "messages",
+        "multiValueExtendedProperties",
+        "operations",
+        "singleValueExtendedProperties",
+        "userConfigurations"
+      ],
+      "properties": [
+        "childFolderCount",
+        "displayName",
+        "isHidden",
+        "parentFolderId",
+        "totalItemCount",
+        "unreadItemCount",
+        "wellKnownName"
+      ]
+    },
+    "mailFolderOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceLocation",
+        "status"
+      ]
+    },
+    "mailSearchFolder": {
+      "navigationProperties": [],
+      "properties": [
+        "filterQuery",
+        "includeNestedFolders",
+        "isSupported",
+        "sourceFolderIds"
+      ]
+    },
+    "malwareStateForWindowsDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionCount",
+        "deviceName",
+        "executionState",
+        "initialDetectionDateTime",
+        "lastStateChangeDateTime",
+        "threatState"
+      ]
+    },
+    "managedAllDeviceCertificateState": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateExpirationDateTime",
+        "certificateExtendedKeyUsages",
+        "certificateIssuanceDateTime",
+        "certificateIssuerName",
+        "certificateKeyUsages",
+        "certificateRevokeStatus",
+        "certificateRevokeStatusLastChangeDateTime",
+        "certificateSerialNumber",
+        "certificateSubjectName",
+        "certificateThumbprint",
+        "managedDeviceDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "managedAndroidLobApp": {
+      "navigationProperties": [],
+      "properties": [
+        "minimumSupportedOperatingSystem",
+        "packageId",
+        "targetedPlatforms",
+        "versionCode",
+        "versionName"
+      ]
+    },
+    "managedAndroidStoreApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appStoreUrl",
+        "minimumSupportedOperatingSystem",
+        "packageId"
+      ]
+    },
+    "managedApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appAvailability",
+        "version"
+      ]
+    },
+    "managedAppConfiguration": {
+      "navigationProperties": [
+        "settings"
+      ],
+      "properties": [
+        "customSettings"
+      ]
+    },
+    "managedAppLogCollectionRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "managedAppRegistrationId",
+        "requestedByUserPrincipalName",
+        "requestedDateTime",
+        "uploadedLogs",
+        "userLogUploadConsent",
+        "version"
+      ]
+    },
+    "managedAppOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastModifiedDateTime",
+        "state",
+        "version"
+      ]
+    },
+    "managedAppPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "roleScopeTagIds",
+        "version"
+      ]
+    },
+    "managedAppPolicyDeploymentSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationDeployedUserCount",
+        "configurationDeploymentSummaryPerApp",
+        "displayName",
+        "lastRefreshTime",
+        "version"
+      ]
+    },
+    "managedAppProtection": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedDataIngestionLocations",
+        "allowedDataStorageLocations",
+        "allowedInboundDataTransferSources",
+        "allowedOutboundClipboardSharingExceptionLength",
+        "allowedOutboundClipboardSharingLevel",
+        "allowedOutboundDataTransferDestinations",
+        "appActionIfDeviceComplianceRequired",
+        "appActionIfMaximumPinRetriesExceeded",
+        "appActionIfUnableToAuthenticateUser",
+        "blockDataIngestionIntoOrganizationDocuments",
+        "contactSyncBlocked",
+        "dataBackupBlocked",
+        "deviceComplianceRequired",
+        "dialerRestrictionLevel",
+        "disableAppPinIfDevicePinIsSet",
+        "fingerprintBlocked",
+        "gracePeriodToBlockAppsDuringOffClockHours",
+        "managedBrowser",
+        "managedBrowserToOpenLinksRequired",
+        "maximumAllowedDeviceThreatLevel",
+        "maximumPinRetries",
+        "maximumRequiredOsVersion",
+        "maximumWarningOsVersion",
+        "maximumWipeOsVersion",
+        "minimumPinLength",
+        "minimumRequiredAppVersion",
+        "minimumRequiredOsVersion",
+        "minimumWarningAppVersion",
+        "minimumWarningOsVersion",
+        "minimumWipeAppVersion",
+        "minimumWipeOsVersion",
+        "mobileThreatDefensePartnerPriority",
+        "mobileThreatDefenseRemediationAction",
+        "notificationRestriction",
+        "organizationalCredentialsRequired",
+        "periodBeforePinReset",
+        "periodOfflineBeforeAccessCheck",
+        "periodOfflineBeforeWipeIsEnforced",
+        "periodOnlineBeforeAccessCheck",
+        "pinCharacterSet",
+        "pinRequired",
+        "pinRequiredInsteadOfBiometricTimeout",
+        "previousPinBlockCount",
+        "printBlocked",
+        "protectedMessagingRedirectAppType",
+        "saveAsBlocked",
+        "simplePinBlocked"
+      ]
+    },
+    "managedAppProtectionPolicySetItem": {
+      "navigationProperties": [],
+      "properties": [
+        "targetedAppManagementLevels"
+      ]
+    },
+    "managedAppRegistration": {
+      "navigationProperties": [
+        "appliedPolicies",
+        "intendedPolicies",
+        "managedAppLogCollectionRequests",
+        "operations"
+      ],
+      "properties": [
+        "appIdentifier",
+        "applicationVersion",
+        "azureADDeviceId",
+        "createdDateTime",
+        "deviceManufacturer",
+        "deviceModel",
+        "deviceName",
+        "deviceTag",
+        "deviceType",
+        "flaggedReasons",
+        "lastSyncDateTime",
+        "managedDeviceId",
+        "managementSdkVersion",
+        "platformVersion",
+        "userId",
+        "version"
+      ]
+    },
+    "managedAppStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "version"
+      ]
+    },
+    "managedAppStatusRaw": {
+      "navigationProperties": [],
+      "properties": [
+        "content"
+      ]
+    },
+    "managedDevice": {
+      "navigationProperties": [
+        "assignmentFilterEvaluationStatusDetails",
+        "detectedApps",
+        "deviceCategory",
+        "deviceCompliancePolicyStates",
+        "deviceConfigurationStates",
+        "deviceHealthScriptStates",
+        "logCollectionRequests",
+        "managedDeviceMobileAppConfigurationStates",
+        "securityBaselineStates",
+        "users",
+        "windowsProtectionState"
+      ],
+      "properties": [
+        "aadRegistered",
+        "activationLockBypassCode",
+        "androidSecurityPatchLevel",
+        "autopilotEnrolled",
+        "azureActiveDirectoryDeviceId",
+        "azureADDeviceId",
+        "azureADRegistered",
+        "bootstrapTokenEscrowed",
+        "chassisType",
+        "chromeOSDeviceInfo",
+        "cloudPcRemoteActionResults",
+        "complianceGracePeriodExpirationDateTime",
+        "complianceState",
+        "configurationManagerClientEnabledFeatures",
+        "configurationManagerClientHealthState",
+        "configurationManagerClientInformation",
+        "deviceActionResults",
+        "deviceCategoryDisplayName",
+        "deviceEnrollmentType",
+        "deviceFirmwareConfigurationInterfaceManaged",
+        "deviceHealthAttestationState",
+        "deviceName",
+        "deviceRegistrationState",
+        "deviceType",
+        "easActivated",
+        "easActivationDateTime",
+        "easDeviceId",
+        "emailAddress",
+        "enrolledByUserPrincipalName",
+        "enrolledDateTime",
+        "enrollmentProfileName",
+        "ethernetMacAddress",
+        "exchangeAccessState",
+        "exchangeAccessStateReason",
+        "exchangeLastSuccessfulSyncDateTime",
+        "freeStorageSpaceInBytes",
+        "hardwareInformation",
+        "iccid",
+        "imei",
+        "isEncrypted",
+        "isSupervised",
+        "jailBroken",
+        "joinType",
+        "lastSyncDateTime",
+        "lostModeState",
+        "managedDeviceName",
+        "managedDeviceOwnerType",
+        "managementAgent",
+        "managementCertificateExpirationDate",
+        "managementFeatures",
+        "managementState",
+        "manufacturer",
+        "meid",
+        "model",
+        "notes",
+        "operatingSystem",
+        "osVersion",
+        "ownerType",
+        "partnerReportedThreatState",
+        "phoneNumber",
+        "physicalMemoryInBytes",
+        "preferMdmOverGroupPolicyAppliedDateTime",
+        "processorArchitecture",
+        "remoteAssistanceSessionErrorDetails",
+        "remoteAssistanceSessionUrl",
+        "requireUserEnrollmentApproval",
+        "retireAfterDateTime",
+        "roleScopeTagIds",
+        "securityPatchLevel",
+        "serialNumber",
+        "skuFamily",
+        "skuNumber",
+        "specificationVersion",
+        "subscriberCarrier",
+        "totalStorageSpaceInBytes",
+        "udid",
+        "userDisplayName",
+        "userId",
+        "userPrincipalName",
+        "usersLoggedOn",
+        "wiFiMacAddress",
+        "windowsActiveMalwareCount",
+        "windowsRemediatedMalwareCount"
+      ]
+    },
+    "managedDeviceCertificateState": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateEnhancedKeyUsage",
+        "certificateErrorCode",
+        "certificateExpirationDateTime",
+        "certificateIssuanceDateTime",
+        "certificateIssuanceState",
+        "certificateIssuer",
+        "certificateKeyLength",
+        "certificateKeyStorageProvider",
+        "certificateKeyUsage",
+        "certificateLastIssuanceStateChangedDateTime",
+        "certificateProfileDisplayName",
+        "certificateRevokeStatus",
+        "certificateSerialNumber",
+        "certificateSubjectAlternativeNameFormat",
+        "certificateSubjectAlternativeNameFormatString",
+        "certificateSubjectNameFormat",
+        "certificateSubjectNameFormatString",
+        "certificateThumbprint",
+        "certificateValidityPeriod",
+        "certificateValidityPeriodUnits",
+        "deviceDisplayName",
+        "devicePlatform",
+        "lastCertificateStateChangeDateTime",
+        "userDisplayName"
+      ]
+    },
+    "managedDeviceCleanupRule": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "deviceCleanupRulePlatformType",
+        "deviceInactivityBeforeRetirementInDays",
+        "displayName",
+        "lastModifiedDateTime"
+      ]
+    },
+    "managedDeviceEncryptionState": {
+      "navigationProperties": [],
+      "properties": [
+        "advancedBitLockerStates",
+        "deviceName",
+        "deviceType",
+        "encryptionPolicySettingState",
+        "encryptionReadinessState",
+        "encryptionState",
+        "fileVaultStates",
+        "osVersion",
+        "policyDetails",
+        "tpmSpecificationVersion",
+        "userPrincipalName"
+      ]
+    },
+    "managedDeviceMobileAppConfiguration": {
+      "navigationProperties": [
+        "assignments",
+        "deviceStatuses",
+        "deviceStatusSummary",
+        "userStatuses",
+        "userStatusSummary"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "roleScopeTagIds",
+        "targetedMobileApps",
+        "version"
+      ]
+    },
+    "managedDeviceMobileAppConfigurationAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "managedDeviceMobileAppConfigurationDeviceStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceGracePeriodExpirationDateTime",
+        "deviceDisplayName",
+        "deviceModel",
+        "lastReportedDateTime",
+        "platform",
+        "status",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "managedDeviceMobileAppConfigurationDeviceSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationVersion",
+        "conflictCount",
+        "errorCount",
+        "failedCount",
+        "lastUpdateDateTime",
+        "notApplicableCount",
+        "notApplicablePlatformCount",
+        "pendingCount",
+        "successCount"
+      ]
+    },
+    "managedDeviceMobileAppConfigurationPolicySetItem": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "managedDeviceMobileAppConfigurationState": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "platformType",
+        "settingCount",
+        "settingStates",
+        "state",
+        "userId",
+        "userPrincipalName",
+        "version"
+      ]
+    },
+    "managedDeviceMobileAppConfigurationUserStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "devicesCount",
+        "lastReportedDateTime",
+        "status",
+        "userDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "managedDeviceMobileAppConfigurationUserSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationVersion",
+        "conflictCount",
+        "errorCount",
+        "failedCount",
+        "lastUpdateDateTime",
+        "notApplicableCount",
+        "pendingCount",
+        "successCount"
+      ]
+    },
+    "managedDeviceOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceExchangeAccessStateSummary",
+        "deviceOperatingSystemSummary",
+        "dualEnrolledDeviceCount",
+        "enrolledDeviceCount",
+        "lastModifiedDateTime",
+        "managedDeviceModelsAndManufacturers",
+        "mdmEnrolledCount"
+      ]
+    },
+    "managedDeviceWindowsOperatingSystemImage": {
+      "navigationProperties": [],
+      "properties": [
+        "availableUpdates",
+        "supportedArchitectures",
+        "supportedEditions"
+      ]
+    },
+    "managedEBook": {
+      "navigationProperties": [
+        "assignments",
+        "categories",
+        "deviceStates",
+        "installSummary",
+        "userStateSummary"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "informationUrl",
+        "largeCover",
+        "lastModifiedDateTime",
+        "privacyInformationUrl",
+        "publishedDateTime",
+        "publisher"
+      ]
+    },
+    "managedEBookAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "installIntent",
+        "target"
+      ]
+    },
+    "managedEBookCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastModifiedDateTime"
+      ]
+    },
+    "managedIOSLobApp": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableDeviceType",
+        "buildNumber",
+        "bundleId",
+        "expirationDateTime",
+        "identityVersion",
+        "minimumSupportedOperatingSystem",
+        "versionNumber"
+      ]
+    },
+    "managedIOSStoreApp": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableDeviceType",
+        "appStoreUrl",
+        "bundleId",
+        "minimumSupportedOperatingSystem"
+      ]
+    },
+    "managedMobileApp": {
+      "navigationProperties": [],
+      "properties": [
+        "mobileAppIdentifier",
+        "version"
+      ]
+    },
+    "managedMobileLobApp": {
+      "navigationProperties": [
+        "contentVersions"
+      ],
+      "properties": [
+        "committedContentVersion",
+        "fileName",
+        "size"
+      ]
+    },
+    "mdmWindowsInformationProtectionPolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mdmWindowsInformationProtectionPolicyPolicySetItem": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "meetingActivityStatistics": {
+      "navigationProperties": [],
+      "properties": [
+        "afterHours",
+        "conflicting",
+        "long",
+        "multitasking",
+        "organized",
+        "recurring"
+      ]
+    },
+    "meetingAttendanceReport": {
+      "navigationProperties": [
+        "attendanceRecords"
+      ],
+      "properties": [
+        "externalEventInformation",
+        "meetingEndDateTime",
+        "meetingStartDateTime",
+        "totalParticipantCount"
+      ]
+    },
+    "meetingRegistrant": {
+      "navigationProperties": [],
+      "properties": [
+        "customQuestionAnswers",
+        "email",
+        "firstName",
+        "lastName",
+        "registrationDateTime",
+        "status"
+      ]
+    },
+    "meetingRegistrantBase": {
+      "navigationProperties": [],
+      "properties": [
+        "joinWebUrl"
+      ]
+    },
+    "meetingRegistration": {
+      "navigationProperties": [
+        "customQuestions"
+      ],
+      "properties": [
+        "description",
+        "endDateTime",
+        "registrationPageViewCount",
+        "registrationPageWebUrl",
+        "speakers",
+        "startDateTime",
+        "subject"
+      ]
+    },
+    "meetingRegistrationBase": {
+      "navigationProperties": [
+        "registrants"
+      ],
+      "properties": [
+        "allowedRegistrant"
+      ]
+    },
+    "meetingRegistrationQuestion": {
+      "navigationProperties": [],
+      "properties": [
+        "answerInputType",
+        "answerOptions",
+        "displayName",
+        "isRequired"
+      ]
+    },
+    "membershipOutlierInsight": {
+      "navigationProperties": [
+        "container",
+        "lastModifiedBy",
+        "member"
+      ],
+      "properties": [
+        "containerId",
+        "memberId",
+        "outlierContainerType",
+        "outlierMemberType"
+      ]
+    },
+    "mention": {
+      "navigationProperties": [],
+      "properties": [
+        "application",
+        "clientReference",
+        "createdBy",
+        "createdDateTime",
+        "deepLink",
+        "mentioned",
+        "mentionText",
+        "serverCreatedDateTime"
+      ]
+    },
+    "message": {
+      "navigationProperties": [
+        "attachments",
+        "extensions",
+        "mentions",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "bccRecipients",
+        "body",
+        "bodyPreview",
+        "ccRecipients",
+        "conversationId",
+        "conversationIndex",
+        "flag",
+        "from",
+        "hasAttachments",
+        "importance",
+        "inferenceClassification",
+        "internetMessageHeaders",
+        "internetMessageId",
+        "isDeliveryReceiptRequested",
+        "isDraft",
+        "isRead",
+        "isReadReceiptRequested",
+        "mentionsPreview",
+        "parentFolderId",
+        "receivedDateTime",
+        "replyTo",
+        "sender",
+        "sentDateTime",
+        "subject",
+        "toRecipients",
+        "uniqueBody",
+        "unsubscribeData",
+        "unsubscribeEnabled",
+        "webLink"
+      ]
+    },
+    "messageEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "dateTime",
+        "description",
+        "eventType"
+      ]
+    },
+    "messageRecipient": {
+      "navigationProperties": [
+        "events"
+      ],
+      "properties": [
+        "deliveryStatus",
+        "recipientEmail"
+      ]
+    },
+    "messageRule": {
+      "navigationProperties": [],
+      "properties": [
+        "actions",
+        "conditions",
+        "displayName",
+        "exceptions",
+        "hasError",
+        "isEnabled",
+        "isReadOnly",
+        "sequence"
+      ]
+    },
+    "messageTrace": {
+      "navigationProperties": [
+        "recipients"
+      ],
+      "properties": [
+        "destinationIPAddress",
+        "messageId",
+        "receivedDateTime",
+        "senderEmail",
+        "size",
+        "sourceIPAddress",
+        "subject"
+      ]
+    },
+    "messageTracingRoot": {
+      "navigationProperties": [
+        "messageTraces"
+      ],
+      "properties": []
+    },
+    "mfaCompletionMetric": {
+      "navigationProperties": [
+        "mfaFailures"
+      ],
+      "properties": [
+        "appId",
+        "attemptsCount",
+        "country",
+        "factDate",
+        "identityProvider",
+        "language",
+        "mfaMethod",
+        "os",
+        "successCount"
+      ]
+    },
+    "mfaFailure": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "reason",
+        "reasonCode"
+      ]
+    },
+    "mfaTelecomFraudMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "captchaFailureCount",
+        "captchaNotTriggeredUserCount",
+        "captchaShownUserCount",
+        "captchaSuccessCount",
+        "factDate",
+        "telecomBlockedUserCount"
+      ]
+    },
+    "mfaUserCountMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "factDate",
+        "mfaType"
+      ]
+    },
+    "microsoftAccountUserConversationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "userId"
+      ]
+    },
+    "microsoftApplicationDataAccessSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "disabledForGroup",
+        "isEnabledForAllMicrosoftApplications"
+      ]
+    },
+    "microsoftAuthenticatorAuthenticationMethod": {
+      "navigationProperties": [
+        "device"
+      ],
+      "properties": [
+        "clientAppName",
+        "deviceTag",
+        "displayName",
+        "phoneAppVersion"
+      ]
+    },
+    "microsoftAuthenticatorAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": [
+        "featureSettings",
+        "isSoftwareOathEnabled"
+      ]
+    },
+    "microsoftAuthenticatorAuthenticationMethodTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationMode"
+      ]
+    },
+    "microsoftStoreForBusinessApp": {
+      "navigationProperties": [
+        "containedApps"
+      ],
+      "properties": [
+        "licenseType",
+        "licensingType",
+        "packageIdentityName",
+        "productKey",
+        "totalLicenseCount",
+        "usedLicenseCount"
+      ]
+    },
+    "microsoftStoreForBusinessContainedApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appUserModelId"
+      ]
+    },
+    "microsoftTunnelConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "advancedSettings",
+        "defaultDomainSuffix",
+        "description",
+        "disableUdpConnections",
+        "displayName",
+        "dnsServers",
+        "ipv6Network",
+        "lastUpdateDateTime",
+        "listenPort",
+        "network",
+        "roleScopeTagIds",
+        "routeExcludes",
+        "routeIncludes",
+        "routesExclude",
+        "routesInclude",
+        "splitDNS"
+      ]
+    },
+    "microsoftTunnelHealthThreshold": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultHealthyThreshold",
+        "defaultUnhealthyThreshold",
+        "healthyThreshold",
+        "unhealthyThreshold"
+      ]
+    },
+    "microsoftTunnelServer": {
+      "navigationProperties": [],
+      "properties": [
+        "agentImageDigest",
+        "deploymentMode",
+        "displayName",
+        "lastCheckinDateTime",
+        "serverImageDigest",
+        "tunnelServerHealthStatus"
+      ]
+    },
+    "microsoftTunnelServerLogCollectionResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "expiryDateTime",
+        "requestDateTime",
+        "serverId",
+        "sizeInBytes",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "microsoftTunnelSite": {
+      "navigationProperties": [
+        "microsoftTunnelConfiguration",
+        "microsoftTunnelServers"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "internalNetworkProbeUrl",
+        "publicAddress",
+        "roleScopeTagIds",
+        "upgradeAutomatically",
+        "upgradeAvailable",
+        "upgradeWindowEndTime",
+        "upgradeWindowStartTime",
+        "upgradeWindowUtcOffsetInMinutes"
+      ]
+    },
+    "migrationsRoot": {
+      "navigationProperties": [
+        "crossTenantMigrationJobs"
+      ],
+      "properties": []
+    },
+    "mobileApp": {
+      "navigationProperties": [
+        "assignments",
+        "categories",
+        "relationships"
+      ],
+      "properties": [
+        "createdDateTime",
+        "dependentAppCount",
+        "description",
+        "developer",
+        "displayName",
+        "informationUrl",
+        "isAssigned",
+        "isFeatured",
+        "largeIcon",
+        "lastModifiedDateTime",
+        "notes",
+        "owner",
+        "privacyInformationUrl",
+        "publisher",
+        "publishingState",
+        "roleScopeTagIds",
+        "supersededAppCount",
+        "supersedingAppCount",
+        "uploadState"
+      ]
+    },
+    "mobileAppAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "intent",
+        "settings",
+        "source",
+        "sourceId",
+        "target"
+      ]
+    },
+    "mobileAppCatalogPackage": {
+      "navigationProperties": [],
+      "properties": [
+        "productDescription",
+        "productDisplayName",
+        "productId",
+        "publisherDisplayName",
+        "versionDisplayName"
+      ]
+    },
+    "mobileAppCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastModifiedDateTime"
+      ]
+    },
+    "mobileAppContent": {
+      "navigationProperties": [
+        "containedApps",
+        "files",
+        "scripts"
+      ],
+      "properties": []
+    },
+    "mobileAppContentFile": {
+      "navigationProperties": [],
+      "properties": [
+        "azureStorageUri",
+        "azureStorageUriExpirationDateTime",
+        "createdDateTime",
+        "isCommitted",
+        "isDependency",
+        "isFrameworkFile",
+        "manifest",
+        "name",
+        "size",
+        "sizeEncrypted",
+        "uploadState"
+      ]
+    },
+    "mobileAppContentScript": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "displayName",
+        "state"
+      ]
+    },
+    "mobileAppDependency": {
+      "navigationProperties": [],
+      "properties": [
+        "dependencyType",
+        "dependentAppCount",
+        "dependsOnAppCount"
+      ]
+    },
+    "mobileAppInstallStatus": {
+      "navigationProperties": [
+        "app"
+      ],
+      "properties": [
+        "deviceId",
+        "deviceName",
+        "displayVersion",
+        "errorCode",
+        "installState",
+        "installStateDetail",
+        "lastSyncDateTime",
+        "mobileAppInstallStatusValue",
+        "osDescription",
+        "osVersion",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "mobileAppInstallSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedDeviceCount",
+        "failedUserCount",
+        "installedDeviceCount",
+        "installedUserCount",
+        "notApplicableDeviceCount",
+        "notApplicableUserCount",
+        "notInstalledDeviceCount",
+        "notInstalledUserCount",
+        "pendingInstallDeviceCount",
+        "pendingInstallUserCount"
+      ]
+    },
+    "mobileAppIntentAndState": {
+      "navigationProperties": [],
+      "properties": [
+        "managedDeviceIdentifier",
+        "mobileAppList",
+        "userId"
+      ]
+    },
+    "mobileAppManagementPolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mobileAppPolicySetItem": {
+      "navigationProperties": [],
+      "properties": [
+        "intent",
+        "settings"
+      ]
+    },
+    "mobileAppProvisioningConfigGroupAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "targetGroupId"
+      ]
+    },
+    "mobileAppRelationship": {
+      "navigationProperties": [],
+      "properties": [
+        "sourceDisplayName",
+        "sourceDisplayVersion",
+        "sourceId",
+        "sourcePublisherDisplayName",
+        "targetDisplayName",
+        "targetDisplayVersion",
+        "targetId",
+        "targetPublisher",
+        "targetPublisherDisplayName",
+        "targetType"
+      ]
+    },
+    "mobileAppSupersedence": {
+      "navigationProperties": [],
+      "properties": [
+        "supersededAppCount",
+        "supersedenceType",
+        "supersedingAppCount"
+      ]
+    },
+    "mobileAppTroubleshootingEvent": {
+      "navigationProperties": [
+        "appLogCollectionRequests"
+      ],
+      "properties": [
+        "applicationId",
+        "deviceId",
+        "history",
+        "managedDeviceIdentifier",
+        "userId"
+      ]
+    },
+    "mobileContainedApp": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mobileDeviceManagementPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "isMdmEnrollmentDuringRegistrationDisabled"
+      ]
+    },
+    "mobileLobApp": {
+      "navigationProperties": [
+        "contentVersions"
+      ],
+      "properties": [
+        "committedContentVersion",
+        "fileName",
+        "size"
+      ]
+    },
+    "mobileThreatDefenseConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "allowPartnerToCollectIOSApplicationMetadata",
+        "allowPartnerToCollectIosCertificateMetadata",
+        "allowPartnerToCollectIOSPersonalApplicationMetadata",
+        "allowPartnerToCollectIosPersonalCertificateMetadata",
+        "androidDeviceBlockedOnMissingPartnerData",
+        "androidEnabled",
+        "androidMobileApplicationManagementEnabled",
+        "iosDeviceBlockedOnMissingPartnerData",
+        "iosEnabled",
+        "iosMobileApplicationManagementEnabled",
+        "lastHeartbeatDateTime",
+        "macDeviceBlockedOnMissingPartnerData",
+        "macEnabled",
+        "microsoftDefenderForEndpointAttachEnabled",
+        "partnerState",
+        "partnerUnresponsivenessThresholdInDays",
+        "partnerUnsupportedOsVersionBlocked",
+        "windowsDeviceBlockedOnMissingPartnerData",
+        "windowsEnabled",
+        "windowsMobileApplicationManagementEnabled"
+      ]
+    },
+    "mobilityManagementPolicy": {
+      "navigationProperties": [
+        "includedGroups"
+      ],
+      "properties": [
+        "appliesTo",
+        "complianceUrl",
+        "description",
+        "discoveryUrl",
+        "displayName",
+        "isValid",
+        "termsOfUseUrl"
+      ]
+    },
+    "monthlyInactiveUsersByApplicationMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "inactiveCalendarMonthCount"
+      ]
+    },
+    "monthlyInactiveUsersMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "inactiveCalendarMonthCount"
+      ]
+    },
+    "monthlyUserInsightMetricsRoot": {
+      "navigationProperties": [
+        "activeUsers",
+        "authentications",
+        "inactiveUsers",
+        "inactiveUsersByApplication",
+        "mfaCompletions",
+        "mfaRegisteredUsers",
+        "requests",
+        "signUps",
+        "summary"
+      ],
+      "properties": []
+    },
+    "multiActivitySubscription": {
+      "navigationProperties": [],
+      "properties": [
+        "activities",
+        "callbackUrl",
+        "chatInfo",
+        "meetingInfo",
+        "userId"
+      ]
+    },
+    "multiTenantOrganization": {
+      "navigationProperties": [
+        "joinRequest",
+        "tenants"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "state"
+      ]
+    },
+    "multiTenantOrganizationIdentitySyncPolicyTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "templateApplicationLevel",
+        "userSyncInbound"
+      ]
+    },
+    "multiTenantOrganizationJoinRequestRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "addedByTenantId",
+        "memberState",
+        "role",
+        "transitionDetails"
+      ]
+    },
+    "multiTenantOrganizationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "addedByTenantId",
+        "addedDateTime",
+        "displayName",
+        "joinedDateTime",
+        "role",
+        "state",
+        "tenantId",
+        "transitionDetails"
+      ]
+    },
+    "multiTenantOrganizationPartnerConfigurationTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "automaticUserConsentSettings",
+        "b2bCollaborationInbound",
+        "b2bCollaborationOutbound",
+        "b2bDirectConnectInbound",
+        "b2bDirectConnectOutbound",
+        "inboundTrust",
+        "templateApplicationLevel"
+      ]
+    },
+    "multiValueLegacyExtendedProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "muteParticipantOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "muteParticipantsOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "participants"
+      ]
+    },
+    "mutualTlsOauthConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "tlsClientAuthParameter"
+      ]
+    },
+    "namedLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "id",
+        "modifiedDateTime"
+      ]
+    },
+    "namePronunciationSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabledInOrganization"
+      ]
+    },
+    "ndesConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "connectorVersion",
+        "displayName",
+        "enrolledDateTime",
+        "lastConnectionDateTime",
+        "machineName",
+        "roleScopeTagIds",
+        "state"
+      ]
+    },
+    "network": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "newsLinkPage": {
+      "navigationProperties": [],
+      "properties": [
+        "bannerImageWebUrl",
+        "newsSharepointIds",
+        "newsWebUrl"
+      ]
+    },
+    "noMfaOnRoleActivationAlertConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "noMfaOnRoleActivationAlertIncident": {
+      "navigationProperties": [],
+      "properties": [
+        "roleDisplayName",
+        "roleTemplateId"
+      ]
+    },
+    "note": {
+      "navigationProperties": [
+        "attachments",
+        "extensions",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "body",
+        "bodyPreview",
+        "hasAttachments",
+        "isDeleted",
+        "subject"
+      ]
+    },
+    "notebook": {
+      "navigationProperties": [
+        "sectionGroups",
+        "sections"
+      ],
+      "properties": [
+        "isDefault",
+        "isShared",
+        "links",
+        "sectionGroupsUrl",
+        "sectionsUrl",
+        "userRole"
+      ]
+    },
+    "notification": {
+      "navigationProperties": [],
+      "properties": [
+        "displayTimeToLive",
+        "expirationDateTime",
+        "groupName",
+        "payload",
+        "priority",
+        "targetHostName",
+        "targetPolicy"
+      ]
+    },
+    "notificationMessageTemplate": {
+      "navigationProperties": [
+        "localizedNotificationMessages"
+      ],
+      "properties": [
+        "brandingOptions",
+        "defaultLocale",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "roleScopeTagIds"
+      ]
+    },
+    "oAuth2PermissionGrant": {
+      "navigationProperties": [],
+      "properties": [
+        "clientId",
+        "consentType",
+        "expiryTime",
+        "principalId",
+        "resourceId",
+        "scope",
+        "startTime"
+      ]
+    },
+    "offboardingActivityLog": {
+      "navigationProperties": [],
+      "properties": [
+        "offboardingDetails",
+        "policyId",
+        "policyName",
+        "policyStatus"
+      ]
+    },
+    "offerShiftRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "recipientActionDateTime",
+        "recipientActionMessage",
+        "recipientUserId",
+        "senderShiftId"
+      ]
+    },
+    "office365ActiveUserCounts": {
+      "navigationProperties": [],
+      "properties": [
+        "exchange",
+        "office365",
+        "oneDrive",
+        "reportDate",
+        "reportPeriod",
+        "reportRefreshDate",
+        "sharePoint",
+        "skypeForBusiness",
+        "teams",
+        "yammer"
+      ]
+    },
+    "office365ActiveUserDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedProducts",
+        "deletedDate",
+        "displayName",
+        "exchangeLastActivityDate",
+        "exchangeLicenseAssignDate",
+        "hasExchangeLicense",
+        "hasOneDriveLicense",
+        "hasSharePointLicense",
+        "hasSkypeForBusinessLicense",
+        "hasTeamsLicense",
+        "hasYammerLicense",
+        "isDeleted",
+        "oneDriveLastActivityDate",
+        "oneDriveLicenseAssignDate",
+        "reportRefreshDate",
+        "sharePointLastActivityDate",
+        "sharePointLicenseAssignDate",
+        "skypeForBusinessLastActivityDate",
+        "skypeForBusinessLicenseAssignDate",
+        "teamsLastActivityDate",
+        "teamsLicenseAssignDate",
+        "userPrincipalName",
+        "yammerLastActivityDate",
+        "yammerLicenseAssignDate"
+      ]
+    },
+    "office365GroupsActivityCounts": {
+      "navigationProperties": [],
+      "properties": [
+        "exchangeEmailsReceived",
+        "reportDate",
+        "reportPeriod",
+        "reportRefreshDate",
+        "teamsChannelMessages",
+        "teamsMeetingsOrganized",
+        "yammerMessagesLiked",
+        "yammerMessagesPosted",
+        "yammerMessagesRead"
+      ]
+    },
+    "office365GroupsActivityDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "exchangeMailboxStorageUsedInBytes",
+        "exchangeMailboxTotalItemCount",
+        "exchangeReceivedEmailCount",
+        "externalMemberCount",
+        "groupDisplayName",
+        "groupId",
+        "groupType",
+        "isDeleted",
+        "lastActivityDate",
+        "memberCount",
+        "ownerPrincipalName",
+        "reportPeriod",
+        "reportRefreshDate",
+        "sharePointActiveFileCount",
+        "sharePointSiteStorageUsedInBytes",
+        "sharePointTotalFileCount",
+        "teamsChannelMessagesCount",
+        "teamsMeetingsOrganizedCount",
+        "yammerLikedMessageCount",
+        "yammerPostedMessageCount",
+        "yammerReadMessageCount"
+      ]
+    },
+    "office365GroupsActivityFileCounts": {
+      "navigationProperties": [],
+      "properties": [
+        "active",
+        "reportDate",
+        "reportPeriod",
+        "reportRefreshDate",
+        "total"
+      ]
+    },
+    "office365GroupsActivityGroupCounts": {
+      "navigationProperties": [],
+      "properties": [
+        "active",
+        "reportDate",
+        "reportPeriod",
+        "reportRefreshDate",
+        "total"
+      ]
+    },
+    "office365GroupsActivityStorage": {
+      "navigationProperties": [],
+      "properties": [
+        "mailboxStorageUsedInBytes",
+        "reportDate",
+        "reportPeriod",
+        "reportRefreshDate",
+        "siteStorageUsedInBytes"
+      ]
+    },
+    "office365ServicesUserCounts": {
+      "navigationProperties": [],
+      "properties": [
+        "exchangeActive",
+        "exchangeInactive",
+        "office365Active",
+        "office365Inactive",
+        "oneDriveActive",
+        "oneDriveInactive",
+        "reportPeriod",
+        "reportRefreshDate",
+        "sharePointActive",
+        "sharePointInactive",
+        "skypeForBusinessActive",
+        "skypeForBusinessInactive",
+        "teamsActive",
+        "teamsInactive",
+        "yammerActive",
+        "yammerInactive"
+      ]
+    },
+    "officeGraphInsights": {
+      "navigationProperties": [
+        "shared",
+        "trending",
+        "used"
+      ],
+      "properties": []
+    },
+    "officeSuiteApp": {
+      "navigationProperties": [],
+      "properties": [
+        "autoAcceptEula",
+        "excludedApps",
+        "installProgressDisplayLevel",
+        "localesToInstall",
+        "officeConfigurationXml",
+        "officePlatformArchitecture",
+        "officeSuiteAppDefaultFileFormat",
+        "productIds",
+        "shouldUninstallOlderVersionsOfOffice",
+        "targetVersion",
+        "updateChannel",
+        "updateVersion",
+        "useSharedComputerActivation"
+      ]
+    },
+    "oidcIdentityProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "clientAuthentication",
+        "clientId",
+        "inboundClaimMapping",
+        "issuer",
+        "responseType",
+        "scope",
+        "wellKnownEndpoint"
+      ]
+    },
+    "onAttributeCollectionListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onAttributeCollectionStartCustomExtension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onAttributeCollectionStartListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onAttributeCollectionSubmitCustomExtension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onAttributeCollectionSubmitListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onAuthenticationMethodLoadStartListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "oneDriveForBusinessBrowseSession": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectId"
+      ]
+    },
+    "oneDriveForBusinessProtectionPolicy": {
+      "navigationProperties": [
+        "driveExclusionUnits",
+        "driveExclusionUnitsBulkAdditionJobs",
+        "driveInclusionRules",
+        "driveProtectionUnits",
+        "driveProtectionUnitsBulkAdditionJobs"
+      ],
+      "properties": []
+    },
+    "oneDriveForBusinessRestoreSession": {
+      "navigationProperties": [
+        "driveRestoreArtifacts",
+        "driveRestoreArtifactsBulkAdditionRequests",
+        "granularDriveRestoreArtifacts"
+      ],
+      "properties": []
+    },
+    "onEmailOtpSendListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onenote": {
+      "navigationProperties": [
+        "notebooks",
+        "operations",
+        "pages",
+        "resources",
+        "sectionGroups",
+        "sections"
+      ],
+      "properties": []
+    },
+    "onenoteEntityBaseModel": {
+      "navigationProperties": [],
+      "properties": [
+        "self"
+      ]
+    },
+    "onenoteEntityHierarchyModel": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "onenoteEntitySchemaObjectModel": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime"
+      ]
+    },
+    "onenoteOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "percentComplete",
+        "resourceId",
+        "resourceLocation"
+      ]
+    },
+    "onenotePage": {
+      "navigationProperties": [
+        "parentNotebook",
+        "parentSection"
+      ],
+      "properties": [
+        "content",
+        "contentUrl",
+        "createdByAppId",
+        "lastModifiedDateTime",
+        "level",
+        "links",
+        "order",
+        "title",
+        "userTags"
+      ]
+    },
+    "onenoteResource": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "contentUrl"
+      ]
+    },
+    "onenoteSection": {
+      "navigationProperties": [
+        "pages",
+        "parentNotebook",
+        "parentSectionGroup"
+      ],
+      "properties": [
+        "isDefault",
+        "links",
+        "pagesUrl"
+      ]
+    },
+    "onFraudProtectionLoadStartListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onInteractiveAuthFlowStartListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onlineMeeting": {
+      "navigationProperties": [
+        "aiInsights",
+        "meetingAttendanceReport",
+        "recordings",
+        "registration",
+        "transcripts"
+      ],
+      "properties": [
+        "alternativeRecording",
+        "attendeeReport",
+        "broadcastRecording",
+        "broadcastSettings",
+        "capabilities",
+        "creationDateTime",
+        "endDateTime",
+        "externalId",
+        "isBroadcast",
+        "joinUrl",
+        "meetingTemplateId",
+        "participants",
+        "recording",
+        "startDateTime"
+      ]
+    },
+    "onlineMeetingBase": {
+      "navigationProperties": [
+        "attendanceReports"
+      ],
+      "properties": [
+        "allowAttendeeToEnableCamera",
+        "allowAttendeeToEnableMic",
+        "allowBreakoutRooms",
+        "allowCopyingAndSharingMeetingContent",
+        "allowedLobbyAdmitters",
+        "allowedPresenters",
+        "allowLiveShare",
+        "allowMeetingChat",
+        "allowParticipantsToChangeName",
+        "allowPowerPointSharing",
+        "allowRecording",
+        "allowTeamworkReactions",
+        "allowTranscription",
+        "allowWhiteboard",
+        "anonymizeIdentityForRoles",
+        "audioConferencing",
+        "chatInfo",
+        "chatRestrictions",
+        "expiryDateTime",
+        "isEndToEndEncryptionEnabled",
+        "isEntryExitAnnounced",
+        "joinInformation",
+        "joinMeetingIdSettings",
+        "joinWebUrl",
+        "lobbyBypassSettings",
+        "meetingOptionsWebUrl",
+        "meetingSpokenLanguageTag",
+        "recordAutomatically",
+        "sensitivityLabelAssignment",
+        "shareMeetingChatHistoryDefault",
+        "subject",
+        "videoTeleconferenceId",
+        "watermarkProtection"
+      ]
+    },
+    "onlineMeetingEngagementConversation": {
+      "navigationProperties": [
+        "onlineMeeting"
+      ],
+      "properties": [
+        "moderationState",
+        "onlineMeetingId",
+        "organizer",
+        "upvoteCount"
+      ]
+    },
+    "onOtpSendCustomExtension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onPasswordSubmitCustomExtension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onPasswordSubmitListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onPhoneMethodLoadStartListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onPremAuthenticationPolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onPremisesAgent": {
+      "navigationProperties": [
+        "agentGroups"
+      ],
+      "properties": [
+        "externalIp",
+        "machineName",
+        "status",
+        "supportedPublishingTypes"
+      ]
+    },
+    "onPremisesAgentGroup": {
+      "navigationProperties": [
+        "agents",
+        "publishedResources"
+      ],
+      "properties": [
+        "displayName",
+        "isDefault",
+        "publishingType"
+      ]
+    },
+    "onPremisesConditionalAccessSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "enabled",
+        "excludedGroups",
+        "includedGroups",
+        "overrideDefaultRule"
+      ]
+    },
+    "onPremisesDirectorySynchronization": {
+      "navigationProperties": [],
+      "properties": [
+        "configuration",
+        "features"
+      ]
+    },
+    "onPremisesPublishingProfile": {
+      "navigationProperties": [
+        "agentGroups",
+        "agents",
+        "applicationSegments",
+        "connectorGroups",
+        "connectors",
+        "publishedResources",
+        "sensors"
+      ],
+      "properties": [
+        "hybridAgentUpdaterConfiguration",
+        "isDefaultAccessEnabled",
+        "isEnabled"
+      ]
+    },
+    "onPremisesSyncBehavior": {
+      "navigationProperties": [],
+      "properties": [
+        "isCloudManaged"
+      ]
+    },
+    "onTokenIssuanceStartCustomExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "claimsForTokenConfiguration"
+      ]
+    },
+    "onTokenIssuanceStartListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onUserCreateStartListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onVerifiedIdClaimValidationCustomExtension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onVerifiedIdClaimValidationListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "openAwsSecurityGroupFinding": {
+      "navigationProperties": [
+        "assignedComputeInstancesDetails",
+        "securityGroup"
+      ],
+      "properties": [
+        "inboundPorts",
+        "totalStorageBucketCount"
+      ]
+    },
+    "openIdConnectIdentityProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "claimsMapping",
+        "clientId",
+        "clientSecret",
+        "domainHint",
+        "metadataUrl",
+        "responseMode",
+        "responseType",
+        "scope"
+      ]
+    },
+    "openIdConnectProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "claimsMapping",
+        "domainHint",
+        "metadataUrl",
+        "responseMode",
+        "responseType",
+        "scope"
+      ]
+    },
+    "openNetworkAzureSecurityGroupFinding": {
+      "navigationProperties": [
+        "securityGroup",
+        "virtualMachines"
+      ],
+      "properties": [
+        "inboundPorts"
+      ]
+    },
+    "openShift": {
+      "navigationProperties": [],
+      "properties": [
+        "draftOpenShift",
+        "isStagedForDeletion",
+        "schedulingGroupId",
+        "schedulingGroupInfo",
+        "sharedOpenShift",
+        "teamInfo"
+      ]
+    },
+    "openShiftChangeRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "openShiftId"
+      ]
+    },
+    "openTypeExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "extensionName"
+      ]
+    },
+    "operation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastActionDateTime",
+        "status"
+      ]
+    },
+    "operationApprovalPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "approverGroupIds",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "policyPlatform",
+        "policySet",
+        "policyType"
+      ]
+    },
+    "operationApprovalRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalJustification",
+        "approver",
+        "expirationDateTime",
+        "lastModifiedDateTime",
+        "requestDateTime",
+        "requestJustification",
+        "requestor",
+        "requiredOperationApprovalPolicyTypes",
+        "status"
+      ]
+    },
+    "organization": {
+      "navigationProperties": [
+        "branding",
+        "certificateBasedAuthConfiguration",
+        "extensions",
+        "partnerInformation",
+        "settings"
+      ],
+      "properties": [
+        "assignedPlans",
+        "businessPhones",
+        "certificateConnectorSetting",
+        "city",
+        "country",
+        "countryLetterCode",
+        "createdDateTime",
+        "defaultUsageLocation",
+        "directorySizeQuota",
+        "displayName",
+        "isMultipleDataLocationsForServicesEnabled",
+        "marketingNotificationEmails",
+        "mobileDeviceManagementAuthority",
+        "onPremisesLastPasswordSyncDateTime",
+        "onPremisesLastSyncDateTime",
+        "onPremisesSyncEnabled",
+        "partnerTenantType",
+        "postalCode",
+        "preferredLanguage",
+        "privacyProfile",
+        "provisionedPlans",
+        "securityComplianceNotificationMails",
+        "securityComplianceNotificationPhones",
+        "state",
+        "street",
+        "technicalNotificationMails",
+        "tenantType",
+        "verifiedDomains"
+      ]
+    },
+    "organizationalBranding": {
+      "navigationProperties": [
+        "localizations",
+        "themes"
+      ],
+      "properties": []
+    },
+    "organizationalBrandingLocalization": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "organizationalBrandingProperties": {
+      "navigationProperties": [],
+      "properties": [
+        "backgroundColor",
+        "backgroundImage",
+        "backgroundImageRelativeUrl",
+        "bannerLogo",
+        "bannerLogoRelativeUrl",
+        "cdnList",
+        "contentCustomization",
+        "customAccountResetCredentialsUrl",
+        "customCannotAccessYourAccountText",
+        "customCannotAccessYourAccountUrl",
+        "customCSS",
+        "customCSSRelativeUrl",
+        "customForgotMyPasswordText",
+        "customPrivacyAndCookiesText",
+        "customPrivacyAndCookiesUrl",
+        "customResetItNowText",
+        "customTermsOfUseText",
+        "customTermsOfUseUrl",
+        "favicon",
+        "faviconRelativeUrl",
+        "headerBackgroundColor",
+        "headerLogo",
+        "headerLogoRelativeUrl",
+        "loginPageLayoutConfiguration",
+        "loginPageTextVisibilitySettings",
+        "signInPageText",
+        "squareLogo",
+        "squareLogoDark",
+        "squareLogoDarkRelativeUrl",
+        "squareLogoRelativeUrl",
+        "usernameHintText"
+      ]
+    },
+    "organizationalBrandingTheme": {
+      "navigationProperties": [
+        "localizations"
+      ],
+      "properties": [
+        "isDefaultTheme",
+        "name"
+      ]
+    },
+    "organizationalBrandingThemeLocalization": {
+      "navigationProperties": [],
+      "properties": [
+        "accountResetCredentials",
+        "backgroundImage",
+        "backgroundImageRelativeUrl",
+        "bannerLogo",
+        "bannerLogoRelativeUrl",
+        "cannotAccessYourAccount",
+        "cdnHosts",
+        "contentCustomization",
+        "customCSS",
+        "customCSSRelativeUrl",
+        "favicon",
+        "faviconRelativeUrl",
+        "forgotMyPassword",
+        "headerBackgroundColor",
+        "headerLogo",
+        "headerLogoRelativeUrl",
+        "locale",
+        "loginPageLayoutConfiguration",
+        "pageBackgroundColor",
+        "privacyAndCookies",
+        "resetItNow",
+        "signInPageText",
+        "squareLogo",
+        "squareLogoDark",
+        "squareLogoDarkRelativeUrl",
+        "squareLogoRelativeUrl",
+        "termsOfUse",
+        "usernameHintText"
+      ]
+    },
+    "organizationSettings": {
+      "navigationProperties": [
+        "contactInsights",
+        "itemInsights",
+        "microsoftApplicationDataAccess",
+        "peopleInsights"
+      ],
+      "properties": []
+    },
+    "orgContact": {
+      "navigationProperties": [
+        "directReports",
+        "manager",
+        "memberOf",
+        "onPremisesSyncBehavior",
+        "transitiveMemberOf",
+        "transitiveReports"
+      ],
+      "properties": [
+        "addresses",
+        "companyName",
+        "department",
+        "displayName",
+        "givenName",
+        "jobTitle",
+        "mail",
+        "mailNickname",
+        "onPremisesLastSyncDateTime",
+        "onPremisesProvisioningErrors",
+        "onPremisesSyncEnabled",
+        "phones",
+        "proxyAddresses",
+        "serviceProvisioningErrors",
+        "surname"
+      ]
+    },
+    "outboundSharedUserProfile": {
+      "navigationProperties": [
+        "tenants"
+      ],
+      "properties": [
+        "userId"
+      ]
+    },
+    "outlookCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "color",
+        "displayName"
+      ]
+    },
+    "outlookItem": {
+      "navigationProperties": [],
+      "properties": [
+        "categories",
+        "changeKey",
+        "createdDateTime",
+        "lastModifiedDateTime"
+      ]
+    },
+    "outlookTask": {
+      "navigationProperties": [
+        "attachments",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "assignedTo",
+        "body",
+        "completedDateTime",
+        "dueDateTime",
+        "hasAttachments",
+        "importance",
+        "isReminderOn",
+        "owner",
+        "parentFolderId",
+        "recurrence",
+        "reminderDateTime",
+        "sensitivity",
+        "startDateTime",
+        "status",
+        "subject"
+      ]
+    },
+    "outlookTaskFolder": {
+      "navigationProperties": [
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties",
+        "tasks"
+      ],
+      "properties": [
+        "changeKey",
+        "isDefaultFolder",
+        "name",
+        "parentGroupKey"
+      ]
+    },
+    "outlookTaskGroup": {
+      "navigationProperties": [
+        "taskFolders"
+      ],
+      "properties": [
+        "changeKey",
+        "groupKey",
+        "isDefaultGroup",
+        "name"
+      ]
+    },
+    "outlookUser": {
+      "navigationProperties": [
+        "masterCategories",
+        "taskFolders",
+        "taskGroups",
+        "tasks"
+      ],
+      "properties": []
+    },
+    "overprovisionedAwsResourceFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "overprovisionedAwsRoleFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "overprovisionedAzureServicePrincipalFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "overprovisionedGcpServiceAccountFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "overprovisionedServerlessFunctionFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "overprovisionedUserFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ownerlessGroupPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "emailInfo",
+        "enabledGroupIds",
+        "isEnabled",
+        "maxMembersToNotify",
+        "notificationDurationInWeeks",
+        "policyWebUrl",
+        "targetOwners"
+      ]
+    },
+    "pageTemplate": {
+      "navigationProperties": [
+        "canvasLayout",
+        "webParts"
+      ],
+      "properties": [
+        "titleArea"
+      ]
+    },
+    "participant": {
+      "navigationProperties": [],
+      "properties": [
+        "info",
+        "isIdentityAnonymized",
+        "isInLobby",
+        "isMuted",
+        "mediaStreams",
+        "metadata",
+        "preferredDisplayName",
+        "recordingInfo",
+        "removedState",
+        "restrictedExperience",
+        "rosterSequenceNumber"
+      ]
+    },
+    "participantJoiningNotification": {
+      "navigationProperties": [
+        "call"
+      ],
+      "properties": []
+    },
+    "participantLeftNotification": {
+      "navigationProperties": [
+        "call"
+      ],
+      "properties": [
+        "participantId"
+      ]
+    },
+    "partnerInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "commerceUrl",
+        "companyName",
+        "companyType",
+        "helpUrl",
+        "partnerTenantId",
+        "supportEmails",
+        "supportTelephones",
+        "supportUrl"
+      ]
+    },
+    "partners": {
+      "navigationProperties": [
+        "billing"
+      ],
+      "properties": []
+    },
+    "passkeyAuthenticationMethodTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedPasskeyProfiles"
+      ]
+    },
+    "passkeyProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "attestationEnforcement",
+        "keyRestrictions",
+        "name",
+        "passkeyTypes"
+      ]
+    },
+    "passwordAuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "password"
+      ]
+    },
+    "passwordlessMicrosoftAuthenticatorAuthenticationMethod": {
+      "navigationProperties": [
+        "device"
+      ],
+      "properties": [
+        "creationDateTime",
+        "displayName"
+      ]
+    },
+    "payload": {
+      "navigationProperties": [],
+      "properties": [
+        "brand",
+        "complexity",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "detail",
+        "displayName",
+        "industry",
+        "isAutomated",
+        "isControversial",
+        "isCurrentEvent",
+        "language",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "payloadTags",
+        "platform",
+        "predictedCompromiseRate",
+        "simulationAttackType",
+        "source",
+        "status",
+        "technique",
+        "theme"
+      ]
+    },
+    "payloadCompatibleAssignmentFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "payloadType"
+      ]
+    },
+    "payloadResponse": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "paymentMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "displayName",
+        "id",
+        "lastModifiedDateTime"
+      ]
+    },
+    "paymentTerm": {
+      "navigationProperties": [],
+      "properties": [
+        "calculateDiscountOnCreditMemos",
+        "code",
+        "discountDateCalculation",
+        "discountPercent",
+        "displayName",
+        "dueDateCalculation",
+        "id",
+        "lastModifiedDateTime"
+      ]
+    },
+    "pendingExternalUserProfile": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "peopleAdminSettings": {
+      "navigationProperties": [
+        "itemInsights",
+        "namePronunciation",
+        "photoUpdateSettings",
+        "profileCardProperties",
+        "profilePropertySettings",
+        "profileSources",
+        "pronouns"
+      ],
+      "properties": []
+    },
+    "permission": {
+      "navigationProperties": [],
+      "properties": [
+        "expirationDateTime",
+        "grantedTo",
+        "grantedToIdentities",
+        "grantedToIdentitiesV2",
+        "grantedToV2",
+        "hasPassword",
+        "inheritedFrom",
+        "invitation",
+        "link",
+        "roles",
+        "shareId"
+      ]
+    },
+    "permissionGrantConditionSet": {
+      "navigationProperties": [],
+      "properties": [
+        "certifiedClientApplicationsOnly",
+        "clientApplicationIds",
+        "clientApplicationPublisherIds",
+        "clientApplicationsFromVerifiedPublisherOnly",
+        "clientApplicationTenantIds",
+        "permissionClassification",
+        "permissions",
+        "permissionType",
+        "resourceApplication",
+        "scopeSensitivityLabels"
+      ]
+    },
+    "permissionGrantPolicy": {
+      "navigationProperties": [
+        "excludes",
+        "includes"
+      ],
+      "properties": [
+        "includeAllPreApprovedApplications",
+        "resourceScopeType"
+      ]
+    },
+    "permissionGrantPreApprovalPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "conditions"
+      ]
+    },
+    "permissionsAnalytics": {
+      "navigationProperties": [
+        "findings",
+        "permissionsCreepIndexDistributions"
+      ],
+      "properties": []
+    },
+    "permissionsAnalyticsAggregation": {
+      "navigationProperties": [
+        "aws",
+        "azure",
+        "gcp"
+      ],
+      "properties": []
+    },
+    "permissionsCreepIndexDistribution": {
+      "navigationProperties": [
+        "authorizationSystem"
+      ],
+      "properties": [
+        "createdDateTime",
+        "highRiskProfile",
+        "lowRiskProfile",
+        "mediumRiskProfile"
+      ]
+    },
+    "permissionsDefinitionAuthorizationSystemIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "externalId",
+        "identityType",
+        "source"
+      ]
+    },
+    "permissionsDefinitionAwsPolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "permissionsDefinitionAzureRole": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "permissionsDefinitionGcpRole": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "permissionsManagement": {
+      "navigationProperties": [
+        "permissionsRequestChanges",
+        "scheduledPermissionsApprovals",
+        "scheduledPermissionsRequests"
+      ],
+      "properties": []
+    },
+    "permissionsRequestChange": {
+      "navigationProperties": [],
+      "properties": [
+        "activeOccurrenceStatus",
+        "modificationDateTime",
+        "permissionsRequestId",
+        "statusDetail",
+        "ticketId"
+      ]
+    },
+    "person": {
+      "navigationProperties": [],
+      "properties": [
+        "birthday",
+        "companyName",
+        "department",
+        "displayName",
+        "emailAddresses",
+        "givenName",
+        "isFavorite",
+        "mailboxType",
+        "officeLocation",
+        "personNotes",
+        "personType",
+        "phones",
+        "postalAddresses",
+        "profession",
+        "sources",
+        "surname",
+        "title",
+        "userPrincipalName",
+        "websites",
+        "yomiCompany"
+      ]
+    },
+    "personAnnotation": {
+      "navigationProperties": [],
+      "properties": [
+        "detail",
+        "displayName",
+        "thumbnailUrl"
+      ]
+    },
+    "personAnnualEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "date",
+        "displayName",
+        "type"
+      ]
+    },
+    "personAward": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "issuedDate",
+        "issuingAuthority",
+        "thumbnailUrl",
+        "webUrl"
+      ]
+    },
+    "personCertification": {
+      "navigationProperties": [],
+      "properties": [
+        "certificationId",
+        "description",
+        "displayName",
+        "endDate",
+        "issuedDate",
+        "issuingAuthority",
+        "issuingCompany",
+        "startDate",
+        "thumbnailUrl",
+        "webUrl"
+      ]
+    },
+    "personExtension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "personInterest": {
+      "navigationProperties": [],
+      "properties": [
+        "categories",
+        "collaborationTags",
+        "description",
+        "displayName",
+        "thumbnailUrl",
+        "webUrl"
+      ]
+    },
+    "personName": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "first",
+        "initials",
+        "languageTag",
+        "last",
+        "maiden",
+        "middle",
+        "nickname",
+        "pronunciation",
+        "suffix",
+        "title"
+      ]
+    },
+    "personResponsibility": {
+      "navigationProperties": [],
+      "properties": [
+        "collaborationTags",
+        "description",
+        "displayName",
+        "thumbnailUrl",
+        "webUrl"
+      ]
+    },
+    "personWebsite": {
+      "navigationProperties": [],
+      "properties": [
+        "categories",
+        "description",
+        "displayName",
+        "thumbnailUrl",
+        "webUrl"
+      ]
+    },
+    "phoneAuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "phoneNumber",
+        "phoneType",
+        "smsSignInState"
+      ]
+    },
+    "phoneUserConversationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "phoneNumber"
+      ]
+    },
+    "photoUpdateSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedRoles"
+      ]
+    },
+    "picture": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "contentType",
+        "height",
+        "id",
+        "width"
+      ]
+    },
+    "pinnedChatMessageInfo": {
+      "navigationProperties": [
+        "message"
+      ],
+      "properties": []
+    },
+    "place": {
+      "navigationProperties": [
+        "checkIns",
+        "children"
+      ],
+      "properties": [
+        "address",
+        "displayName",
+        "geoCoordinates",
+        "isWheelChairAccessible",
+        "label",
+        "parentId",
+        "phone",
+        "tags"
+      ]
+    },
+    "placeOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "details",
+        "progress",
+        "status"
+      ]
+    },
+    "planner": {
+      "navigationProperties": [
+        "buckets",
+        "plans",
+        "rosters",
+        "tasks"
+      ],
+      "properties": []
+    },
+    "plannerAssignedToTaskBoardTaskFormat": {
+      "navigationProperties": [],
+      "properties": [
+        "orderHintsByAssignee",
+        "unassignedOrderHint"
+      ]
+    },
+    "plannerBucket": {
+      "navigationProperties": [
+        "tasks"
+      ],
+      "properties": [
+        "archivalInfo",
+        "creationSource",
+        "isArchived",
+        "name",
+        "orderHint",
+        "planId"
+      ]
+    },
+    "plannerBucketTaskBoardTaskFormat": {
+      "navigationProperties": [],
+      "properties": [
+        "orderHint"
+      ]
+    },
+    "plannerDelta": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerGroup": {
+      "navigationProperties": [
+        "plans"
+      ],
+      "properties": []
+    },
+    "plannerPlan": {
+      "navigationProperties": [
+        "buckets",
+        "details",
+        "tasks"
+      ],
+      "properties": [
+        "archivalInfo",
+        "container",
+        "contentSensitivityLabelAssignment",
+        "contexts",
+        "createdBy",
+        "createdDateTime",
+        "creationSource",
+        "isArchived",
+        "owner",
+        "sharedWithContainers",
+        "title"
+      ]
+    },
+    "plannerPlanConfiguration": {
+      "navigationProperties": [
+        "localizations"
+      ],
+      "properties": [
+        "buckets",
+        "createdBy",
+        "createdDateTime",
+        "defaultLanguage",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "plannerPlanConfigurationLocalization": {
+      "navigationProperties": [],
+      "properties": [
+        "buckets",
+        "languageTag",
+        "planTitle"
+      ]
+    },
+    "plannerPlanDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "categoryDescriptions",
+        "contextDetails",
+        "sharedWith"
+      ]
+    },
+    "plannerProgressTaskBoardTaskFormat": {
+      "navigationProperties": [],
+      "properties": [
+        "orderHint"
+      ]
+    },
+    "plannerRoster": {
+      "navigationProperties": [
+        "members",
+        "plans"
+      ],
+      "properties": [
+        "assignedSensitivityLabel"
+      ]
+    },
+    "plannerRosterMember": {
+      "navigationProperties": [],
+      "properties": [
+        "roles",
+        "tenantId",
+        "userId"
+      ]
+    },
+    "plannerTask": {
+      "navigationProperties": [
+        "assignedToTaskBoardFormat",
+        "bucketTaskBoardFormat",
+        "details",
+        "messages",
+        "progressTaskBoardFormat"
+      ],
+      "properties": [
+        "activeChecklistItemCount",
+        "appliedCategories",
+        "archivalInfo",
+        "assigneePriority",
+        "assignments",
+        "bucketId",
+        "checklistItemCount",
+        "completedBy",
+        "completedDateTime",
+        "conversationThreadId",
+        "createdBy",
+        "createdDateTime",
+        "creationSource",
+        "dueDateTime",
+        "hasChat",
+        "hasDescription",
+        "isArchived",
+        "isOnMyDay",
+        "isOnMyDayLastModifiedDate",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "orderHint",
+        "percentComplete",
+        "planId",
+        "previewType",
+        "priority",
+        "recurrence",
+        "referenceCount",
+        "specifiedCompletionRequirements",
+        "startDateTime",
+        "title"
+      ]
+    },
+    "plannerTaskChatMessage": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "createdBy",
+        "createdDateTime",
+        "deletedDateTime",
+        "editedDateTime",
+        "mentions",
+        "messageType",
+        "parentEntityId",
+        "reactions"
+      ]
+    },
+    "plannerTaskConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "editPolicy"
+      ]
+    },
+    "plannerTaskDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalAttachment",
+        "checklist",
+        "completionRequirements",
+        "description",
+        "forms",
+        "notes",
+        "previewType",
+        "references"
+      ]
+    },
+    "plannerUser": {
+      "navigationProperties": [
+        "all",
+        "favoritePlans",
+        "myDayTasks",
+        "plans",
+        "recentPlans",
+        "rosterPlans",
+        "tasks"
+      ],
+      "properties": [
+        "favoritePlanReferences",
+        "recentPlanReferences"
+      ]
+    },
+    "platformCredentialAuthenticationMethod": {
+      "navigationProperties": [
+        "device"
+      ],
+      "properties": [
+        "displayName",
+        "keyStrength",
+        "platform"
+      ]
+    },
+    "playPromptOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "completionReason"
+      ]
+    },
+    "policyBase": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName"
+      ]
+    },
+    "policyDeletableItem": {
+      "navigationProperties": [],
+      "properties": [
+        "deletedDateTime"
+      ]
+    },
+    "policyDeletableRoot": {
+      "navigationProperties": [
+        "crossTenantPartners",
+        "crossTenantSyncPolicyPartners"
+      ],
+      "properties": []
+    },
+    "policyFile": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "fileType",
+        "status",
+        "version"
+      ]
+    },
+    "policyRoot": {
+      "navigationProperties": [
+        "accessReviewPolicy",
+        "activityBasedTimeoutPolicies",
+        "adminConsentRequestPolicy",
+        "appManagementPolicies",
+        "authenticationFlowsPolicy",
+        "authenticationMethodsPolicy",
+        "authenticationStrengthPolicies",
+        "authorizationPolicy",
+        "b2bManagementPolicies",
+        "b2cAuthenticationMethodsPolicy",
+        "claimsMappingPolicies",
+        "conditionalAccessPolicies",
+        "crossTenantAccessPolicy",
+        "defaultAppManagementPolicy",
+        "deletedItems",
+        "deviceRegistrationPolicy",
+        "directoryRoleAccessReviewPolicy",
+        "externalIdentitiesPolicy",
+        "featureRolloutPolicies",
+        "federatedTokenValidationPolicy",
+        "homeRealmDiscoveryPolicies",
+        "identitySecurityDefaultsEnforcementPolicy",
+        "mobileAppManagementPolicies",
+        "mobileDeviceManagementPolicies",
+        "onPremAuthenticationPolicies",
+        "ownerlessGroupPolicy",
+        "permissionGrantPolicies",
+        "permissionGrantPreApprovalPolicies",
+        "roleManagementPolicies",
+        "roleManagementPolicyAssignments",
+        "servicePrincipalCreationPolicies",
+        "tokenIssuancePolicies",
+        "tokenLifetimePolicies"
+      ],
+      "properties": []
+    },
+    "policySet": {
+      "navigationProperties": [
+        "assignments",
+        "items"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "errorCode",
+        "guidedDeploymentTags",
+        "lastModifiedDateTime",
+        "roleScopeTags",
+        "status"
+      ]
+    },
+    "policySetAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedDateTime",
+        "target"
+      ]
+    },
+    "policySetItem": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "errorCode",
+        "guidedDeploymentTags",
+        "itemType",
+        "lastModifiedDateTime",
+        "payloadId",
+        "status"
+      ]
+    },
+    "policyTemplate": {
+      "navigationProperties": [
+        "multiTenantOrganizationIdentitySynchronization",
+        "multiTenantOrganizationPartnerConfiguration"
+      ],
+      "properties": []
+    },
+    "post": {
+      "navigationProperties": [
+        "attachments",
+        "extensions",
+        "inReplyTo",
+        "mentions",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "body",
+        "conversationId",
+        "conversationThreadId",
+        "from",
+        "hasAttachments",
+        "importance",
+        "newParticipants",
+        "receivedDateTime",
+        "sender"
+      ]
+    },
+    "presence": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "availability",
+        "outOfOfficeSettings",
+        "sequenceNumber",
+        "statusMessage",
+        "workLocation"
+      ]
+    },
+    "presentation": {
+      "navigationProperties": [
+        "comments"
+      ],
+      "properties": []
+    },
+    "print": {
+      "navigationProperties": [
+        "connectors",
+        "operations",
+        "printers",
+        "printerShares",
+        "services",
+        "shares",
+        "taskDefinitions"
+      ],
+      "properties": [
+        "settings"
+      ]
+    },
+    "printConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "appVersion",
+        "deviceHealth",
+        "displayName",
+        "fullyQualifiedDomainName",
+        "location",
+        "name",
+        "operatingSystem",
+        "registeredDateTime"
+      ]
+    },
+    "printDocument": {
+      "navigationProperties": [],
+      "properties": [
+        "configuration",
+        "contentType",
+        "displayName",
+        "downloadedDateTime",
+        "size",
+        "uploadedDateTime"
+      ]
+    },
+    "printer": {
+      "navigationProperties": [
+        "connectors",
+        "share",
+        "shares",
+        "taskTriggers"
+      ],
+      "properties": [
+        "acceptingJobs",
+        "hasPhysicalDevice",
+        "isShared",
+        "lastSeenDateTime",
+        "registeredDateTime"
+      ]
+    },
+    "printerBase": {
+      "navigationProperties": [
+        "jobs"
+      ],
+      "properties": [
+        "capabilities",
+        "defaults",
+        "displayName",
+        "isAcceptingJobs",
+        "location",
+        "manufacturer",
+        "model",
+        "name",
+        "status"
+      ]
+    },
+    "printerCreateOperation": {
+      "navigationProperties": [
+        "printer"
+      ],
+      "properties": [
+        "certificate"
+      ]
+    },
+    "printerShare": {
+      "navigationProperties": [
+        "allowedGroups",
+        "allowedUsers",
+        "printer"
+      ],
+      "properties": [
+        "allowAllUsers",
+        "createdDateTime",
+        "viewPoint"
+      ]
+    },
+    "printJob": {
+      "navigationProperties": [
+        "documents",
+        "tasks"
+      ],
+      "properties": [
+        "acknowledgedDateTime",
+        "completedDateTime",
+        "configuration",
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "errorCode",
+        "isFetchable",
+        "redirectedFrom",
+        "redirectedTo",
+        "status"
+      ]
+    },
+    "printOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "status"
+      ]
+    },
+    "printService": {
+      "navigationProperties": [
+        "endpoints"
+      ],
+      "properties": []
+    },
+    "printServiceEndpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "name",
+        "uri"
+      ]
+    },
+    "printTask": {
+      "navigationProperties": [
+        "definition",
+        "trigger"
+      ],
+      "properties": [
+        "parentUrl",
+        "status"
+      ]
+    },
+    "printTaskDefinition": {
+      "navigationProperties": [
+        "tasks"
+      ],
+      "properties": [
+        "createdBy",
+        "displayName"
+      ]
+    },
+    "printTaskTrigger": {
+      "navigationProperties": [
+        "definition"
+      ],
+      "properties": [
+        "event"
+      ]
+    },
+    "printUsage": {
+      "navigationProperties": [],
+      "properties": [
+        "blackAndWhitePageCount",
+        "colorPageCount",
+        "completedBlackAndWhiteJobCount",
+        "completedColorJobCount",
+        "completedJobCount",
+        "doubleSidedSheetCount",
+        "incompleteJobCount",
+        "mediaSheetCount",
+        "pageCount",
+        "singleSidedSheetCount",
+        "usageDate"
+      ]
+    },
+    "printUsageByPrinter": {
+      "navigationProperties": [],
+      "properties": [
+        "printerId",
+        "printerName"
+      ]
+    },
+    "printUsageByUser": {
+      "navigationProperties": [],
+      "properties": [
+        "userPrincipalName"
+      ]
+    },
+    "privacy": {
+      "navigationProperties": [
+        "subjectRightsRequests"
+      ],
+      "properties": []
+    },
+    "privateAccessSensor": {
+      "navigationProperties": [],
+      "properties": [
+        "externalIp",
+        "isAuditMode",
+        "isBreakglassEnabled",
+        "machineName",
+        "status",
+        "version"
+      ]
+    },
+    "privateLinkNamedLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "isTrusted",
+        "privateLinkResourcePolicyIds"
+      ]
+    },
+    "privilegedAccess": {
+      "navigationProperties": [
+        "resources",
+        "roleAssignmentRequests",
+        "roleAssignments",
+        "roleDefinitions",
+        "roleSettings"
+      ],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "privilegedAccessGroup": {
+      "navigationProperties": [
+        "assignmentApprovals",
+        "assignmentScheduleInstances",
+        "assignmentScheduleRequests",
+        "assignmentSchedules",
+        "eligibilityScheduleInstances",
+        "eligibilityScheduleRequests",
+        "eligibilitySchedules",
+        "resources"
+      ],
+      "properties": []
+    },
+    "privilegedAccessGroupAssignmentSchedule": {
+      "navigationProperties": [
+        "activatedUsing",
+        "group",
+        "principal"
+      ],
+      "properties": [
+        "accessId",
+        "assignmentType",
+        "groupId",
+        "memberType",
+        "principalId"
+      ]
+    },
+    "privilegedAccessGroupAssignmentScheduleInstance": {
+      "navigationProperties": [
+        "activatedUsing",
+        "group",
+        "principal"
+      ],
+      "properties": [
+        "accessId",
+        "assignmentScheduleId",
+        "assignmentType",
+        "groupId",
+        "memberType",
+        "principalId"
+      ]
+    },
+    "privilegedAccessGroupAssignmentScheduleRequest": {
+      "navigationProperties": [
+        "activatedUsing",
+        "group",
+        "principal",
+        "targetSchedule"
+      ],
+      "properties": [
+        "accessId",
+        "groupId",
+        "principalId",
+        "targetScheduleId"
+      ]
+    },
+    "privilegedAccessGroupEligibilitySchedule": {
+      "navigationProperties": [
+        "group",
+        "principal"
+      ],
+      "properties": [
+        "accessId",
+        "groupId",
+        "memberType",
+        "principalId"
+      ]
+    },
+    "privilegedAccessGroupEligibilityScheduleInstance": {
+      "navigationProperties": [
+        "group",
+        "principal"
+      ],
+      "properties": [
+        "accessId",
+        "eligibilityScheduleId",
+        "groupId",
+        "memberType",
+        "principalId"
+      ]
+    },
+    "privilegedAccessGroupEligibilityScheduleRequest": {
+      "navigationProperties": [
+        "group",
+        "principal",
+        "targetSchedule"
+      ],
+      "properties": [
+        "accessId",
+        "groupId",
+        "principalId",
+        "targetScheduleId"
+      ]
+    },
+    "privilegedAccessRoot": {
+      "navigationProperties": [
+        "group"
+      ],
+      "properties": []
+    },
+    "privilegedAccessSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "createdUsing",
+        "modifiedDateTime",
+        "scheduleInfo",
+        "status"
+      ]
+    },
+    "privilegedAccessScheduleInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "startDateTime"
+      ]
+    },
+    "privilegedAccessScheduleRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "isValidationOnly",
+        "justification",
+        "scheduleInfo",
+        "ticketInfo"
+      ]
+    },
+    "privilegedApproval": {
+      "navigationProperties": [
+        "request",
+        "roleInfo"
+      ],
+      "properties": [
+        "approvalDuration",
+        "approvalState",
+        "approvalType",
+        "approverReason",
+        "endDateTime",
+        "requestorReason",
+        "roleId",
+        "startDateTime",
+        "userId"
+      ]
+    },
+    "privilegedOperationEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformation",
+        "creationDateTime",
+        "expirationDateTime",
+        "referenceKey",
+        "referenceSystem",
+        "requestorId",
+        "requestorName",
+        "requestType",
+        "roleId",
+        "roleName",
+        "tenantId",
+        "userId",
+        "userMail",
+        "userName"
+      ]
+    },
+    "privilegedRole": {
+      "navigationProperties": [
+        "assignments",
+        "settings",
+        "summary"
+      ],
+      "properties": [
+        "name"
+      ]
+    },
+    "privilegedRoleAssignment": {
+      "navigationProperties": [
+        "roleInfo"
+      ],
+      "properties": [
+        "expirationDateTime",
+        "isElevated",
+        "resultMessage",
+        "roleId",
+        "userId"
+      ]
+    },
+    "privilegedRoleAssignmentRequest": {
+      "navigationProperties": [
+        "roleInfo"
+      ],
+      "properties": [
+        "assignmentState",
+        "duration",
+        "reason",
+        "requestedDateTime",
+        "roleId",
+        "schedule",
+        "status",
+        "ticketNumber",
+        "ticketSystem",
+        "type",
+        "userId"
+      ]
+    },
+    "privilegedRoleSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalOnElevation",
+        "approverIds",
+        "elevationDuration",
+        "isMfaOnElevationConfigurable",
+        "lastGlobalAdmin",
+        "maxElavationDuration",
+        "mfaOnElevation",
+        "minElevationDuration",
+        "notificationToUserOnElevation",
+        "ticketingInfoOnElevation"
+      ]
+    },
+    "privilegedRoleSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "elevatedCount",
+        "managedCount",
+        "mfaEnabled",
+        "status",
+        "usersCount"
+      ]
+    },
+    "privilegedSignupStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "isRegistered",
+        "status"
+      ]
+    },
+    "privilegeEscalation": {
+      "navigationProperties": [
+        "actions",
+        "resources"
+      ],
+      "properties": [
+        "description",
+        "displayName"
+      ]
+    },
+    "privilegeEscalationAwsResourceFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "privilegeEscalationAwsRoleFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "privilegeEscalationFinding": {
+      "navigationProperties": [
+        "identity",
+        "privilegeEscalationDetails"
+      ],
+      "properties": [
+        "identityDetails",
+        "permissionsCreepIndex"
+      ]
+    },
+    "privilegeEscalationGcpServiceAccountFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "privilegeEscalationUserFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "privilegeManagementElevation": {
+      "navigationProperties": [],
+      "properties": [
+        "certificatePayload",
+        "companyName",
+        "deviceId",
+        "deviceName",
+        "elevationType",
+        "eventDateTime",
+        "fileDescription",
+        "filePath",
+        "fileVersion",
+        "hash",
+        "internalName",
+        "justification",
+        "parentProcessName",
+        "policyId",
+        "policyName",
+        "processType",
+        "productName",
+        "result",
+        "ruleId",
+        "systemInitiatedElevation",
+        "upn",
+        "userType"
+      ]
+    },
+    "privilegeManagementElevationRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationDetail",
+        "deviceName",
+        "requestCreatedDateTime",
+        "requestedByUserId",
+        "requestedByUserPrincipalName",
+        "requestedOnDeviceId",
+        "requestExpiryDateTime",
+        "requestJustification",
+        "requestLastModifiedDateTime",
+        "reviewCompletedByUserId",
+        "reviewCompletedByUserPrincipalName",
+        "reviewCompletedDateTime",
+        "reviewerJustification",
+        "status"
+      ]
+    },
+    "profile": {
+      "navigationProperties": [
+        "account",
+        "addresses",
+        "anniversaries",
+        "awards",
+        "certifications",
+        "educationalActivities",
+        "emails",
+        "interests",
+        "languages",
+        "names",
+        "notes",
+        "patents",
+        "phones",
+        "positions",
+        "projects",
+        "publications",
+        "skills",
+        "webAccounts",
+        "websites"
+      ],
+      "properties": []
+    },
+    "profileCardProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "annotations",
+        "directoryPropertyName",
+        "isVisible"
+      ]
+    },
+    "profilePhoto": {
+      "navigationProperties": [],
+      "properties": [
+        "height",
+        "width"
+      ]
+    },
+    "profilePropertySetting": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "name",
+        "prioritizedSourceUrls"
+      ]
+    },
+    "profileSource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "kind",
+        "localizations",
+        "sourceId",
+        "webUrl"
+      ]
+    },
+    "program": {
+      "navigationProperties": [
+        "controls"
+      ],
+      "properties": [
+        "description",
+        "displayName"
+      ]
+    },
+    "programControl": {
+      "navigationProperties": [
+        "program"
+      ],
+      "properties": [
+        "controlId",
+        "controlTypeId",
+        "createdDateTime",
+        "displayName",
+        "owner",
+        "programId",
+        "resource",
+        "status"
+      ]
+    },
+    "programControlType": {
+      "navigationProperties": [],
+      "properties": [
+        "controlTypeGroupId",
+        "displayName"
+      ]
+    },
+    "projectParticipation": {
+      "navigationProperties": [],
+      "properties": [
+        "categories",
+        "client",
+        "collaborationTags",
+        "colleagues",
+        "detail",
+        "displayName",
+        "sponsors",
+        "thumbnailUrl"
+      ]
+    },
+    "pronounsSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabledInOrganization"
+      ]
+    },
+    "protectionPolicyBase": {
+      "navigationProperties": [],
+      "properties": [
+        "billingPolicyId",
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "isEnabled",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "offboardRequestedDateTime",
+        "protectionMode",
+        "protectionPolicyArtifactCount",
+        "retentionSettings",
+        "status"
+      ]
+    },
+    "protectionRuleBase": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "error",
+        "isAutoApplyEnabled",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "protectionUnitBase": {
+      "navigationProperties": [],
+      "properties": [
+        "backupRetentionPeriodInDays",
+        "billingPolicyId",
+        "createdBy",
+        "createdDateTime",
+        "error",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "offboardRequestedDateTime",
+        "policyId",
+        "protectionSources",
+        "status"
+      ]
+    },
+    "protectionUnitsBulkJobBase": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "error",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "providerTenantSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "azureTenantId",
+        "enabled",
+        "lastModifiedDateTime",
+        "provider",
+        "vendor"
+      ]
+    },
+    "provisioningObjectSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "activityDateTime",
+        "changeId",
+        "cycleId",
+        "durationInMilliseconds",
+        "initiatedBy",
+        "jobId",
+        "modifiedProperties",
+        "provisioningAction",
+        "provisioningStatusInfo",
+        "provisioningSteps",
+        "servicePrincipal",
+        "sourceIdentity",
+        "sourceSystem",
+        "statusInfo",
+        "targetIdentity",
+        "targetSystem",
+        "tenantId"
+      ]
+    },
+    "publicKeyInfrastructureRoot": {
+      "navigationProperties": [
+        "certificateBasedAuthConfigurations"
+      ],
+      "properties": []
+    },
+    "publishedResource": {
+      "navigationProperties": [
+        "agentGroups"
+      ],
+      "properties": [
+        "displayName",
+        "publishingType",
+        "resourceName"
+      ]
+    },
+    "purchaseInvoice": {
+      "navigationProperties": [
+        "currency",
+        "purchaseInvoiceLines",
+        "vendor"
+      ],
+      "properties": [
+        "buyFromAddress",
+        "currencyCode",
+        "currencyId",
+        "discountAmount",
+        "discountAppliedBeforeTax",
+        "dueDate",
+        "id",
+        "invoiceDate",
+        "lastModifiedDateTime",
+        "number",
+        "payToAddress",
+        "payToContact",
+        "payToName",
+        "payToVendorId",
+        "payToVendorNumber",
+        "pricesIncludeTax",
+        "shipToAddress",
+        "shipToContact",
+        "shipToName",
+        "status",
+        "totalAmountExcludingTax",
+        "totalAmountIncludingTax",
+        "totalTaxAmount",
+        "vendorId",
+        "vendorInvoiceNumber",
+        "vendorName",
+        "vendorNumber"
+      ]
+    },
+    "purchaseInvoiceLine": {
+      "navigationProperties": [
+        "account",
+        "item"
+      ],
+      "properties": [
+        "accountId",
+        "amountExcludingTax",
+        "amountIncludingTax",
+        "description",
+        "discountAmount",
+        "discountAppliedBeforeTax",
+        "discountPercent",
+        "documentId",
+        "expectedReceiptDate",
+        "invoiceDiscountAllocation",
+        "itemId",
+        "lineType",
+        "netAmount",
+        "netAmountIncludingTax",
+        "netTaxAmount",
+        "quantity",
+        "sequence",
+        "taxCode",
+        "taxPercent",
+        "totalTaxAmount",
+        "unitCost"
+      ]
+    },
+    "qrCode": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "expireDateTime",
+        "image",
+        "lastUsedDateTime",
+        "startDateTime"
+      ]
+    },
+    "qrCodePinAuthenticationMethod": {
+      "navigationProperties": [
+        "pin",
+        "standardQRCode",
+        "temporaryQRCode"
+      ],
+      "properties": []
+    },
+    "qrCodePinAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": [
+        "pinLength",
+        "standardQRCodeLifetimeInDays"
+      ]
+    },
+    "qrPin": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "createdDateTime",
+        "forceChangePinNextSignIn",
+        "updatedDateTime"
+      ]
+    },
+    "rbacApplication": {
+      "navigationProperties": [
+        "resourceNamespaces",
+        "roleAssignmentApprovals",
+        "roleAssignments",
+        "roleAssignmentScheduleInstances",
+        "roleAssignmentScheduleRequests",
+        "roleAssignmentSchedules",
+        "roleDefinitions",
+        "roleEligibilityScheduleInstances",
+        "roleEligibilityScheduleRequests",
+        "roleEligibilitySchedules",
+        "transitiveRoleAssignments"
+      ],
+      "properties": []
+    },
+    "rbacApplicationMultiple": {
+      "navigationProperties": [
+        "resourceNamespaces",
+        "roleAssignments",
+        "roleDefinitions"
+      ],
+      "properties": []
+    },
+    "readingAssignmentSubmission": {
+      "navigationProperties": [],
+      "properties": [
+        "accuracyScore",
+        "action",
+        "assignmentId",
+        "challengingWords",
+        "classId",
+        "insertions",
+        "mispronunciations",
+        "missedExclamationMarks",
+        "missedPeriods",
+        "missedQuestionMarks",
+        "missedShorts",
+        "monotoneScore",
+        "omissions",
+        "repetitions",
+        "selfCorrections",
+        "studentId",
+        "submissionDateTime",
+        "submissionId",
+        "unexpectedPauses",
+        "wordCount",
+        "wordsPerMinute"
+      ]
+    },
+    "readingCoachPassage": {
+      "navigationProperties": [],
+      "properties": [
+        "isReadingCompleted",
+        "languageTag",
+        "practicedAtDateTime",
+        "practiceWords",
+        "storyType",
+        "studentId",
+        "timeSpentReadingInSeconds",
+        "wordsAccuracyPercentage",
+        "wordsPerMinute"
+      ]
+    },
+    "realtimeActivityFeedRoot": {
+      "navigationProperties": [
+        "meetings",
+        "multiActivitySubscriptions"
+      ],
+      "properties": []
+    },
+    "realtimeActivityMeeting": {
+      "navigationProperties": [
+        "transcripts"
+      ],
+      "properties": []
+    },
+    "realTimeTranscript": {
+      "navigationProperties": [],
+      "properties": [
+        "payloads"
+      ]
+    },
+    "recommendation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "recommendationBase": {
+      "navigationProperties": [
+        "impactedResources"
+      ],
+      "properties": [
+        "actionSteps",
+        "benefits",
+        "category",
+        "createdDateTime",
+        "currentScore",
+        "displayName",
+        "featureAreas",
+        "impactStartDateTime",
+        "impactType",
+        "insights",
+        "lastCheckedDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "maxScore",
+        "postponeUntilDateTime",
+        "priority",
+        "recommendationType",
+        "releaseType",
+        "remediationImpact",
+        "requiredLicenses",
+        "status"
+      ]
+    },
+    "recommendationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isNotificationEnabled"
+      ]
+    },
+    "recordOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "completionReason",
+        "recordingAccessToken",
+        "recordingLocation"
+      ]
+    },
+    "recycleBin": {
+      "navigationProperties": [
+        "items"
+      ],
+      "properties": [
+        "settings"
+      ]
+    },
+    "recycleBinItem": {
+      "navigationProperties": [],
+      "properties": [
+        "deletedDateTime",
+        "deletedFromLocation",
+        "size"
+      ]
+    },
+    "redundantAssignmentAlertConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "duration"
+      ]
+    },
+    "redundantAssignmentAlertIncident": {
+      "navigationProperties": [],
+      "properties": [
+        "assigneeDisplayName",
+        "assigneeId",
+        "assigneeUserPrincipalName",
+        "lastActivationDateTime",
+        "roleDefinitionId",
+        "roleDisplayName",
+        "roleTemplateId"
+      ]
+    },
+    "referenceAttachment": {
+      "navigationProperties": [],
+      "properties": [
+        "isFolder",
+        "permission",
+        "previewUrl",
+        "providerType",
+        "sourceUrl",
+        "thumbnailUrl"
+      ]
+    },
+    "reflectCheckInResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "checkInId",
+        "checkInTitle",
+        "classId",
+        "createdDateTime",
+        "creatorId",
+        "isClosed",
+        "responderId",
+        "responseEmotion",
+        "responseFeedback",
+        "submitDateTime"
+      ]
+    },
+    "regionalAndLanguageSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "authoringLanguages",
+        "defaultDisplayLanguage",
+        "defaultRegionalFormat",
+        "defaultSpeechInputLanguage",
+        "defaultTranslationLanguage",
+        "regionalFormatOverrides",
+        "translationPreferences"
+      ]
+    },
+    "relyingPartyDetailedSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedSignInCount",
+        "migrationStatus",
+        "migrationValidationDetails",
+        "relyingPartyId",
+        "relyingPartyName",
+        "replyUrls",
+        "serviceId",
+        "signInSuccessRate",
+        "successfulSignInCount",
+        "totalSignInCount",
+        "uniqueUserCount"
+      ]
+    },
+    "remoteActionAudit": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "actionState",
+        "bulkDeviceActionId",
+        "deviceActionCategory",
+        "deviceDisplayName",
+        "deviceIMEI",
+        "deviceOwnerUserPrincipalName",
+        "initiatedByUserPrincipalName",
+        "managedDeviceId",
+        "requestDateTime",
+        "userName"
+      ]
+    },
+    "remoteAssistancePartner": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastConnectionDateTime",
+        "onboardingRequestExpiryDateTime",
+        "onboardingStatus",
+        "onboardingUrl"
+      ]
+    },
+    "remoteAssistanceSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowSessionsToUnenrolledDevices",
+        "blockChat",
+        "remoteAssistanceState"
+      ]
+    },
+    "remoteDesktopSecurityConfiguration": {
+      "navigationProperties": [
+        "approvedClientApps",
+        "targetDeviceGroups"
+      ],
+      "properties": [
+        "isRemoteDesktopProtocolEnabled"
+      ]
+    },
+    "reportRoot": {
+      "navigationProperties": [
+        "appCredentialSignInActivities",
+        "applicationSignInDetailedSummary",
+        "authenticationMethods",
+        "azureADPremiumLicenseInsight",
+        "credentialUserRegistrationDetails",
+        "dailyPrintUsage",
+        "dailyPrintUsageByPrinter",
+        "dailyPrintUsageByUser",
+        "dailyPrintUsageSummariesByPrinter",
+        "dailyPrintUsageSummariesByUser",
+        "healthMonitoring",
+        "monthlyPrintUsageByPrinter",
+        "monthlyPrintUsageByUser",
+        "monthlyPrintUsageSummariesByPrinter",
+        "monthlyPrintUsageSummariesByUser",
+        "partners",
+        "security",
+        "serviceActivity",
+        "servicePrincipalSignInActivities",
+        "sla",
+        "userCredentialUsageDetails",
+        "userInsights"
+      ],
+      "properties": []
+    },
+    "reportsRoot": {
+      "navigationProperties": [
+        "readingAssignmentSubmissions",
+        "readingCoachPassages",
+        "reflectCheckInResponses",
+        "speakerAssignmentSubmissions"
+      ],
+      "properties": []
+    },
+    "request": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalId",
+        "completedDateTime",
+        "createdBy",
+        "createdDateTime",
+        "customData",
+        "status"
+      ]
+    },
+    "resellerDelegatedAdminRelationship": {
+      "navigationProperties": [],
+      "properties": [
+        "indirectProviderTenantId",
+        "isPartnerConsentPending"
+      ]
+    },
+    "resourceOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "actionName",
+        "description",
+        "enabledForScopeValidation",
+        "resource",
+        "resourceName"
+      ]
+    },
+    "resourceSpecificPermissionGrant": {
+      "navigationProperties": [],
+      "properties": [
+        "clientAppId",
+        "clientId",
+        "permission",
+        "permissionType",
+        "resourceAppId"
+      ]
+    },
+    "restoreArtifactBase": {
+      "navigationProperties": [
+        "restorePoint"
+      ],
+      "properties": [
+        "completionDateTime",
+        "destinationType",
+        "error",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "restoreArtifactsBulkRequestBase": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "destinationType",
+        "displayName",
+        "error",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "protectionTimePeriod",
+        "protectionUnitIds",
+        "restorePointPreference",
+        "status",
+        "tags"
+      ]
+    },
+    "restorePoint": {
+      "navigationProperties": [
+        "protectionUnit"
+      ],
+      "properties": [
+        "expirationDateTime",
+        "protectionDateTime",
+        "tags"
+      ]
+    },
+    "restoreSessionBase": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "createdBy",
+        "createdDateTime",
+        "error",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "restoreJobType",
+        "restoreSessionArtifactCount",
+        "status"
+      ]
+    },
+    "restoreTaskActivityLog": {
+      "navigationProperties": [],
+      "properties": [
+        "destinationType",
+        "restoreArtifactDetails",
+        "restoreCompletionDateTime",
+        "restoreSessionId",
+        "restoreSessionStatus",
+        "tags"
+      ]
+    },
+    "restrictedAppsViolation": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceConfigurationId",
+        "deviceConfigurationName",
+        "deviceName",
+        "managedDeviceId",
+        "platformType",
+        "restrictedApps",
+        "restrictedAppsState",
+        "userId",
+        "userName"
+      ]
+    },
+    "richLongRunningOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "percentageComplete",
+        "resourceId",
+        "type"
+      ]
+    },
+    "riskDetection": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "activityDateTime",
+        "additionalInfo",
+        "correlationId",
+        "detectedDateTime",
+        "detectionTimingType",
+        "ipAddress",
+        "lastUpdatedDateTime",
+        "location",
+        "mitreTechniqueId",
+        "requestId",
+        "riskDetail",
+        "riskEventType",
+        "riskLevel",
+        "riskState",
+        "riskType",
+        "source",
+        "tokenIssuerType",
+        "userDisplayName",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "riskPreventionContainer": {
+      "navigationProperties": [
+        "fraudProtectionProviders",
+        "webApplicationFirewallProviders",
+        "webApplicationFirewallVerifications"
+      ],
+      "properties": []
+    },
+    "riskyAgent": {
+      "navigationProperties": [],
+      "properties": [
+        "agentDisplayName",
+        "blueprintId",
+        "identityType",
+        "isDeleted",
+        "isEnabled",
+        "isProcessing",
+        "riskDetail",
+        "riskLastModifiedDateTime",
+        "riskLevel",
+        "riskState"
+      ]
+    },
+    "riskyAgentIdentity": {
+      "navigationProperties": [
+        "agentIdentity"
+      ],
+      "properties": []
+    },
+    "riskyAgentIdentityBlueprintPrincipal": {
+      "navigationProperties": [
+        "agentIdentityBlueprintPrincipal"
+      ],
+      "properties": []
+    },
+    "riskyAgentUser": {
+      "navigationProperties": [
+        "agentUser"
+      ],
+      "properties": []
+    },
+    "riskyServicePrincipal": {
+      "navigationProperties": [
+        "history"
+      ],
+      "properties": [
+        "accountEnabled",
+        "appId",
+        "displayName",
+        "isEnabled",
+        "isProcessing",
+        "riskDetail",
+        "riskLastUpdatedDateTime",
+        "riskLevel",
+        "riskState",
+        "servicePrincipalType"
+      ]
+    },
+    "riskyServicePrincipalHistoryItem": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "initiatedBy",
+        "servicePrincipalId"
+      ]
+    },
+    "riskyUser": {
+      "navigationProperties": [
+        "history"
+      ],
+      "properties": [
+        "isDeleted",
+        "isProcessing",
+        "riskDetail",
+        "riskLastUpdatedDateTime",
+        "riskLevel",
+        "riskState",
+        "userDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "riskyUserHistoryItem": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "initiatedBy",
+        "userId"
+      ]
+    },
+    "roleAssignment": {
+      "navigationProperties": [
+        "roleDefinition"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "resourceScopes",
+        "scopeMembers",
+        "scopeType"
+      ]
+    },
+    "roleDefinition": {
+      "navigationProperties": [
+        "roleAssignments"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "isBuiltIn",
+        "isBuiltInRoleDefinition",
+        "permissions",
+        "rolePermissions",
+        "roleScopeTagIds"
+      ]
+    },
+    "roleManagement": {
+      "navigationProperties": [
+        "cloudPC",
+        "defender",
+        "deviceManagement",
+        "directory",
+        "enterpriseApps",
+        "entitlementManagement",
+        "exchange"
+      ],
+      "properties": []
+    },
+    "roleManagementAlert": {
+      "navigationProperties": [
+        "alertConfigurations",
+        "alertDefinitions",
+        "alerts",
+        "operations"
+      ],
+      "properties": []
+    },
+    "rolesAssignedOutsidePrivilegedIdentityManagementAlertConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "rolesAssignedOutsidePrivilegedIdentityManagementAlertIncident": {
+      "navigationProperties": [],
+      "properties": [
+        "assigneeDisplayName",
+        "assigneeId",
+        "assigneeUserPrincipalName",
+        "assignmentCreatedDateTime",
+        "roleDefinitionId",
+        "roleDisplayName",
+        "roleTemplateId"
+      ]
+    },
+    "roleScopeTag": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "isBuiltIn"
+      ]
+    },
+    "roleScopeTagAutoAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "room": {
+      "navigationProperties": [],
+      "properties": [
+        "audioDeviceName",
+        "bookingType",
+        "building",
+        "capacity",
+        "displayDeviceName",
+        "emailAddress",
+        "floorLabel",
+        "floorNumber",
+        "isTeamsEnabled",
+        "nickname",
+        "placeId",
+        "teamsEnabledState",
+        "videoDeviceName"
+      ]
+    },
+    "roomList": {
+      "navigationProperties": [
+        "rooms",
+        "workspaces"
+      ],
+      "properties": [
+        "emailAddress"
+      ]
+    },
+    "salesCreditMemo": {
+      "navigationProperties": [
+        "currency",
+        "customer",
+        "paymentTerm",
+        "salesCreditMemoLines"
+      ],
+      "properties": [
+        "billingPostalAddress",
+        "billToCustomerId",
+        "billToCustomerNumber",
+        "billToName",
+        "creditMemoDate",
+        "currencyCode",
+        "currencyId",
+        "customerId",
+        "customerName",
+        "customerNumber",
+        "discountAmount",
+        "discountAppliedBeforeTax",
+        "dueDate",
+        "email",
+        "externalDocumentNumber",
+        "id",
+        "invoiceId",
+        "invoiceNumber",
+        "lastModifiedDateTime",
+        "number",
+        "paymentTermsId",
+        "phoneNumber",
+        "pricesIncludeTax",
+        "salesperson",
+        "sellingPostalAddress",
+        "status",
+        "totalAmountExcludingTax",
+        "totalAmountIncludingTax",
+        "totalTaxAmount"
+      ]
+    },
+    "salesCreditMemoLine": {
+      "navigationProperties": [
+        "account",
+        "item"
+      ],
+      "properties": [
+        "accountId",
+        "amountExcludingTax",
+        "amountIncludingTax",
+        "description",
+        "discountAmount",
+        "discountAppliedBeforeTax",
+        "discountPercent",
+        "documentId",
+        "invoiceDiscountAllocation",
+        "itemId",
+        "lineType",
+        "netAmount",
+        "netAmountIncludingTax",
+        "netTaxAmount",
+        "quantity",
+        "sequence",
+        "shipmentDate",
+        "taxCode",
+        "taxPercent",
+        "totalTaxAmount",
+        "unitOfMeasureId",
+        "unitPrice"
+      ]
+    },
+    "salesInvoice": {
+      "navigationProperties": [
+        "currency",
+        "customer",
+        "paymentTerm",
+        "salesInvoiceLines",
+        "shipmentMethod"
+      ],
+      "properties": [
+        "billingPostalAddress",
+        "billToCustomerId",
+        "billToCustomerNumber",
+        "billToName",
+        "currencyCode",
+        "currencyId",
+        "customerId",
+        "customerName",
+        "customerNumber",
+        "customerPurchaseOrderReference",
+        "discountAmount",
+        "discountAppliedBeforeTax",
+        "dueDate",
+        "email",
+        "externalDocumentNumber",
+        "id",
+        "invoiceDate",
+        "lastModifiedDateTime",
+        "number",
+        "orderId",
+        "orderNumber",
+        "paymentTermsId",
+        "phoneNumber",
+        "pricesIncludeTax",
+        "salesperson",
+        "sellingPostalAddress",
+        "shipmentMethodId",
+        "shippingPostalAddress",
+        "shipToContact",
+        "shipToName",
+        "status",
+        "totalAmountExcludingTax",
+        "totalAmountIncludingTax",
+        "totalTaxAmount"
+      ]
+    },
+    "salesInvoiceLine": {
+      "navigationProperties": [
+        "account",
+        "item"
+      ],
+      "properties": [
+        "accountId",
+        "amountExcludingTax",
+        "amountIncludingTax",
+        "description",
+        "discountAmount",
+        "discountAppliedBeforeTax",
+        "discountPercent",
+        "documentId",
+        "invoiceDiscountAllocation",
+        "itemId",
+        "lineType",
+        "netAmount",
+        "netAmountIncludingTax",
+        "netTaxAmount",
+        "quantity",
+        "sequence",
+        "shipmentDate",
+        "taxCode",
+        "taxPercent",
+        "totalTaxAmount",
+        "unitOfMeasureId",
+        "unitPrice"
+      ]
+    },
+    "salesOrder": {
+      "navigationProperties": [
+        "currency",
+        "customer",
+        "paymentTerm",
+        "salesOrderLines"
+      ],
+      "properties": [
+        "billingPostalAddress",
+        "billToCustomerId",
+        "billToCustomerNumber",
+        "billToName",
+        "currencyCode",
+        "currencyId",
+        "customerId",
+        "customerName",
+        "customerNumber",
+        "discountAmount",
+        "discountAppliedBeforeTax",
+        "email",
+        "externalDocumentNumber",
+        "fullyShipped",
+        "id",
+        "lastModifiedDateTime",
+        "number",
+        "orderDate",
+        "partialShipping",
+        "paymentTermsId",
+        "phoneNumber",
+        "pricesIncludeTax",
+        "requestedDeliveryDate",
+        "salesperson",
+        "sellingPostalAddress",
+        "shippingPostalAddress",
+        "shipToContact",
+        "shipToName",
+        "status",
+        "totalAmountExcludingTax",
+        "totalAmountIncludingTax",
+        "totalTaxAmount"
+      ]
+    },
+    "salesOrderLine": {
+      "navigationProperties": [
+        "account",
+        "item"
+      ],
+      "properties": [
+        "accountId",
+        "amountExcludingTax",
+        "amountIncludingTax",
+        "description",
+        "discountAmount",
+        "discountAppliedBeforeTax",
+        "discountPercent",
+        "documentId",
+        "invoiceDiscountAllocation",
+        "invoicedQuantity",
+        "invoiceQuantity",
+        "itemId",
+        "lineType",
+        "netAmount",
+        "netAmountIncludingTax",
+        "netTaxAmount",
+        "quantity",
+        "sequence",
+        "shipmentDate",
+        "shippedQuantity",
+        "shipQuantity",
+        "taxCode",
+        "taxPercent",
+        "totalTaxAmount",
+        "unitOfMeasureId",
+        "unitPrice"
+      ]
+    },
+    "salesQuote": {
+      "navigationProperties": [
+        "currency",
+        "customer",
+        "paymentTerm",
+        "salesQuoteLines",
+        "shipmentMethod"
+      ],
+      "properties": [
+        "acceptedDate",
+        "billingPostalAddress",
+        "billToCustomerId",
+        "billToCustomerNumber",
+        "billToName",
+        "currencyCode",
+        "currencyId",
+        "customerId",
+        "customerName",
+        "customerNumber",
+        "discountAmount",
+        "documentDate",
+        "dueDate",
+        "email",
+        "externalDocumentNumber",
+        "id",
+        "lastModifiedDateTime",
+        "number",
+        "paymentTermsId",
+        "phoneNumber",
+        "salesperson",
+        "sellingPostalAddress",
+        "sentDate",
+        "shipmentMethodId",
+        "shippingPostalAddress",
+        "shipToContact",
+        "shipToName",
+        "status",
+        "totalAmountExcludingTax",
+        "totalAmountIncludingTax",
+        "totalTaxAmount",
+        "validUntilDate"
+      ]
+    },
+    "salesQuoteLine": {
+      "navigationProperties": [
+        "account",
+        "item"
+      ],
+      "properties": [
+        "accountId",
+        "amountExcludingTax",
+        "amountIncludingTax",
+        "description",
+        "discountAmount",
+        "discountAppliedBeforeTax",
+        "discountPercent",
+        "documentId",
+        "itemId",
+        "lineType",
+        "netAmount",
+        "netAmountIncludingTax",
+        "netTaxAmount",
+        "quantity",
+        "sequence",
+        "taxCode",
+        "taxPercent",
+        "totalTaxAmount",
+        "unitOfMeasureId",
+        "unitPrice"
+      ]
+    },
+    "samlOrWsFedExternalDomainFederation": {
+      "navigationProperties": [
+        "domains"
+      ],
+      "properties": []
+    },
+    "samlOrWsFedProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "issuerUri",
+        "metadataExchangeUri",
+        "passiveSignInUri",
+        "preferredAuthenticationProtocol",
+        "signingCertificate"
+      ]
+    },
+    "schedule": {
+      "navigationProperties": [
+        "dayNotes",
+        "offerShiftRequests",
+        "openShiftChangeRequests",
+        "openShifts",
+        "schedulingGroups",
+        "shifts",
+        "shiftsRoleDefinitions",
+        "swapShiftsChangeRequests",
+        "timeCards",
+        "timeOffReasons",
+        "timeOffRequests",
+        "timesOff"
+      ],
+      "properties": [
+        "activitiesIncludedWhenCopyingShiftsEnabled",
+        "enabled",
+        "isActivitiesIncludedWhenCopyingShiftsEnabled",
+        "isCrossLocationShiftRequestApprovalRequired",
+        "isCrossLocationShiftsEnabled",
+        "offerShiftRequestsEnabled",
+        "openShiftsEnabled",
+        "provisionStatus",
+        "provisionStatusCode",
+        "startDayOfWeek",
+        "swapShiftsRequestsEnabled",
+        "timeClockEnabled",
+        "timeClockSettings",
+        "timeOffRequestsEnabled",
+        "timeZone",
+        "workforceIntegrationIds"
+      ]
+    },
+    "scheduleChangeRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedTo",
+        "managerActionDateTime",
+        "managerActionMessage",
+        "managerUserId",
+        "senderDateTime",
+        "senderMessage",
+        "senderUserId",
+        "state"
+      ]
+    },
+    "scheduledPermissionsRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "createdDateTime",
+        "justification",
+        "notes",
+        "requestedPermissions",
+        "scheduleInfo",
+        "statusDetail",
+        "ticketInfo"
+      ]
+    },
+    "schedulingGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "displayName",
+        "isActive",
+        "userIds"
+      ]
+    },
+    "schema": {
+      "navigationProperties": [],
+      "properties": [
+        "baseType",
+        "properties"
+      ]
+    },
+    "schemaExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "owner",
+        "properties",
+        "status",
+        "targetTypes"
+      ]
+    },
+    "scopedRoleMembership": {
+      "navigationProperties": [],
+      "properties": [
+        "administrativeUnitId",
+        "roleId",
+        "roleMemberInfo"
+      ]
+    },
+    "searchEntity": {
+      "navigationProperties": [
+        "acronyms",
+        "bookmarks",
+        "qnas"
+      ],
+      "properties": []
+    },
+    "secretInformationAccessAwsResourceFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "secretInformationAccessAwsRoleFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "secretInformationAccessAwsServerlessFunctionFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "secretInformationAccessAwsUserFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "section": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sectionGroup": {
+      "navigationProperties": [
+        "parentNotebook",
+        "parentSectionGroup",
+        "sectionGroups",
+        "sections"
+      ],
+      "properties": [
+        "sectionGroupsUrl",
+        "sectionsUrl"
+      ]
+    },
+    "sectionMap": {
+      "navigationProperties": [],
+      "properties": [
+        "placeId"
+      ]
+    },
+    "secureScore": {
+      "navigationProperties": [],
+      "properties": [
+        "activeUserCount",
+        "averageComparativeScores",
+        "azureTenantId",
+        "controlScores",
+        "createdDateTime",
+        "currentScore",
+        "enabledServices",
+        "licensedUserCount",
+        "maxScore",
+        "vendorInformation"
+      ]
+    },
+    "secureScoreControlProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "actionType",
+        "actionUrl",
+        "azureTenantId",
+        "complianceInformation",
+        "controlCategory",
+        "controlStateUpdates",
+        "deprecated",
+        "implementationCost",
+        "lastModifiedDateTime",
+        "maxScore",
+        "rank",
+        "remediation",
+        "remediationImpact",
+        "service",
+        "threats",
+        "tier",
+        "title",
+        "userImpact",
+        "vendorInformation"
+      ]
+    },
+    "security": {
+      "navigationProperties": [
+        "alerts",
+        "alerts_v2",
+        "attackSimulation",
+        "auditLog",
+        "cases",
+        "cloudAppSecurityProfiles",
+        "collaboration",
+        "dataDiscovery",
+        "dataSecurityAndGovernance",
+        "domainSecurityProfiles",
+        "fileSecurityProfiles",
+        "hostSecurityProfiles",
+        "identities",
+        "incidents",
+        "incidentTasks",
+        "informationProtection",
+        "ipSecurityProfiles",
+        "labels",
+        "partner",
+        "providerTenantSettings",
+        "rules",
+        "secureScoreControlProfiles",
+        "secureScores",
+        "securityActions",
+        "securityCopilot",
+        "subjectRightsRequests",
+        "threatIntelligence",
+        "threatSubmission",
+        "tiIndicators",
+        "triggers",
+        "triggerTypes",
+        "userSecurityProfiles",
+        "zones"
+      ],
+      "properties": []
+    },
+    "securityAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actionReason",
+        "appId",
+        "azureTenantId",
+        "clientContext",
+        "completedDateTime",
+        "createdDateTime",
+        "errorInfo",
+        "lastActionDateTime",
+        "name",
+        "parameters",
+        "states",
+        "status",
+        "user",
+        "vendorInformation"
+      ]
+    },
+    "securityBaselineCategoryStateSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "securityBaselineDeviceState": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceDisplayName",
+        "lastReportedDateTime",
+        "managedDeviceId",
+        "state",
+        "userPrincipalName"
+      ]
+    },
+    "securityBaselineSettingState": {
+      "navigationProperties": [],
+      "properties": [
+        "contributingPolicies",
+        "errorCode",
+        "settingCategoryId",
+        "settingCategoryName",
+        "settingId",
+        "settingName",
+        "sourcePolicies",
+        "state"
+      ]
+    },
+    "securityBaselineState": {
+      "navigationProperties": [
+        "settingStates"
+      ],
+      "properties": [
+        "displayName",
+        "securityBaselineTemplateId",
+        "state",
+        "userPrincipalName"
+      ]
+    },
+    "securityBaselineStateSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "conflictCount",
+        "errorCount",
+        "notApplicableCount",
+        "notSecureCount",
+        "secureCount",
+        "unknownCount"
+      ]
+    },
+    "securityBaselineTemplate": {
+      "navigationProperties": [
+        "categoryDeviceStateSummaries",
+        "deviceStates",
+        "deviceStateSummary"
+      ],
+      "properties": []
+    },
+    "securityConfigurationTask": {
+      "navigationProperties": [
+        "managedDevices"
+      ],
+      "properties": [
+        "applicablePlatform",
+        "endpointSecurityPolicy",
+        "endpointSecurityPolicyProfile",
+        "insights",
+        "intendedSettings",
+        "managedDeviceCount"
+      ]
+    },
+    "securityCopilot": {
+      "navigationProperties": [
+        "workspaces"
+      ],
+      "properties": []
+    },
+    "securityReportsRoot": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityToolAwsResourceAdministratorFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityToolAwsRoleAdministratorFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityToolAwsServerlessFunctionAdministratorFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityToolAwsUserAdministratorFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "selfServiceSignUp": {
+      "navigationProperties": [],
+      "properties": [
+        "appDisplayName",
+        "appId",
+        "appliedEventListeners",
+        "correlationId",
+        "createdDateTime",
+        "fraudProtectionDetails",
+        "signUpIdentity",
+        "signUpIdentityProvider",
+        "signUpStage",
+        "status",
+        "userId"
+      ]
+    },
+    "sendDtmfTonesOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "completionReason"
+      ]
+    },
+    "sensitiveType": {
+      "navigationProperties": [],
+      "properties": [
+        "classificationMethod",
+        "description",
+        "lastModifiedDateTime",
+        "name",
+        "publisherName",
+        "rulePackageId",
+        "rulePackageType",
+        "scope",
+        "sensitiveTypeSource",
+        "state"
+      ]
+    },
+    "sensitivityLabel": {
+      "navigationProperties": [
+        "rights",
+        "sublabels"
+      ],
+      "properties": [
+        "actionSource",
+        "applicableTo",
+        "applicationMode",
+        "autoTooltip",
+        "color",
+        "description",
+        "displayName",
+        "hasProtection",
+        "isDefault",
+        "isEnabled",
+        "isEndpointProtectionEnabled",
+        "isScopedToUser",
+        "locale",
+        "name",
+        "priority",
+        "toolTip"
+      ]
+    },
+    "sensitivityPolicySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableTo",
+        "downgradeSensitivityRequiresJustification",
+        "helpWebUrl",
+        "isMandatory"
+      ]
+    },
+    "sequentialActivationRenewalsAlertConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "sequentialActivationCounterThreshold",
+        "timeIntervalBetweenActivations"
+      ]
+    },
+    "sequentialActivationRenewalsAlertIncident": {
+      "navigationProperties": [],
+      "properties": [
+        "activationCount",
+        "assigneeDisplayName",
+        "assigneeId",
+        "assigneeUserPrincipalName",
+        "roleDefinitionId",
+        "roleDisplayName",
+        "roleTemplateId",
+        "sequenceEndDateTime",
+        "sequenceStartDateTime"
+      ]
+    },
+    "serviceActivity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "serviceAnnouncement": {
+      "navigationProperties": [
+        "healthOverviews",
+        "issues",
+        "messages"
+      ],
+      "properties": []
+    },
+    "serviceAnnouncementAttachment": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "contentType",
+        "lastModifiedDateTime",
+        "name",
+        "size"
+      ]
+    },
+    "serviceAnnouncementBase": {
+      "navigationProperties": [],
+      "properties": [
+        "details",
+        "endDateTime",
+        "lastModifiedDateTime",
+        "startDateTime",
+        "title"
+      ]
+    },
+    "serviceApp": {
+      "navigationProperties": [],
+      "properties": [
+        "application",
+        "effectiveDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "registrationDateTime",
+        "status"
+      ]
+    },
+    "serviceHealth": {
+      "navigationProperties": [
+        "issues"
+      ],
+      "properties": [
+        "service",
+        "status"
+      ]
+    },
+    "serviceHealthIssue": {
+      "navigationProperties": [],
+      "properties": [
+        "classification",
+        "feature",
+        "featureGroup",
+        "impactDescription",
+        "isResolved",
+        "origin",
+        "posts",
+        "service",
+        "status"
+      ]
+    },
+    "serviceLevelAgreementRoot": {
+      "navigationProperties": [
+        "azureADAuthentication"
+      ],
+      "properties": []
+    },
+    "serviceNowConnection": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationMethod",
+        "createdDateTime",
+        "incidentApiUrl",
+        "instanceUrl",
+        "lastModifiedDateTime",
+        "lastQueriedDateTime",
+        "serviceNowConnectionStatus"
+      ]
+    },
+    "servicePrincipal": {
+      "navigationProperties": [
+        "appManagementPolicies",
+        "appRoleAssignedTo",
+        "appRoleAssignments",
+        "claimsMappingPolicies",
+        "claimsPolicy",
+        "createdObjects",
+        "delegatedPermissionClassifications",
+        "endpoints",
+        "federatedIdentityCredentials",
+        "homeRealmDiscoveryPolicies",
+        "licenseDetails",
+        "memberOf",
+        "oauth2PermissionGrants",
+        "ownedObjects",
+        "owners",
+        "permissionGrantPreApprovalPolicies",
+        "remoteDesktopSecurityConfiguration",
+        "synchronization",
+        "tokenIssuancePolicies",
+        "tokenLifetimePolicies",
+        "transitiveMemberOf"
+      ],
+      "properties": [
+        "accountEnabled",
+        "addIns",
+        "alternativeNames",
+        "appDescription",
+        "appDisplayName",
+        "appId",
+        "applicationTemplateId",
+        "appOwnerOrganizationId",
+        "appRoleAssignmentRequired",
+        "appRoles",
+        "createdByAppId",
+        "customSecurityAttributes",
+        "description",
+        "disabledByMicrosoftStatus",
+        "displayName",
+        "errorUrl",
+        "homepage",
+        "info",
+        "isDisabled",
+        "keyCredentials",
+        "loginUrl",
+        "logoutUrl",
+        "notes",
+        "notificationEmailAddresses",
+        "passwordCredentials",
+        "passwordSingleSignOnSettings",
+        "preferredSingleSignOnMode",
+        "preferredTokenSigningKeyEndDateTime",
+        "preferredTokenSigningKeyThumbprint",
+        "publishedPermissionScopes",
+        "publisherName",
+        "replyUrls",
+        "samlMetadataUrl",
+        "samlSingleSignOnSettings",
+        "servicePrincipalNames",
+        "servicePrincipalType",
+        "signInAudience",
+        "tags",
+        "tokenEncryptionKeyId",
+        "verifiedPublisher"
+      ]
+    },
+    "servicePrincipalCreationConditionSet": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationIds",
+        "applicationPublisherIds",
+        "applicationsFromVerifiedPublisherOnly",
+        "applicationTenantIds",
+        "certifiedApplicationsOnly"
+      ]
+    },
+    "servicePrincipalCreationPolicy": {
+      "navigationProperties": [
+        "excludes",
+        "includes"
+      ],
+      "properties": [
+        "isBuiltIn"
+      ]
+    },
+    "servicePrincipalRiskDetection": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "activityDateTime",
+        "additionalInfo",
+        "appId",
+        "correlationId",
+        "detectedDateTime",
+        "detectionTimingType",
+        "ipAddress",
+        "keyIds",
+        "lastUpdatedDateTime",
+        "location",
+        "mitreTechniqueId",
+        "requestId",
+        "riskDetail",
+        "riskEventType",
+        "riskLevel",
+        "riskState",
+        "servicePrincipalDisplayName",
+        "servicePrincipalId",
+        "source",
+        "tokenIssuerType"
+      ]
+    },
+    "servicePrincipalSignInActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "applicationAuthenticationClientSignInActivity",
+        "applicationAuthenticationResourceSignInActivity",
+        "delegatedClientSignInActivity",
+        "delegatedResourceSignInActivity",
+        "lastSignInActivity"
+      ]
+    },
+    "serviceStorageQuotaBreakdown": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "serviceTagNamedLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "isTrusted",
+        "serviceTags"
+      ]
+    },
+    "serviceUpdateMessage": {
+      "navigationProperties": [
+        "attachments"
+      ],
+      "properties": [
+        "actionRequiredByDateTime",
+        "attachmentsArchive",
+        "body",
+        "category",
+        "hasAttachments",
+        "isMajorChange",
+        "services",
+        "severity",
+        "tags",
+        "viewPoint"
+      ]
+    },
+    "settingStateDeviceSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantDeviceCount",
+        "conflictDeviceCount",
+        "errorDeviceCount",
+        "instancePath",
+        "nonCompliantDeviceCount",
+        "notApplicableDeviceCount",
+        "remediatedDeviceCount",
+        "settingName",
+        "unknownDeviceCount"
+      ]
+    },
+    "sharedDriveItem": {
+      "navigationProperties": [
+        "driveItem",
+        "items",
+        "list",
+        "listItem",
+        "permission",
+        "root",
+        "site"
+      ],
+      "properties": [
+        "owner"
+      ]
+    },
+    "sharedEmailDomain": {
+      "navigationProperties": [],
+      "properties": [
+        "provisioningStatus"
+      ]
+    },
+    "sharedEmailDomainInvitation": {
+      "navigationProperties": [],
+      "properties": [
+        "expiryTime",
+        "invitationDomain",
+        "invitationStatus"
+      ]
+    },
+    "sharedInsight": {
+      "navigationProperties": [
+        "lastSharedMethod",
+        "resource"
+      ],
+      "properties": [
+        "lastShared",
+        "resourceReference",
+        "resourceVisualization",
+        "sharingHistory"
+      ]
+    },
+    "sharedPCConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accountManagerPolicy",
+        "allowedAccounts",
+        "allowLocalStorage",
+        "disableAccountManager",
+        "disableEduPolicies",
+        "disablePowerPolicies",
+        "disableSignInOnResume",
+        "enabled",
+        "fastFirstSignIn",
+        "idleTimeBeforeSleepInSeconds",
+        "kioskAppDisplayName",
+        "kioskAppUserModelId",
+        "localStorage",
+        "maintenanceStartTime",
+        "setAccountManager",
+        "setEduPolicies",
+        "setPowerPolicies",
+        "signInOnResume"
+      ]
+    },
+    "sharedWithChannelTeamInfo": {
+      "navigationProperties": [
+        "allowedMembers"
+      ],
+      "properties": [
+        "isHostTeam"
+      ]
+    },
+    "sharepoint": {
+      "navigationProperties": [
+        "settings"
+      ],
+      "properties": []
+    },
+    "sharePointBrowseSession": {
+      "navigationProperties": [],
+      "properties": [
+        "siteId"
+      ]
+    },
+    "sharePointGroup": {
+      "navigationProperties": [
+        "members"
+      ],
+      "properties": [
+        "description",
+        "principalId",
+        "title"
+      ]
+    },
+    "sharePointGroupIdentityMapping": {
+      "navigationProperties": [],
+      "properties": [
+        "groupType",
+        "sourceGroupIdentity",
+        "targetGroupIdentity",
+        "targetGroupMigrationData"
+      ]
+    },
+    "sharePointGroupMember": {
+      "navigationProperties": [],
+      "properties": [
+        "identity"
+      ]
+    },
+    "sharePointIdentityMapping": {
+      "navigationProperties": [],
+      "properties": [
+        "deleted",
+        "sourceOrganizationId"
+      ]
+    },
+    "sharePointMigrationEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "correlationId",
+        "eventDateTime",
+        "jobId"
+      ]
+    },
+    "sharePointMigrationFinishManifestFileUploadEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "manifestFileName"
+      ]
+    },
+    "sharePointMigrationJob": {
+      "navigationProperties": [
+        "progressEvents"
+      ],
+      "properties": [
+        "containerInfo"
+      ]
+    },
+    "sharePointMigrationJobCancelledEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "isCancelledByUser",
+        "totalRetryCount"
+      ]
+    },
+    "sharePointMigrationJobDeletedEvent": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointMigrationJobErrorEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "errorLevel",
+        "objectId",
+        "objectType",
+        "objectUrl",
+        "totalRetryCount"
+      ]
+    },
+    "sharePointMigrationJobPostponedEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "jobsInQueue",
+        "nextPickupDateTime",
+        "reason",
+        "totalRetryCount"
+      ]
+    },
+    "sharePointMigrationJobProgressEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "bytesProcessed",
+        "bytesProcessedOnlyCurrentVersion",
+        "cpuDurationMs",
+        "filesProcessed",
+        "filesProcessedOnlyCurrentVersion",
+        "isCompleted",
+        "lastProcessedObjectId",
+        "objectsProcessed",
+        "sqlDurationMs",
+        "sqlQueryCount",
+        "totalDurationMs",
+        "totalErrors",
+        "totalExpectedBytes",
+        "totalExpectedObjects",
+        "totalRetryCount",
+        "totalWarnings",
+        "waitTimeOnSqlThrottlingMs"
+      ]
+    },
+    "sharePointMigrationJobQueuedEvent": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointMigrationJobStartEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "isRestarted",
+        "totalRetryCount"
+      ]
+    },
+    "sharePointMigrationsRoot": {
+      "navigationProperties": [
+        "crossOrganizationGroupMappings",
+        "crossOrganizationMigrationTasks",
+        "crossOrganizationUserMappings"
+      ],
+      "properties": []
+    },
+    "sharePointMigrationTask": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "finishedDateTime",
+        "lastUpdatedDateTime",
+        "parameters",
+        "startedDateTime",
+        "status"
+      ]
+    },
+    "sharePointProtectionPolicy": {
+      "navigationProperties": [
+        "siteExclusionUnits",
+        "siteExclusionUnitsBulkAdditionJobs",
+        "siteInclusionRules",
+        "siteProtectionUnits",
+        "siteProtectionUnitsBulkAdditionJobs"
+      ],
+      "properties": []
+    },
+    "sharePointRestoreSession": {
+      "navigationProperties": [
+        "granularSiteRestoreArtifacts",
+        "siteRestoreArtifacts",
+        "siteRestoreArtifactsBulkAdditionRequests"
+      ],
+      "properties": []
+    },
+    "sharePointRoot": {
+      "navigationProperties": [
+        "migrations"
+      ],
+      "properties": []
+    },
+    "sharepointSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedDomainGuidsForSyncApp",
+        "availableManagedPathsForSiteCreation",
+        "deletedUserPersonalSiteRetentionPeriodInDays",
+        "excludedFileExtensionsForSyncApp",
+        "idleSessionSignOut",
+        "imageTaggingOption",
+        "isCommentingOnSitePagesEnabled",
+        "isFileActivityNotificationEnabled",
+        "isLegacyAuthProtocolsEnabled",
+        "isLoopEnabled",
+        "isMacSyncAppEnabled",
+        "isRequireAcceptingUserToMatchInvitedUserEnabled",
+        "isResharingByExternalUsersEnabled",
+        "isSharePointMobileNotificationEnabled",
+        "isSharePointNewsfeedEnabled",
+        "isSiteCreationEnabled",
+        "isSiteCreationUIEnabled",
+        "isSitePagesCreationEnabled",
+        "isSitesStorageLimitAutomatic",
+        "isSyncButtonHiddenOnPersonalSite",
+        "isUnmanagedSyncAppForTenantRestricted",
+        "personalSiteDefaultStorageLimitInMB",
+        "sharingAllowedDomainList",
+        "sharingBlockedDomainList",
+        "sharingCapability",
+        "sharingDomainRestrictionMode",
+        "siteCreationDefaultManagedPath",
+        "siteCreationDefaultStorageLimitInMB",
+        "tenantDefaultTimezone"
+      ]
+    },
+    "sharePointUserIdentityMapping": {
+      "navigationProperties": [],
+      "properties": [
+        "sourceUserIdentity",
+        "targetUserIdentity",
+        "targetUserMigrationData",
+        "userType"
+      ]
+    },
+    "shift": {
+      "navigationProperties": [],
+      "properties": [
+        "draftShift",
+        "isStagedForDeletion",
+        "schedulingGroupId",
+        "schedulingGroupInfo",
+        "sharedShift",
+        "teamInfo",
+        "userId",
+        "userInfo"
+      ]
+    },
+    "shiftPreferences": {
+      "navigationProperties": [],
+      "properties": [
+        "availability"
+      ]
+    },
+    "shiftsRoleDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "shiftsRolePermissions"
+      ]
+    },
+    "shipmentMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "displayName",
+        "id",
+        "lastModifiedDateTime"
+      ]
+    },
+    "signIn": {
+      "navigationProperties": [],
+      "properties": [
+        "agent",
+        "appDisplayName",
+        "appId",
+        "appliedConditionalAccessPolicies",
+        "appliedEventListeners",
+        "appOwnerTenantId",
+        "appTokenProtectionStatus",
+        "authenticationAppDeviceDetails",
+        "authenticationAppPolicyEvaluationDetails",
+        "authenticationContextClassReferences",
+        "authenticationDetails",
+        "authenticationMethodsUsed",
+        "authenticationProcessingDetails",
+        "authenticationProtocol",
+        "authenticationRequirement",
+        "authenticationRequirementPolicies",
+        "autonomousSystemNumber",
+        "azureResourceId",
+        "clientAppUsed",
+        "clientCredentialType",
+        "conditionalAccessAudiences",
+        "conditionalAccessStatus",
+        "correlationId",
+        "createdDateTime",
+        "crossTenantAccessType",
+        "deviceDetail",
+        "federatedCredentialId",
+        "flaggedForReview",
+        "globalSecureAccessIpAddress",
+        "homeTenantId",
+        "homeTenantName",
+        "incomingTokenType",
+        "ipAddress",
+        "ipAddressFromResourceProvider",
+        "isInteractive",
+        "isTenantRestricted",
+        "isThroughGlobalSecureAccess",
+        "location",
+        "managedServiceIdentity",
+        "mfaDetail",
+        "networkLocationDetails",
+        "originalRequestId",
+        "originalTransferMethod",
+        "privateLinkDetails",
+        "processingTimeInMilliseconds",
+        "resourceDisplayName",
+        "resourceId",
+        "resourceOwnerTenantId",
+        "resourceServicePrincipalId",
+        "resourceTenantId",
+        "riskDetail",
+        "riskEventTypes_v2",
+        "riskLevelAggregated",
+        "riskLevelDuringSignIn",
+        "riskState",
+        "servicePrincipalCredentialKeyId",
+        "servicePrincipalCredentialThumbprint",
+        "servicePrincipalId",
+        "servicePrincipalName",
+        "sessionId",
+        "sessionLifetimePolicies",
+        "signInEventTypes",
+        "signInIdentifier",
+        "signInIdentifierType",
+        "signInTokenProtectionStatus",
+        "status",
+        "tokenIssuerName",
+        "tokenIssuerType",
+        "tokenProtectionStatusDetails",
+        "uniqueTokenIdentifier",
+        "userAgent",
+        "userDisplayName",
+        "userId",
+        "userPrincipalName",
+        "userType"
+      ]
+    },
+    "signInEventsActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "activityDateTime",
+        "signInCount"
+      ]
+    },
+    "signInEventsAppActivity": {
+      "navigationProperties": [
+        "application"
+      ],
+      "properties": [
+        "appId",
+        "signInCount",
+        "tenantId"
+      ]
+    },
+    "signInIdentifierBase": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "name"
+      ]
+    },
+    "simulation": {
+      "navigationProperties": [
+        "landingPage",
+        "loginPage",
+        "payload"
+      ],
+      "properties": [
+        "attackTechnique",
+        "attackType",
+        "automationId",
+        "completionDateTime",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "durationInDays",
+        "endUserNotificationSetting",
+        "excludedAccountTarget",
+        "includedAccountTarget",
+        "isAutomated",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "launchDateTime",
+        "oAuthConsentAppDetail",
+        "payloadDeliveryPlatform",
+        "report",
+        "status",
+        "trainingSetting"
+      ]
+    },
+    "simulationAutomation": {
+      "navigationProperties": [
+        "runs"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "lastRunDateTime",
+        "nextRunDateTime",
+        "status"
+      ]
+    },
+    "simulationAutomationRun": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "simulationId",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "singleValueExtendedProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "singleValueLegacyExtendedProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "site": {
+      "navigationProperties": [
+        "analytics",
+        "columns",
+        "contentModels",
+        "contentTypes",
+        "documentProcessingJobs",
+        "drive",
+        "drives",
+        "extensions",
+        "externalColumns",
+        "informationProtection",
+        "items",
+        "lists",
+        "onenote",
+        "operations",
+        "pages",
+        "pageTemplates",
+        "permissions",
+        "recycleBin",
+        "sites",
+        "termStore"
+      ],
+      "properties": [
+        "deleted",
+        "displayName",
+        "isPersonalSite",
+        "locale",
+        "lockState",
+        "ownerIdentityToResolve",
+        "root",
+        "settings",
+        "shareByEmailEnabled",
+        "sharepointIds",
+        "siteCollection",
+        "template"
+      ]
+    },
+    "siteExclusionUnit": {
+      "navigationProperties": [],
+      "properties": [
+        "siteId",
+        "siteName",
+        "siteWebUrl"
+      ]
+    },
+    "siteExclusionUnitsBulkAdditionJob": {
+      "navigationProperties": [],
+      "properties": [
+        "siteWebUrls"
+      ]
+    },
+    "sitePage": {
+      "navigationProperties": [
+        "canvasLayout",
+        "webParts"
+      ],
+      "properties": [
+        "promotionKind",
+        "reactions",
+        "showComments",
+        "showRecommendedPages",
+        "thumbnailWebUrl",
+        "titleArea"
+      ]
+    },
+    "siteProtectionRule": {
+      "navigationProperties": [],
+      "properties": [
+        "siteExpression"
+      ]
+    },
+    "siteProtectionUnit": {
+      "navigationProperties": [],
+      "properties": [
+        "siteId",
+        "siteName",
+        "siteWebUrl"
+      ]
+    },
+    "siteProtectionUnitsBulkAdditionJob": {
+      "navigationProperties": [],
+      "properties": [
+        "siteIds",
+        "siteWebUrls"
+      ]
+    },
+    "siteRestoreArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "restoredSiteId",
+        "restoredSiteName",
+        "restoredSiteWebUrl"
+      ]
+    },
+    "siteRestoreArtifactsBulkAdditionRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "siteIds",
+        "siteWebUrls"
+      ]
+    },
+    "skillProficiency": {
+      "navigationProperties": [],
+      "properties": [
+        "categories",
+        "collaborationTags",
+        "displayName",
+        "proficiency",
+        "thumbnailUrl",
+        "webUrl"
+      ]
+    },
+    "skypeForBusinessUserConversationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "tenantId",
+        "userId"
+      ]
+    },
+    "skypeUserConversationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "skypeId"
+      ]
+    },
+    "smsAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": []
+    },
+    "smsAuthenticationMethodTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "isUsableForSignIn"
+      ]
+    },
+    "socialIdentityProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "clientId",
+        "clientSecret",
+        "identityProviderType"
+      ]
+    },
+    "softwareOathAuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "secretKey"
+      ]
+    },
+    "softwareOathAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": []
+    },
+    "softwareUpdateStatusSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantDeviceCount",
+        "compliantUserCount",
+        "conflictDeviceCount",
+        "conflictUserCount",
+        "displayName",
+        "errorDeviceCount",
+        "errorUserCount",
+        "nonCompliantDeviceCount",
+        "nonCompliantUserCount",
+        "notApplicableDeviceCount",
+        "notApplicableUserCount",
+        "remediatedDeviceCount",
+        "remediatedUserCount",
+        "unknownDeviceCount",
+        "unknownUserCount"
+      ]
+    },
+    "solutionsRoot": {
+      "navigationProperties": [
+        "approval",
+        "backupRestore",
+        "bookingBusinesses",
+        "bookingCurrencies",
+        "businessScenarios",
+        "migrations",
+        "sharePoint",
+        "virtualEvents"
+      ],
+      "properties": []
+    },
+    "speakerAssignmentSubmission": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentId",
+        "averageWordsPerMinutePace",
+        "classId",
+        "fillerWordsOccurrencesCount",
+        "incorrectCameraDistanceOccurrencesCount",
+        "lengthOfSubmissionInSeconds",
+        "lostEyeContactOccurrencesCount",
+        "monotoneOccurrencesCount",
+        "nonInclusiveLanguageOccurrencesCount",
+        "obstructedViewOccurrencesCount",
+        "repetitiveLanguageOccurrencesCount",
+        "studentId",
+        "submissionDateTime",
+        "submissionId",
+        "topFillerWords",
+        "topMispronouncedWords",
+        "topNonInclusiveWordsAndPhrases",
+        "topRepetitiveWordsAndPhrases",
+        "wordsSpokenCount"
+      ]
+    },
+    "staleSignInAlertConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "duration"
+      ]
+    },
+    "staleSignInAlertIncident": {
+      "navigationProperties": [],
+      "properties": [
+        "assigneeDisplayName",
+        "assigneeId",
+        "assigneeUserPrincipalName",
+        "assignmentCreatedDateTime",
+        "lastSignInDateTime",
+        "roleDefinitionId",
+        "roleDisplayName",
+        "roleTemplateId"
+      ]
+    },
+    "standardWebPart": {
+      "navigationProperties": [],
+      "properties": [
+        "containerTextWebPartId",
+        "data",
+        "webPartType"
+      ]
+    },
+    "startHoldMusicOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "startRecordingOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "startTranscriptionOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "stopHoldMusicOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "stopRecordingOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "stopTranscriptionOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "storage": {
+      "navigationProperties": [
+        "fileStorage",
+        "settings"
+      ],
+      "properties": []
+    },
+    "storageQuotaBreakdown": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "manageWebUrl",
+        "used"
+      ]
+    },
+    "storageSettings": {
+      "navigationProperties": [
+        "quota"
+      ],
+      "properties": []
+    },
+    "storyline": {
+      "navigationProperties": [
+        "followers",
+        "followings"
+      ],
+      "properties": []
+    },
+    "storylineFollower": {
+      "navigationProperties": [],
+      "properties": [
+        "follower"
+      ]
+    },
+    "storylineFollowing": {
+      "navigationProperties": [],
+      "properties": [
+        "following"
+      ]
+    },
+    "strongAuthenticationDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "encryptedPinHashHistory",
+        "proofupTime"
+      ]
+    },
+    "strongAuthenticationPhoneAppDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationType",
+        "authenticatorFlavor",
+        "deviceId",
+        "deviceName",
+        "deviceTag",
+        "deviceToken",
+        "hashFunction",
+        "lastAuthenticatedDateTime",
+        "notificationType",
+        "oathSecretKey",
+        "oathTokenMetadata",
+        "oathTokenTimeDriftInSeconds",
+        "phoneAppVersion",
+        "tenantDeviceId",
+        "tokenGenerationIntervalInSeconds"
+      ]
+    },
+    "stsPolicy": {
+      "navigationProperties": [
+        "appliesTo"
+      ],
+      "properties": [
+        "definition",
+        "isOrganizationDefault"
+      ]
+    },
+    "subjectRightsRequest": {
+      "navigationProperties": [
+        "approvers",
+        "collaborators",
+        "notes",
+        "team"
+      ],
+      "properties": [
+        "assignedTo",
+        "closedDateTime",
+        "contentQuery",
+        "createdBy",
+        "createdDateTime",
+        "dataSubject",
+        "dataSubjectType",
+        "description",
+        "displayName",
+        "externalId",
+        "history",
+        "includeAllVersions",
+        "includeAuthoredContent",
+        "insight",
+        "internalDueDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "mailboxLocations",
+        "pauseAfterEstimate",
+        "regulations",
+        "siteLocations",
+        "stages",
+        "status",
+        "type"
+      ]
+    },
+    "subscribedSku": {
+      "navigationProperties": [],
+      "properties": [
+        "accountId",
+        "accountName",
+        "appliesTo",
+        "capabilityStatus",
+        "consumedUnits",
+        "prepaidUnits",
+        "servicePlans",
+        "skuId",
+        "skuPartNumber",
+        "subscriptionIds"
+      ]
+    },
+    "subscribeToToneOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "subscription": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationId",
+        "changeType",
+        "clientState",
+        "creatorId",
+        "encryptionCertificate",
+        "encryptionCertificateId",
+        "expirationDateTime",
+        "includeResourceData",
+        "latestSupportedTlsVersion",
+        "lifecycleNotificationUrl",
+        "notificationContentType",
+        "notificationQueryOptions",
+        "notificationUrl",
+        "notificationUrlAppId",
+        "resource"
+      ]
+    },
+    "summarizedSignIn": {
+      "navigationProperties": [],
+      "properties": [
+        "agent",
+        "aggregationDateTime",
+        "appDisplayName",
+        "appId",
+        "conditionalAccessStatus",
+        "firstSignInDateTime",
+        "ipAddress",
+        "managedServiceIdentity",
+        "resourceDisplayName",
+        "resourceId",
+        "servicePrincipalId",
+        "servicePrincipalName",
+        "signInCount",
+        "status",
+        "tenantId",
+        "userPrincipalName"
+      ]
+    },
+    "superAwsResourceFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "superAwsRoleFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "superAzureServicePrincipalFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "superGcpServiceAccountFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "superServerlessFunctionFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "superUserFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "swapShiftsChangeRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "recipientShiftId"
+      ]
+    },
+    "symantecCodeSigningCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "expirationDateTime",
+        "issuer",
+        "issuerName",
+        "password",
+        "status",
+        "subject",
+        "subjectName",
+        "uploadDateTime"
+      ]
+    },
+    "synchronization": {
+      "navigationProperties": [
+        "jobs",
+        "templates"
+      ],
+      "properties": [
+        "secrets"
+      ]
+    },
+    "synchronizationJob": {
+      "navigationProperties": [
+        "bulkUpload",
+        "schema"
+      ],
+      "properties": [
+        "schedule",
+        "status",
+        "synchronizationJobSettings",
+        "templateId"
+      ]
+    },
+    "synchronizationSchema": {
+      "navigationProperties": [
+        "directories"
+      ],
+      "properties": [
+        "synchronizationRules",
+        "version"
+      ]
+    },
+    "synchronizationTemplate": {
+      "navigationProperties": [
+        "schema"
+      ],
+      "properties": [
+        "applicationId",
+        "default",
+        "description",
+        "discoverable",
+        "factoryTag",
+        "metadata"
+      ]
+    },
+    "targetDeviceGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "targetedChatMessage": {
+      "navigationProperties": [],
+      "properties": [
+        "recipient"
+      ]
+    },
+    "targetedManagedAppConfiguration": {
+      "navigationProperties": [
+        "apps",
+        "assignments",
+        "deploymentSummary"
+      ],
+      "properties": [
+        "appGroupType",
+        "deployedAppCount",
+        "isAssigned",
+        "targetedAppManagementLevels"
+      ]
+    },
+    "targetedManagedAppConfigurationPolicySetItem": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "targetedManagedAppPolicyAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "source",
+        "sourceId",
+        "target"
+      ]
+    },
+    "targetedManagedAppProtection": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "appGroupType",
+        "isAssigned",
+        "targetedAppManagementLevels"
+      ]
+    },
+    "taskFileAttachment": {
+      "navigationProperties": [],
+      "properties": [
+        "contentBytes"
+      ]
+    },
+    "taxArea": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "displayName",
+        "id",
+        "lastModifiedDateTime",
+        "taxType"
+      ]
+    },
+    "taxGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "displayName",
+        "lastModifiedDateTime",
+        "taxType"
+      ]
+    },
+    "team": {
+      "navigationProperties": [
+        "allChannels",
+        "channels",
+        "group",
+        "incomingChannels",
+        "installedApps",
+        "members",
+        "operations",
+        "owners",
+        "permissionGrants",
+        "photo",
+        "primaryChannel",
+        "schedule",
+        "tags",
+        "template",
+        "templateDefinition"
+      ],
+      "properties": [
+        "classification",
+        "createdDateTime",
+        "description",
+        "discoverySettings",
+        "displayName",
+        "firstChannelName",
+        "funSettings",
+        "guestSettings",
+        "internalId",
+        "isArchived",
+        "isMembershipLimitedToOwners",
+        "memberSettings",
+        "messagingSettings",
+        "specialization",
+        "summary",
+        "tenantId",
+        "visibility",
+        "webUrl"
+      ]
+    },
+    "teamInfo": {
+      "navigationProperties": [
+        "team"
+      ],
+      "properties": [
+        "displayName",
+        "tenantId"
+      ]
+    },
+    "teamsApp": {
+      "navigationProperties": [
+        "appDefinitions"
+      ],
+      "properties": [
+        "displayName",
+        "distributionMethod",
+        "externalId"
+      ]
+    },
+    "teamsAppDashboardCardDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "contentSource",
+        "defaultSize",
+        "description",
+        "displayName",
+        "icon",
+        "pickerGroupId"
+      ]
+    },
+    "teamsAppDefinition": {
+      "navigationProperties": [
+        "bot",
+        "colorIcon",
+        "dashboardCards",
+        "outlineIcon"
+      ],
+      "properties": [
+        "allowedInstallationScopes",
+        "authorization",
+        "azureADAppId",
+        "createdBy",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "publishingState",
+        "shortdescription",
+        "teamsAppId",
+        "version"
+      ]
+    },
+    "teamsAppIcon": {
+      "navigationProperties": [
+        "hostedContent"
+      ],
+      "properties": [
+        "webUrl"
+      ]
+    },
+    "teamsAppInstallation": {
+      "navigationProperties": [
+        "teamsApp",
+        "teamsAppDefinition"
+      ],
+      "properties": [
+        "consentedPermissionSet",
+        "scopeInfo"
+      ]
+    },
+    "teamsAppSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowUserRequestsForAppAccess",
+        "customAppSettings",
+        "isChatResourceSpecificConsentEnabled",
+        "isUserPersonalScopeResourceSpecificConsentEnabled"
+      ]
+    },
+    "teamsAsyncOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "attemptsCount",
+        "createdDateTime",
+        "error",
+        "lastActionDateTime",
+        "operationType",
+        "status",
+        "targetResourceId",
+        "targetResourceLocation"
+      ]
+    },
+    "teamsChannelPlanner": {
+      "navigationProperties": [
+        "plans"
+      ],
+      "properties": []
+    },
+    "teamsTab": {
+      "navigationProperties": [
+        "teamsApp"
+      ],
+      "properties": [
+        "configuration",
+        "displayName",
+        "messageId",
+        "sortOrderIndex",
+        "teamsAppId",
+        "webUrl"
+      ]
+    },
+    "teamsTemplate": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamTemplate": {
+      "navigationProperties": [
+        "definitions"
+      ],
+      "properties": []
+    },
+    "teamTemplateDefinition": {
+      "navigationProperties": [
+        "teamDefinition"
+      ],
+      "properties": [
+        "audience",
+        "categories",
+        "description",
+        "displayName",
+        "iconUrl",
+        "languageTag",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "parentTemplateId",
+        "publisherName",
+        "shortDescription"
+      ]
+    },
+    "teamwork": {
+      "navigationProperties": [
+        "deletedChats",
+        "deletedTeams",
+        "devices",
+        "teamsAppSettings",
+        "teamTemplates",
+        "workforceIntegrations"
+      ],
+      "properties": [
+        "isTeamsEnabled",
+        "region"
+      ]
+    },
+    "teamworkBot": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamworkDevice": {
+      "navigationProperties": [
+        "activity",
+        "configuration",
+        "health",
+        "operations"
+      ],
+      "properties": [
+        "activityState",
+        "companyAssetTag",
+        "createdBy",
+        "createdDateTime",
+        "currentUser",
+        "deviceType",
+        "hardwareDetail",
+        "healthStatus",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "notes"
+      ]
+    },
+    "teamworkDeviceActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "activePeripherals",
+        "createdBy",
+        "createdDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "teamworkDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "cameraConfiguration",
+        "createdBy",
+        "createdDateTime",
+        "displayConfiguration",
+        "hardwareConfiguration",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "microphoneConfiguration",
+        "softwareVersions",
+        "speakerConfiguration",
+        "systemConfiguration",
+        "teamsClientConfiguration"
+      ]
+    },
+    "teamworkDeviceHealth": {
+      "navigationProperties": [],
+      "properties": [
+        "connection",
+        "createdBy",
+        "createdDateTime",
+        "hardwareHealth",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "loginStatus",
+        "peripheralsHealth",
+        "softwareUpdateHealth"
+      ]
+    },
+    "teamworkDeviceOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "createdBy",
+        "createdDateTime",
+        "error",
+        "lastActionBy",
+        "lastActionDateTime",
+        "operationType",
+        "startedDateTime",
+        "status"
+      ]
+    },
+    "teamworkHostedContent": {
+      "navigationProperties": [],
+      "properties": [
+        "contentBytes",
+        "contentType"
+      ]
+    },
+    "teamworkPeripheral": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "productId",
+        "vendorId"
+      ]
+    },
+    "teamworkSection": {
+      "navigationProperties": [
+        "items"
+      ],
+      "properties": [
+        "createdDateTime",
+        "displayIcon",
+        "displayName",
+        "isExpanded",
+        "isHierarchicalViewEnabled",
+        "lastModifiedDateTime",
+        "sectionType",
+        "sortType"
+      ]
+    },
+    "teamworkSectionItem": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "itemType",
+        "lastModifiedDateTime"
+      ]
+    },
+    "teamworkTag": {
+      "navigationProperties": [
+        "members"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "memberCount",
+        "tagType",
+        "teamId"
+      ]
+    },
+    "teamworkTagMember": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "tenantId",
+        "userId"
+      ]
+    },
+    "template": {
+      "navigationProperties": [
+        "deviceTemplates"
+      ],
+      "properties": []
+    },
+    "temporaryAccessPassAuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "isUsableOnce",
+        "lifetimeInMinutes",
+        "startDateTime",
+        "temporaryAccessPass"
+      ]
+    },
+    "temporaryAccessPassAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": [
+        "defaultLength",
+        "defaultLifetimeInMinutes",
+        "isUsableOnce",
+        "maximumLifetimeInMinutes",
+        "minimumLifetimeInMinutes"
+      ]
+    },
+    "tenantAppManagementPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationRestrictions",
+        "isEnabled",
+        "servicePrincipalRestrictions"
+      ]
+    },
+    "tenantAttachRBAC": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "tenantDataSecurityAndGovernance": {
+      "navigationProperties": [
+        "policyFiles",
+        "protectionScopes"
+      ],
+      "properties": []
+    },
+    "tenantProtectionScopeContainer": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "tenantReference": {
+      "navigationProperties": [],
+      "properties": [
+        "tenantId"
+      ]
+    },
+    "tenantRelationship": {
+      "navigationProperties": [
+        "delegatedAdminCustomers",
+        "delegatedAdminRelationships",
+        "managedTenants",
+        "multiTenantOrganization"
+      ],
+      "properties": []
+    },
+    "tenantRelationshipAccessPolicyBase": {
+      "navigationProperties": [],
+      "properties": [
+        "definition"
+      ]
+    },
+    "tenantSetupInfo": {
+      "navigationProperties": [
+        "defaultRolesSettings"
+      ],
+      "properties": [
+        "firstTimeSetup",
+        "relevantRolesSettings",
+        "setupStatus",
+        "skipSetup",
+        "userRolesActions"
+      ]
+    },
+    "termsAndConditions": {
+      "navigationProperties": [
+        "acceptanceStatuses",
+        "assignments",
+        "groupAssignments"
+      ],
+      "properties": [
+        "acceptanceStatement",
+        "bodyText",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "modifiedDateTime",
+        "roleScopeTagIds",
+        "title",
+        "version"
+      ]
+    },
+    "termsAndConditionsAcceptanceStatus": {
+      "navigationProperties": [
+        "termsAndConditions"
+      ],
+      "properties": [
+        "acceptedDateTime",
+        "acceptedVersion",
+        "userDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "termsAndConditionsAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "termsAndConditionsGroupAssignment": {
+      "navigationProperties": [
+        "termsAndConditions"
+      ],
+      "properties": [
+        "targetGroupId"
+      ]
+    },
+    "termsOfUseContainer": {
+      "navigationProperties": [
+        "agreementAcceptances",
+        "agreements"
+      ],
+      "properties": []
+    },
+    "textClassificationRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "contentMetaData",
+        "fileExtension",
+        "matchTolerancesToInclude",
+        "scopesToRun",
+        "sensitiveTypeIds",
+        "text"
+      ]
+    },
+    "textWebPart": {
+      "navigationProperties": [],
+      "properties": [
+        "innerHtml"
+      ]
+    },
+    "threatAssessmentRequest": {
+      "navigationProperties": [
+        "results"
+      ],
+      "properties": [
+        "category",
+        "contentType",
+        "createdBy",
+        "createdDateTime",
+        "expectedAssessment",
+        "requestSource",
+        "status"
+      ]
+    },
+    "threatAssessmentResult": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "message",
+        "resultType"
+      ]
+    },
+    "thumbnailSet": {
+      "navigationProperties": [],
+      "properties": [
+        "large",
+        "medium",
+        "small",
+        "source"
+      ]
+    },
+    "tiIndicator": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "activityGroupNames",
+        "additionalInformation",
+        "azureTenantId",
+        "confidence",
+        "description",
+        "diamondModel",
+        "domainName",
+        "emailEncoding",
+        "emailLanguage",
+        "emailRecipient",
+        "emailSenderAddress",
+        "emailSenderName",
+        "emailSourceDomain",
+        "emailSourceIpAddress",
+        "emailSubject",
+        "emailXMailer",
+        "expirationDateTime",
+        "externalId",
+        "fileCompileDateTime",
+        "fileCreatedDateTime",
+        "fileHashType",
+        "fileHashValue",
+        "fileMutexName",
+        "fileName",
+        "filePacker",
+        "filePath",
+        "fileSize",
+        "fileType",
+        "ingestedDateTime",
+        "isActive",
+        "killChain",
+        "knownFalsePositives",
+        "lastReportedDateTime",
+        "malwareFamilyNames",
+        "networkCidrBlock",
+        "networkDestinationAsn",
+        "networkDestinationCidrBlock",
+        "networkDestinationIPv4",
+        "networkDestinationIPv6",
+        "networkDestinationPort",
+        "networkIPv4",
+        "networkIPv6",
+        "networkPort",
+        "networkProtocol",
+        "networkSourceAsn",
+        "networkSourceCidrBlock",
+        "networkSourceIPv4",
+        "networkSourceIPv6",
+        "networkSourcePort",
+        "passiveOnly",
+        "severity",
+        "tags",
+        "targetProduct",
+        "threatType",
+        "tlpLevel",
+        "url",
+        "userAgent"
+      ]
+    },
+    "timeCard": {
+      "navigationProperties": [],
+      "properties": [
+        "breaks",
+        "clockInEvent",
+        "clockOutEvent",
+        "confirmedBy",
+        "notes",
+        "originalEntry",
+        "state",
+        "userId"
+      ]
+    },
+    "timeOff": {
+      "navigationProperties": [],
+      "properties": [
+        "draftTimeOff",
+        "isStagedForDeletion",
+        "sharedTimeOff",
+        "teamInfo",
+        "userId",
+        "userInfo"
+      ]
+    },
+    "timeOffReason": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "displayName",
+        "iconType",
+        "isActive"
+      ]
+    },
+    "timeOffRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "startDateTime",
+        "timeOffReasonId"
+      ]
+    },
+    "todo": {
+      "navigationProperties": [
+        "lists"
+      ],
+      "properties": []
+    },
+    "todoTask": {
+      "navigationProperties": [
+        "attachments",
+        "attachmentSessions",
+        "checklistItems",
+        "extensions",
+        "linkedResources",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "body",
+        "bodyLastModifiedDateTime",
+        "categories",
+        "completedDateTime",
+        "createdDateTime",
+        "dueDateTime",
+        "hasAttachments",
+        "importance",
+        "isReminderOn",
+        "lastModifiedDateTime",
+        "recurrence",
+        "reminderDateTime",
+        "startDateTime",
+        "status",
+        "title"
+      ]
+    },
+    "todoTaskList": {
+      "navigationProperties": [
+        "extensions",
+        "singleValueExtendedProperties",
+        "tasks"
+      ],
+      "properties": [
+        "displayName",
+        "isOwner",
+        "isShared",
+        "wellknownListName"
+      ]
+    },
+    "tokenIssuancePolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "tokenLifetimePolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "tooManyGlobalAdminsAssignedToTenantAlertConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "globalAdminCountThreshold",
+        "percentageOfGlobalAdminsOutOfRolesThreshold"
+      ]
+    },
+    "tooManyGlobalAdminsAssignedToTenantAlertIncident": {
+      "navigationProperties": [],
+      "properties": [
+        "assigneeDisplayName",
+        "assigneeId",
+        "assigneeUserPrincipalName"
+      ]
+    },
+    "training": {
+      "navigationProperties": [
+        "languageDetails"
+      ],
+      "properties": [
+        "availabilityStatus",
+        "createdBy",
+        "createdDateTime",
+        "customUrl",
+        "description",
+        "displayName",
+        "durationInMinutes",
+        "hasEvaluation",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "source",
+        "supportedLocales",
+        "tags",
+        "type"
+      ]
+    },
+    "trainingCampaign": {
+      "navigationProperties": [],
+      "properties": [
+        "campaignSchedule",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "endUserNotificationSetting",
+        "excludedAccountTarget",
+        "includedAccountTarget",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "report",
+        "trainingSetting"
+      ]
+    },
+    "trainingLanguageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "isDefaultLangauge",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "locale"
+      ]
+    },
+    "trending": {
+      "navigationProperties": [
+        "resource"
+      ],
+      "properties": [
+        "lastModifiedDateTime",
+        "resourceReference",
+        "resourceVisualization",
+        "weight"
+      ]
+    },
+    "trustedCertificateAuthorityAsEntityBase": {
+      "navigationProperties": [
+        "trustedCertificateAuthorities"
+      ],
+      "properties": []
+    },
+    "trustedCertificateAuthorityBase": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateAuthorities"
+      ]
+    },
+    "trustFramework": {
+      "navigationProperties": [
+        "keySets",
+        "policies"
+      ],
+      "properties": []
+    },
+    "trustFrameworkKey_v2": {
+      "navigationProperties": [],
+      "properties": [
+        "d",
+        "dp",
+        "dq",
+        "e",
+        "exp",
+        "k",
+        "kid",
+        "kty",
+        "n",
+        "nbf",
+        "p",
+        "q",
+        "qi",
+        "status",
+        "use",
+        "x5c",
+        "x5t"
+      ]
+    },
+    "trustFrameworkKeySet": {
+      "navigationProperties": [
+        "keys_v2"
+      ],
+      "properties": [
+        "keys"
+      ]
+    },
+    "trustFrameworkPolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unenforcedMfaAwsUserFinding": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unifiedRbacApplication": {
+      "navigationProperties": [
+        "customAppScopes",
+        "resourceNamespaces",
+        "roleAssignments",
+        "roleDefinitions",
+        "transitiveRoleAssignments"
+      ],
+      "properties": []
+    },
+    "unifiedRbacApplicationMultiple": {
+      "navigationProperties": [
+        "customAppScopes"
+      ],
+      "properties": []
+    },
+    "unifiedRbacResourceAction": {
+      "navigationProperties": [
+        "authenticationContext",
+        "resourceScope"
+      ],
+      "properties": [
+        "actionVerb",
+        "authenticationContextId",
+        "description",
+        "isAuthenticationContextSettable",
+        "isPrivileged",
+        "name",
+        "resourceScopeId"
+      ]
+    },
+    "unifiedRbacResourceNamespace": {
+      "navigationProperties": [
+        "resourceActions"
+      ],
+      "properties": [
+        "name"
+      ]
+    },
+    "unifiedRbacResourceScope": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "scope",
+        "type"
+      ]
+    },
+    "unifiedRoleAssignment": {
+      "navigationProperties": [
+        "appScope",
+        "directoryScope",
+        "principal",
+        "roleDefinition"
+      ],
+      "properties": [
+        "appScopeId",
+        "condition",
+        "directoryScopeId",
+        "principalId",
+        "principalOrganizationId",
+        "resourceScope",
+        "roleDefinitionId"
+      ]
+    },
+    "unifiedRoleAssignmentMultiple": {
+      "navigationProperties": [
+        "appScopes",
+        "directoryScopes",
+        "principals",
+        "roleDefinition"
+      ],
+      "properties": [
+        "appScopeIds",
+        "condition",
+        "description",
+        "directoryScopeIds",
+        "displayName",
+        "principalIds",
+        "roleDefinitionId"
+      ]
+    },
+    "unifiedRoleAssignmentSchedule": {
+      "navigationProperties": [
+        "activatedUsing"
+      ],
+      "properties": [
+        "assignmentType",
+        "memberType",
+        "scheduleInfo"
+      ]
+    },
+    "unifiedRoleAssignmentScheduleInstance": {
+      "navigationProperties": [
+        "activatedUsing"
+      ],
+      "properties": [
+        "assignmentType",
+        "endDateTime",
+        "memberType",
+        "roleAssignmentOriginId",
+        "roleAssignmentScheduleId",
+        "startDateTime"
+      ]
+    },
+    "unifiedRoleAssignmentScheduleRequest": {
+      "navigationProperties": [
+        "activatedUsing",
+        "appScope",
+        "directoryScope",
+        "principal",
+        "roleDefinition",
+        "targetSchedule"
+      ],
+      "properties": [
+        "action",
+        "appScopeId",
+        "directoryScopeId",
+        "isValidationOnly",
+        "justification",
+        "principalId",
+        "roleDefinitionId",
+        "scheduleInfo",
+        "targetScheduleId",
+        "ticketInfo"
+      ]
+    },
+    "unifiedRoleDefinition": {
+      "navigationProperties": [
+        "inheritsPermissionsFrom"
+      ],
+      "properties": [
+        "allowedPrincipalTypes",
+        "description",
+        "displayName",
+        "isBuiltIn",
+        "isEnabled",
+        "isPrivileged",
+        "resourceScopes",
+        "rolePermissions",
+        "templateId",
+        "version"
+      ]
+    },
+    "unifiedRoleEligibilitySchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "memberType",
+        "scheduleInfo"
+      ]
+    },
+    "unifiedRoleEligibilityScheduleInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "memberType",
+        "roleEligibilityScheduleId",
+        "startDateTime"
+      ]
+    },
+    "unifiedRoleEligibilityScheduleRequest": {
+      "navigationProperties": [
+        "appScope",
+        "directoryScope",
+        "principal",
+        "roleDefinition",
+        "targetSchedule"
+      ],
+      "properties": [
+        "action",
+        "appScopeId",
+        "directoryScopeId",
+        "isValidationOnly",
+        "justification",
+        "principalId",
+        "roleDefinitionId",
+        "scheduleInfo",
+        "targetScheduleId",
+        "ticketInfo"
+      ]
+    },
+    "unifiedRoleManagementAlert": {
+      "navigationProperties": [
+        "alertConfiguration",
+        "alertDefinition",
+        "alertIncidents"
+      ],
+      "properties": [
+        "alertDefinitionId",
+        "incidentCount",
+        "isActive",
+        "lastModifiedDateTime",
+        "lastScannedDateTime",
+        "scopeId",
+        "scopeType"
+      ]
+    },
+    "unifiedRoleManagementAlertConfiguration": {
+      "navigationProperties": [
+        "alertDefinition"
+      ],
+      "properties": [
+        "alertDefinitionId",
+        "isEnabled",
+        "scopeId",
+        "scopeType"
+      ]
+    },
+    "unifiedRoleManagementAlertDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "howToPrevent",
+        "isConfigurable",
+        "isRemediatable",
+        "mitigationSteps",
+        "scopeId",
+        "scopeType",
+        "securityImpact",
+        "severityLevel"
+      ]
+    },
+    "unifiedRoleManagementAlertIncident": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unifiedRoleManagementPolicy": {
+      "navigationProperties": [
+        "effectiveRules",
+        "rules"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "isOrganizationDefault",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "scopeId",
+        "scopeType"
+      ]
+    },
+    "unifiedRoleManagementPolicyApprovalRule": {
+      "navigationProperties": [],
+      "properties": [
+        "setting"
+      ]
+    },
+    "unifiedRoleManagementPolicyAssignment": {
+      "navigationProperties": [
+        "policy"
+      ],
+      "properties": [
+        "policyId",
+        "roleDefinitionId",
+        "scopeId",
+        "scopeType"
+      ]
+    },
+    "unifiedRoleManagementPolicyAuthenticationContextRule": {
+      "navigationProperties": [],
+      "properties": [
+        "claimValue",
+        "isEnabled"
+      ]
+    },
+    "unifiedRoleManagementPolicyEnablementRule": {
+      "navigationProperties": [],
+      "properties": [
+        "enabledRules"
+      ]
+    },
+    "unifiedRoleManagementPolicyExpirationRule": {
+      "navigationProperties": [],
+      "properties": [
+        "isExpirationRequired",
+        "maximumDuration"
+      ]
+    },
+    "unifiedRoleManagementPolicyNotificationRule": {
+      "navigationProperties": [],
+      "properties": [
+        "isDefaultRecipientsEnabled",
+        "notificationLevel",
+        "notificationRecipients",
+        "notificationType",
+        "recipientType"
+      ]
+    },
+    "unifiedRoleManagementPolicyRule": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "unifiedRoleScheduleBase": {
+      "navigationProperties": [
+        "appScope",
+        "directoryScope",
+        "principal",
+        "roleDefinition"
+      ],
+      "properties": [
+        "appScopeId",
+        "createdDateTime",
+        "createdUsing",
+        "directoryScopeId",
+        "modifiedDateTime",
+        "principalId",
+        "roleDefinitionId",
+        "status"
+      ]
+    },
+    "unifiedRoleScheduleInstanceBase": {
+      "navigationProperties": [
+        "appScope",
+        "directoryScope",
+        "principal",
+        "roleDefinition"
+      ],
+      "properties": [
+        "appScopeId",
+        "directoryScopeId",
+        "principalId",
+        "roleDefinitionId"
+      ]
+    },
+    "unifiedStorageQuota": {
+      "navigationProperties": [
+        "services"
+      ],
+      "properties": [
+        "deleted",
+        "manageWebUrl",
+        "remaining",
+        "state",
+        "total",
+        "used"
+      ]
+    },
+    "unitMap": {
+      "navigationProperties": [],
+      "properties": [
+        "placeId"
+      ]
+    },
+    "unitOfMeasure": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "displayName",
+        "id",
+        "internationalStandardCode",
+        "lastModifiedDateTime"
+      ]
+    },
+    "unmanagedDeviceDiscoveryTask": {
+      "navigationProperties": [],
+      "properties": [
+        "unmanagedDevices"
+      ]
+    },
+    "unmuteParticipantOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unsupportedDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "details",
+        "originalEntityTypeName"
+      ]
+    },
+    "unsupportedGroupPolicyExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "extensionType",
+        "namespaceUrl",
+        "nodeName",
+        "settingScope"
+      ]
+    },
+    "updateAllMessagesReadStateOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "updateRecordingStatusOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "upnSignInIdentifier": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "urlAssessmentRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "url"
+      ]
+    },
+    "usageRight": {
+      "navigationProperties": [],
+      "properties": [
+        "catalogId",
+        "serviceIdentifier",
+        "state"
+      ]
+    },
+    "usageRightsIncluded": {
+      "navigationProperties": [],
+      "properties": [
+        "ownerEmail",
+        "userEmail",
+        "value"
+      ]
+    },
+    "usedInsight": {
+      "navigationProperties": [
+        "resource"
+      ],
+      "properties": [
+        "lastUsed",
+        "resourceReference",
+        "resourceVisualization"
+      ]
+    },
+    "user": {
+      "navigationProperties": [
+        "activities",
+        "adhocCalls",
+        "agreementAcceptances",
+        "analytics",
+        "appConsentRequestsForApproval",
+        "appRoleAssignedResources",
+        "appRoleAssignments",
+        "approvals",
+        "authentication",
+        "calendar",
+        "calendarGroups",
+        "calendars",
+        "calendarView",
+        "chats",
+        "cloudClipboard",
+        "cloudPcPools",
+        "cloudPCs",
+        "communications",
+        "contactFolders",
+        "contacts",
+        "createdObjects",
+        "dataSecurityAndGovernance",
+        "deviceEnrollmentConfigurations",
+        "deviceManagementTroubleshootingEvents",
+        "devices",
+        "directReports",
+        "drive",
+        "drives",
+        "employeeExperience",
+        "events",
+        "extensions",
+        "followedSites",
+        "inferenceClassification",
+        "informationProtection",
+        "insights",
+        "invitedBy",
+        "joinedGroups",
+        "joinedTeams",
+        "licenseDetails",
+        "mailFolders",
+        "managedAppLogCollectionRequests",
+        "managedAppRegistrations",
+        "managedDevices",
+        "manager",
+        "memberOf",
+        "messages",
+        "mobileAppIntentAndStates",
+        "mobileAppTroubleshootingEvents",
+        "notifications",
+        "oauth2PermissionGrants",
+        "onenote",
+        "onlineMeetings",
+        "onPremisesSyncBehavior",
+        "outlook",
+        "ownedDevices",
+        "ownedObjects",
+        "pendingAccessReviewInstances",
+        "people",
+        "permissionGrants",
+        "photo",
+        "photos",
+        "planner",
+        "presence",
+        "profile",
+        "registeredDevices",
+        "scopedRoleMemberOf",
+        "security",
+        "settings",
+        "solutions",
+        "sponsors",
+        "teamwork",
+        "todo",
+        "transitiveMemberOf",
+        "transitiveReports",
+        "usageRights",
+        "virtualEvents",
+        "windowsInformationProtectionDeviceRegistrations"
+      ],
+      "properties": [
+        "aboutMe",
+        "accountEnabled",
+        "ageGroup",
+        "assignedLicenses",
+        "assignedPlans",
+        "authorizationInfo",
+        "birthday",
+        "businessPhones",
+        "city",
+        "cloudLicensing",
+        "cloudRealtimeCommunicationInfo",
+        "companyName",
+        "consentProvidedForMinor",
+        "country",
+        "createdDateTime",
+        "creationType",
+        "customSecurityAttributes",
+        "department",
+        "deviceEnrollmentLimit",
+        "deviceKeys",
+        "displayName",
+        "employeeHireDate",
+        "employeeId",
+        "employeeLeaveDateTime",
+        "employeeOrgData",
+        "employeeType",
+        "externalUserState",
+        "externalUserStateChangeDateTime",
+        "faxNumber",
+        "givenName",
+        "hireDate",
+        "identities",
+        "identityGovernance",
+        "identityParentId",
+        "imAddresses",
+        "infoCatalogs",
+        "interests",
+        "isLicenseReconciliationNeeded",
+        "isManagementRestricted",
+        "isResourceAccount",
+        "jobTitle",
+        "lastPasswordChangeDateTime",
+        "legalAgeGroupClassification",
+        "licenseAssignmentStates",
+        "mail",
+        "mailboxSettings",
+        "mailNickname",
+        "mobilePhone",
+        "mySite",
+        "officeLocation",
+        "onPremisesDistinguishedName",
+        "onPremisesDomainName",
+        "onPremisesExtensionAttributes",
+        "onPremisesImmutableId",
+        "onPremisesLastSyncDateTime",
+        "onPremisesProvisioningErrors",
+        "onPremisesSamAccountName",
+        "onPremisesSecurityIdentifier",
+        "onPremisesSipInfo",
+        "onPremisesSyncEnabled",
+        "onPremisesUserPrincipalName",
+        "otherMails",
+        "passwordPolicies",
+        "passwordProfile",
+        "pastProjects",
+        "postalCode",
+        "preferredDataLocation",
+        "preferredLanguage",
+        "preferredName",
+        "print",
+        "provisionedPlans",
+        "proxyAddresses",
+        "refreshTokensValidFromDateTime",
+        "responsibilities",
+        "schools",
+        "securityIdentifier",
+        "serviceProvisioningErrors",
+        "showInAddressList",
+        "signInActivity",
+        "signInSessionsValidFromDateTime",
+        "skills",
+        "state",
+        "streetAddress",
+        "surname",
+        "usageLocation",
+        "userPrincipalName",
+        "userType"
+      ]
+    },
+    "userAccountInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "ageGroup",
+        "countryCode",
+        "originTenantInfo",
+        "preferredLanguageTag",
+        "userPersona",
+        "userPrincipalName"
+      ]
+    },
+    "userActivity": {
+      "navigationProperties": [
+        "historyItems"
+      ],
+      "properties": [
+        "activationUrl",
+        "activitySourceHost",
+        "appActivityId",
+        "appDisplayName",
+        "contentInfo",
+        "contentUrl",
+        "createdDateTime",
+        "expirationDateTime",
+        "fallbackUrl",
+        "lastModifiedDateTime",
+        "status",
+        "userTimezone",
+        "visualElements"
+      ]
+    },
+    "userAnalytics": {
+      "navigationProperties": [
+        "activityStatistics"
+      ],
+      "properties": [
+        "settings"
+      ]
+    },
+    "userAppInstallStatus": {
+      "navigationProperties": [
+        "app",
+        "deviceStatuses"
+      ],
+      "properties": [
+        "failedDeviceCount",
+        "installedDeviceCount",
+        "notInstalledDeviceCount",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "userCloudCommunication": {
+      "navigationProperties": [
+        "callSettings"
+      ],
+      "properties": []
+    },
+    "userConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "binaryData",
+        "structuredData",
+        "xmlData"
+      ]
+    },
+    "userConsentRequest": {
+      "navigationProperties": [
+        "approval"
+      ],
+      "properties": [
+        "reason"
+      ]
+    },
+    "userCountMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "factDate",
+        "language"
+      ]
+    },
+    "userCredentialUsageDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "authMethod",
+        "eventDateTime",
+        "failureReason",
+        "feature",
+        "isSuccess",
+        "userDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "userDataSecurityAndGovernance": {
+      "navigationProperties": [
+        "activities",
+        "protectionScopes"
+      ],
+      "properties": []
+    },
+    "userEventsSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "authMethod",
+        "eventDateTime",
+        "failureReason",
+        "feature",
+        "isSuccess",
+        "userDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "userExperienceAnalyticsAnomaly": {
+      "navigationProperties": [],
+      "properties": [
+        "anomalyFirstOccurrenceDateTime",
+        "anomalyId",
+        "anomalyLatestOccurrenceDateTime",
+        "anomalyName",
+        "anomalyType",
+        "assetName",
+        "assetPublisher",
+        "assetVersion",
+        "detectionModelId",
+        "deviceImpactedCount",
+        "issueId",
+        "severity",
+        "state"
+      ]
+    },
+    "userExperienceAnalyticsAnomalyCorrelationGroupOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "anomalyCorrelationGroupCount",
+        "anomalyId",
+        "correlationGroupAnomalousDeviceCount",
+        "correlationGroupAtRiskDeviceCount",
+        "correlationGroupDeviceCount",
+        "correlationGroupFeatures",
+        "correlationGroupId",
+        "correlationGroupPrevalence",
+        "correlationGroupPrevalencePercentage",
+        "totalDeviceCount"
+      ]
+    },
+    "userExperienceAnalyticsAnomalyDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "anomalyId",
+        "anomalyOnDeviceFirstOccurrenceDateTime",
+        "anomalyOnDeviceLatestOccurrenceDateTime",
+        "correlationGroupId",
+        "deviceId",
+        "deviceManufacturer",
+        "deviceModel",
+        "deviceName",
+        "deviceStatus",
+        "osName",
+        "osVersion"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthApplicationPerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDeviceCount",
+        "appCrashCount",
+        "appDisplayName",
+        "appHangCount",
+        "appHealthScore",
+        "appName",
+        "appPublisher",
+        "appUsageDuration",
+        "meanTimeToFailureInMinutes"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthAppPerformanceByAppVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "appCrashCount",
+        "appDisplayName",
+        "appName",
+        "appPublisher",
+        "appUsageDuration",
+        "appVersion",
+        "meanTimeToFailureInMinutes"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "appCrashCount",
+        "appDisplayName",
+        "appName",
+        "appPublisher",
+        "appVersion",
+        "deviceCountWithCrashes",
+        "isLatestUsedVersion",
+        "isMostUsedVersion"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDeviceId": {
+      "navigationProperties": [],
+      "properties": [
+        "appCrashCount",
+        "appDisplayName",
+        "appName",
+        "appPublisher",
+        "appVersion",
+        "deviceDisplayName",
+        "deviceId",
+        "processedDateTime"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthAppPerformanceByOSVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDeviceCount",
+        "appCrashCount",
+        "appDisplayName",
+        "appName",
+        "appPublisher",
+        "appUsageDuration",
+        "meanTimeToFailureInMinutes",
+        "osBuildNumber",
+        "osVersion"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthDeviceModelPerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDeviceCount",
+        "deviceManufacturer",
+        "deviceModel",
+        "healthStatus",
+        "meanTimeToFailureInMinutes",
+        "modelAppHealthScore"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthDevicePerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "appCrashCount",
+        "appHangCount",
+        "crashedAppCount",
+        "deviceAppHealthScore",
+        "deviceDisplayName",
+        "deviceId",
+        "deviceManufacturer",
+        "deviceModel",
+        "healthStatus",
+        "meanTimeToFailureInMinutes",
+        "processedDateTime"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthDevicePerformanceDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "appDisplayName",
+        "appPublisher",
+        "appVersion",
+        "deviceDisplayName",
+        "deviceId",
+        "eventDateTime",
+        "eventType"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthOSVersionPerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDeviceCount",
+        "meanTimeToFailureInMinutes",
+        "osBuildNumber",
+        "osVersion",
+        "osVersionAppHealthScore"
+      ]
+    },
+    "userExperienceAnalyticsBaseline": {
+      "navigationProperties": [
+        "appHealthMetrics",
+        "batteryHealthMetrics",
+        "bestPracticesMetrics",
+        "deviceBootPerformanceMetrics",
+        "rebootAnalyticsMetrics",
+        "resourcePerformanceMetrics",
+        "workFromAnywhereMetrics"
+      ],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "isBuiltIn"
+      ]
+    },
+    "userExperienceAnalyticsBatteryHealthAppImpact": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDevices",
+        "appDisplayName",
+        "appName",
+        "appPublisher",
+        "batteryUsagePercentage",
+        "isForegroundApp"
+      ]
+    },
+    "userExperienceAnalyticsBatteryHealthCapacityDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDevices",
+        "batteryCapacityFair",
+        "batteryCapacityGood",
+        "batteryCapacityPoor",
+        "lastRefreshedDateTime"
+      ]
+    },
+    "userExperienceAnalyticsBatteryHealthDeviceAppImpact": {
+      "navigationProperties": [],
+      "properties": [
+        "appDisplayName",
+        "appName",
+        "appPublisher",
+        "batteryUsagePercentage",
+        "deviceId",
+        "isForegroundApp"
+      ]
+    },
+    "userExperienceAnalyticsBatteryHealthDevicePerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "batteryAgeInDays",
+        "deviceBatteriesDetails",
+        "deviceBatteryCount",
+        "deviceBatteryHealthScore",
+        "deviceBatteryTags",
+        "deviceId",
+        "deviceManufacturerName",
+        "deviceModelName",
+        "deviceName",
+        "estimatedRuntimeInMinutes",
+        "fullBatteryDrainCount",
+        "healthStatus",
+        "manufacturer",
+        "maxCapacityPercentage",
+        "model"
+      ]
+    },
+    "userExperienceAnalyticsBatteryHealthDeviceRuntimeHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "estimatedRuntimeInMinutes",
+        "runtimeDateTime"
+      ]
+    },
+    "userExperienceAnalyticsBatteryHealthModelPerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDevices",
+        "averageBatteryAgeInDays",
+        "averageEstimatedRuntimeInMinutes",
+        "averageMaxCapacityPercentage",
+        "deviceManufacturerName",
+        "deviceModelName",
+        "manufacturer",
+        "meanFullBatteryDrainCount",
+        "medianEstimatedRuntimeInMinutes",
+        "medianFullBatteryDrainCount",
+        "medianMaxCapacityPercentage",
+        "model",
+        "modelBatteryHealthScore",
+        "modelHealthStatus"
+      ]
+    },
+    "userExperienceAnalyticsBatteryHealthOsPerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDevices",
+        "averageBatteryAgeInDays",
+        "averageEstimatedRuntimeInMinutes",
+        "averageMaxCapacityPercentage",
+        "meanFullBatteryDrainCount",
+        "medianEstimatedRuntimeInMinutes",
+        "medianFullBatteryDrainCount",
+        "medianMaxCapacityPercentage",
+        "osBatteryHealthScore",
+        "osBuildNumber",
+        "osHealthStatus",
+        "osVersion"
+      ]
+    },
+    "userExperienceAnalyticsBatteryHealthRuntimeDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDevices",
+        "batteryRuntimeFair",
+        "batteryRuntimeGood",
+        "batteryRuntimePoor",
+        "lastRefreshedDateTime"
+      ]
+    },
+    "userExperienceAnalyticsCategory": {
+      "navigationProperties": [
+        "metricValues"
+      ],
+      "properties": [
+        "insights"
+      ]
+    },
+    "userExperienceAnalyticsDevicePerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "averageBlueScreens",
+        "averageRestarts",
+        "blueScreenCount",
+        "bootScore",
+        "coreBootTimeInMs",
+        "coreLoginTimeInMs",
+        "deviceCount",
+        "deviceName",
+        "diskType",
+        "groupPolicyBootTimeInMs",
+        "groupPolicyLoginTimeInMs",
+        "healthStatus",
+        "loginScore",
+        "manufacturer",
+        "model",
+        "modelStartupPerformanceScore",
+        "operatingSystemVersion",
+        "responsiveDesktopTimeInMs",
+        "restartCount",
+        "startupPerformanceScore"
+      ]
+    },
+    "userExperienceAnalyticsDeviceScope": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "deviceScopeName",
+        "enabled",
+        "isBuiltIn",
+        "lastModifiedDateTime",
+        "operator",
+        "ownerId",
+        "parameter",
+        "status",
+        "value",
+        "valueObjectId"
+      ]
+    },
+    "userExperienceAnalyticsDeviceScores": {
+      "navigationProperties": [],
+      "properties": [
+        "appReliabilityScore",
+        "batteryHealthScore",
+        "deviceName",
+        "endpointAnalyticsScore",
+        "healthStatus",
+        "manufacturer",
+        "meanResourceSpikeTimeScore",
+        "model",
+        "startupPerformanceScore",
+        "workFromAnywhereScore"
+      ]
+    },
+    "userExperienceAnalyticsDeviceStartupHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "coreBootTimeInMs",
+        "coreLoginTimeInMs",
+        "deviceId",
+        "featureUpdateBootTimeInMs",
+        "groupPolicyBootTimeInMs",
+        "groupPolicyLoginTimeInMs",
+        "isFeatureUpdate",
+        "isFirstLogin",
+        "operatingSystemVersion",
+        "responsiveDesktopTimeInMs",
+        "restartCategory",
+        "restartFaultBucket",
+        "restartStopCode",
+        "startTime",
+        "totalBootTimeInMs",
+        "totalLoginTimeInMs"
+      ]
+    },
+    "userExperienceAnalyticsDeviceStartupProcess": {
+      "navigationProperties": [],
+      "properties": [
+        "managedDeviceId",
+        "processName",
+        "productName",
+        "publisher",
+        "startupImpactInMs"
+      ]
+    },
+    "userExperienceAnalyticsDeviceStartupProcessPerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "medianImpactInMs",
+        "processName",
+        "productName",
+        "publisher",
+        "totalImpactInMs"
+      ]
+    },
+    "userExperienceAnalyticsDeviceTimelineEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "eventDateTime",
+        "eventDetails",
+        "eventLevel",
+        "eventName",
+        "eventSource"
+      ]
+    },
+    "userExperienceAnalyticsDeviceWithoutCloudIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "azureAdDeviceId",
+        "deviceName"
+      ]
+    },
+    "userExperienceAnalyticsImpactingProcess": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "description",
+        "deviceId",
+        "impactValue",
+        "processName",
+        "publisher"
+      ]
+    },
+    "userExperienceAnalyticsMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "unit",
+        "value"
+      ]
+    },
+    "userExperienceAnalyticsMetricHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "metricDateTime",
+        "metricType"
+      ]
+    },
+    "userExperienceAnalyticsModelScores": {
+      "navigationProperties": [],
+      "properties": [
+        "appReliabilityScore",
+        "batteryHealthScore",
+        "endpointAnalyticsScore",
+        "healthStatus",
+        "manufacturer",
+        "meanResourceSpikeTimeScore",
+        "model",
+        "modelDeviceCount",
+        "startupPerformanceScore",
+        "workFromAnywhereScore"
+      ]
+    },
+    "userExperienceAnalyticsNotAutopilotReadyDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "autoPilotProfileAssigned",
+        "autoPilotRegistered",
+        "azureAdJoinType",
+        "azureAdRegistered",
+        "deviceName",
+        "managedBy",
+        "manufacturer",
+        "model",
+        "serialNumber"
+      ]
+    },
+    "userExperienceAnalyticsOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "insights"
+      ]
+    },
+    "userExperienceAnalyticsRemoteConnection": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudPcFailurePercentage",
+        "cloudPcRoundTripTime",
+        "cloudPcSignInTime",
+        "coreBootTime",
+        "coreSignInTime",
+        "deviceCount",
+        "deviceId",
+        "deviceName",
+        "manufacturer",
+        "model",
+        "remoteSignInTime",
+        "userPrincipalName",
+        "virtualNetwork"
+      ]
+    },
+    "userExperienceAnalyticsResourcePerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "averageSpikeTimeScore",
+        "cpuClockSpeedInMHz",
+        "cpuDisplayName",
+        "cpuSpikeTimePercentage",
+        "cpuSpikeTimePercentageThreshold",
+        "cpuSpikeTimeScore",
+        "deviceCount",
+        "deviceId",
+        "deviceName",
+        "deviceResourcePerformanceScore",
+        "diskType",
+        "healthStatus",
+        "machineType",
+        "manufacturer",
+        "model",
+        "ramSpikeTimePercentage",
+        "ramSpikeTimePercentageThreshold",
+        "ramSpikeTimeScore",
+        "totalProcessorCoreCount",
+        "totalRamInMB"
+      ]
+    },
+    "userExperienceAnalyticsScoreHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "startupDateTime"
+      ]
+    },
+    "userExperienceAnalyticsWorkFromAnywhereDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "autoPilotProfileAssigned",
+        "autoPilotRegistered",
+        "azureAdDeviceId",
+        "azureAdJoinType",
+        "azureAdRegistered",
+        "cloudIdentityScore",
+        "cloudManagementScore",
+        "cloudProvisioningScore",
+        "compliancePolicySetToIntune",
+        "deviceId",
+        "deviceName",
+        "healthStatus",
+        "isCloudManagedGatewayEnabled",
+        "managedBy",
+        "manufacturer",
+        "model",
+        "osCheckFailed",
+        "osDescription",
+        "osVersion",
+        "otherWorkloadsSetToIntune",
+        "ownership",
+        "processor64BitCheckFailed",
+        "processorCoreCountCheckFailed",
+        "processorFamilyCheckFailed",
+        "processorSpeedCheckFailed",
+        "ramCheckFailed",
+        "secureBootCheckFailed",
+        "serialNumber",
+        "storageCheckFailed",
+        "tenantAttached",
+        "tpmCheckFailed",
+        "upgradeEligibility",
+        "windowsScore",
+        "workFromAnywhereScore"
+      ]
+    },
+    "userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "osCheckFailedPercentage",
+        "processor64BitCheckFailedPercentage",
+        "processorCoreCountCheckFailedPercentage",
+        "processorFamilyCheckFailedPercentage",
+        "processorSpeedCheckFailedPercentage",
+        "ramCheckFailedPercentage",
+        "secureBootCheckFailedPercentage",
+        "storageCheckFailedPercentage",
+        "totalDeviceCount",
+        "tpmCheckFailedPercentage",
+        "upgradeEligibleDeviceCount"
+      ]
+    },
+    "userExperienceAnalyticsWorkFromAnywhereMetric": {
+      "navigationProperties": [
+        "metricDevices"
+      ],
+      "properties": []
+    },
+    "userExperienceAnalyticsWorkFromAnywhereModelPerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudIdentityScore",
+        "cloudManagementScore",
+        "cloudProvisioningScore",
+        "healthStatus",
+        "manufacturer",
+        "model",
+        "modelDeviceCount",
+        "windowsScore",
+        "workFromAnywhereScore"
+      ]
+    },
+    "userFlowLanguageConfiguration": {
+      "navigationProperties": [
+        "defaultPages",
+        "overridesPages"
+      ],
+      "properties": [
+        "displayName",
+        "isEnabled"
+      ]
+    },
+    "userFlowLanguagePage": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "userInsightsRoot": {
+      "navigationProperties": [
+        "daily",
+        "monthly"
+      ],
+      "properties": []
+    },
+    "userInsightsSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "userInstallStateSummary": {
+      "navigationProperties": [
+        "deviceStates"
+      ],
+      "properties": [
+        "failedDeviceCount",
+        "installedDeviceCount",
+        "notInstalledDeviceCount",
+        "userName"
+      ]
+    },
+    "userMfaSignInSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "multiFactorSignIns",
+        "singleFactorSignIns",
+        "totalSignIns"
+      ]
+    },
+    "usernameSignInIdentifier": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "userPasswordResetsAndChangesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "aggregatedDateTime",
+        "changePasswordSelfServiceCount",
+        "passwordResetsByAdminCount",
+        "passwordResetsSelfServiceCount"
+      ]
+    },
+    "userPFXCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "encryptedPfxBlob",
+        "encryptedPfxPassword",
+        "expirationDateTime",
+        "intendedPurpose",
+        "keyName",
+        "lastModifiedDateTime",
+        "paddingScheme",
+        "providerName",
+        "startDateTime",
+        "thumbprint",
+        "userPrincipalName"
+      ]
+    },
+    "userProtectionScopeContainer": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "userRegistrationActivitySummary": {
+      "navigationProperties": [],
+      "properties": [
+        "authMethod",
+        "failureActivityCount",
+        "feature",
+        "successfulActivityCount"
+      ]
+    },
+    "userRegistrationDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultMfaMethod",
+        "isAdmin",
+        "isMfaCapable",
+        "isMfaRegistered",
+        "isPasswordlessCapable",
+        "isSsprCapable",
+        "isSsprEnabled",
+        "isSsprRegistered",
+        "isSystemPreferredAuthenticationMethodEnabled",
+        "lastUpdatedDateTime",
+        "methodsRegistered",
+        "systemPreferredAuthenticationMethods",
+        "userDisplayName",
+        "userPreferredMethodForSecondaryAuthentication",
+        "userPrincipalName",
+        "userType"
+      ]
+    },
+    "userRequestsMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "browser",
+        "country",
+        "factDate",
+        "identityProvider",
+        "language",
+        "requestCount"
+      ]
+    },
+    "userScopeTeamsAppInstallation": {
+      "navigationProperties": [
+        "chat"
+      ],
+      "properties": []
+    },
+    "userSecurityProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "accounts",
+        "azureSubscriptionId",
+        "azureTenantId",
+        "createdDateTime",
+        "displayName",
+        "lastModifiedDateTime",
+        "riskScore",
+        "tags",
+        "userPrincipalName",
+        "vendorInformation"
+      ]
+    },
+    "userSettings": {
+      "navigationProperties": [
+        "contactMergeSuggestions",
+        "exchange",
+        "itemInsights",
+        "regionalAndLanguageSettings",
+        "shiftPreferences",
+        "storage",
+        "windows",
+        "workHoursAndLocations"
+      ],
+      "properties": [
+        "contributionToContentDiscoveryAsOrganizationDisabled",
+        "contributionToContentDiscoveryDisabled"
+      ]
+    },
+    "userSignInInsight": {
+      "navigationProperties": [],
+      "properties": [
+        "lastSignInDateTime"
+      ]
+    },
+    "userSignInUsageByAuthMethodActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationMethod",
+        "successActivityCount"
+      ]
+    },
+    "userSignUpMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "browser",
+        "count",
+        "country",
+        "factDate",
+        "identityProvider",
+        "language",
+        "os"
+      ]
+    },
+    "userSolutionRoot": {
+      "navigationProperties": [
+        "workingTimeSchedule"
+      ],
+      "properties": []
+    },
+    "userStorage": {
+      "navigationProperties": [
+        "quota"
+      ],
+      "properties": []
+    },
+    "userTeamwork": {
+      "navigationProperties": [
+        "associatedTeams",
+        "installedApps",
+        "sections"
+      ],
+      "properties": [
+        "locale",
+        "region"
+      ]
+    },
+    "userVirtualEventsRoot": {
+      "navigationProperties": [
+        "webinars"
+      ],
+      "properties": []
+    },
+    "uxSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "restrictNonAdminAccess"
+      ]
+    },
+    "vendor": {
+      "navigationProperties": [
+        "currency",
+        "paymentMethod",
+        "paymentTerm",
+        "picture"
+      ],
+      "properties": [
+        "address",
+        "balance",
+        "blocked",
+        "currencyCode",
+        "currencyId",
+        "displayName",
+        "email",
+        "id",
+        "lastModifiedDateTime",
+        "number",
+        "paymentMethodId",
+        "paymentTermsId",
+        "phoneNumber",
+        "taxLiable",
+        "taxRegistrationNumber",
+        "website"
+      ]
+    },
+    "verifiableCredentialAuthenticationMethodTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "verifiedIdProfiles"
+      ]
+    },
+    "verifiableCredentialsAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": []
+    },
+    "verifiedIdProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "faceCheckConfiguration",
+        "lastModifiedDateTime",
+        "name",
+        "priority",
+        "state",
+        "verifiedIdProfileConfiguration",
+        "verifiedIdUsageConfigurations",
+        "verifierDid"
+      ]
+    },
+    "verticalSection": {
+      "navigationProperties": [
+        "webparts"
+      ],
+      "properties": [
+        "emphasis"
+      ]
+    },
+    "videoNewsLinkPage": {
+      "navigationProperties": [],
+      "properties": [
+        "bannerImageWebUrl",
+        "newsSharepointIds",
+        "newsWebUrl",
+        "videoDuration"
+      ]
+    },
+    "virtualEndpoint": {
+      "navigationProperties": [
+        "auditEvents",
+        "bulkActions",
+        "cloudApps",
+        "cloudPcPools",
+        "cloudPCs",
+        "crossCloudGovernmentOrganizationMapping",
+        "deviceImages",
+        "externalPartners",
+        "externalPartnerSettings",
+        "frontLineServicePlans",
+        "galleryImages",
+        "managedLicenses",
+        "onPremisesConnections",
+        "organizationSettings",
+        "provisioningPolicies",
+        "report",
+        "reports",
+        "servicePlans",
+        "snapshots",
+        "supportedRegions",
+        "userSettings"
+      ],
+      "properties": []
+    },
+    "virtualEvent": {
+      "navigationProperties": [
+        "presenters",
+        "sessions"
+      ],
+      "properties": [
+        "createdBy",
+        "description",
+        "displayName",
+        "endDateTime",
+        "externalEventInformation",
+        "settings",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "virtualEventPresenter": {
+      "navigationProperties": [
+        "sessions"
+      ],
+      "properties": [
+        "email",
+        "identity",
+        "presenterDetails"
+      ]
+    },
+    "virtualEventRegistration": {
+      "navigationProperties": [
+        "sessions"
+      ],
+      "properties": [
+        "cancelationDateTime",
+        "email",
+        "externalRegistrationInformation",
+        "firstName",
+        "lastName",
+        "preferredLanguage",
+        "preferredTimezone",
+        "registrantVideoOnDemandWebUrl",
+        "registrationDateTime",
+        "registrationQuestionAnswers",
+        "status",
+        "userId"
+      ]
+    },
+    "virtualEventRegistrationConfiguration": {
+      "navigationProperties": [
+        "questions"
+      ],
+      "properties": [
+        "capacity",
+        "registrationWebUrl"
+      ]
+    },
+    "virtualEventRegistrationCustomQuestion": {
+      "navigationProperties": [],
+      "properties": [
+        "answerChoices",
+        "answerInputType"
+      ]
+    },
+    "virtualEventRegistrationPredefinedQuestion": {
+      "navigationProperties": [],
+      "properties": [
+        "label"
+      ]
+    },
+    "virtualEventRegistrationQuestionBase": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "isRequired"
+      ]
+    },
+    "virtualEventSession": {
+      "navigationProperties": [
+        "presenters",
+        "registrations"
+      ],
+      "properties": [
+        "endDateTime",
+        "startDateTime",
+        "videoOnDemandWebUrl"
+      ]
+    },
+    "virtualEventsRoot": {
+      "navigationProperties": [
+        "events",
+        "townhalls",
+        "webinars"
+      ],
+      "properties": []
+    },
+    "virtualEventTownhall": {
+      "navigationProperties": [],
+      "properties": [
+        "audience",
+        "coOrganizers",
+        "invitedAttendees",
+        "isInviteOnly"
+      ]
+    },
+    "virtualEventWebinar": {
+      "navigationProperties": [
+        "registrationConfiguration",
+        "registrations"
+      ],
+      "properties": [
+        "audience",
+        "coOrganizers"
+      ]
+    },
+    "virtualEventWebinarRegistrationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isManualApprovalEnabled",
+        "isWaitlistEnabled"
+      ]
+    },
+    "virtualMachineDetails": {
+      "navigationProperties": [
+        "virtualMachine"
+      ],
+      "properties": []
+    },
+    "virtualMachineWithAwsStorageBucketAccessFinding": {
+      "navigationProperties": [
+        "ec2Instance",
+        "role"
+      ],
+      "properties": [
+        "accessibleCount",
+        "bucketCount",
+        "permissionsCreepIndex"
+      ]
+    },
+    "voiceAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": [
+        "isOfficePhoneAllowed"
+      ]
+    },
+    "voiceAuthenticationMethodTarget": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "vpnConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationMethod",
+        "connectionName",
+        "realm",
+        "role",
+        "servers"
+      ]
+    },
+    "vppToken": {
+      "navigationProperties": [],
+      "properties": [
+        "appleId",
+        "automaticallyUpdateApps",
+        "claimTokenManagementFromExternalMdm",
+        "countryOrRegion",
+        "dataSharingConsentGranted",
+        "displayName",
+        "expirationDateTime",
+        "lastModifiedDateTime",
+        "lastSyncDateTime",
+        "lastSyncStatus",
+        "locationName",
+        "organizationName",
+        "roleScopeTagIds",
+        "state",
+        "token",
+        "tokenActionResults",
+        "vppTokenAccountType"
+      ]
+    },
+    "vulnerableManagedDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastSyncDateTime",
+        "managedDeviceId"
+      ]
+    },
+    "webAccount": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "service",
+        "statusMessage",
+        "thumbnailUrl",
+        "userId",
+        "webUrl"
+      ]
+    },
+    "webApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appUrl",
+        "useManagedBrowser"
+      ]
+    },
+    "webApplicationFirewallProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "webApplicationFirewallVerificationModel": {
+      "navigationProperties": [
+        "provider"
+      ],
+      "properties": [
+        "providerType",
+        "verificationResult",
+        "verifiedDetails",
+        "verifiedHost"
+      ]
+    },
+    "webApplicationSegment": {
+      "navigationProperties": [
+        "corsConfigurations"
+      ],
+      "properties": [
+        "alternateUrl",
+        "externalUrl",
+        "internalUrl"
+      ]
+    },
+    "webPart": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "whatIfAnalysisResult": {
+      "navigationProperties": [],
+      "properties": [
+        "analysisReasons",
+        "policyApplies"
+      ]
+    },
+    "win32CatalogApp": {
+      "navigationProperties": [
+        "latestUpgradeCatalogPackage",
+        "referencedCatalogPackage"
+      ],
+      "properties": [
+        "mobileAppCatalogPackageId"
+      ]
+    },
+    "win32LobApp": {
+      "navigationProperties": [],
+      "properties": [
+        "activeInstallScript",
+        "activeUninstallScript",
+        "allowAvailableUninstall",
+        "allowedArchitectures",
+        "applicableArchitectures",
+        "detectionRules",
+        "displayVersion",
+        "installCommandLine",
+        "installExperience",
+        "minimumCpuSpeedInMHz",
+        "minimumFreeDiskSpaceInMB",
+        "minimumMemoryInMB",
+        "minimumNumberOfProcessors",
+        "minimumSupportedOperatingSystem",
+        "minimumSupportedWindowsRelease",
+        "msiInformation",
+        "requirementRules",
+        "returnCodes",
+        "rules",
+        "setupFilePath",
+        "uninstallCommandLine"
+      ]
+    },
+    "win32LobAppInstallPowerShellScript": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "win32LobAppScript": {
+      "navigationProperties": [],
+      "properties": [
+        "enforceSignatureCheck",
+        "runAs32Bit"
+      ]
+    },
+    "win32LobAppUninstallPowerShellScript": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "win32MobileAppCatalogPackage": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableArchitectures",
+        "branchDisplayName",
+        "branchId",
+        "locales",
+        "packageAutoUpdateCapable"
+      ]
+    },
+    "windows10CertificateProfileBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "windows10CompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "activeFirewallRequired",
+        "antiSpywareRequired",
+        "antivirusRequired",
+        "bitLockerEnabled",
+        "codeIntegrityEnabled",
+        "configurationManagerComplianceRequired",
+        "defenderEnabled",
+        "defenderVersion",
+        "deviceCompliancePolicyScript",
+        "deviceThreatProtectionEnabled",
+        "deviceThreatProtectionRequiredSecurityLevel",
+        "earlyLaunchAntiMalwareDriverEnabled",
+        "firmwareProtectionEnabled",
+        "kernelDmaProtectionEnabled",
+        "memoryIntegrityEnabled",
+        "mobileOsMaximumVersion",
+        "mobileOsMinimumVersion",
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredToUnlockFromIdle",
+        "passwordRequiredType",
+        "requireHealthyDeviceReport",
+        "rtpEnabled",
+        "secureBootEnabled",
+        "signatureOutOfDate",
+        "storageRequireEncryption",
+        "tpmRequired",
+        "validOperatingSystemBuildRanges",
+        "virtualizationBasedSecurityEnabled",
+        "wslDistributions"
+      ]
+    },
+    "windows10CustomConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "omaSettings"
+      ]
+    },
+    "windows10DeviceFirmwareConfigurationInterface": {
+      "navigationProperties": [],
+      "properties": [
+        "bluetooth",
+        "bootFromBuiltInNetworkAdapters",
+        "bootFromExternalMedia",
+        "cameras",
+        "changeUefiSettingsPermission",
+        "frontCamera",
+        "infraredCamera",
+        "microphone",
+        "microphonesAndSpeakers",
+        "nearFieldCommunication",
+        "radios",
+        "rearCamera",
+        "sdCard",
+        "simultaneousMultiThreading",
+        "usbTypeAPort",
+        "virtualizationOfCpuAndIO",
+        "wakeOnLAN",
+        "wakeOnPower",
+        "wiFi",
+        "windowsPlatformBinaryTable",
+        "wirelessWideAreaNetwork"
+      ]
+    },
+    "windows10EasEmailProfileConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accountName",
+        "durationOfEmailToSync",
+        "emailAddressSource",
+        "emailSyncSchedule",
+        "hostName",
+        "requireSsl",
+        "syncCalendar",
+        "syncContacts",
+        "syncTasks"
+      ]
+    },
+    "windows10EndpointProtectionConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationGuardAllowCameraMicrophoneRedirection",
+        "applicationGuardAllowFileSaveOnHost",
+        "applicationGuardAllowPersistence",
+        "applicationGuardAllowPrintToLocalPrinters",
+        "applicationGuardAllowPrintToNetworkPrinters",
+        "applicationGuardAllowPrintToPDF",
+        "applicationGuardAllowPrintToXPS",
+        "applicationGuardAllowVirtualGPU",
+        "applicationGuardBlockClipboardSharing",
+        "applicationGuardBlockFileTransfer",
+        "applicationGuardBlockNonEnterpriseContent",
+        "applicationGuardCertificateThumbprints",
+        "applicationGuardEnabled",
+        "applicationGuardEnabledOptions",
+        "applicationGuardForceAuditing",
+        "appLockerApplicationControl",
+        "bitLockerAllowStandardUserEncryption",
+        "bitLockerDisableWarningForOtherDiskEncryption",
+        "bitLockerEnableStorageCardEncryptionOnMobile",
+        "bitLockerEncryptDevice",
+        "bitLockerFixedDrivePolicy",
+        "bitLockerRecoveryPasswordRotation",
+        "bitLockerRemovableDrivePolicy",
+        "bitLockerSystemDrivePolicy",
+        "defenderAdditionalGuardedFolders",
+        "defenderAdobeReaderLaunchChildProcess",
+        "defenderAdvancedRansomewareProtectionType",
+        "defenderAllowBehaviorMonitoring",
+        "defenderAllowCloudProtection",
+        "defenderAllowEndUserAccess",
+        "defenderAllowIntrusionPreventionSystem",
+        "defenderAllowOnAccessProtection",
+        "defenderAllowRealTimeMonitoring",
+        "defenderAllowScanArchiveFiles",
+        "defenderAllowScanDownloads",
+        "defenderAllowScanNetworkFiles",
+        "defenderAllowScanRemovableDrivesDuringFullScan",
+        "defenderAllowScanScriptsLoadedInInternetExplorer",
+        "defenderAttackSurfaceReductionExcludedPaths",
+        "defenderBlockEndUserAccess",
+        "defenderBlockPersistenceThroughWmiType",
+        "defenderCheckForSignaturesBeforeRunningScan",
+        "defenderCloudBlockLevel",
+        "defenderCloudExtendedTimeoutInSeconds",
+        "defenderDaysBeforeDeletingQuarantinedMalware",
+        "defenderDetectedMalwareActions",
+        "defenderDisableBehaviorMonitoring",
+        "defenderDisableCatchupFullScan",
+        "defenderDisableCatchupQuickScan",
+        "defenderDisableCloudProtection",
+        "defenderDisableIntrusionPreventionSystem",
+        "defenderDisableOnAccessProtection",
+        "defenderDisableRealTimeMonitoring",
+        "defenderDisableScanArchiveFiles",
+        "defenderDisableScanDownloads",
+        "defenderDisableScanNetworkFiles",
+        "defenderDisableScanRemovableDrivesDuringFullScan",
+        "defenderDisableScanScriptsLoadedInInternetExplorer",
+        "defenderEmailContentExecution",
+        "defenderEmailContentExecutionType",
+        "defenderEnableLowCpuPriority",
+        "defenderEnableScanIncomingMail",
+        "defenderEnableScanMappedNetworkDrivesDuringFullScan",
+        "defenderExploitProtectionXml",
+        "defenderExploitProtectionXmlFileName",
+        "defenderFileExtensionsToExclude",
+        "defenderFilesAndFoldersToExclude",
+        "defenderGuardedFoldersAllowedAppPaths",
+        "defenderGuardMyFoldersType",
+        "defenderNetworkProtectionType",
+        "defenderOfficeAppsExecutableContentCreationOrLaunch",
+        "defenderOfficeAppsExecutableContentCreationOrLaunchType",
+        "defenderOfficeAppsLaunchChildProcess",
+        "defenderOfficeAppsLaunchChildProcessType",
+        "defenderOfficeAppsOtherProcessInjection",
+        "defenderOfficeAppsOtherProcessInjectionType",
+        "defenderOfficeCommunicationAppsLaunchChildProcess",
+        "defenderOfficeMacroCodeAllowWin32Imports",
+        "defenderOfficeMacroCodeAllowWin32ImportsType",
+        "defenderPotentiallyUnwantedAppAction",
+        "defenderPreventCredentialStealingType",
+        "defenderProcessCreation",
+        "defenderProcessCreationType",
+        "defenderProcessesToExclude",
+        "defenderScanDirection",
+        "defenderScanMaxCpuPercentage",
+        "defenderScanType",
+        "defenderScheduledQuickScanTime",
+        "defenderScheduledScanDay",
+        "defenderScheduledScanTime",
+        "defenderScriptDownloadedPayloadExecution",
+        "defenderScriptDownloadedPayloadExecutionType",
+        "defenderScriptObfuscatedMacroCode",
+        "defenderScriptObfuscatedMacroCodeType",
+        "defenderSecurityCenterBlockExploitProtectionOverride",
+        "defenderSecurityCenterDisableAccountUI",
+        "defenderSecurityCenterDisableAppBrowserUI",
+        "defenderSecurityCenterDisableClearTpmUI",
+        "defenderSecurityCenterDisableFamilyUI",
+        "defenderSecurityCenterDisableHardwareUI",
+        "defenderSecurityCenterDisableHealthUI",
+        "defenderSecurityCenterDisableNetworkUI",
+        "defenderSecurityCenterDisableNotificationAreaUI",
+        "defenderSecurityCenterDisableRansomwareUI",
+        "defenderSecurityCenterDisableSecureBootUI",
+        "defenderSecurityCenterDisableTroubleshootingUI",
+        "defenderSecurityCenterDisableVirusUI",
+        "defenderSecurityCenterDisableVulnerableTpmFirmwareUpdateUI",
+        "defenderSecurityCenterHelpEmail",
+        "defenderSecurityCenterHelpPhone",
+        "defenderSecurityCenterHelpURL",
+        "defenderSecurityCenterITContactDisplay",
+        "defenderSecurityCenterNotificationsFromApp",
+        "defenderSecurityCenterOrganizationDisplayName",
+        "defenderSignatureUpdateIntervalInHours",
+        "defenderSubmitSamplesConsentType",
+        "defenderUntrustedExecutable",
+        "defenderUntrustedExecutableType",
+        "defenderUntrustedUSBProcess",
+        "defenderUntrustedUSBProcessType",
+        "deviceGuardEnableSecureBootWithDMA",
+        "deviceGuardEnableVirtualizationBasedSecurity",
+        "deviceGuardLaunchSystemGuard",
+        "deviceGuardLocalSystemAuthorityCredentialGuardSettings",
+        "deviceGuardSecureBootWithDMA",
+        "dmaGuardDeviceEnumerationPolicy",
+        "firewallBlockStatefulFTP",
+        "firewallCertificateRevocationListCheckMethod",
+        "firewallIdleTimeoutForSecurityAssociationInSeconds",
+        "firewallIPSecExemptionsAllowDHCP",
+        "firewallIPSecExemptionsAllowICMP",
+        "firewallIPSecExemptionsAllowNeighborDiscovery",
+        "firewallIPSecExemptionsAllowRouterDiscovery",
+        "firewallIPSecExemptionsNone",
+        "firewallMergeKeyingModuleSettings",
+        "firewallPacketQueueingMethod",
+        "firewallPreSharedKeyEncodingMethod",
+        "firewallProfileDomain",
+        "firewallProfilePrivate",
+        "firewallProfilePublic",
+        "firewallRules",
+        "lanManagerAuthenticationLevel",
+        "lanManagerWorkstationDisableInsecureGuestLogons",
+        "localSecurityOptionsAdministratorAccountName",
+        "localSecurityOptionsAdministratorElevationPromptBehavior",
+        "localSecurityOptionsAllowAnonymousEnumerationOfSAMAccountsAndShares",
+        "localSecurityOptionsAllowPKU2UAuthenticationRequests",
+        "localSecurityOptionsAllowRemoteCallsToSecurityAccountsManager",
+        "localSecurityOptionsAllowRemoteCallsToSecurityAccountsManagerHelperBool",
+        "localSecurityOptionsAllowSystemToBeShutDownWithoutHavingToLogOn",
+        "localSecurityOptionsAllowUIAccessApplicationElevation",
+        "localSecurityOptionsAllowUIAccessApplicationsForSecureLocations",
+        "localSecurityOptionsAllowUndockWithoutHavingToLogon",
+        "localSecurityOptionsBlockMicrosoftAccounts",
+        "localSecurityOptionsBlockRemoteLogonWithBlankPassword",
+        "localSecurityOptionsBlockRemoteOpticalDriveAccess",
+        "localSecurityOptionsBlockUsersInstallingPrinterDrivers",
+        "localSecurityOptionsClearVirtualMemoryPageFile",
+        "localSecurityOptionsClientDigitallySignCommunicationsAlways",
+        "localSecurityOptionsClientSendUnencryptedPasswordToThirdPartySMBServers",
+        "localSecurityOptionsDetectApplicationInstallationsAndPromptForElevation",
+        "localSecurityOptionsDisableAdministratorAccount",
+        "localSecurityOptionsDisableClientDigitallySignCommunicationsIfServerAgrees",
+        "localSecurityOptionsDisableGuestAccount",
+        "localSecurityOptionsDisableServerDigitallySignCommunicationsAlways",
+        "localSecurityOptionsDisableServerDigitallySignCommunicationsIfClientAgrees",
+        "localSecurityOptionsDoNotAllowAnonymousEnumerationOfSAMAccounts",
+        "localSecurityOptionsDoNotRequireCtrlAltDel",
+        "localSecurityOptionsDoNotStoreLANManagerHashValueOnNextPasswordChange",
+        "localSecurityOptionsFormatAndEjectOfRemovableMediaAllowedUser",
+        "localSecurityOptionsGuestAccountName",
+        "localSecurityOptionsHideLastSignedInUser",
+        "localSecurityOptionsHideUsernameAtSignIn",
+        "localSecurityOptionsInformationDisplayedOnLockScreen",
+        "localSecurityOptionsInformationShownOnLockScreen",
+        "localSecurityOptionsLogOnMessageText",
+        "localSecurityOptionsLogOnMessageTitle",
+        "localSecurityOptionsMachineInactivityLimit",
+        "localSecurityOptionsMachineInactivityLimitInMinutes",
+        "localSecurityOptionsMinimumSessionSecurityForNtlmSspBasedClients",
+        "localSecurityOptionsMinimumSessionSecurityForNtlmSspBasedServers",
+        "localSecurityOptionsOnlyElevateSignedExecutables",
+        "localSecurityOptionsRestrictAnonymousAccessToNamedPipesAndShares",
+        "localSecurityOptionsSmartCardRemovalBehavior",
+        "localSecurityOptionsStandardUserElevationPromptBehavior",
+        "localSecurityOptionsSwitchToSecureDesktopWhenPromptingForElevation",
+        "localSecurityOptionsUseAdminApprovalMode",
+        "localSecurityOptionsUseAdminApprovalModeForAdministrators",
+        "localSecurityOptionsVirtualizeFileAndRegistryWriteFailuresToPerUserLocations",
+        "smartScreenBlockOverrideForFiles",
+        "smartScreenEnableInShell",
+        "userRightsAccessCredentialManagerAsTrustedCaller",
+        "userRightsActAsPartOfTheOperatingSystem",
+        "userRightsAllowAccessFromNetwork",
+        "userRightsBackupData",
+        "userRightsBlockAccessFromNetwork",
+        "userRightsChangeSystemTime",
+        "userRightsCreateGlobalObjects",
+        "userRightsCreatePageFile",
+        "userRightsCreatePermanentSharedObjects",
+        "userRightsCreateSymbolicLinks",
+        "userRightsCreateToken",
+        "userRightsDebugPrograms",
+        "userRightsDelegation",
+        "userRightsDenyLocalLogOn",
+        "userRightsGenerateSecurityAudits",
+        "userRightsImpersonateClient",
+        "userRightsIncreaseSchedulingPriority",
+        "userRightsLoadUnloadDrivers",
+        "userRightsLocalLogOn",
+        "userRightsLockMemory",
+        "userRightsManageAuditingAndSecurityLogs",
+        "userRightsManageVolumes",
+        "userRightsModifyFirmwareEnvironment",
+        "userRightsModifyObjectLabels",
+        "userRightsProfileSingleProcess",
+        "userRightsRemoteDesktopServicesLogOn",
+        "userRightsRemoteShutdown",
+        "userRightsRestoreData",
+        "userRightsTakeOwnership",
+        "windowsDefenderTamperProtection",
+        "xboxServicesAccessoryManagementServiceStartupMode",
+        "xboxServicesEnableXboxGameSaveTask",
+        "xboxServicesLiveAuthManagerServiceStartupMode",
+        "xboxServicesLiveGameSaveServiceStartupMode",
+        "xboxServicesLiveNetworkingServiceStartupMode"
+      ]
+    },
+    "windows10EnrollmentCompletionPageConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowDeviceResetOnInstallFailure",
+        "allowDeviceUseOnInstallFailure",
+        "allowLogCollectionOnInstallFailure",
+        "allowNonBlockingAppInstallation",
+        "blockDeviceSetupRetryByUser",
+        "customErrorMessage",
+        "disableUserStatusTrackingAfterFirstUser",
+        "installProgressTimeoutInMinutes",
+        "installQualityUpdates",
+        "selectedMobileAppIds",
+        "showInstallationProgress",
+        "trackInstallProgressForAutopilotOnly"
+      ]
+    },
+    "windows10EnrollmentCompletionPageConfigurationPolicySetItem": {
+      "navigationProperties": [],
+      "properties": [
+        "priority"
+      ]
+    },
+    "windows10EnterpriseModernAppManagementConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "uninstallBuiltInApps"
+      ]
+    },
+    "windows10GeneralConfiguration": {
+      "navigationProperties": [
+        "privacyAccessControls"
+      ],
+      "properties": [
+        "accountsBlockAddingNonMicrosoftAccountEmail",
+        "activateAppsWithVoice",
+        "antiTheftModeBlocked",
+        "appManagementMSIAllowUserControlOverInstall",
+        "appManagementMSIAlwaysInstallWithElevatedPrivileges",
+        "appManagementPackageFamilyNamesToLaunchAfterLogOn",
+        "appsAllowTrustedAppsSideloading",
+        "appsBlockWindowsStoreOriginatedApps",
+        "authenticationAllowSecondaryDevice",
+        "authenticationPreferredAzureADTenantDomainName",
+        "authenticationWebSignIn",
+        "bluetoothAllowedServices",
+        "bluetoothBlockAdvertising",
+        "bluetoothBlockDiscoverableMode",
+        "bluetoothBlocked",
+        "bluetoothBlockPrePairing",
+        "bluetoothBlockPromptedProximalConnections",
+        "cameraBlocked",
+        "cellularBlockDataWhenRoaming",
+        "cellularBlockVpn",
+        "cellularBlockVpnWhenRoaming",
+        "cellularData",
+        "certificatesBlockManualRootCertificateInstallation",
+        "configureTimeZone",
+        "connectedDevicesServiceBlocked",
+        "copyPasteBlocked",
+        "cortanaBlocked",
+        "cryptographyAllowFipsAlgorithmPolicy",
+        "dataProtectionBlockDirectMemoryAccess",
+        "defenderBlockEndUserAccess",
+        "defenderBlockOnAccessProtection",
+        "defenderCloudBlockLevel",
+        "defenderCloudExtendedTimeout",
+        "defenderCloudExtendedTimeoutInSeconds",
+        "defenderDaysBeforeDeletingQuarantinedMalware",
+        "defenderDetectedMalwareActions",
+        "defenderDisableCatchupFullScan",
+        "defenderDisableCatchupQuickScan",
+        "defenderFileExtensionsToExclude",
+        "defenderFilesAndFoldersToExclude",
+        "defenderMonitorFileActivity",
+        "defenderPotentiallyUnwantedAppAction",
+        "defenderPotentiallyUnwantedAppActionSetting",
+        "defenderProcessesToExclude",
+        "defenderPromptForSampleSubmission",
+        "defenderRequireBehaviorMonitoring",
+        "defenderRequireCloudProtection",
+        "defenderRequireNetworkInspectionSystem",
+        "defenderRequireRealTimeMonitoring",
+        "defenderScanArchiveFiles",
+        "defenderScanDownloads",
+        "defenderScanIncomingMail",
+        "defenderScanMappedNetworkDrivesDuringFullScan",
+        "defenderScanMaxCpu",
+        "defenderScanNetworkFiles",
+        "defenderScanRemovableDrivesDuringFullScan",
+        "defenderScanScriptsLoadedInInternetExplorer",
+        "defenderScanType",
+        "defenderScheduledQuickScanTime",
+        "defenderScheduledScanTime",
+        "defenderScheduleScanEnableLowCpuPriority",
+        "defenderSignatureUpdateIntervalInHours",
+        "defenderSubmitSamplesConsentType",
+        "defenderSystemScanSchedule",
+        "developerUnlockSetting",
+        "deviceManagementBlockFactoryResetOnMobile",
+        "deviceManagementBlockManualUnenroll",
+        "diagnosticsDataSubmissionMode",
+        "displayAppListWithGdiDPIScalingTurnedOff",
+        "displayAppListWithGdiDPIScalingTurnedOn",
+        "edgeAllowStartPagesModification",
+        "edgeBlockAccessToAboutFlags",
+        "edgeBlockAddressBarDropdown",
+        "edgeBlockAutofill",
+        "edgeBlockCompatibilityList",
+        "edgeBlockDeveloperTools",
+        "edgeBlocked",
+        "edgeBlockEditFavorites",
+        "edgeBlockExtensions",
+        "edgeBlockFullScreenMode",
+        "edgeBlockInPrivateBrowsing",
+        "edgeBlockJavaScript",
+        "edgeBlockLiveTileDataCollection",
+        "edgeBlockPasswordManager",
+        "edgeBlockPopups",
+        "edgeBlockPrelaunch",
+        "edgeBlockPrinting",
+        "edgeBlockSavingHistory",
+        "edgeBlockSearchEngineCustomization",
+        "edgeBlockSearchSuggestions",
+        "edgeBlockSendingDoNotTrackHeader",
+        "edgeBlockSendingIntranetTrafficToInternetExplorer",
+        "edgeBlockSideloadingExtensions",
+        "edgeBlockTabPreloading",
+        "edgeBlockWebContentOnNewTabPage",
+        "edgeClearBrowsingDataOnExit",
+        "edgeCookiePolicy",
+        "edgeDisableFirstRunPage",
+        "edgeEnterpriseModeSiteListLocation",
+        "edgeFavoritesBarVisibility",
+        "edgeFavoritesListLocation",
+        "edgeFirstRunUrl",
+        "edgeHomeButtonConfiguration",
+        "edgeHomeButtonConfigurationEnabled",
+        "edgeHomepageUrls",
+        "edgeKioskModeRestriction",
+        "edgeKioskResetAfterIdleTimeInMinutes",
+        "edgeNewTabPageURL",
+        "edgeOpensWith",
+        "edgePreventCertificateErrorOverride",
+        "edgeRequiredExtensionPackageFamilyNames",
+        "edgeRequireSmartScreen",
+        "edgeSearchEngine",
+        "edgeSendIntranetTrafficToInternetExplorer",
+        "edgeShowMessageWhenOpeningInternetExplorerSites",
+        "edgeSyncFavoritesWithInternetExplorer",
+        "edgeTelemetryForMicrosoft365Analytics",
+        "enableAutomaticRedeployment",
+        "energySaverOnBatteryThresholdPercentage",
+        "energySaverPluggedInThresholdPercentage",
+        "enterpriseCloudPrintDiscoveryEndPoint",
+        "enterpriseCloudPrintDiscoveryMaxLimit",
+        "enterpriseCloudPrintMopriaDiscoveryResourceIdentifier",
+        "enterpriseCloudPrintOAuthAuthority",
+        "enterpriseCloudPrintOAuthClientIdentifier",
+        "enterpriseCloudPrintResourceIdentifier",
+        "experienceBlockDeviceDiscovery",
+        "experienceBlockErrorDialogWhenNoSIM",
+        "experienceBlockTaskSwitcher",
+        "experienceDoNotSyncBrowserSettings",
+        "findMyFiles",
+        "gameDvrBlocked",
+        "inkWorkspaceAccess",
+        "inkWorkspaceAccessState",
+        "inkWorkspaceBlockSuggestedApps",
+        "internetSharingBlocked",
+        "locationServicesBlocked",
+        "lockScreenActivateAppsWithVoice",
+        "lockScreenAllowTimeoutConfiguration",
+        "lockScreenBlockActionCenterNotifications",
+        "lockScreenBlockCortana",
+        "lockScreenBlockToastNotifications",
+        "lockScreenTimeoutInSeconds",
+        "logonBlockFastUserSwitching",
+        "messagingBlockMMS",
+        "messagingBlockRichCommunicationServices",
+        "messagingBlockSync",
+        "microsoftAccountBlocked",
+        "microsoftAccountBlockSettingsSync",
+        "microsoftAccountSignInAssistantSettings",
+        "networkProxyApplySettingsDeviceWide",
+        "networkProxyAutomaticConfigurationUrl",
+        "networkProxyDisableAutoDetect",
+        "networkProxyServer",
+        "nfcBlocked",
+        "oneDriveDisableFileSync",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumAgeInDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "passwordRequireWhenResumeFromIdleState",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "personalizationDesktopImageUrl",
+        "personalizationLockScreenImageUrl",
+        "powerButtonActionOnBattery",
+        "powerButtonActionPluggedIn",
+        "powerHybridSleepOnBattery",
+        "powerHybridSleepPluggedIn",
+        "powerLidCloseActionOnBattery",
+        "powerLidCloseActionPluggedIn",
+        "powerSleepButtonActionOnBattery",
+        "powerSleepButtonActionPluggedIn",
+        "printerBlockAddition",
+        "printerDefaultName",
+        "printerNames",
+        "privacyAdvertisingId",
+        "privacyAutoAcceptPairingAndConsentPrompts",
+        "privacyBlockActivityFeed",
+        "privacyBlockInputPersonalization",
+        "privacyBlockPublishUserActivities",
+        "privacyDisableLaunchExperience",
+        "resetProtectionModeBlocked",
+        "safeSearchFilter",
+        "screenCaptureBlocked",
+        "searchBlockDiacritics",
+        "searchBlockWebResults",
+        "searchDisableAutoLanguageDetection",
+        "searchDisableIndexerBackoff",
+        "searchDisableIndexingEncryptedItems",
+        "searchDisableIndexingRemovableDrive",
+        "searchDisableLocation",
+        "searchDisableUseLocation",
+        "searchEnableAutomaticIndexSizeManangement",
+        "searchEnableRemoteQueries",
+        "securityBlockAzureADJoinedDevicesAutoEncryption",
+        "settingsBlockAccountsPage",
+        "settingsBlockAddProvisioningPackage",
+        "settingsBlockAppsPage",
+        "settingsBlockChangeLanguage",
+        "settingsBlockChangePowerSleep",
+        "settingsBlockChangeRegion",
+        "settingsBlockChangeSystemTime",
+        "settingsBlockDevicesPage",
+        "settingsBlockEaseOfAccessPage",
+        "settingsBlockEditDeviceName",
+        "settingsBlockGamingPage",
+        "settingsBlockNetworkInternetPage",
+        "settingsBlockPersonalizationPage",
+        "settingsBlockPrivacyPage",
+        "settingsBlockRemoveProvisioningPackage",
+        "settingsBlockSettingsApp",
+        "settingsBlockSystemPage",
+        "settingsBlockTimeLanguagePage",
+        "settingsBlockUpdateSecurityPage",
+        "sharedUserAppDataAllowed",
+        "smartScreenAppInstallControl",
+        "smartScreenBlockPromptOverride",
+        "smartScreenBlockPromptOverrideForFiles",
+        "smartScreenEnableAppInstallControl",
+        "startBlockUnpinningAppsFromTaskbar",
+        "startMenuAppListVisibility",
+        "startMenuHideChangeAccountSettings",
+        "startMenuHideFrequentlyUsedApps",
+        "startMenuHideHibernate",
+        "startMenuHideLock",
+        "startMenuHidePowerButton",
+        "startMenuHideRecentJumpLists",
+        "startMenuHideRecentlyAddedApps",
+        "startMenuHideRestartOptions",
+        "startMenuHideShutDown",
+        "startMenuHideSignOut",
+        "startMenuHideSleep",
+        "startMenuHideSwitchAccount",
+        "startMenuHideUserTile",
+        "startMenuLayoutEdgeAssetsXml",
+        "startMenuLayoutXml",
+        "startMenuMode",
+        "startMenuPinnedFolderDocuments",
+        "startMenuPinnedFolderDownloads",
+        "startMenuPinnedFolderFileExplorer",
+        "startMenuPinnedFolderHomeGroup",
+        "startMenuPinnedFolderMusic",
+        "startMenuPinnedFolderNetwork",
+        "startMenuPinnedFolderPersonalFolder",
+        "startMenuPinnedFolderPictures",
+        "startMenuPinnedFolderSettings",
+        "startMenuPinnedFolderVideos",
+        "storageBlockRemovableStorage",
+        "storageRequireMobileDeviceEncryption",
+        "storageRestrictAppDataToSystemVolume",
+        "storageRestrictAppInstallToSystemVolume",
+        "systemTelemetryProxyServer",
+        "taskManagerBlockEndTask",
+        "tenantLockdownRequireNetworkDuringOutOfBoxExperience",
+        "uninstallBuiltInApps",
+        "usbBlocked",
+        "voiceRecordingBlocked",
+        "webRtcBlockLocalhostIpAddress",
+        "wiFiBlockAutomaticConnectHotspots",
+        "wiFiBlocked",
+        "wiFiBlockManualConfiguration",
+        "wiFiScanInterval",
+        "windows10AppsForceUpdateSchedule",
+        "windowsSpotlightBlockConsumerSpecificFeatures",
+        "windowsSpotlightBlocked",
+        "windowsSpotlightBlockOnActionCenter",
+        "windowsSpotlightBlockTailoredExperiences",
+        "windowsSpotlightBlockThirdPartyNotifications",
+        "windowsSpotlightBlockWelcomeExperience",
+        "windowsSpotlightBlockWindowsTips",
+        "windowsSpotlightConfigureOnLockScreen",
+        "windowsStoreBlockAutoUpdate",
+        "windowsStoreBlocked",
+        "windowsStoreEnablePrivateStoreOnly",
+        "wirelessDisplayBlockProjectionToThisDevice",
+        "wirelessDisplayBlockUserInputFromReceiver",
+        "wirelessDisplayRequirePinForPairing"
+      ]
+    },
+    "windows10ImportedPFXCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "intendedPurpose"
+      ]
+    },
+    "windows10MobileCompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "activeFirewallRequired",
+        "bitLockerEnabled",
+        "codeIntegrityEnabled",
+        "earlyLaunchAntiMalwareDriverEnabled",
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "passwordRequireToUnlockFromIdle",
+        "secureBootEnabled",
+        "storageRequireEncryption",
+        "validOperatingSystemBuildRanges"
+      ]
+    },
+    "windows10NetworkBoundaryConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "windowsNetworkIsolationPolicy"
+      ]
+    },
+    "windows10PFXImportCertificateProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "keyStorageProvider"
+      ]
+    },
+    "windows10PkcsCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "certificateStore",
+        "certificateTemplateName",
+        "certificationAuthority",
+        "certificationAuthorityName",
+        "customSubjectAlternativeNames",
+        "extendedKeyUsages",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "windows10SecureAssessmentConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowPrinting",
+        "allowScreenCapture",
+        "allowTextSuggestion",
+        "assessmentAppUserModelId",
+        "configurationAccount",
+        "configurationAccountType",
+        "launchUri",
+        "localGuestAccountName"
+      ]
+    },
+    "windows10TeamGeneralConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "azureOperationalInsightsBlockTelemetry",
+        "azureOperationalInsightsWorkspaceId",
+        "azureOperationalInsightsWorkspaceKey",
+        "connectAppBlockAutoLaunch",
+        "maintenanceWindowBlocked",
+        "maintenanceWindowDurationInHours",
+        "maintenanceWindowStartTime",
+        "miracastBlocked",
+        "miracastChannel",
+        "miracastRequirePin",
+        "settingsBlockMyMeetingsAndFiles",
+        "settingsBlockSessionResume",
+        "settingsBlockSigninSuggestions",
+        "settingsDefaultVolume",
+        "settingsScreenTimeoutInMinutes",
+        "settingsSessionTimeoutInMinutes",
+        "settingsSleepTimeoutInMinutes",
+        "welcomeScreenBackgroundImageUrl",
+        "welcomeScreenBlockAutomaticWakeUp",
+        "welcomeScreenMeetingInformation"
+      ]
+    },
+    "windows10VpnConfiguration": {
+      "navigationProperties": [
+        "identityCertificate"
+      ],
+      "properties": [
+        "associatedApps",
+        "authenticationMethod",
+        "connectionType",
+        "cryptographySuite",
+        "dnsRules",
+        "dnsSuffixes",
+        "eapXml",
+        "enableAlwaysOn",
+        "enableConditionalAccess",
+        "enableDeviceTunnel",
+        "enableDnsRegistration",
+        "enableSingleSignOnWithAlternateCertificate",
+        "enableSplitTunneling",
+        "microsoftTunnelSiteId",
+        "onlyAssociatedAppsCanUseConnection",
+        "profileTarget",
+        "proxyServer",
+        "rememberUserCredentials",
+        "routes",
+        "singleSignOnEku",
+        "singleSignOnIssuerHash",
+        "trafficRules",
+        "trustedNetworkDomains",
+        "windowsInformationProtectionDomain"
+      ]
+    },
+    "windows10XCertificateProfile": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "windows10XSCEPCertificateProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateStore",
+        "certificateValidityPeriodScale",
+        "certificateValidityPeriodValue",
+        "extendedKeyUsages",
+        "hashAlgorithm",
+        "keySize",
+        "keyStorageProvider",
+        "keyUsage",
+        "renewalThresholdPercentage",
+        "rootCertificateId",
+        "scepServerUrls",
+        "subjectAlternativeNameFormats",
+        "subjectNameFormatString"
+      ]
+    },
+    "windows10XTrustedRootCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "certFileName",
+        "destinationStore",
+        "trustedRootCertificate"
+      ]
+    },
+    "windows10XVpnConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationCertificateId",
+        "customXml",
+        "customXmlFileName"
+      ]
+    },
+    "windows10XWifiConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationCertificateId",
+        "customXml",
+        "customXmlFileName"
+      ]
+    },
+    "windows81CertificateProfileBase": {
+      "navigationProperties": [],
+      "properties": [
+        "customSubjectAlternativeNames",
+        "extendedKeyUsages"
+      ]
+    },
+    "windows81CompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "storageRequireEncryption"
+      ]
+    },
+    "windows81GeneralConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accountsBlockAddingNonMicrosoftAccountEmail",
+        "applyOnlyToWindows81",
+        "browserBlockAutofill",
+        "browserBlockAutomaticDetectionOfIntranetSites",
+        "browserBlockEnterpriseModeAccess",
+        "browserBlockJavaScript",
+        "browserBlockPlugins",
+        "browserBlockPopups",
+        "browserBlockSendingDoNotTrackHeader",
+        "browserBlockSingleWordEntryOnIntranetSites",
+        "browserEnterpriseModeSiteListLocation",
+        "browserInternetSecurityLevel",
+        "browserIntranetSecurityLevel",
+        "browserLoggingReportLocation",
+        "browserRequireFirewall",
+        "browserRequireFraudWarning",
+        "browserRequireHighSecurityForRestrictedSites",
+        "browserRequireSmartScreen",
+        "browserTrustedSitesSecurityLevel",
+        "cellularBlockDataRoaming",
+        "diagnosticsBlockDataSubmission",
+        "minimumAutoInstallClassification",
+        "passwordBlockPicturePasswordAndPin",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequiredType",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "storageRequireDeviceEncryption",
+        "updatesMinimumAutoInstallClassification",
+        "updatesRequireAutomaticUpdates",
+        "userAccountControlSettings",
+        "workFoldersUrl"
+      ]
+    },
+    "windows81SCEPCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates",
+        "rootCertificate"
+      ],
+      "properties": [
+        "certificateStore",
+        "hashAlgorithm",
+        "keySize",
+        "keyUsage",
+        "scepServerUrls",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "windows81TrustedRootCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "certFileName",
+        "destinationStore",
+        "trustedRootCertificate"
+      ]
+    },
+    "windows81VpnConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "applyOnlyToWindows81",
+        "connectionType",
+        "enableSplitTunneling",
+        "loginGroupOrDomain",
+        "proxyServer"
+      ]
+    },
+    "windows81WifiImportConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "payload",
+        "payloadFileName",
+        "profileName"
+      ]
+    },
+    "windowsAppX": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableArchitectures",
+        "identityName",
+        "identityPublisherHash",
+        "identityResourceIdentifier",
+        "identityVersion",
+        "isBundle",
+        "minimumSupportedOperatingSystem"
+      ]
+    },
+    "windowsAssignedAccessProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "appUserModelIds",
+        "desktopAppPaths",
+        "profileName",
+        "showTaskBar",
+        "startMenuLayoutXml",
+        "userAccounts"
+      ]
+    },
+    "windowsAutopilotDeploymentProfile": {
+      "navigationProperties": [
+        "assignedDevices",
+        "assignments"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "deviceNameTemplate",
+        "deviceType",
+        "displayName",
+        "enableWhiteGlove",
+        "enrollmentStatusScreenSettings",
+        "extractHardwareHash",
+        "hardwareHashExtractionEnabled",
+        "language",
+        "lastModifiedDateTime",
+        "locale",
+        "managementServiceAppId",
+        "outOfBoxExperienceSetting",
+        "outOfBoxExperienceSettings",
+        "preprovisioningAllowed",
+        "roleScopeTagIds"
+      ]
+    },
+    "windowsAutopilotDeploymentProfileAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "source",
+        "sourceId",
+        "target"
+      ]
+    },
+    "windowsAutopilotDeploymentProfilePolicySetItem": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "windowsAutopilotDeviceIdentity": {
+      "navigationProperties": [
+        "deploymentProfile",
+        "intendedDeploymentProfile"
+      ],
+      "properties": [
+        "addressableUserName",
+        "azureActiveDirectoryDeviceId",
+        "azureAdDeviceId",
+        "deploymentProfileAssignedDateTime",
+        "deploymentProfileAssignmentDetailedStatus",
+        "deploymentProfileAssignmentStatus",
+        "deviceAccountPassword",
+        "deviceAccountUpn",
+        "deviceFriendlyName",
+        "displayName",
+        "enrollmentState",
+        "groupTag",
+        "lastContactedDateTime",
+        "managedDeviceId",
+        "manufacturer",
+        "model",
+        "productKey",
+        "purchaseOrderIdentifier",
+        "remediationState",
+        "remediationStateLastModifiedDateTime",
+        "resourceName",
+        "serialNumber",
+        "skuNumber",
+        "systemFamily",
+        "userlessEnrollmentStatus",
+        "userPrincipalName"
+      ]
+    },
+    "windowsAutopilotSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "lastManualSyncTriggerDateTime",
+        "lastSyncDateTime",
+        "syncStatus"
+      ]
+    },
+    "windowsAutoUpdateCatalogApp": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedArchitectures",
+        "installExperience",
+        "mobileAppCatalogPackageBranchId"
+      ]
+    },
+    "windowsCertificateProfileBase": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateValidityPeriodScale",
+        "certificateValidityPeriodValue",
+        "keyStorageProvider",
+        "renewalThresholdPercentage",
+        "subjectAlternativeNameType",
+        "subjectNameFormat"
+      ]
+    },
+    "windowsDefenderAdvancedThreatProtectionConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "advancedThreatProtectionAutoPopulateOnboardingBlob",
+        "advancedThreatProtectionOffboardingBlob",
+        "advancedThreatProtectionOffboardingFilename",
+        "advancedThreatProtectionOnboardingBlob",
+        "advancedThreatProtectionOnboardingFilename",
+        "allowSampleSharing",
+        "enableExpeditedTelemetryReporting"
+      ]
+    },
+    "windowsDefenderApplicationControlSupplementalPolicy": {
+      "navigationProperties": [
+        "assignments",
+        "deploySummary",
+        "deviceStatuses"
+      ],
+      "properties": [
+        "content",
+        "contentFileName",
+        "creationDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "roleScopeTagIds",
+        "version"
+      ]
+    },
+    "windowsDefenderApplicationControlSupplementalPolicyAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "windowsDefenderApplicationControlSupplementalPolicyDeploymentStatus": {
+      "navigationProperties": [
+        "policy"
+      ],
+      "properties": [
+        "deploymentStatus",
+        "deviceId",
+        "deviceName",
+        "lastSyncDateTime",
+        "osDescription",
+        "osVersion",
+        "policyVersion",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "windowsDefenderApplicationControlSupplementalPolicyDeploymentSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "deployedDeviceCount",
+        "failedDeviceCount"
+      ]
+    },
+    "windowsDeliveryOptimizationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "backgroundDownloadFromHttpDelayInSeconds",
+        "bandwidthMode",
+        "cacheServerBackgroundDownloadFallbackToHttpDelayInSeconds",
+        "cacheServerForegroundDownloadFallbackToHttpDelayInSeconds",
+        "cacheServerHostNames",
+        "deliveryOptimizationMode",
+        "foregroundDownloadFromHttpDelayInSeconds",
+        "groupIdSource",
+        "maximumCacheAgeInDays",
+        "maximumCacheSize",
+        "minimumBatteryPercentageAllowedToUpload",
+        "minimumDiskSizeAllowedToPeerInGigabytes",
+        "minimumFileSizeToCacheInMegabytes",
+        "minimumRamAllowedToPeerInGigabytes",
+        "modifyCacheLocation",
+        "restrictPeerSelectionBy",
+        "vpnPeerCaching"
+      ]
+    },
+    "windowsDeviceMalwareState": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformationUrl",
+        "category",
+        "detectionCount",
+        "displayName",
+        "executionState",
+        "initialDetectionDateTime",
+        "lastStateChangeDateTime",
+        "severity",
+        "state",
+        "threatState"
+      ]
+    },
+    "windowsDomainJoinConfiguration": {
+      "navigationProperties": [
+        "networkAccessConfigurations"
+      ],
+      "properties": [
+        "activeDirectoryDomainName",
+        "computerNameStaticPrefix",
+        "computerNameSuffixRandomCharCount",
+        "organizationalUnit"
+      ]
+    },
+    "windowsDriverUpdateInventory": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableDeviceCount",
+        "approvalStatus",
+        "category",
+        "deployDateTime",
+        "driverClass",
+        "manufacturer",
+        "name",
+        "releaseDateTime",
+        "version"
+      ]
+    },
+    "windowsDriverUpdateProfile": {
+      "navigationProperties": [
+        "assignments",
+        "driverInventories"
+      ],
+      "properties": [
+        "approvalType",
+        "createdDateTime",
+        "deploymentDeferralInDays",
+        "description",
+        "deviceReporting",
+        "displayName",
+        "inventorySyncStatus",
+        "lastModifiedDateTime",
+        "newUpdates",
+        "roleScopeTagIds"
+      ]
+    },
+    "windowsDriverUpdateProfileAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "windowsFeatureUpdateCatalogItem": {
+      "navigationProperties": [],
+      "properties": [
+        "version"
+      ]
+    },
+    "windowsFeatureUpdateProfile": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "createdDateTime",
+        "deployableContentDisplayName",
+        "description",
+        "displayName",
+        "endOfSupportDate",
+        "featureUpdateVersion",
+        "installFeatureUpdatesOptional",
+        "installLatestWindows10OnWindows11IneligibleDevice",
+        "lastModifiedDateTime",
+        "roleScopeTagIds",
+        "rolloutSettings"
+      ]
+    },
+    "windowsFeatureUpdateProfileAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "windowsHealthMonitoringConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowDeviceHealthMonitoring",
+        "configDeviceHealthMonitoringCustomScope",
+        "configDeviceHealthMonitoringScope"
+      ]
+    },
+    "windowsHelloForBusinessAuthenticationMethod": {
+      "navigationProperties": [
+        "device"
+      ],
+      "properties": [
+        "displayName",
+        "keyStrength"
+      ]
+    },
+    "windowsIdentityProtectionConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "enhancedAntiSpoofingForFacialFeaturesEnabled",
+        "pinExpirationInDays",
+        "pinLowercaseCharactersUsage",
+        "pinMaximumLength",
+        "pinMinimumLength",
+        "pinPreviousBlockCount",
+        "pinRecoveryEnabled",
+        "pinSpecialCharactersUsage",
+        "pinUppercaseCharactersUsage",
+        "securityDeviceRequired",
+        "unlockWithBiometricsEnabled",
+        "useCertificatesForOnPremisesAuthEnabled",
+        "useSecurityKeyForSignin",
+        "windowsHelloForBusinessBlocked"
+      ]
+    },
+    "windowsInformationProtection": {
+      "navigationProperties": [
+        "assignments",
+        "exemptAppLockerFiles",
+        "protectedAppLockerFiles"
+      ],
+      "properties": [
+        "azureRightsManagementServicesAllowed",
+        "dataRecoveryCertificate",
+        "enforcementLevel",
+        "enterpriseDomain",
+        "enterpriseInternalProxyServers",
+        "enterpriseIPRanges",
+        "enterpriseIPRangesAreAuthoritative",
+        "enterpriseNetworkDomainNames",
+        "enterpriseProtectedDomainNames",
+        "enterpriseProxiedDomains",
+        "enterpriseProxyServers",
+        "enterpriseProxyServersAreAuthoritative",
+        "exemptApps",
+        "iconsVisible",
+        "indexingEncryptedStoresOrItemsBlocked",
+        "isAssigned",
+        "neutralDomainResources",
+        "protectedApps",
+        "protectionUnderLockConfigRequired",
+        "revokeOnUnenrollDisabled",
+        "rightsManagementServicesTemplateId",
+        "smbAutoEncryptedFileExtensions"
+      ]
+    },
+    "windowsInformationProtectionAppLearningSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationName",
+        "applicationType",
+        "deviceCount"
+      ]
+    },
+    "windowsInformationProtectionAppLockerFile": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "file",
+        "fileHash",
+        "version"
+      ]
+    },
+    "windowsInformationProtectionDeviceRegistration": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceMacAddress",
+        "deviceName",
+        "deviceRegistrationId",
+        "deviceType",
+        "lastCheckInDateTime",
+        "userId"
+      ]
+    },
+    "windowsInformationProtectionNetworkLearningSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "url"
+      ]
+    },
+    "windowsInformationProtectionPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "daysWithoutContactBeforeUnenroll",
+        "mdmEnrollmentUrl",
+        "minutesOfInactivityBeforeDeviceLock",
+        "numberOfPastPinsRemembered",
+        "passwordMaximumAttemptCount",
+        "pinExpirationDays",
+        "pinLowercaseLetters",
+        "pinMinimumLength",
+        "pinSpecialCharacters",
+        "pinUppercaseLetters",
+        "revokeOnMdmHandoffDisabled",
+        "windowsHelloForBusinessBlocked"
+      ]
+    },
+    "windowsInformationProtectionWipeAction": {
+      "navigationProperties": [],
+      "properties": [
+        "lastCheckInDateTime",
+        "status",
+        "targetedDeviceMacAddress",
+        "targetedDeviceName",
+        "targetedDeviceRegistrationId",
+        "targetedUserId"
+      ]
+    },
+    "windowsKioskConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "edgeKioskEnablePublicBrowsing",
+        "kioskBrowserBlockedUrlExceptions",
+        "kioskBrowserBlockedURLs",
+        "kioskBrowserDefaultUrl",
+        "kioskBrowserEnableEndSessionButton",
+        "kioskBrowserEnableHomeButton",
+        "kioskBrowserEnableNavigationButtons",
+        "kioskBrowserRestartOnIdleTimeInMinutes",
+        "kioskProfiles",
+        "windowsKioskForceUpdateSchedule"
+      ]
+    },
+    "windowsMalwareInformation": {
+      "navigationProperties": [
+        "deviceMalwareStates"
+      ],
+      "properties": [
+        "additionalInformationUrl",
+        "category",
+        "displayName",
+        "lastDetectionDateTime",
+        "severity"
+      ]
+    },
+    "windowsManagedAppProtection": {
+      "navigationProperties": [
+        "apps",
+        "assignments",
+        "deploymentSummary"
+      ],
+      "properties": [
+        "allowedInboundDataTransferSources",
+        "allowedOutboundClipboardSharingLevel",
+        "allowedOutboundDataTransferDestinations",
+        "appActionIfUnableToAuthenticateUser",
+        "deployedAppCount",
+        "isAssigned",
+        "maximumAllowedDeviceThreatLevel",
+        "maximumRequiredOsVersion",
+        "maximumWarningOsVersion",
+        "maximumWipeOsVersion",
+        "minimumRequiredAppVersion",
+        "minimumRequiredOsVersion",
+        "minimumRequiredSdkVersion",
+        "minimumWarningAppVersion",
+        "minimumWarningOsVersion",
+        "minimumWipeAppVersion",
+        "minimumWipeOsVersion",
+        "minimumWipeSdkVersion",
+        "mobileThreatDefenseRemediationAction",
+        "periodOfflineBeforeAccessCheck",
+        "periodOfflineBeforeWipeIsEnforced",
+        "printBlocked"
+      ]
+    },
+    "windowsManagedAppRegistration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "windowsManagedDevice": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "windowsManagementApp": {
+      "navigationProperties": [
+        "healthStates"
+      ],
+      "properties": [
+        "availableVersion",
+        "managedInstaller",
+        "managedInstallerConfiguredDateTime"
+      ]
+    },
+    "windowsManagementAppHealthState": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceName",
+        "deviceOSVersion",
+        "healthState",
+        "installedVersion",
+        "lastCheckInDateTime"
+      ]
+    },
+    "windowsManagementAppHealthSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "healthyDeviceCount",
+        "unhealthyDeviceCount",
+        "unknownDeviceCount"
+      ]
+    },
+    "windowsMicrosoftEdgeApp": {
+      "navigationProperties": [],
+      "properties": [
+        "channel",
+        "displayLanguageLocale"
+      ]
+    },
+    "windowsMobileMSI": {
+      "navigationProperties": [],
+      "properties": [
+        "commandLine",
+        "identityVersion",
+        "ignoreVersionDetection",
+        "productCode",
+        "productVersion",
+        "useDeviceContext"
+      ]
+    },
+    "windowsPhone81AppX": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableArchitectures",
+        "identityName",
+        "identityPublisherHash",
+        "identityResourceIdentifier",
+        "identityVersion",
+        "minimumSupportedOperatingSystem",
+        "phoneProductIdentifier",
+        "phonePublisherId"
+      ]
+    },
+    "windowsPhone81AppXBundle": {
+      "navigationProperties": [],
+      "properties": [
+        "appXPackageInformationList"
+      ]
+    },
+    "windowsPhone81CertificateProfileBase": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateValidityPeriodScale",
+        "certificateValidityPeriodValue",
+        "extendedKeyUsages",
+        "keyStorageProvider",
+        "renewalThresholdPercentage",
+        "subjectAlternativeNameType",
+        "subjectNameFormat"
+      ]
+    },
+    "windowsPhone81CompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "storageRequireEncryption"
+      ]
+    },
+    "windowsPhone81CustomConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "omaSettings"
+      ]
+    },
+    "windowsPhone81GeneralConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "applyOnlyToWindowsPhone81",
+        "appsBlockCopyPaste",
+        "bluetoothBlocked",
+        "cameraBlocked",
+        "cellularBlockWifiTethering",
+        "compliantAppListType",
+        "compliantAppsList",
+        "diagnosticDataBlockSubmission",
+        "emailBlockAddingAccounts",
+        "locationServicesBlocked",
+        "microsoftAccountBlocked",
+        "nfcBlocked",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "screenCaptureBlocked",
+        "storageBlockRemovableStorage",
+        "storageRequireEncryption",
+        "webBrowserBlocked",
+        "wifiBlockAutomaticConnectHotspots",
+        "wifiBlocked",
+        "wifiBlockHotspotReporting",
+        "windowsStoreBlocked"
+      ]
+    },
+    "windowsPhone81ImportedPFXCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates"
+      ],
+      "properties": [
+        "intendedPurpose"
+      ]
+    },
+    "windowsPhone81SCEPCertificateProfile": {
+      "navigationProperties": [
+        "managedDeviceCertificateStates",
+        "rootCertificate"
+      ],
+      "properties": [
+        "hashAlgorithm",
+        "keySize",
+        "keyUsage",
+        "scepServerUrls",
+        "subjectAlternativeNameFormatString",
+        "subjectNameFormatString"
+      ]
+    },
+    "windowsPhone81StoreApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appStoreUrl"
+      ]
+    },
+    "windowsPhone81TrustedRootCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "certFileName",
+        "trustedRootCertificate"
+      ]
+    },
+    "windowsPhone81VpnConfiguration": {
+      "navigationProperties": [
+        "identityCertificate"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "bypassVpnOnCompanyWifi",
+        "bypassVpnOnHomeWifi",
+        "dnsSuffixSearchList",
+        "rememberUserCredentials"
+      ]
+    },
+    "windowsPhoneEASEmailProfileConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accountName",
+        "applyOnlyToWindowsPhone81",
+        "durationOfEmailToSync",
+        "emailAddressSource",
+        "emailSyncSchedule",
+        "hostName",
+        "requireSsl",
+        "syncCalendar",
+        "syncContacts",
+        "syncTasks"
+      ]
+    },
+    "windowsPhoneXAP": {
+      "navigationProperties": [],
+      "properties": [
+        "identityVersion",
+        "minimumSupportedOperatingSystem",
+        "productIdentifier"
+      ]
+    },
+    "windowsPrivacyDataAccessControlItem": {
+      "navigationProperties": [],
+      "properties": [
+        "accessLevel",
+        "appDisplayName",
+        "appPackageFamilyName",
+        "dataCategory"
+      ]
+    },
+    "windowsProtectionState": {
+      "navigationProperties": [
+        "detectedMalwareState"
+      ],
+      "properties": [
+        "antiMalwareVersion",
+        "controlledConfigurationEnabled",
+        "deviceState",
+        "engineVersion",
+        "fullScanOverdue",
+        "fullScanRequired",
+        "isVirtualMachine",
+        "lastFullScanDateTime",
+        "lastFullScanSignatureVersion",
+        "lastQuickScanDateTime",
+        "lastQuickScanSignatureVersion",
+        "lastReportedDateTime",
+        "malwareProtectionEnabled",
+        "networkInspectionSystemEnabled",
+        "productStatus",
+        "quickScanOverdue",
+        "realTimeProtectionEnabled",
+        "rebootRequired",
+        "signatureUpdateOverdue",
+        "signatureVersion",
+        "tamperProtectionEnabled"
+      ]
+    },
+    "windowsQualityUpdateCatalogItem": {
+      "navigationProperties": [],
+      "properties": [
+        "classification",
+        "cveSeverityInformation",
+        "isExpeditable",
+        "kbArticleId",
+        "productRevisions",
+        "qualityUpdateCadence"
+      ]
+    },
+    "windowsQualityUpdatePolicy": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "approvalSettings",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "hotpatchEnabled",
+        "lastModifiedDateTime",
+        "roleScopeTagIds"
+      ]
+    },
+    "windowsQualityUpdatePolicyAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "windowsQualityUpdateProfile": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "createdDateTime",
+        "deployableContentDisplayName",
+        "description",
+        "displayName",
+        "expeditedUpdateSettings",
+        "lastModifiedDateTime",
+        "releaseDateDisplayName",
+        "roleScopeTagIds"
+      ]
+    },
+    "windowsQualityUpdateProfileAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "windowsRestoreDeviceEnrollmentConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "state"
+      ]
+    },
+    "windowsSetting": {
+      "navigationProperties": [
+        "instances"
+      ],
+      "properties": [
+        "payloadType",
+        "settingType",
+        "windowsDeviceId"
+      ]
+    },
+    "windowsSettingInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "expirationDateTime",
+        "lastModifiedDateTime",
+        "payload"
+      ]
+    },
+    "windowsStoreApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appStoreUrl"
+      ]
+    },
+    "windowsUniversalAppX": {
+      "navigationProperties": [
+        "committedContainedApps"
+      ],
+      "properties": [
+        "applicableArchitectures",
+        "applicableDeviceTypes",
+        "identityName",
+        "identityPublisherHash",
+        "identityResourceIdentifier",
+        "identityVersion",
+        "isBundle",
+        "minimumSupportedOperatingSystem"
+      ]
+    },
+    "windowsUniversalAppXContainedApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appUserModelId"
+      ]
+    },
+    "windowsUpdateCatalogItem": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "endOfSupportDate",
+        "releaseDateTime"
+      ]
+    },
+    "windowsUpdateForBusinessConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowWindows11Upgrade",
+        "automaticUpdateMode",
+        "autoRestartNotificationDismissal",
+        "businessReadyUpdatesOnly",
+        "deadlineForFeatureUpdatesInDays",
+        "deadlineForQualityUpdatesInDays",
+        "deadlineGracePeriodInDays",
+        "deliveryOptimizationMode",
+        "driversExcluded",
+        "engagedRestartDeadlineInDays",
+        "engagedRestartSnoozeScheduleInDays",
+        "engagedRestartTransitionScheduleInDays",
+        "featureUpdatesDeferralPeriodInDays",
+        "featureUpdatesPaused",
+        "featureUpdatesPauseExpiryDateTime",
+        "featureUpdatesPauseStartDate",
+        "featureUpdatesRollbackStartDateTime",
+        "featureUpdatesRollbackWindowInDays",
+        "featureUpdatesWillBeRolledBack",
+        "installationSchedule",
+        "microsoftUpdateServiceAllowed",
+        "postponeRebootUntilAfterDeadline",
+        "prereleaseFeatures",
+        "qualityUpdatesDeferralPeriodInDays",
+        "qualityUpdatesPaused",
+        "qualityUpdatesPauseExpiryDateTime",
+        "qualityUpdatesPauseStartDate",
+        "qualityUpdatesRollbackStartDateTime",
+        "qualityUpdatesWillBeRolledBack",
+        "scheduleImminentRestartWarningInMinutes",
+        "scheduleRestartWarningInHours",
+        "skipChecksBeforeRestart",
+        "updateNotificationLevel",
+        "updateWeeks",
+        "userPauseAccess",
+        "userWindowsUpdateScanAccess"
+      ]
+    },
+    "windowsUpdateState": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceDisplayName",
+        "deviceId",
+        "featureUpdateVersion",
+        "lastScanDateTime",
+        "lastSyncDateTime",
+        "qualityUpdateVersion",
+        "status",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "windowsVpnConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "connectionName",
+        "customXml",
+        "servers"
+      ]
+    },
+    "windowsWebApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appUrl"
+      ]
+    },
+    "windowsWifiConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "connectAutomatically",
+        "connectToPreferredNetwork",
+        "connectWhenNetworkNameIsHidden",
+        "forceFIPSCompliance",
+        "meteredConnectionLimit",
+        "networkName",
+        "preSharedKey",
+        "proxyAutomaticConfigurationUrl",
+        "proxyManualAddress",
+        "proxyManualPort",
+        "proxySetting",
+        "ssid",
+        "wifiSecurityType"
+      ]
+    },
+    "windowsWifiEnterpriseEAPConfiguration": {
+      "navigationProperties": [
+        "identityCertificateForClientAuthentication",
+        "rootCertificateForClientValidation",
+        "rootCertificatesForServerValidation"
+      ],
+      "properties": [
+        "authenticationMethod",
+        "authenticationPeriodInSeconds",
+        "authenticationRetryDelayPeriodInSeconds",
+        "authenticationType",
+        "cacheCredentials",
+        "disableUserPromptForServerValidation",
+        "eapolStartPeriodInSeconds",
+        "eapType",
+        "enablePairwiseMasterKeyCaching",
+        "enablePreAuthentication",
+        "innerAuthenticationProtocolForEAPTTLS",
+        "maximumAuthenticationFailures",
+        "maximumAuthenticationTimeoutInSeconds",
+        "maximumEAPOLStartMessages",
+        "maximumNumberOfPairwiseMasterKeysInCache",
+        "maximumPairwiseMasterKeyCacheTimeInMinutes",
+        "maximumPreAuthenticationAttempts",
+        "networkSingleSignOn",
+        "outerIdentityPrivacyTemporaryValue",
+        "performServerValidation",
+        "promptForAdditionalAuthenticationCredentials",
+        "requireCryptographicBinding",
+        "trustedServerCertificateNames",
+        "userBasedVirtualLan"
+      ]
+    },
+    "windowsWiredNetworkConfiguration": {
+      "navigationProperties": [
+        "identityCertificateForClientAuthentication",
+        "rootCertificateForClientValidation",
+        "rootCertificatesForServerValidation",
+        "secondaryIdentityCertificateForClientAuthentication",
+        "secondaryRootCertificateForClientValidation"
+      ],
+      "properties": [
+        "authenticationBlockPeriodInMinutes",
+        "authenticationMethod",
+        "authenticationPeriodInSeconds",
+        "authenticationRetryDelayPeriodInSeconds",
+        "authenticationType",
+        "cacheCredentials",
+        "disableUserPromptForServerValidation",
+        "eapolStartPeriodInSeconds",
+        "eapType",
+        "enforce8021X",
+        "forceFIPSCompliance",
+        "innerAuthenticationProtocolForEAPTTLS",
+        "maximumAuthenticationFailures",
+        "maximumEAPOLStartMessages",
+        "outerIdentityPrivacyTemporaryValue",
+        "performServerValidation",
+        "requireCryptographicBinding",
+        "secondaryAuthenticationMethod",
+        "trustedServerCertificateNames"
+      ]
+    },
+    "windowsZtdnsConfiguration": {
+      "navigationProperties": [
+        "rootCertificatesForClientValidation",
+        "rootCertificatesForServerValidation"
+      ],
+      "properties": [
+        "auditModeEnabled",
+        "exemptionRules",
+        "extendedKeyUsagesForClientAuthentication",
+        "hostsFileResolutionEnabled",
+        "loopbackDnsForwarderEnabled",
+        "loopbackTrafficBlocked",
+        "maximumConnectionTimeInSeconds",
+        "secureDnsServers"
+      ]
+    },
+    "winGetApp": {
+      "navigationProperties": [],
+      "properties": [
+        "installExperience",
+        "manifestHash",
+        "packageIdentifier"
+      ]
+    },
+    "workbook": {
+      "navigationProperties": [
+        "application",
+        "comments",
+        "functions",
+        "names",
+        "operations",
+        "tables",
+        "worksheets"
+      ],
+      "properties": []
+    },
+    "workbookApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "calculationMode"
+      ]
+    },
+    "workbookChart": {
+      "navigationProperties": [
+        "axes",
+        "dataLabels",
+        "format",
+        "legend",
+        "series",
+        "title",
+        "worksheet"
+      ],
+      "properties": [
+        "height",
+        "left",
+        "name",
+        "top",
+        "width"
+      ]
+    },
+    "workbookChartAreaFormat": {
+      "navigationProperties": [
+        "fill",
+        "font"
+      ],
+      "properties": []
+    },
+    "workbookChartAxes": {
+      "navigationProperties": [
+        "categoryAxis",
+        "seriesAxis",
+        "valueAxis"
+      ],
+      "properties": []
+    },
+    "workbookChartAxis": {
+      "navigationProperties": [
+        "format",
+        "majorGridlines",
+        "minorGridlines",
+        "title"
+      ],
+      "properties": [
+        "majorUnit",
+        "maximum",
+        "minimum",
+        "minorUnit"
+      ]
+    },
+    "workbookChartAxisFormat": {
+      "navigationProperties": [
+        "font",
+        "line"
+      ],
+      "properties": []
+    },
+    "workbookChartAxisTitle": {
+      "navigationProperties": [
+        "format"
+      ],
+      "properties": [
+        "text",
+        "visible"
+      ]
+    },
+    "workbookChartAxisTitleFormat": {
+      "navigationProperties": [
+        "font"
+      ],
+      "properties": []
+    },
+    "workbookChartDataLabelFormat": {
+      "navigationProperties": [
+        "fill",
+        "font"
+      ],
+      "properties": []
+    },
+    "workbookChartDataLabels": {
+      "navigationProperties": [
+        "format"
+      ],
+      "properties": [
+        "position",
+        "separator",
+        "showBubbleSize",
+        "showCategoryName",
+        "showLegendKey",
+        "showPercentage",
+        "showSeriesName",
+        "showValue"
+      ]
+    },
+    "workbookChartFill": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "workbookChartFont": {
+      "navigationProperties": [],
+      "properties": [
+        "bold",
+        "color",
+        "italic",
+        "name",
+        "size",
+        "underline"
+      ]
+    },
+    "workbookChartGridlines": {
+      "navigationProperties": [
+        "format"
+      ],
+      "properties": [
+        "visible"
+      ]
+    },
+    "workbookChartGridlinesFormat": {
+      "navigationProperties": [
+        "line"
+      ],
+      "properties": []
+    },
+    "workbookChartLegend": {
+      "navigationProperties": [
+        "format"
+      ],
+      "properties": [
+        "overlay",
+        "position",
+        "visible"
+      ]
+    },
+    "workbookChartLegendFormat": {
+      "navigationProperties": [
+        "fill",
+        "font"
+      ],
+      "properties": []
+    },
+    "workbookChartLineFormat": {
+      "navigationProperties": [],
+      "properties": [
+        "color"
+      ]
+    },
+    "workbookChartPoint": {
+      "navigationProperties": [
+        "format"
+      ],
+      "properties": [
+        "value"
+      ]
+    },
+    "workbookChartPointFormat": {
+      "navigationProperties": [
+        "fill"
+      ],
+      "properties": []
+    },
+    "workbookChartSeries": {
+      "navigationProperties": [
+        "format",
+        "points"
+      ],
+      "properties": [
+        "name"
+      ]
+    },
+    "workbookChartSeriesFormat": {
+      "navigationProperties": [
+        "fill",
+        "line"
+      ],
+      "properties": []
+    },
+    "workbookChartTitle": {
+      "navigationProperties": [
+        "format"
+      ],
+      "properties": [
+        "overlay",
+        "text",
+        "visible"
+      ]
+    },
+    "workbookChartTitleFormat": {
+      "navigationProperties": [
+        "fill",
+        "font"
+      ],
+      "properties": []
+    },
+    "workbookComment": {
+      "navigationProperties": [
+        "replies",
+        "task"
+      ],
+      "properties": [
+        "cellAddress",
+        "content",
+        "contentType",
+        "mentions",
+        "richContent"
+      ]
+    },
+    "workbookCommentReply": {
+      "navigationProperties": [
+        "task"
+      ],
+      "properties": [
+        "content",
+        "contentType",
+        "mentions",
+        "richContent"
+      ]
+    },
+    "workbookDocumentTask": {
+      "navigationProperties": [
+        "changes",
+        "comment"
+      ],
+      "properties": [
+        "assignees",
+        "completedBy",
+        "completedDateTime",
+        "createdBy",
+        "createdDateTime",
+        "percentComplete",
+        "priority",
+        "startAndDueDateTime",
+        "title"
+      ]
+    },
+    "workbookDocumentTaskChange": {
+      "navigationProperties": [],
+      "properties": [
+        "assignee",
+        "changedBy",
+        "commentId",
+        "createdDateTime",
+        "dueDateTime",
+        "percentComplete",
+        "priority",
+        "startDateTime",
+        "title",
+        "type",
+        "undoChangeId"
+      ]
+    },
+    "workbookFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "criteria"
+      ]
+    },
+    "workbookFormatProtection": {
+      "navigationProperties": [],
+      "properties": [
+        "formulaHidden",
+        "locked"
+      ]
+    },
+    "workbookFunctionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "value"
+      ]
+    },
+    "workbookFunctions": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "workbookNamedItem": {
+      "navigationProperties": [
+        "worksheet"
+      ],
+      "properties": [
+        "comment",
+        "name",
+        "scope",
+        "type",
+        "value",
+        "visible"
+      ]
+    },
+    "workbookOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "resourceLocation",
+        "status"
+      ]
+    },
+    "workbookPivotTable": {
+      "navigationProperties": [
+        "worksheet"
+      ],
+      "properties": [
+        "name"
+      ]
+    },
+    "workbookRange": {
+      "navigationProperties": [
+        "format",
+        "sort",
+        "worksheet"
+      ],
+      "properties": [
+        "address",
+        "addressLocal",
+        "cellCount",
+        "columnCount",
+        "columnHidden",
+        "columnIndex",
+        "formulas",
+        "formulasLocal",
+        "formulasR1C1",
+        "hidden",
+        "numberFormat",
+        "rowCount",
+        "rowHidden",
+        "rowIndex",
+        "text",
+        "values",
+        "valueTypes"
+      ]
+    },
+    "workbookRangeBorder": {
+      "navigationProperties": [],
+      "properties": [
+        "color",
+        "sideIndex",
+        "style",
+        "weight"
+      ]
+    },
+    "workbookRangeFill": {
+      "navigationProperties": [],
+      "properties": [
+        "color"
+      ]
+    },
+    "workbookRangeFont": {
+      "navigationProperties": [],
+      "properties": [
+        "bold",
+        "color",
+        "italic",
+        "name",
+        "size",
+        "underline"
+      ]
+    },
+    "workbookRangeFormat": {
+      "navigationProperties": [
+        "borders",
+        "fill",
+        "font",
+        "protection"
+      ],
+      "properties": [
+        "columnWidth",
+        "horizontalAlignment",
+        "rowHeight",
+        "verticalAlignment",
+        "wrapText"
+      ]
+    },
+    "workbookRangeSort": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "workbookRangeView": {
+      "navigationProperties": [
+        "rows"
+      ],
+      "properties": [
+        "cellAddresses",
+        "columnCount",
+        "formulas",
+        "formulasLocal",
+        "formulasR1C1",
+        "index",
+        "numberFormat",
+        "rowCount",
+        "text",
+        "values",
+        "valueTypes"
+      ]
+    },
+    "workbookTable": {
+      "navigationProperties": [
+        "columns",
+        "rows",
+        "sort",
+        "worksheet"
+      ],
+      "properties": [
+        "highlightFirstColumn",
+        "highlightLastColumn",
+        "legacyId",
+        "name",
+        "showBandedColumns",
+        "showBandedRows",
+        "showFilterButton",
+        "showHeaders",
+        "showTotals",
+        "style"
+      ]
+    },
+    "workbookTableColumn": {
+      "navigationProperties": [
+        "filter"
+      ],
+      "properties": [
+        "index",
+        "name",
+        "values"
+      ]
+    },
+    "workbookTableRow": {
+      "navigationProperties": [],
+      "properties": [
+        "index",
+        "values"
+      ]
+    },
+    "workbookTableSort": {
+      "navigationProperties": [],
+      "properties": [
+        "fields",
+        "matchCase",
+        "method"
+      ]
+    },
+    "workbookWorksheet": {
+      "navigationProperties": [
+        "charts",
+        "names",
+        "pivotTables",
+        "protection",
+        "tables",
+        "tasks"
+      ],
+      "properties": [
+        "name",
+        "position",
+        "visibility"
+      ]
+    },
+    "workbookWorksheetProtection": {
+      "navigationProperties": [],
+      "properties": [
+        "options",
+        "protected"
+      ]
+    },
+    "workforceIntegration": {
+      "navigationProperties": [],
+      "properties": [
+        "apiVersion",
+        "displayName",
+        "eligibilityFilteringEnabledEntities",
+        "encryption",
+        "isActive",
+        "supportedEntities",
+        "supports",
+        "url"
+      ]
+    },
+    "workHoursAndLocationsSetting": {
+      "navigationProperties": [
+        "occurrences",
+        "recurrences"
+      ],
+      "properties": [
+        "maxSharedWorkLocationDetails"
+      ]
+    },
+    "workingTimeSchedule": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "workplace": {
+      "navigationProperties": [
+        "sensorDevices"
+      ],
+      "properties": []
+    },
+    "workplaceSensorDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "deviceId",
+        "displayName",
+        "ipV4Address",
+        "ipV6Address",
+        "macAddress",
+        "manufacturer",
+        "placeId",
+        "sensors",
+        "tags"
+      ]
+    },
+    "workPlanOccurrence": {
+      "navigationProperties": [],
+      "properties": [
+        "end",
+        "placeId",
+        "recurrenceId",
+        "start",
+        "timeOffDetails",
+        "workLocationType"
+      ]
+    },
+    "workPlanRecurrence": {
+      "navigationProperties": [],
+      "properties": [
+        "end",
+        "placeId",
+        "recurrence",
+        "start",
+        "workLocationType"
+      ]
+    },
+    "workPosition": {
+      "navigationProperties": [],
+      "properties": [
+        "categories",
+        "colleagues",
+        "detail",
+        "isCurrent",
+        "manager"
+      ]
+    },
+    "workspace": {
+      "navigationProperties": [],
+      "properties": [
+        "building",
+        "capacity",
+        "displayDeviceName",
+        "emailAddress",
+        "floorLabel",
+        "floorNumber",
+        "mode",
+        "nickname",
+        "placeId"
+      ]
+    },
+    "x509CertificateAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": [
+        "authenticationModeConfiguration",
+        "certificateAuthorityScopes",
+        "certificateUserBindings",
+        "issuerHintsConfiguration"
+      ]
+    },
+    "x509CertificateCombinationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedIssuerSkis",
+        "allowedPolicyOIDs"
+      ]
+    },
+    "zebraFotaArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "boardSupportPackageVersion",
+        "description",
+        "deviceModel",
+        "osVersion",
+        "patchVersion",
+        "releaseNotesUrl"
+      ]
+    },
+    "zebraFotaConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "enrollmentAuthorizationUrl",
+        "enrollmentToken",
+        "fotaAppsApproved",
+        "lastSyncDateTime",
+        "state"
+      ]
+    },
+    "zebraFotaDeployment": {
+      "navigationProperties": [],
+      "properties": [
+        "deploymentSettings",
+        "deploymentStatus",
+        "description",
+        "displayName",
+        "roleScopeTagIds"
+      ]
+    }
+  },
+  "microsoft.graph.callRecords": {
+    "callRecord": {
+      "navigationProperties": [
+        "organizer_v2",
+        "participants_v2",
+        "sessions"
+      ],
+      "properties": [
+        "endDateTime",
+        "joinWebUrl",
+        "lastModifiedDateTime",
+        "modalities",
+        "organizer",
+        "participants",
+        "startDateTime",
+        "type",
+        "version"
+      ]
+    },
+    "organizer": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "participant": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "participantBase": {
+      "navigationProperties": [],
+      "properties": [
+        "administrativeUnitInfos",
+        "identity"
+      ]
+    },
+    "segment": {
+      "navigationProperties": [],
+      "properties": [
+        "callee",
+        "caller",
+        "endDateTime",
+        "failureInfo",
+        "media",
+        "startDateTime"
+      ]
+    },
+    "session": {
+      "navigationProperties": [
+        "segments"
+      ],
+      "properties": [
+        "callee",
+        "caller",
+        "endDateTime",
+        "failureInfo",
+        "isTest",
+        "modalities",
+        "startDateTime"
+      ]
+    }
+  },
+  "microsoft.graph.cloudLicensing": {
+    "adminCloudLicensing": {
+      "navigationProperties": [
+        "allotments",
+        "assignmentErrors",
+        "assignments"
+      ],
+      "properties": []
+    },
+    "allotment": {
+      "navigationProperties": [
+        "assignments",
+        "waitingMembers"
+      ],
+      "properties": [
+        "allottedUnits",
+        "assignableTo",
+        "consumedUnits",
+        "services",
+        "skuId",
+        "skuPartNumber",
+        "subscriptions"
+      ]
+    },
+    "assignment": {
+      "navigationProperties": [
+        "allotment",
+        "assignedTo"
+      ],
+      "properties": [
+        "disabledServicePlanIds"
+      ]
+    },
+    "assignmentError": {
+      "navigationProperties": [
+        "assignedTo",
+        "usageRight"
+      ],
+      "properties": [
+        "code",
+        "message",
+        "occurrenceDateTime",
+        "skuId"
+      ]
+    },
+    "usageRight": {
+      "navigationProperties": [
+        "allotments",
+        "assignments"
+      ],
+      "properties": [
+        "services",
+        "skuId",
+        "skuPartNumber"
+      ]
+    },
+    "waitingMember": {
+      "navigationProperties": [
+        "allotment",
+        "assignedTo"
+      ],
+      "properties": [
+        "waitingSinceDateTime"
+      ]
+    }
+  },
+  "microsoft.graph.deviceManagement": {
+    "alertRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "alertImpact",
+        "alertRuleId",
+        "alertRuleTemplate",
+        "detectedDateTime",
+        "displayName",
+        "lastUpdatedDateTime",
+        "resolvedDateTime",
+        "severity",
+        "status"
+      ]
+    },
+    "alertRule": {
+      "navigationProperties": [],
+      "properties": [
+        "alertRuleTemplate",
+        "conditions",
+        "description",
+        "displayName",
+        "enabled",
+        "isSystemRule",
+        "notificationChannels",
+        "severity",
+        "threshold"
+      ]
+    },
+    "monitoring": {
+      "navigationProperties": [
+        "alertRecords",
+        "alertRules"
+      ],
+      "properties": []
+    }
+  },
+  "microsoft.graph.ediscovery": {
+    "addToReviewSetOperation": {
+      "navigationProperties": [
+        "reviewSet",
+        "sourceCollection"
+      ],
+      "properties": []
+    },
+    "case": {
+      "navigationProperties": [
+        "custodians",
+        "legalHolds",
+        "noncustodialDataSources",
+        "operations",
+        "reviewSets",
+        "settings",
+        "sourceCollections",
+        "tags"
+      ],
+      "properties": [
+        "closedBy",
+        "closedDateTime",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "externalId",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "caseExportOperation": {
+      "navigationProperties": [
+        "reviewSet"
+      ],
+      "properties": [
+        "azureBlobContainer",
+        "azureBlobToken",
+        "description",
+        "exportOptions",
+        "exportStructure",
+        "outputFolderId",
+        "outputName"
+      ]
+    },
+    "caseHoldOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "caseIndexOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "caseOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "completedDateTime",
+        "createdBy",
+        "createdDateTime",
+        "percentProgress",
+        "resultInfo",
+        "status"
+      ]
+    },
+    "caseSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "ocr",
+        "redundancyDetection",
+        "topicModeling"
+      ]
+    },
+    "custodian": {
+      "navigationProperties": [
+        "siteSources",
+        "unifiedGroupSources",
+        "userSources"
+      ],
+      "properties": [
+        "acknowledgedDateTime",
+        "applyHoldToSources",
+        "email"
+      ]
+    },
+    "dataSource": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "holdStatus"
+      ]
+    },
+    "dataSourceContainer": {
+      "navigationProperties": [
+        "lastIndexOperation"
+      ],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "holdStatus",
+        "lastModifiedDateTime",
+        "releasedDateTime",
+        "status"
+      ]
+    },
+    "ediscoveryroot": {
+      "navigationProperties": [
+        "cases"
+      ],
+      "properties": []
+    },
+    "estimateStatisticsOperation": {
+      "navigationProperties": [
+        "sourceCollection"
+      ],
+      "properties": [
+        "indexedItemCount",
+        "indexedItemsSize",
+        "mailboxCount",
+        "siteCount",
+        "unindexedItemCount",
+        "unindexedItemsSize"
+      ]
+    },
+    "legalHold": {
+      "navigationProperties": [
+        "siteSources",
+        "unifiedGroupSources",
+        "userSources"
+      ],
+      "properties": [
+        "contentQuery",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "errors",
+        "isEnabled",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "noncustodialDataSource": {
+      "navigationProperties": [
+        "dataSource"
+      ],
+      "properties": [
+        "applyHoldToSource"
+      ]
+    },
+    "purgeDataOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "reviewSet": {
+      "navigationProperties": [
+        "queries"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName"
+      ]
+    },
+    "reviewSetQuery": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "query"
+      ]
+    },
+    "siteSource": {
+      "navigationProperties": [
+        "site"
+      ],
+      "properties": []
+    },
+    "sourceCollection": {
+      "navigationProperties": [
+        "additionalSources",
+        "addToReviewSetOperation",
+        "custodianSources",
+        "lastEstimateStatisticsOperation",
+        "noncustodialSources"
+      ],
+      "properties": [
+        "contentQuery",
+        "createdBy",
+        "createdDateTime",
+        "dataSourceScopes",
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "tag": {
+      "navigationProperties": [
+        "childTags",
+        "parent"
+      ],
+      "properties": [
+        "childSelectability",
+        "createdBy",
+        "description",
+        "displayName",
+        "lastModifiedDateTime"
+      ]
+    },
+    "tagOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unifiedGroupSource": {
+      "navigationProperties": [
+        "group"
+      ],
+      "properties": [
+        "includedSources"
+      ]
+    },
+    "userSource": {
+      "navigationProperties": [],
+      "properties": [
+        "email",
+        "includedSources",
+        "siteWebUrl"
+      ]
+    }
+  },
+  "microsoft.graph.entraRecoveryServices": {
+    "recovery": {
+      "navigationProperties": [
+        "jobs",
+        "snapshots"
+      ],
+      "properties": []
+    },
+    "recoveryChangeObjectBase": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "entityTypeName",
+        "failureMessage",
+        "recoveryAction"
+      ]
+    },
+    "recoveryJob": {
+      "navigationProperties": [],
+      "properties": [
+        "totalFailedChanges",
+        "totalLinksModified",
+        "totalObjectsModified"
+      ]
+    },
+    "recoveryJobBase": {
+      "navigationProperties": [],
+      "properties": [
+        "filteringCriteria",
+        "jobCompletionDateTime",
+        "jobStartDateTime",
+        "status",
+        "targetStateDateTime",
+        "totalChangedLinksCalculated",
+        "totalChangedObjectsCalculated"
+      ]
+    },
+    "recoveryPreviewJob": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "snapshot": {
+      "navigationProperties": [
+        "recoveryJobs",
+        "recoveryPreviewJobs"
+      ],
+      "properties": [
+        "createdDateTime",
+        "totalChangedObjects"
+      ]
+    }
+  },
+  "microsoft.graph.externalConnectors": {
+    "connectionOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "status"
+      ]
+    },
+    "connectionQuota": {
+      "navigationProperties": [],
+      "properties": [
+        "itemsRemaining"
+      ]
+    },
+    "external": {
+      "navigationProperties": [
+        "authorizationSystems",
+        "connections",
+        "industryData"
+      ],
+      "properties": []
+    },
+    "externalActivity": {
+      "navigationProperties": [
+        "performedBy"
+      ],
+      "properties": [
+        "startDateTime",
+        "type"
+      ]
+    },
+    "externalActivityResult": {
+      "navigationProperties": [],
+      "properties": [
+        "error"
+      ]
+    },
+    "externalConnection": {
+      "navigationProperties": [
+        "groups",
+        "items",
+        "operations",
+        "quota",
+        "schema"
+      ],
+      "properties": [
+        "activitySettings",
+        "complianceSettings",
+        "configuration",
+        "connectorId",
+        "contentCategory",
+        "description",
+        "enabledContentExperiences",
+        "ingestedItemsCount",
+        "name",
+        "searchSettings",
+        "state"
+      ]
+    },
+    "externalGroup": {
+      "navigationProperties": [
+        "members"
+      ],
+      "properties": [
+        "description",
+        "displayName"
+      ]
+    },
+    "externalItem": {
+      "navigationProperties": [
+        "activities"
+      ],
+      "properties": [
+        "acl",
+        "content",
+        "properties"
+      ]
+    },
+    "identity": {
+      "navigationProperties": [],
+      "properties": [
+        "type"
+      ]
+    },
+    "schema": {
+      "navigationProperties": [],
+      "properties": [
+        "baseType",
+        "properties"
+      ]
+    }
+  },
+  "microsoft.graph.healthMonitoring": {
+    "alert": {
+      "navigationProperties": [],
+      "properties": [
+        "alertType",
+        "category",
+        "createdDateTime",
+        "documentation",
+        "enrichment",
+        "scenario",
+        "signals",
+        "state"
+      ]
+    },
+    "alertConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "emailNotificationConfigurations"
+      ]
+    },
+    "healthMonitoringRoot": {
+      "navigationProperties": [
+        "alertConfigurations",
+        "alerts"
+      ],
+      "properties": []
+    }
+  },
+  "microsoft.graph.identityGovernance": {
+    "customTaskExtension": {
+      "navigationProperties": [
+        "createdBy",
+        "lastModifiedBy"
+      ],
+      "properties": [
+        "callbackConfiguration",
+        "createdDateTime",
+        "lastModifiedDateTime"
+      ]
+    },
+    "insights": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "lifecycleManagementSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "emailSettings",
+        "workflowScheduleIntervalInHours"
+      ]
+    },
+    "lifecycleWorkflowsContainer": {
+      "navigationProperties": [
+        "customTaskExtensions",
+        "deletedItems",
+        "insights",
+        "settings",
+        "taskDefinitions",
+        "workflows",
+        "workflowTemplates"
+      ],
+      "properties": []
+    },
+    "run": {
+      "navigationProperties": [
+        "reprocessedRuns",
+        "taskProcessingResults",
+        "userProcessingResults"
+      ],
+      "properties": [
+        "activatedOnScope",
+        "completedDateTime",
+        "failedTasksCount",
+        "failedUsersCount",
+        "lastUpdatedDateTime",
+        "processingStatus",
+        "scheduledDateTime",
+        "startedDateTime",
+        "successfulUsersCount",
+        "totalTasksCount",
+        "totalUnprocessedTasksCount",
+        "totalUsersCount",
+        "workflowExecutionType"
+      ]
+    },
+    "task": {
+      "navigationProperties": [
+        "taskProcessingResults"
+      ],
+      "properties": [
+        "arguments",
+        "category",
+        "continueOnError",
+        "description",
+        "displayName",
+        "executionSequence",
+        "isEnabled",
+        "taskDefinitionId"
+      ]
+    },
+    "taskDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "continueOnError",
+        "description",
+        "displayName",
+        "parameters",
+        "version"
+      ]
+    },
+    "taskProcessingResult": {
+      "navigationProperties": [
+        "subject",
+        "task"
+      ],
+      "properties": [
+        "completedDateTime",
+        "createdDateTime",
+        "failureReason",
+        "processingStatus",
+        "startedDateTime"
+      ]
+    },
+    "taskReport": {
+      "navigationProperties": [
+        "task",
+        "taskDefinition",
+        "taskProcessingResults"
+      ],
+      "properties": [
+        "completedDateTime",
+        "failedUsersCount",
+        "lastUpdatedDateTime",
+        "processingStatus",
+        "runId",
+        "startedDateTime",
+        "successfulUsersCount",
+        "totalUsersCount",
+        "unprocessedUsersCount"
+      ]
+    },
+    "userProcessingResult": {
+      "navigationProperties": [
+        "reprocessedRuns",
+        "subject",
+        "taskProcessingResults"
+      ],
+      "properties": [
+        "completedDateTime",
+        "failedTasksCount",
+        "processingStatus",
+        "scheduledDateTime",
+        "startedDateTime",
+        "totalTasksCount",
+        "totalUnprocessedTasksCount",
+        "workflowExecutionType",
+        "workflowVersion"
+      ]
+    },
+    "workflow": {
+      "navigationProperties": [
+        "executionScope",
+        "previewScope",
+        "runs",
+        "taskReports",
+        "userProcessingResults",
+        "versions"
+      ],
+      "properties": [
+        "deletedDateTime",
+        "id",
+        "nextScheduleRunDateTime",
+        "version"
+      ]
+    },
+    "workflowBase": {
+      "navigationProperties": [
+        "administrationScopeTargets",
+        "createdBy",
+        "lastModifiedBy",
+        "tasks"
+      ],
+      "properties": [
+        "category",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "executionConditions",
+        "isEnabled",
+        "isSchedulingEnabled",
+        "lastModifiedDateTime"
+      ]
+    },
+    "workflowTemplate": {
+      "navigationProperties": [
+        "tasks"
+      ],
+      "properties": [
+        "category",
+        "description",
+        "displayName",
+        "executionConditions"
+      ]
+    },
+    "workflowVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "versionNumber"
+      ]
+    }
+  },
+  "microsoft.graph.industryData": {
+    "administrativeUnitProvisioningFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "creationOptions"
+      ]
+    },
+    "apiDataConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "apiFormat",
+        "baseUrl",
+        "credential"
+      ]
+    },
+    "azureDataLakeConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "fileFormat"
+      ]
+    },
+    "classGroupProvisioningFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "configuration"
+      ]
+    },
+    "fileDataConnector": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "fileValidateOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "validatedFiles"
+      ]
+    },
+    "inboundApiFlow": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "inboundFileFlow": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "inboundFlow": {
+      "navigationProperties": [
+        "dataConnector",
+        "year"
+      ],
+      "properties": [
+        "dataDomain",
+        "effectiveDateTime",
+        "expirationDateTime"
+      ]
+    },
+    "inboundFlowActivity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "industryDataActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "readinessStatus"
+      ]
+    },
+    "industryDataConnector": {
+      "navigationProperties": [
+        "sourceSystem"
+      ],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "industryDataRoot": {
+      "navigationProperties": [
+        "dataConnectors",
+        "inboundFlows",
+        "operations",
+        "outboundProvisioningFlowSets",
+        "referenceDefinitions",
+        "roleGroups",
+        "runs",
+        "sourceSystems",
+        "years"
+      ],
+      "properties": []
+    },
+    "industryDataRun": {
+      "navigationProperties": [
+        "activities"
+      ],
+      "properties": [
+        "blockingError",
+        "displayName",
+        "endDateTime",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "industryDataRunActivity": {
+      "navigationProperties": [
+        "activity"
+      ],
+      "properties": [
+        "blockingError",
+        "displayName",
+        "status"
+      ]
+    },
+    "oneRosterApiDataConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "apiVersion",
+        "isContactsEnabled",
+        "isDemographicsEnabled",
+        "isFlagsEnabled"
+      ]
+    },
+    "outboundFlowActivity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "outboundProvisioningFlowSet": {
+      "navigationProperties": [
+        "provisioningFlows"
+      ],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "filter",
+        "lastModifiedDateTime"
+      ]
+    },
+    "provisioningFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastModifiedDateTime",
+        "readinessStatus"
+      ]
+    },
+    "referenceDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "createdDateTime",
+        "displayName",
+        "isDisabled",
+        "lastModifiedDateTime",
+        "referenceType",
+        "sortIndex",
+        "source"
+      ]
+    },
+    "roleGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "roles"
+      ]
+    },
+    "securityGroupProvisioningFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "creationOptions"
+      ]
+    },
+    "sourceSystemDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "userMatchingSettings",
+        "vendor"
+      ]
+    },
+    "userProvisioningFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "createUnmatchedUsers",
+        "creationOptions",
+        "managementOptions"
+      ]
+    },
+    "validateOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "errors",
+        "warnings"
+      ]
+    },
+    "yearTimePeriodDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "endDate",
+        "startDate",
+        "year"
+      ]
+    }
+  },
+  "microsoft.graph.managedTenants": {
+    "aggregatedPolicyCompliance": {
+      "navigationProperties": [],
+      "properties": [
+        "compliancePolicyId",
+        "compliancePolicyName",
+        "compliancePolicyPlatform",
+        "compliancePolicyType",
+        "lastRefreshedDateTime",
+        "numberOfCompliantDevices",
+        "numberOfErrorDevices",
+        "numberOfNonCompliantDevices",
+        "policyModifiedDateTime",
+        "tenantDisplayName",
+        "tenantId"
+      ]
+    },
+    "appPerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "appFriendlyName",
+        "appName",
+        "appPublisher",
+        "lastUpdatedDateTime",
+        "meanTimeToFailureInMinutes",
+        "tenantDisplayName",
+        "tenantId",
+        "totalActiveDeviceCount",
+        "totalAppCrashCount",
+        "totalAppFreezeCount"
+      ]
+    },
+    "auditEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "activityDateTime",
+        "activityId",
+        "category",
+        "httpVerb",
+        "initiatedByAppId",
+        "initiatedByUpn",
+        "initiatedByUserId",
+        "ipAddress",
+        "requestBody",
+        "requestUrl",
+        "tenantIds",
+        "tenantNames"
+      ]
+    },
+    "cloudPcConnection": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "healthCheckStatus",
+        "lastRefreshedDateTime",
+        "tenantDisplayName",
+        "tenantId"
+      ]
+    },
+    "cloudPcDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudPcStatus",
+        "deviceSpecification",
+        "displayName",
+        "lastRefreshedDateTime",
+        "managedDeviceId",
+        "managedDeviceName",
+        "provisioningPolicyId",
+        "servicePlanName",
+        "servicePlanType",
+        "tenantDisplayName",
+        "tenantId",
+        "userPrincipalName"
+      ]
+    },
+    "cloudPcOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "frontlineLicensesCount",
+        "lastRefreshedDateTime",
+        "numberOfCloudPcConnectionStatusFailed",
+        "numberOfCloudPcConnectionStatusPassed",
+        "numberOfCloudPcConnectionStatusPending",
+        "numberOfCloudPcConnectionStatusRunning",
+        "numberOfCloudPcConnectionStatusUnkownFutureValue",
+        "numberOfCloudPcStatusDeprovisioning",
+        "numberOfCloudPcStatusFailed",
+        "numberOfCloudPcStatusInGracePeriod",
+        "numberOfCloudPcStatusNotProvisioned",
+        "numberOfCloudPcStatusProvisioned",
+        "numberOfCloudPcStatusProvisioning",
+        "numberOfCloudPcStatusUnknown",
+        "numberOfCloudPcStatusUpgrading",
+        "tenantDisplayName",
+        "tenantId",
+        "totalBusinessLicenses",
+        "totalCloudPcConnectionStatus",
+        "totalCloudPcStatus",
+        "totalEnterpriseLicenses"
+      ]
+    },
+    "conditionalAccessPolicyCoverage": {
+      "navigationProperties": [],
+      "properties": [
+        "conditionalAccessPolicyState",
+        "latestPolicyModifiedDateTime",
+        "requiresDeviceCompliance",
+        "tenantDisplayName"
+      ]
+    },
+    "credentialUserRegistrationsSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "lastRefreshedDateTime",
+        "mfaAndSsprCapableUserCount",
+        "mfaConditionalAccessPolicyState",
+        "mfaExcludedUserCount",
+        "mfaRegisteredUserCount",
+        "securityDefaultsEnabled",
+        "ssprEnabledUserCount",
+        "ssprRegisteredUserCount",
+        "tenantDisplayName",
+        "tenantId",
+        "tenantLicenseType",
+        "totalUserCount"
+      ]
+    },
+    "deviceAppPerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "appFriendlyName",
+        "appName",
+        "appPublisher",
+        "appVersion",
+        "deviceId",
+        "deviceManufacturer",
+        "deviceModel",
+        "deviceName",
+        "healthStatus",
+        "isLatestUsedVersion",
+        "isMostUsedVersion",
+        "lastUpdatedDateTime",
+        "tenantDisplayName",
+        "tenantId",
+        "totalAppCrashCount",
+        "totalAppFreezeCount"
+      ]
+    },
+    "deviceCompliancePolicySettingStateSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "conflictDeviceCount",
+        "errorDeviceCount",
+        "failedDeviceCount",
+        "intuneAccountId",
+        "intuneSettingId",
+        "lastRefreshedDateTime",
+        "notApplicableDeviceCount",
+        "pendingDeviceCount",
+        "policyType",
+        "settingName",
+        "succeededDeviceCount",
+        "tenantDisplayName",
+        "tenantId"
+      ]
+    },
+    "deviceHealthStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "blueScreenCount",
+        "bootTotalDurationInSeconds",
+        "deviceId",
+        "deviceMake",
+        "deviceModel",
+        "deviceName",
+        "healthStatus",
+        "lastUpdatedDateTime",
+        "osVersion",
+        "primaryDiskType",
+        "restartCount",
+        "startupPerformanceScore",
+        "tenantDisplayName",
+        "tenantId",
+        "topProcesses"
+      ]
+    },
+    "managedDeviceCompliance": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceStatus",
+        "deviceType",
+        "inGracePeriodUntilDateTime",
+        "lastRefreshedDateTime",
+        "lastSyncDateTime",
+        "managedDeviceId",
+        "managedDeviceName",
+        "manufacturer",
+        "model",
+        "osDescription",
+        "osVersion",
+        "ownerType",
+        "tenantDisplayName",
+        "tenantId"
+      ]
+    },
+    "managedDeviceComplianceTrend": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantDeviceCount",
+        "configManagerDeviceCount",
+        "countDateTime",
+        "errorDeviceCount",
+        "inGracePeriodDeviceCount",
+        "noncompliantDeviceCount",
+        "tenantDisplayName",
+        "tenantId",
+        "unknownDeviceCount"
+      ]
+    },
+    "managedTenant": {
+      "navigationProperties": [
+        "aggregatedPolicyCompliances",
+        "appPerformances",
+        "auditEvents",
+        "cloudPcConnections",
+        "cloudPcDevices",
+        "cloudPcsOverview",
+        "conditionalAccessPolicyCoverages",
+        "credentialUserRegistrationsSummaries",
+        "deviceAppPerformances",
+        "deviceCompliancePolicySettingStateSummaries",
+        "deviceHealthStatuses",
+        "managedDeviceCompliances",
+        "managedDeviceComplianceTrends",
+        "managedTenantAlertLogs",
+        "managedTenantAlertRuleDefinitions",
+        "managedTenantAlertRules",
+        "managedTenantAlerts",
+        "managedTenantApiNotifications",
+        "managedTenantEmailNotifications",
+        "managedTenantTicketingEndpoints",
+        "managementActions",
+        "managementActionTenantDeploymentStatuses",
+        "managementIntents",
+        "managementTemplateCollections",
+        "managementTemplateCollectionTenantSummaries",
+        "managementTemplates",
+        "managementTemplateSteps",
+        "managementTemplateStepTenantSummaries",
+        "managementTemplateStepVersions",
+        "myRoles",
+        "tenantGroups",
+        "tenants",
+        "tenantsCustomizedInformation",
+        "tenantsDetailedInformation",
+        "tenantTags",
+        "windowsDeviceMalwareStates",
+        "windowsProtectionStates"
+      ],
+      "properties": []
+    },
+    "managedTenantAlert": {
+      "navigationProperties": [
+        "alertLogs",
+        "alertRule",
+        "apiNotifications",
+        "emailNotifications"
+      ],
+      "properties": [
+        "alertData",
+        "alertDataReferenceStrings",
+        "alertRuleDisplayName",
+        "assignedToUserId",
+        "correlationCount",
+        "correlationId",
+        "createdByUserId",
+        "createdDateTime",
+        "lastActionByUserId",
+        "lastActionDateTime",
+        "message",
+        "severity",
+        "status",
+        "tenantId",
+        "title"
+      ]
+    },
+    "managedTenantAlertLog": {
+      "navigationProperties": [
+        "alert"
+      ],
+      "properties": [
+        "content",
+        "createdByUserId",
+        "createdDateTime",
+        "lastActionByUserId",
+        "lastActionDateTime"
+      ]
+    },
+    "managedTenantAlertRule": {
+      "navigationProperties": [
+        "alerts",
+        "ruleDefinition"
+      ],
+      "properties": [
+        "alertDisplayName",
+        "alertTTL",
+        "createdByUserId",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastActionByUserId",
+        "lastActionDateTime",
+        "lastRunDateTime",
+        "notificationFinalDestinations",
+        "severity",
+        "targets",
+        "tenantIds"
+      ]
+    },
+    "managedTenantAlertRuleDefinition": {
+      "navigationProperties": [
+        "alertRules"
+      ],
+      "properties": [
+        "createdByUserId",
+        "createdDateTime",
+        "definitionTemplate",
+        "displayName",
+        "lastActionByUserId",
+        "lastActionDateTime"
+      ]
+    },
+    "managedTenantApiNotification": {
+      "navigationProperties": [
+        "alert"
+      ],
+      "properties": [
+        "createdByUserId",
+        "createdDateTime",
+        "isAcknowledged",
+        "lastActionByUserId",
+        "lastActionDateTime",
+        "message",
+        "title",
+        "userId"
+      ]
+    },
+    "managedTenantEmailNotification": {
+      "navigationProperties": [
+        "alert"
+      ],
+      "properties": [
+        "createdByUserId",
+        "createdDateTime",
+        "emailAddresses",
+        "emailBody",
+        "lastActionByUserId",
+        "lastActionDateTime",
+        "subject"
+      ]
+    },
+    "managedTenantTicketingEndpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "createdByUserId",
+        "createdDateTime",
+        "displayName",
+        "emailAddress",
+        "lastActionByUserId",
+        "lastActionDateTime",
+        "phoneNumber"
+      ]
+    },
+    "managementAction": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "description",
+        "displayName",
+        "referenceTemplateId",
+        "referenceTemplateVersion",
+        "workloadActions"
+      ]
+    },
+    "managementActionTenantDeploymentStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "statuses",
+        "tenantGroupId",
+        "tenantId"
+      ]
+    },
+    "managementIntent": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "isGlobal",
+        "managementTemplates"
+      ]
+    },
+    "managementTemplate": {
+      "navigationProperties": [
+        "managementTemplateCollections",
+        "managementTemplateSteps"
+      ],
+      "properties": [
+        "category",
+        "createdByUserId",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "informationLinks",
+        "lastActionByUserId",
+        "lastActionDateTime",
+        "parameters",
+        "priority",
+        "provider",
+        "userImpact",
+        "version",
+        "workloadActions"
+      ]
+    },
+    "managementTemplateCollection": {
+      "navigationProperties": [
+        "managementTemplates"
+      ],
+      "properties": [
+        "createdByUserId",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastActionByUserId",
+        "lastActionDateTime"
+      ]
+    },
+    "managementTemplateCollectionTenantSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "completeStepsCount",
+        "completeUsersCount",
+        "createdByUserId",
+        "createdDateTime",
+        "dismissedStepsCount",
+        "excludedUsersCount",
+        "excludedUsersDistinctCount",
+        "incompleteStepsCount",
+        "incompleteUsersCount",
+        "ineligibleStepsCount",
+        "isComplete",
+        "lastActionByUserId",
+        "lastActionDateTime",
+        "managementTemplateCollectionDisplayName",
+        "managementTemplateCollectionId",
+        "regressedStepsCount",
+        "regressedUsersCount",
+        "tenantId",
+        "unlicensedUsersCount"
+      ]
+    },
+    "managementTemplateStep": {
+      "navigationProperties": [
+        "acceptedVersion",
+        "managementTemplate",
+        "versions"
+      ],
+      "properties": [
+        "category",
+        "createdByUserId",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "informationLinks",
+        "lastActionByUserId",
+        "lastActionDateTime",
+        "portalLink",
+        "priority",
+        "userImpact"
+      ]
+    },
+    "managementTemplateStepDeployment": {
+      "navigationProperties": [
+        "templateStepVersion"
+      ],
+      "properties": [
+        "createdByUserId",
+        "createdDateTime",
+        "error",
+        "lastActionByUserId",
+        "lastActionDateTime",
+        "status",
+        "tenantId"
+      ]
+    },
+    "managementTemplateStepTenantSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedTenantsCount",
+        "compliantTenantsCount",
+        "createdByUserId",
+        "createdDateTime",
+        "dismissedTenantsCount",
+        "ineligibleTenantsCount",
+        "lastActionByUserId",
+        "lastActionDateTime",
+        "managementTemplateCollectionDisplayName",
+        "managementTemplateCollectionId",
+        "managementTemplateDisplayName",
+        "managementTemplateId",
+        "managementTemplateStepDisplayName",
+        "managementTemplateStepId",
+        "notCompliantTenantsCount"
+      ]
+    },
+    "managementTemplateStepVersion": {
+      "navigationProperties": [
+        "acceptedFor",
+        "deployments",
+        "templateStep"
+      ],
+      "properties": [
+        "contentMarkdown",
+        "createdByUserId",
+        "createdDateTime",
+        "lastActionByUserId",
+        "lastActionDateTime",
+        "name",
+        "version",
+        "versionInformation"
+      ]
+    },
+    "myRole": {
+      "navigationProperties": [],
+      "properties": [
+        "assignments",
+        "tenantId"
+      ]
+    },
+    "tenant": {
+      "navigationProperties": [],
+      "properties": [
+        "contract",
+        "createdDateTime",
+        "displayName",
+        "lastUpdatedDateTime",
+        "tenantId",
+        "tenantStatusInformation"
+      ]
+    },
+    "tenantCustomizedInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "businessRelationship",
+        "complianceRequirements",
+        "contacts",
+        "displayName",
+        "managedServicesPlans",
+        "note",
+        "noteLastModifiedDateTime",
+        "partnerRelationshipManagerUserIds",
+        "tenantId",
+        "website"
+      ]
+    },
+    "tenantDetailedInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "city",
+        "countryCode",
+        "countryName",
+        "defaultDomainName",
+        "displayName",
+        "industryName",
+        "region",
+        "segmentName",
+        "tenantId",
+        "verticalName"
+      ]
+    },
+    "tenantGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "allTenantsIncluded",
+        "displayName",
+        "managementActions",
+        "managementIntents",
+        "tenantIds"
+      ]
+    },
+    "tenantTag": {
+      "navigationProperties": [],
+      "properties": [
+        "createdByUserId",
+        "createdDateTime",
+        "deletedDateTime",
+        "description",
+        "displayName",
+        "lastActionByUserId",
+        "lastActionDateTime",
+        "tenants"
+      ]
+    },
+    "windowsDeviceMalwareState": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformationUrl",
+        "detectionCount",
+        "deviceDeleted",
+        "initialDetectionDateTime",
+        "lastRefreshedDateTime",
+        "lastStateChangeDateTime",
+        "malwareCategory",
+        "malwareDisplayName",
+        "malwareExecutionState",
+        "malwareId",
+        "malwareSeverity",
+        "malwareThreatState",
+        "managedDeviceId",
+        "managedDeviceName",
+        "tenantDisplayName",
+        "tenantId"
+      ]
+    },
+    "windowsProtectionState": {
+      "navigationProperties": [],
+      "properties": [
+        "antiMalwareVersion",
+        "attentionRequired",
+        "deviceDeleted",
+        "devicePropertyRefreshDateTime",
+        "engineVersion",
+        "fullScanOverdue",
+        "fullScanRequired",
+        "lastFullScanDateTime",
+        "lastFullScanSignatureVersion",
+        "lastQuickScanDateTime",
+        "lastQuickScanSignatureVersion",
+        "lastRefreshedDateTime",
+        "lastReportedDateTime",
+        "malwareProtectionEnabled",
+        "managedDeviceHealthState",
+        "managedDeviceId",
+        "managedDeviceName",
+        "networkInspectionSystemEnabled",
+        "quickScanOverdue",
+        "realTimeProtectionEnabled",
+        "rebootRequired",
+        "signatureUpdateOverdue",
+        "signatureVersion",
+        "tenantDisplayName",
+        "tenantId"
+      ]
+    }
+  },
+  "microsoft.graph.networkaccess": {
+    "alert": {
+      "navigationProperties": [
+        "policy"
+      ],
+      "properties": [
+        "actions",
+        "alertType",
+        "categories",
+        "componentName",
+        "creationDateTime",
+        "description",
+        "detectionTechnology",
+        "displayName",
+        "extendedProperties",
+        "firstActivityDateTime",
+        "isPreview",
+        "lastActivityDateTime",
+        "productName",
+        "relatedResources",
+        "severity",
+        "subTechniques",
+        "techniques",
+        "vendorName"
+      ]
+    },
+    "baseEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "branchConnectivityConfiguration": {
+      "navigationProperties": [
+        "links"
+      ],
+      "properties": [
+        "branchId",
+        "branchName"
+      ]
+    },
+    "branchSite": {
+      "navigationProperties": [
+        "connectivityConfiguration",
+        "deviceLinks",
+        "forwardingProfiles"
+      ],
+      "properties": [
+        "bandwidthCapacity",
+        "connectivityState",
+        "country",
+        "lastModifiedDateTime",
+        "name",
+        "region",
+        "version"
+      ]
+    },
+    "cloudFirewallPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedDateTime",
+        "settings"
+      ]
+    },
+    "cloudFirewallPolicyLink": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudFirewallRule": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "description",
+        "matchingConditions",
+        "priority",
+        "settings"
+      ]
+    },
+    "conditionalAccessPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "modifiedDateTime"
+      ]
+    },
+    "conditionalAccessSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "signalingStatus"
+      ]
+    },
+    "connection": {
+      "navigationProperties": [],
+      "properties": [
+        "agentVersion",
+        "applicationSnapshot",
+        "createdDateTime",
+        "crossTenantAccessType",
+        "destinationFqdn",
+        "destinationIp",
+        "destinationPort",
+        "deviceCategory",
+        "deviceId",
+        "deviceJoinType",
+        "deviceOperatingSystem",
+        "deviceOperatingSystemVersion",
+        "endDateTime",
+        "homeTenantId",
+        "initiatingProcessName",
+        "lastUpdateDateTime",
+        "networkProtocol",
+        "popProcessingRegion",
+        "privateAccessDetails",
+        "receivedBytes",
+        "sentBytes",
+        "sourceIp",
+        "sourcePort",
+        "status",
+        "tenantId",
+        "trafficType",
+        "transactionBlockCount",
+        "transactionCount",
+        "transportProtocol",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "connectivity": {
+      "navigationProperties": [
+        "branches",
+        "remoteNetworks"
+      ],
+      "properties": [
+        "webCategories"
+      ]
+    },
+    "connectivityConfigurationLink": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "localConfigurations",
+        "peerConfiguration"
+      ]
+    },
+    "crossTenantAccessSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "networkPacketTaggingStatus"
+      ]
+    },
+    "customBlockPage": {
+      "navigationProperties": [],
+      "properties": [
+        "configuration",
+        "state"
+      ]
+    },
+    "deployment": {
+      "navigationProperties": [],
+      "properties": [
+        "configuration",
+        "deploymentEndDateTime",
+        "initiatedBy",
+        "lastModifiedDateTime",
+        "requestId",
+        "status"
+      ]
+    },
+    "deviceLink": {
+      "navigationProperties": [],
+      "properties": [
+        "bandwidthCapacityInMbps",
+        "bgpConfiguration",
+        "deviceVendor",
+        "ipAddress",
+        "lastModifiedDateTime",
+        "name",
+        "redundancyConfiguration",
+        "tunnelConfiguration"
+      ]
+    },
+    "externalCertificateAuthorityCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "certificate",
+        "certificateSigningRequest",
+        "chain",
+        "commonName",
+        "name",
+        "organizationName",
+        "status",
+        "validity"
+      ]
+    },
+    "filteringPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "createdDateTime",
+        "lastModifiedDateTime"
+      ]
+    },
+    "filteringPolicyLink": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastModifiedDateTime",
+        "loggingState",
+        "priority"
+      ]
+    },
+    "filteringProfile": {
+      "navigationProperties": [
+        "conditionalAccessPolicies"
+      ],
+      "properties": [
+        "createdDateTime",
+        "priority"
+      ]
+    },
+    "filteringRule": {
+      "navigationProperties": [],
+      "properties": [
+        "destinations",
+        "ruleType"
+      ]
+    },
+    "forwardingOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "skipDnsLookupState"
+      ]
+    },
+    "forwardingPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "privateAccessAppId",
+        "trafficForwardingType"
+      ]
+    },
+    "forwardingPolicyLink": {
+      "navigationProperties": [],
+      "properties": [
+        "priority"
+      ]
+    },
+    "forwardingProfile": {
+      "navigationProperties": [
+        "servicePrincipal"
+      ],
+      "properties": [
+        "associations",
+        "isCustomProfile",
+        "priority",
+        "trafficForwardingType"
+      ]
+    },
+    "forwardingRule": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "clientFallbackAction",
+        "destinations",
+        "ruleType"
+      ]
+    },
+    "fqdnFilteringRule": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "generativeAIInsight": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "content",
+        "createdDateTime",
+        "destinationUrl",
+        "eventId",
+        "eventType",
+        "mcpClientName",
+        "mcpServerName",
+        "sessionId",
+        "subactivity",
+        "transactionId",
+        "userPrincipalName"
+      ]
+    },
+    "internetAccessForwardingRule": {
+      "navigationProperties": [],
+      "properties": [
+        "ports",
+        "protocol"
+      ]
+    },
+    "logs": {
+      "navigationProperties": [
+        "connections",
+        "generativeAIInsights",
+        "remoteNetworks",
+        "traffic"
+      ],
+      "properties": []
+    },
+    "m365ForwardingRule": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "ports",
+        "protocol"
+      ]
+    },
+    "networkAccessRoot": {
+      "navigationProperties": [
+        "alerts",
+        "cloudFirewallPolicies",
+        "connectivity",
+        "filteringPolicies",
+        "filteringProfiles",
+        "forwardingPolicies",
+        "forwardingProfiles",
+        "logs",
+        "reports",
+        "settings",
+        "tenantStatus",
+        "threatIntelligencePolicies",
+        "tls",
+        "tlsInspectionPolicies"
+      ],
+      "properties": []
+    },
+    "networkAccessTraffic": {
+      "navigationProperties": [
+        "device",
+        "user"
+      ],
+      "properties": [
+        "action",
+        "agentVersion",
+        "applicationSnapshot",
+        "cloudApplicationMetadata",
+        "connectionId",
+        "createdDateTime",
+        "description",
+        "destinationFQDN",
+        "destinationIp",
+        "destinationPort",
+        "destinationUrl",
+        "destinationWebCategory",
+        "deviceCategory",
+        "deviceId",
+        "deviceOperatingSystem",
+        "deviceOperatingSystemVersion",
+        "filteringProfileId",
+        "filteringProfileName",
+        "headers",
+        "httpMethod",
+        "initiatingProcessName",
+        "networkProtocol",
+        "operationStatus",
+        "policyId",
+        "policyName",
+        "policyRuleId",
+        "policyRuleName",
+        "popProcessingRegion",
+        "privateAccessDetails",
+        "receivedBytes",
+        "remoteNetworkId",
+        "resourceTenantId",
+        "responseCode",
+        "sentBytes",
+        "sessionId",
+        "sourceIp",
+        "sourcePort",
+        "tenantId",
+        "threatType",
+        "trafficType",
+        "transactionId",
+        "transportProtocol",
+        "userId",
+        "userPrincipalName",
+        "vendorNames"
+      ]
+    },
+    "policy": {
+      "navigationProperties": [
+        "policyRules"
+      ],
+      "properties": [
+        "description",
+        "name",
+        "version"
+      ]
+    },
+    "policyLink": {
+      "navigationProperties": [
+        "policy"
+      ],
+      "properties": [
+        "state",
+        "version"
+      ]
+    },
+    "policyRule": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "privateAccessForwardingRule": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "profile": {
+      "navigationProperties": [
+        "policies"
+      ],
+      "properties": [
+        "description",
+        "lastModifiedDateTime",
+        "state",
+        "version"
+      ]
+    },
+    "remoteNetwork": {
+      "navigationProperties": [
+        "connectivityConfiguration",
+        "deviceLinks",
+        "forwardingProfiles"
+      ],
+      "properties": [
+        "lastModifiedDateTime",
+        "region",
+        "version"
+      ]
+    },
+    "remoteNetworkConnectivityConfiguration": {
+      "navigationProperties": [
+        "links"
+      ],
+      "properties": [
+        "remoteNetworkId",
+        "remoteNetworkName"
+      ]
+    },
+    "remoteNetworkHealthEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "bgpRoutesAdvertisedCount",
+        "createdDateTime",
+        "description",
+        "destinationIp",
+        "receivedBytes",
+        "remoteNetworkId",
+        "sentBytes",
+        "sourceIp",
+        "status"
+      ]
+    },
+    "reports": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "settings": {
+      "navigationProperties": [
+        "conditionalAccess",
+        "crossTenantAccess",
+        "customBlockPage",
+        "forwardingOptions"
+      ],
+      "properties": []
+    },
+    "tenantStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "onboardingErrorMessage",
+        "onboardingStatus"
+      ]
+    },
+    "threatIntelligencePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedDateTime",
+        "settings"
+      ]
+    },
+    "threatIntelligencePolicyLink": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "threatIntelligenceRule": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "description",
+        "matchingConditions",
+        "priority",
+        "settings"
+      ]
+    },
+    "tlsInspectionPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedDateTime",
+        "settings"
+      ]
+    },
+    "tlsInspectionPolicyLink": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "tlsInspectionRule": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "matchingConditions",
+        "priority",
+        "settings"
+      ]
+    },
+    "tlsTermination": {
+      "navigationProperties": [
+        "externalCertificateAuthorityCertificates"
+      ],
+      "properties": []
+    },
+    "urlDestinationFilteringRule": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "webCategoryFilteringRule": {
+      "navigationProperties": [],
+      "properties": []
+    }
+  },
+  "microsoft.graph.partner.security": {
+    "adminsMfaEnforcedSecurityRequirement": {
+      "navigationProperties": [],
+      "properties": [
+        "adminsRequiredNotUsingMfaCount",
+        "legacyPerUserMfaStatus",
+        "mfaConditionalAccessPolicyStatus",
+        "mfaEnabledAdminsCount",
+        "mfaEnabledUsersCount",
+        "securityDefaultsStatus",
+        "totalAdminsCount",
+        "totalUsersCount",
+        "usersRequiredNotUsingMfaCount"
+      ]
+    },
+    "customerInsight": {
+      "navigationProperties": [],
+      "properties": [
+        "mfa",
+        "tenantId"
+      ]
+    },
+    "customersMfaEnforcedSecurityRequirement": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantTenantCount",
+        "totalTenantCount"
+      ]
+    },
+    "customersSpendingBudgetSecurityRequirement": {
+      "navigationProperties": [],
+      "properties": [
+        "customersWithSpendBudgetCount",
+        "totalCustomersCount"
+      ]
+    },
+    "partnerSecurity": {
+      "navigationProperties": [
+        "securityAlerts",
+        "securityScore"
+      ],
+      "properties": []
+    },
+    "partnerSecurityAlert": {
+      "navigationProperties": [],
+      "properties": [
+        "activityLogs",
+        "additionalDetails",
+        "affectedResources",
+        "alertType",
+        "catalogOfferId",
+        "confidenceLevel",
+        "customerTenantId",
+        "description",
+        "detectedDateTime",
+        "displayName",
+        "firstObservedDateTime",
+        "isTest",
+        "lastObservedDateTime",
+        "resolvedBy",
+        "resolvedOnDateTime",
+        "resolvedReason",
+        "severity",
+        "status",
+        "subscriptionId",
+        "valueAddedResellerTenantId"
+      ]
+    },
+    "partnerSecurityScore": {
+      "navigationProperties": [
+        "customerInsights",
+        "history",
+        "requirements"
+      ],
+      "properties": [
+        "currentScore",
+        "lastRefreshDateTime",
+        "maxScore",
+        "updatedDateTime"
+      ]
+    },
+    "responseTimeSecurityRequirement": {
+      "navigationProperties": [],
+      "properties": [
+        "averageResponseTimeInHours"
+      ]
+    },
+    "securityRequirement": {
+      "navigationProperties": [],
+      "properties": [
+        "actionUrl",
+        "complianceStatus",
+        "helpUrl",
+        "maxScore",
+        "requirementType",
+        "score",
+        "state",
+        "updatedDateTime"
+      ]
+    },
+    "securityScoreHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantRequirementsCount",
+        "createdDateTime",
+        "score",
+        "totalRequirementsCount"
+      ]
+    }
+  },
+  "microsoft.graph.partners.billing": {
+    "azureUsage": {
+      "navigationProperties": [
+        "billed",
+        "unbilled"
+      ],
+      "properties": []
+    },
+    "billedReconciliation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "billedUsage": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "billing": {
+      "navigationProperties": [
+        "manifests",
+        "operations",
+        "reconciliation",
+        "usage"
+      ],
+      "properties": []
+    },
+    "billingReconciliation": {
+      "navigationProperties": [
+        "billed",
+        "unbilled"
+      ],
+      "properties": []
+    },
+    "exportSuccessOperation": {
+      "navigationProperties": [
+        "resourceLocation"
+      ],
+      "properties": []
+    },
+    "failedOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "error"
+      ]
+    },
+    "manifest": {
+      "navigationProperties": [],
+      "properties": [
+        "blobCount",
+        "blobs",
+        "createdDateTime",
+        "dataFormat",
+        "eTag",
+        "partitionType",
+        "partnerTenantId",
+        "rootDirectory",
+        "sasToken",
+        "schemaVersion"
+      ]
+    },
+    "operation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastActionDateTime",
+        "status"
+      ]
+    },
+    "runningOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unbilledReconciliation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unbilledUsage": {
+      "navigationProperties": [],
+      "properties": []
+    }
+  },
+  "microsoft.graph.search": {
+    "acronym": {
+      "navigationProperties": [],
+      "properties": [
+        "standsFor",
+        "state"
+      ]
+    },
+    "bookmark": {
+      "navigationProperties": [],
+      "properties": [
+        "availabilityEndDateTime",
+        "availabilityStartDateTime",
+        "categories",
+        "groupIds",
+        "isSuggested",
+        "keywords",
+        "languageTags",
+        "platforms",
+        "powerAppIds",
+        "state",
+        "targetedVariations"
+      ]
+    },
+    "qna": {
+      "navigationProperties": [],
+      "properties": [
+        "availabilityEndDateTime",
+        "availabilityStartDateTime",
+        "groupIds",
+        "isSuggested",
+        "keywords",
+        "languageTags",
+        "platforms",
+        "state",
+        "targetedVariations"
+      ]
+    },
+    "searchAnswer": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "webUrl"
+      ]
+    }
+  },
+  "microsoft.graph.security": {
+    "aggregatedEnvironment": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "kind"
+      ]
+    },
+    "alert": {
+      "navigationProperties": [],
+      "properties": [
+        "actorDisplayName",
+        "additionalData",
+        "alertPolicyId",
+        "alertWebUrl",
+        "assignedTo",
+        "category",
+        "classification",
+        "comments",
+        "createdDateTime",
+        "customDetails",
+        "description",
+        "detectionSource",
+        "detectorId",
+        "determination",
+        "evidence",
+        "firstActivityDateTime",
+        "incidentId",
+        "incidentWebUrl",
+        "investigationState",
+        "lastActivityDateTime",
+        "lastUpdateDateTime",
+        "mitreTechniques",
+        "productName",
+        "providerAlertId",
+        "recommendedActions",
+        "resolvedDateTime",
+        "serviceSource",
+        "severity",
+        "status",
+        "systemTags",
+        "tenantId",
+        "threatDisplayName",
+        "threatFamilyName",
+        "title"
+      ]
+    },
+    "analyzedEmail": {
+      "navigationProperties": [],
+      "properties": [
+        "alertIds",
+        "attachments",
+        "authenticationDetails",
+        "bulkComplaintLevel",
+        "clientType",
+        "contexts",
+        "detectionMethods",
+        "directionality",
+        "distributionList",
+        "dlpRules",
+        "emailClusterId",
+        "exchangeTransportRules",
+        "forwardingDetail",
+        "inboundConnectorFormattedName",
+        "internetMessageId",
+        "language",
+        "latestDelivery",
+        "loggedDateTime",
+        "networkMessageId",
+        "originalDelivery",
+        "overrideSources",
+        "phishConfidenceLevel",
+        "policy",
+        "policyAction",
+        "policyType",
+        "primaryOverrideSource",
+        "recipientDetail",
+        "recipientEmailAddress",
+        "returnPath",
+        "senderDetail",
+        "sizeInBytes",
+        "spamConfidenceLevel",
+        "subject",
+        "threatDetectionDetails",
+        "threatTypes",
+        "timelineEvents",
+        "urls"
+      ]
+    },
+    "article": {
+      "navigationProperties": [
+        "indicators"
+      ],
+      "properties": [
+        "body",
+        "createdDateTime",
+        "imageUrl",
+        "isFeatured",
+        "lastUpdatedDateTime",
+        "summary",
+        "tags",
+        "title"
+      ]
+    },
+    "articleIndicator": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "artifact": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "auditCoreRoot": {
+      "navigationProperties": [
+        "queries"
+      ],
+      "properties": []
+    },
+    "auditLogQuery": {
+      "navigationProperties": [
+        "records"
+      ],
+      "properties": [
+        "administrativeUnitIdFilters",
+        "displayName",
+        "filterEndDateTime",
+        "filterStartDateTime",
+        "ipAddressFilters",
+        "keywordFilter",
+        "objectIdFilters",
+        "operationFilters",
+        "recordTypeFilters",
+        "serviceFilters",
+        "status",
+        "userPrincipalNameFilters"
+      ]
+    },
+    "auditLogRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "administrativeUnits",
+        "auditData",
+        "auditLogRecordType",
+        "clientIp",
+        "createdDateTime",
+        "objectId",
+        "operation",
+        "organizationId",
+        "service",
+        "userId",
+        "userPrincipalName",
+        "userType"
+      ]
+    },
+    "authorityTemplate": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "autoAuditingConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isAutomatic"
+      ]
+    },
+    "case": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "caseOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "completedDateTime",
+        "createdBy",
+        "createdDateTime",
+        "percentProgress",
+        "resultInfo",
+        "status"
+      ]
+    },
+    "casesRoot": {
+      "navigationProperties": [
+        "ediscoveryCases"
+      ],
+      "properties": []
+    },
+    "categoryTemplate": {
+      "navigationProperties": [
+        "subcategories"
+      ],
+      "properties": []
+    },
+    "citationTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "citationJurisdiction",
+        "citationUrl"
+      ]
+    },
+    "cloudAppDiscoveryReport": {
+      "navigationProperties": [],
+      "properties": [
+        "anonymizeMachineData",
+        "anonymizeUserData",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "isSnapshotReport",
+        "lastDataReceivedDateTime",
+        "lastModifiedDateTime",
+        "logDataProvider",
+        "logFileCount",
+        "receiverProtocol",
+        "supportedEntityTypes",
+        "supportedTrafficTypes"
+      ]
+    },
+    "collaborationRoot": {
+      "navigationProperties": [
+        "analyzedEmails"
+      ],
+      "properties": []
+    },
+    "dataDiscoveryReport": {
+      "navigationProperties": [
+        "uploadedStreams"
+      ],
+      "properties": []
+    },
+    "dataDiscoveryRoot": {
+      "navigationProperties": [
+        "cloudAppDiscovery"
+      ],
+      "properties": []
+    },
+    "dataSet": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName"
+      ]
+    },
+    "dataSource": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "holdStatus"
+      ]
+    },
+    "dataSourceContainer": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "holdStatus",
+        "lastModifiedDateTime",
+        "releasedDateTime",
+        "status"
+      ]
+    },
+    "departmentTemplate": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "detectionRule": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionAction",
+        "detectorId",
+        "lastRunDetails",
+        "queryCondition",
+        "schedule"
+      ]
+    },
+    "discoveredCloudAppDetail": {
+      "navigationProperties": [
+        "appInfo",
+        "ipAddresses",
+        "users"
+      ],
+      "properties": [
+        "category",
+        "description",
+        "displayName",
+        "domains",
+        "downloadNetworkTrafficInBytes",
+        "firstSeenDateTime",
+        "ipAddressCount",
+        "lastSeenDateTime",
+        "riskScore",
+        "tags",
+        "transactionCount",
+        "uploadNetworkTrafficInBytes",
+        "userCount"
+      ]
+    },
+    "discoveredCloudAppDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "discoveredCloudAppInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "csaStarLevel",
+        "dataAtRestEncryptionMethod",
+        "dataCenter",
+        "dataRetentionPolicy",
+        "dataTypes",
+        "domainRegistrationDateTime",
+        "encryptionProtocol",
+        "fedRampLevel",
+        "founded",
+        "gdprReadinessStatement",
+        "headquarters",
+        "holding",
+        "hostingCompany",
+        "isAdminAuditTrail",
+        "isCobitCompliant",
+        "isCoppaCompliant",
+        "isDataAuditTrail",
+        "isDataClassification",
+        "isDataOwnership",
+        "isDisasterRecoveryPlan",
+        "isDmca",
+        "isFerpaCompliant",
+        "isFfiecCompliant",
+        "isFileSharing",
+        "isFinraCompliant",
+        "isFismaCompliant",
+        "isGaapCompliant",
+        "isGdprDataProtectionImpactAssessment",
+        "isGdprDataProtectionOfficer",
+        "isGdprDataProtectionSecureCrossBorderDataTransfer",
+        "isGdprImpactAssessment",
+        "isGdprLawfulBasisForProcessing",
+        "isGdprReportDataBreaches",
+        "isGdprRightsRelatedToAutomatedDecisionMaking",
+        "isGdprRightToAccess",
+        "isGdprRightToBeInformed",
+        "isGdprRightToDataPortablility",
+        "isGdprRightToErasure",
+        "isGdprRightToObject",
+        "isGdprRightToRectification",
+        "isGdprRightToRestrictionOfProcessing",
+        "isGdprSecureCrossBorderDataControl",
+        "isGlbaCompliant",
+        "isHipaaCompliant",
+        "isHitrustCsfCompliant",
+        "isHttpSecurityHeadersContentSecurityPolicy",
+        "isHttpSecurityHeadersStrictTransportSecurity",
+        "isHttpSecurityHeadersXContentTypeOptions",
+        "isHttpSecurityHeadersXFrameOptions",
+        "isHttpSecurityHeadersXXssProtection",
+        "isIpAddressRestriction",
+        "isIsae3402Compliant",
+        "isIso27001Compliant",
+        "isIso27017Compliant",
+        "isIso27018Compliant",
+        "isItarCompliant",
+        "isMultiFactorAuthentication",
+        "isPasswordPolicy",
+        "isPasswordPolicyChangePasswordPeriod",
+        "isPasswordPolicyCharacterCombination",
+        "isPasswordPolicyPasswordHistoryAndReuse",
+        "isPasswordPolicyPasswordLengthLimit",
+        "isPasswordPolicyPersonalInformationUse",
+        "isPenetrationTesting",
+        "isPrivacyShieldCompliant",
+        "isRememberPassword",
+        "isRequiresUserAuthentication",
+        "isSoc1Compliant",
+        "isSoc2Compliant",
+        "isSoc3Compliant",
+        "isSoxCompliant",
+        "isSp80053Compliant",
+        "isSsae16Compliant",
+        "isSupportsSaml",
+        "isTrustedCertificate",
+        "isUserAuditTrail",
+        "isUserCanUploadData",
+        "isUserRolesSupport",
+        "isValidCertificateName",
+        "latestBreachDateTime",
+        "logonUrls",
+        "pciDssVersion",
+        "vendor"
+      ]
+    },
+    "discoveredCloudAppIPAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "ipAddress"
+      ]
+    },
+    "discoveredCloudAppUser": {
+      "navigationProperties": [],
+      "properties": [
+        "userIdentifier"
+      ]
+    },
+    "dispositionReviewStage": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "reviewersEmailAddresses",
+        "stageNumber"
+      ]
+    },
+    "ediscoveryAddToReviewSetOperation": {
+      "navigationProperties": [
+        "reviewSet",
+        "search"
+      ],
+      "properties": [
+        "additionalDataOptions",
+        "cloudAttachmentVersion",
+        "documentVersion",
+        "itemsToInclude",
+        "reportFileMetadata"
+      ]
+    },
+    "ediscoveryCase": {
+      "navigationProperties": [
+        "caseMembers",
+        "custodians",
+        "legalHolds",
+        "noncustodialDataSources",
+        "operations",
+        "reviewSets",
+        "searches",
+        "settings",
+        "tags"
+      ],
+      "properties": [
+        "closedBy",
+        "closedDateTime",
+        "externalId"
+      ]
+    },
+    "ediscoveryCaseMember": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "recipientType",
+        "smtpAddress"
+      ]
+    },
+    "ediscoveryCaseSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "caseType",
+        "ocr",
+        "redundancyDetection",
+        "reviewSetSettings",
+        "topicModeling"
+      ]
+    },
+    "ediscoveryCustodian": {
+      "navigationProperties": [
+        "lastIndexOperation",
+        "siteSources",
+        "unifiedGroupSources",
+        "userSources"
+      ],
+      "properties": [
+        "acknowledgedDateTime",
+        "email"
+      ]
+    },
+    "ediscoveryEstimateOperation": {
+      "navigationProperties": [
+        "search"
+      ],
+      "properties": [
+        "indexedItemCount",
+        "indexedItemsSize",
+        "mailboxCount",
+        "reportFileMetadata",
+        "siteCount",
+        "statisticsOptions",
+        "unindexedItemCount",
+        "unindexedItemsSize"
+      ]
+    },
+    "ediscoveryExportOperation": {
+      "navigationProperties": [
+        "reviewSet",
+        "reviewSetQuery"
+      ],
+      "properties": [
+        "azureBlobContainer",
+        "azureBlobToken",
+        "description",
+        "exportFileMetadata",
+        "exportOptions",
+        "exportStructure",
+        "outputFolderId",
+        "outputName"
+      ]
+    },
+    "ediscoveryFile": {
+      "navigationProperties": [
+        "custodian",
+        "tags"
+      ],
+      "properties": []
+    },
+    "ediscoveryHoldOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ediscoveryHoldPolicy": {
+      "navigationProperties": [
+        "siteSources",
+        "userSources"
+      ],
+      "properties": [
+        "contentQuery",
+        "errors",
+        "isEnabled"
+      ]
+    },
+    "ediscoveryHoldPolicySyncOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "reportFileMetadata"
+      ]
+    },
+    "ediscoveryIndexOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ediscoveryNoncustodialDataSource": {
+      "navigationProperties": [
+        "dataSource",
+        "lastIndexOperation"
+      ],
+      "properties": []
+    },
+    "ediscoveryPurgeDataOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "reportFileMetadata"
+      ]
+    },
+    "ediscoveryReviewSet": {
+      "navigationProperties": [
+        "files",
+        "queries"
+      ],
+      "properties": []
+    },
+    "ediscoveryReviewSetQuery": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ediscoveryReviewTag": {
+      "navigationProperties": [
+        "childTags",
+        "parent"
+      ],
+      "properties": [
+        "childSelectability"
+      ]
+    },
+    "ediscoverySearch": {
+      "navigationProperties": [
+        "additionalSources",
+        "addToReviewSetOperation",
+        "custodianSources",
+        "lastEstimateStatisticsOperation",
+        "noncustodialSources"
+      ],
+      "properties": [
+        "dataSourceScopes"
+      ]
+    },
+    "ediscoverySearchExportOperation": {
+      "navigationProperties": [
+        "search"
+      ],
+      "properties": [
+        "additionalOptions",
+        "cloudAttachmentVersion",
+        "description",
+        "displayName",
+        "documentVersion",
+        "exportCriteria",
+        "exportFileMetadata",
+        "exportFormat",
+        "exportLocation",
+        "exportSingleItems"
+      ]
+    },
+    "ediscoveryTagOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "emailContentThreatSubmission": {
+      "navigationProperties": [],
+      "properties": [
+        "fileContent"
+      ]
+    },
+    "emailThreatSubmission": {
+      "navigationProperties": [],
+      "properties": [
+        "attackSimulationInfo",
+        "internetMessageId",
+        "originalCategory",
+        "receivedDateTime",
+        "recipientEmailAddress",
+        "sender",
+        "senderIP",
+        "subject",
+        "tenantAllowOrBlockListAction"
+      ]
+    },
+    "emailThreatSubmissionPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "customizedNotificationSenderEmailAddress",
+        "customizedReportRecipientEmailAddress",
+        "isAlwaysReportEnabledForUsers",
+        "isAskMeEnabledForUsers",
+        "isCustomizedMessageEnabled",
+        "isCustomizedMessageEnabledForPhishing",
+        "isCustomizedNotificationSenderEnabled",
+        "isNeverReportEnabledForUsers",
+        "isOrganizationBrandingEnabled",
+        "isReportFromQuarantineEnabled",
+        "isReportToCustomizedEmailAddressEnabled",
+        "isReportToMicrosoftEnabled",
+        "isReviewEmailNotificationEnabled"
+      ]
+    },
+    "emailUrlThreatSubmission": {
+      "navigationProperties": [],
+      "properties": [
+        "messageUrl"
+      ]
+    },
+    "endpointDiscoveredCloudAppDetail": {
+      "navigationProperties": [
+        "devices"
+      ],
+      "properties": [
+        "deviceCount"
+      ]
+    },
+    "environment": {
+      "navigationProperties": [],
+      "properties": [
+        "kind"
+      ]
+    },
+    "file": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "dateTime",
+        "extension",
+        "extractedTextContent",
+        "mediaType",
+        "name",
+        "otherProperties",
+        "processingStatus",
+        "senderOrAuthors",
+        "size",
+        "sourceType",
+        "subjectTitle"
+      ]
+    },
+    "fileContentThreatSubmission": {
+      "navigationProperties": [],
+      "properties": [
+        "fileContent"
+      ]
+    },
+    "filePlanDescriptor": {
+      "navigationProperties": [
+        "authorityTemplate",
+        "categoryTemplate",
+        "citationTemplate",
+        "departmentTemplate",
+        "filePlanReferenceTemplate"
+      ],
+      "properties": [
+        "authority",
+        "category",
+        "citation",
+        "department",
+        "filePlanReference"
+      ]
+    },
+    "filePlanDescriptorTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName"
+      ]
+    },
+    "filePlanReferenceTemplate": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "fileThreatSubmission": {
+      "navigationProperties": [],
+      "properties": [
+        "fileName"
+      ]
+    },
+    "fileUrlThreatSubmission": {
+      "navigationProperties": [],
+      "properties": [
+        "fileUrl"
+      ]
+    },
+    "healthIssue": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformation",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "domainNames",
+        "healthIssueType",
+        "issueTypeId",
+        "lastModifiedDateTime",
+        "recommendations",
+        "recommendedActionCommands",
+        "sensorDNSNames",
+        "severity",
+        "status"
+      ]
+    },
+    "host": {
+      "navigationProperties": [
+        "childHostPairs",
+        "components",
+        "cookies",
+        "hostPairs",
+        "parentHostPairs",
+        "passiveDns",
+        "passiveDnsReverse",
+        "ports",
+        "reputation",
+        "sslCertificates",
+        "subdomains",
+        "trackers",
+        "whois"
+      ],
+      "properties": [
+        "firstSeenDateTime",
+        "lastSeenDateTime"
+      ]
+    },
+    "hostComponent": {
+      "navigationProperties": [
+        "host"
+      ],
+      "properties": [
+        "category",
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "name",
+        "version"
+      ]
+    },
+    "hostCookie": {
+      "navigationProperties": [
+        "host"
+      ],
+      "properties": [
+        "domain",
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "name"
+      ]
+    },
+    "hostname": {
+      "navigationProperties": [],
+      "properties": [
+        "registrant",
+        "registrar"
+      ]
+    },
+    "hostPair": {
+      "navigationProperties": [
+        "childHost",
+        "parentHost"
+      ],
+      "properties": [
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "linkKind"
+      ]
+    },
+    "hostPort": {
+      "navigationProperties": [
+        "host",
+        "mostRecentSslCertificate"
+      ],
+      "properties": [
+        "banners",
+        "firstSeenDateTime",
+        "lastScanDateTime",
+        "lastSeenDateTime",
+        "port",
+        "protocol",
+        "services",
+        "status",
+        "timesObserved"
+      ]
+    },
+    "hostReputation": {
+      "navigationProperties": [],
+      "properties": [
+        "classification",
+        "rules",
+        "score"
+      ]
+    },
+    "hostSslCertificate": {
+      "navigationProperties": [
+        "host",
+        "sslCertificate"
+      ],
+      "properties": [
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "ports"
+      ]
+    },
+    "hostTracker": {
+      "navigationProperties": [
+        "host"
+      ],
+      "properties": [
+        "firstSeenDateTime",
+        "kind",
+        "lastSeenDateTime",
+        "value"
+      ]
+    },
+    "identityAccounts": {
+      "navigationProperties": [],
+      "properties": [
+        "accounts",
+        "cloudSecurityIdentifier",
+        "displayName",
+        "domain",
+        "isEnabled",
+        "onPremisesSecurityIdentifier"
+      ]
+    },
+    "identityContainer": {
+      "navigationProperties": [
+        "healthIssues",
+        "identityAccounts",
+        "sensorCandidateActivationConfiguration",
+        "sensorCandidates",
+        "sensorMigration",
+        "sensors",
+        "settings"
+      ],
+      "properties": []
+    },
+    "incident": {
+      "navigationProperties": [
+        "alerts"
+      ],
+      "properties": [
+        "assignedTo",
+        "classification",
+        "comments",
+        "createdDateTime",
+        "customTags",
+        "description",
+        "determination",
+        "displayName",
+        "incidentWebUrl",
+        "lastModifiedBy",
+        "lastUpdateDateTime",
+        "priorityScore",
+        "recommendedActions",
+        "recommendedHuntingQueries",
+        "redirectIncidentId",
+        "resolvingComment",
+        "severity",
+        "status",
+        "summary",
+        "systemTags",
+        "tenantId"
+      ]
+    },
+    "incidentTask": {
+      "navigationProperties": [
+        "incident"
+      ],
+      "properties": [
+        "actionStatus",
+        "actionType",
+        "createdByDisplayName",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedByDisplayName",
+        "lastModifiedDateTime",
+        "responseAction",
+        "source",
+        "status"
+      ]
+    },
+    "indicator": {
+      "navigationProperties": [
+        "artifact"
+      ],
+      "properties": [
+        "source"
+      ]
+    },
+    "informationProtection": {
+      "navigationProperties": [
+        "labelPolicySettings",
+        "sensitivityLabels"
+      ],
+      "properties": []
+    },
+    "informationProtectionPolicySetting": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultLabelId",
+        "isDowngradeJustificationRequired",
+        "isMandatory",
+        "moreInfoUrl"
+      ]
+    },
+    "intelligenceProfile": {
+      "navigationProperties": [
+        "indicators"
+      ],
+      "properties": [
+        "aliases",
+        "countriesOrRegionsOfOrigin",
+        "description",
+        "firstActiveDateTime",
+        "kind",
+        "summary",
+        "targets",
+        "title",
+        "tradecraft"
+      ]
+    },
+    "intelligenceProfileIndicator": {
+      "navigationProperties": [],
+      "properties": [
+        "firstSeenDateTime",
+        "lastSeenDateTime"
+      ]
+    },
+    "ipAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "autonomousSystem",
+        "countryOrRegion",
+        "hostingProvider",
+        "netblock"
+      ]
+    },
+    "labelsRoot": {
+      "navigationProperties": [
+        "authorities",
+        "categories",
+        "citations",
+        "departments",
+        "filePlanReferences",
+        "retentionLabels"
+      ],
+      "properties": []
+    },
+    "networkAdapter": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "name"
+      ]
+    },
+    "passiveDnsRecord": {
+      "navigationProperties": [
+        "artifact",
+        "parentHost"
+      ],
+      "properties": [
+        "collectedDateTime",
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "recordType"
+      ]
+    },
+    "policyBase": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "protectionRule": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "isEnabled",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "retentionEvent": {
+      "navigationProperties": [
+        "retentionEventType"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "eventPropagationResults",
+        "eventQueries",
+        "eventStatus",
+        "eventTriggerDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "lastStatusUpdateDateTime"
+      ]
+    },
+    "retentionEventType": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "retentionLabel": {
+      "navigationProperties": [
+        "descriptors",
+        "dispositionReviewStages",
+        "retentionEventType"
+      ],
+      "properties": [
+        "actionAfterRetentionPeriod",
+        "behaviorDuringRetentionPeriod",
+        "createdBy",
+        "createdDateTime",
+        "defaultRecordBehavior",
+        "descriptionForAdmins",
+        "descriptionForUsers",
+        "displayName",
+        "isInUse",
+        "labelToBeApplied",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "retentionDuration",
+        "retentionTrigger"
+      ]
+    },
+    "rulesRoot": {
+      "navigationProperties": [
+        "detectionRules"
+      ],
+      "properties": []
+    },
+    "search": {
+      "navigationProperties": [],
+      "properties": [
+        "contentQuery",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "security": {
+      "navigationProperties": [
+        "informationProtection"
+      ],
+      "properties": []
+    },
+    "sensitivityLabel": {
+      "navigationProperties": [
+        "parent"
+      ],
+      "properties": [
+        "color",
+        "contentFormats",
+        "description",
+        "hasProtection",
+        "isActive",
+        "isAppliable",
+        "name",
+        "sensitivity",
+        "tooltip"
+      ]
+    },
+    "sensor": {
+      "navigationProperties": [
+        "healthIssues"
+      ],
+      "properties": [
+        "createdDateTime",
+        "deploymentStatus",
+        "displayName",
+        "domainName",
+        "healthStatus",
+        "migrationState",
+        "openHealthIssuesCount",
+        "sensorType",
+        "serviceStatus",
+        "settings",
+        "version"
+      ]
+    },
+    "sensorCandidate": {
+      "navigationProperties": [],
+      "properties": [
+        "computerDnsName",
+        "domainName",
+        "lastSeenDateTime",
+        "senseClientVersion",
+        "sensorTypes"
+      ]
+    },
+    "sensorCandidateActivationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "activationMode"
+      ]
+    },
+    "sensorMigration": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "domainName",
+        "healthStatus",
+        "migrationState",
+        "sensorType",
+        "serviceStatus",
+        "version"
+      ]
+    },
+    "settingsContainer": {
+      "navigationProperties": [
+        "autoAuditingConfiguration"
+      ],
+      "properties": []
+    },
+    "siteSource": {
+      "navigationProperties": [
+        "site"
+      ],
+      "properties": []
+    },
+    "sslCertificate": {
+      "navigationProperties": [
+        "relatedHosts"
+      ],
+      "properties": [
+        "expirationDateTime",
+        "fingerprint",
+        "firstSeenDateTime",
+        "issueDateTime",
+        "issuer",
+        "lastSeenDateTime",
+        "serialNumber",
+        "sha1",
+        "subject"
+      ]
+    },
+    "subcategoryTemplate": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "subdomain": {
+      "navigationProperties": [
+        "host"
+      ],
+      "properties": [
+        "firstSeenDateTime"
+      ]
+    },
+    "tag": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "description",
+        "displayName",
+        "lastModifiedDateTime"
+      ]
+    },
+    "threatIntelligence": {
+      "navigationProperties": [
+        "articleIndicators",
+        "articles",
+        "hostComponents",
+        "hostCookies",
+        "hostPairs",
+        "hostPorts",
+        "hosts",
+        "hostSslCertificates",
+        "hostTrackers",
+        "intelligenceProfileIndicators",
+        "intelProfiles",
+        "passiveDnsRecords",
+        "sslCertificates",
+        "subdomains",
+        "vulnerabilities",
+        "whoisHistoryRecords",
+        "whoisRecords"
+      ],
+      "properties": []
+    },
+    "threatSubmission": {
+      "navigationProperties": [],
+      "properties": [
+        "adminReview",
+        "category",
+        "clientSource",
+        "contentType",
+        "createdBy",
+        "createdDateTime",
+        "result",
+        "source",
+        "status",
+        "tenantId"
+      ]
+    },
+    "threatSubmissionRoot": {
+      "navigationProperties": [
+        "emailThreats",
+        "emailThreatSubmissionPolicies",
+        "fileThreats",
+        "urlThreats"
+      ],
+      "properties": []
+    },
+    "triggersRoot": {
+      "navigationProperties": [
+        "retentionEvents"
+      ],
+      "properties": []
+    },
+    "triggerTypesRoot": {
+      "navigationProperties": [
+        "retentionEventTypes"
+      ],
+      "properties": []
+    },
+    "unclassifiedArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "kind",
+        "value"
+      ]
+    },
+    "unifiedGroupSource": {
+      "navigationProperties": [
+        "group"
+      ],
+      "properties": [
+        "includedSources"
+      ]
+    },
+    "urlThreatSubmission": {
+      "navigationProperties": [],
+      "properties": [
+        "webUrl"
+      ]
+    },
+    "user": {
+      "navigationProperties": [],
+      "properties": [
+        "emailAddress",
+        "userPrincipalName"
+      ]
+    },
+    "userSource": {
+      "navigationProperties": [],
+      "properties": [
+        "email",
+        "includedSources",
+        "siteWebUrl"
+      ]
+    },
+    "vulnerability": {
+      "navigationProperties": [
+        "articles",
+        "components"
+      ],
+      "properties": [
+        "activeExploitsObserved",
+        "commonWeaknessEnumerationIds",
+        "createdDateTime",
+        "cvss2Summary",
+        "cvss3Summary",
+        "description",
+        "exploits",
+        "exploitsAvailable",
+        "hasChatter",
+        "lastModifiedDateTime",
+        "priorityScore",
+        "publishedDateTime",
+        "references",
+        "remediation",
+        "severity"
+      ]
+    },
+    "vulnerabilityComponent": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "whoisBaseRecord": {
+      "navigationProperties": [
+        "host"
+      ],
+      "properties": [
+        "abuse",
+        "admin",
+        "billing",
+        "domainStatus",
+        "expirationDateTime",
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "lastUpdateDateTime",
+        "nameservers",
+        "noc",
+        "rawWhoisText",
+        "registrant",
+        "registrar",
+        "registrationDateTime",
+        "technical",
+        "whoisServer",
+        "zone"
+      ]
+    },
+    "whoisHistoryRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "whoisRecord": {
+      "navigationProperties": [
+        "history"
+      ],
+      "properties": []
+    },
+    "zone": {
+      "navigationProperties": [
+        "aggregations",
+        "environments"
+      ],
+      "properties": [
+        "created",
+        "description",
+        "displayName",
+        "modified"
+      ]
+    }
+  },
+  "microsoft.graph.security.dlp": {
+    "baseAuditRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "agentBlueprintId",
+        "agentBlueprintName",
+        "agentId",
+        "agentName",
+        "agentPlatform",
+        "agentVersion",
+        "appAccessContext",
+        "appIdentity",
+        "applicationName",
+        "associatedAdminUnitIds",
+        "correlationIdentity",
+        "createdDateTime",
+        "isRequiresCustomerKeyEncryption",
+        "operation",
+        "opId",
+        "organizationId",
+        "parentId",
+        "purpose",
+        "recordType",
+        "resultStatus",
+        "scopingEntityIds",
+        "scopingEntityType",
+        "sessionIdentity",
+        "subjectType",
+        "subscription",
+        "userKey",
+        "userType",
+        "version",
+        "workload"
+      ]
+    },
+    "complianceBaseAuditRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceDLPBaseAuditRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "enforcementType",
+        "evaluationSource",
+        "exceptionInfo",
+        "incidentId",
+        "isSensitiveInfoDetectionIsIncluded",
+        "location",
+        "policyDetails",
+        "remediationDetails",
+        "sessionMetadata"
+      ]
+    },
+    "complianceDlpEndpointAuditRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "authorizedGroup",
+        "endpointMetaData",
+        "evidenceFile",
+        "networkLocationContextInAction"
+      ]
+    },
+    "complianceDlpExchangeAuditRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "exchangeMetaData"
+      ]
+    },
+    "complianceDlpSharePointAuditRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "sharePointMetaData"
+      ]
+    }
+  },
+  "microsoft.graph.security.securityCopilot": {
+    "evaluation": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "createdDateTime",
+        "executionCount",
+        "isCancelled",
+        "lastModifiedDateTime",
+        "result",
+        "runStartDateTime",
+        "state"
+      ]
+    },
+    "plugin": {
+      "navigationProperties": [],
+      "properties": [
+        "authorization",
+        "catalogScope",
+        "category",
+        "description",
+        "displayName",
+        "isEnabled",
+        "name",
+        "previewState",
+        "settings",
+        "supportedAuthTypes"
+      ]
+    },
+    "prompt": {
+      "navigationProperties": [
+        "evaluations"
+      ],
+      "properties": [
+        "content",
+        "createdDateTime",
+        "inputs",
+        "lastModifiedDateTime",
+        "skillInputDescriptors",
+        "skillName",
+        "type"
+      ]
+    },
+    "session": {
+      "navigationProperties": [
+        "prompts"
+      ],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "lastModifiedDateTime"
+      ]
+    },
+    "workspace": {
+      "navigationProperties": [
+        "plugins",
+        "sessions"
+      ],
+      "properties": [
+        "displayName"
+      ]
+    }
+  },
+  "microsoft.graph.teamsAdministration": {
+    "numberAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "activationState",
+        "assignmentCategory",
+        "assignmentStatus",
+        "assignmentTargetId",
+        "capabilities",
+        "city",
+        "civicAddressId",
+        "isoCountryCode",
+        "locationId",
+        "networkSiteId",
+        "numberSource",
+        "numberType",
+        "operatorId",
+        "portInStatus",
+        "reverseNumberLookupOptions",
+        "supportedCustomerActions",
+        "telephoneNumber"
+      ]
+    },
+    "policyIdentifierDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "policyId"
+      ]
+    },
+    "teamsAdminRoot": {
+      "navigationProperties": [
+        "policy",
+        "telephoneNumberManagement",
+        "userConfigurations"
+      ],
+      "properties": []
+    },
+    "teamsPolicyAssignment": {
+      "navigationProperties": [
+        "userAssignments"
+      ],
+      "properties": []
+    },
+    "teamsPolicyUserAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "policyId",
+        "policyType",
+        "userId"
+      ]
+    },
+    "teamsUserConfiguration": {
+      "navigationProperties": [
+        "user"
+      ],
+      "properties": [
+        "accountType",
+        "createdDateTime",
+        "effectivePolicyAssignments",
+        "featureTypes",
+        "isEnterpriseVoiceEnabled",
+        "modifiedDateTime",
+        "telephoneNumbers",
+        "tenantId",
+        "userPrincipalName"
+      ]
+    },
+    "telephoneNumberLongRunningOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "numbers",
+        "status"
+      ]
+    },
+    "telephoneNumberManagementRoot": {
+      "navigationProperties": [
+        "numberAssignments",
+        "operations"
+      ],
+      "properties": []
+    }
+  },
+  "microsoft.graph.tenantGovernanceServices": {
+    "b2bRegistrationMetrics": {
+      "navigationProperties": [
+        "initial",
+        "recent"
+      ],
+      "properties": []
+    },
+    "b2BRegistrationMetricsBase": {
+      "navigationProperties": [],
+      "properties": [
+        "inboundTotalUsers",
+        "outboundTotalUsers",
+        "watermarkDateTime"
+      ]
+    },
+    "b2BRegistrationMetricsInitial": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime"
+      ]
+    },
+    "b2BRegistrationMetricsRecent": {
+      "navigationProperties": [],
+      "properties": [
+        "updateDateTime"
+      ]
+    },
+    "b2BSignInActivityMetrics": {
+      "navigationProperties": [
+        "initial",
+        "recent"
+      ],
+      "properties": []
+    },
+    "b2BSignInActivityMetricsBase": {
+      "navigationProperties": [],
+      "properties": [
+        "inboundMonthlyTotalApplications",
+        "inboundMonthlyTotalUsers",
+        "outboundMonthlyTotalApplications",
+        "outboundMonthlyTotalUsers",
+        "watermarkDateTime"
+      ]
+    },
+    "b2BSignInActivityMetricsInitial": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime"
+      ]
+    },
+    "b2BSignInActivityMetricsRecent": {
+      "navigationProperties": [],
+      "properties": [
+        "updateDateTime"
+      ]
+    },
+    "billingMetrics": {
+      "navigationProperties": [
+        "initial",
+        "recent"
+      ],
+      "properties": []
+    },
+    "billingMetricsBase": {
+      "navigationProperties": [],
+      "properties": [
+        "foreignAssociatedTenantBillingManagementActiveCount",
+        "foreignAssociatedTenantCount",
+        "foreignAssociatedTenantProvisioningActiveCount",
+        "localAssociatedTenantBillingManagementActiveCount",
+        "localAssociatedTenantCount",
+        "localAssociatedTenantIds",
+        "localAssociatedTenantProvisioningActiveCount",
+        "watermarkDateTime"
+      ]
+    },
+    "billingMetricsInitial": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime"
+      ]
+    },
+    "billingMetricsRecent": {
+      "navigationProperties": [],
+      "properties": [
+        "updateDateTime"
+      ]
+    },
+    "governanceInvitation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "expirationDateTime",
+        "governedTenantId",
+        "governedTenantName",
+        "governingTenantId",
+        "governingTenantName"
+      ]
+    },
+    "governancePolicyTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "delegatedAdministrationRoleAssignments",
+        "description",
+        "displayName",
+        "governedTenantCanTerminate",
+        "lastModifiedDateTime",
+        "multiTenantApplicationsToProvision",
+        "version"
+      ]
+    },
+    "governanceRelationship": {
+      "navigationProperties": [],
+      "properties": [
+        "createdType",
+        "creationDateTime",
+        "governedTenantId",
+        "governedTenantName",
+        "governingTenantId",
+        "governingTenantName",
+        "policySnapshot",
+        "status"
+      ]
+    },
+    "governanceRequest": {
+      "navigationProperties": [
+        "governancePolicyTemplate"
+      ],
+      "properties": [
+        "expirationDateTime",
+        "governedTenantId",
+        "governedTenantName",
+        "governingTenantId",
+        "governingTenantName",
+        "policySnapshot",
+        "requestDateTime",
+        "status"
+      ]
+    },
+    "longRunningOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastActionDateTime",
+        "resourceLocation",
+        "status",
+        "statusDetail"
+      ]
+    },
+    "multiTenantApplicationMetrics": {
+      "navigationProperties": [
+        "initial",
+        "recent"
+      ],
+      "properties": []
+    },
+    "multiTenantApplicationMetricsBase": {
+      "navigationProperties": [],
+      "properties": [
+        "inboundMonthlyTotalApplications",
+        "outboundMonthlyTotalApplications",
+        "watermarkDateTime"
+      ]
+    },
+    "multiTenantApplicationMetricsInitial": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime"
+      ]
+    },
+    "multiTenantApplicationMetricsRecent": {
+      "navigationProperties": [],
+      "properties": [
+        "updateDateTime"
+      ]
+    },
+    "relatedTenant": {
+      "navigationProperties": [
+        "appB2BSignInActivityMetrics",
+        "b2BRegistrationMetrics",
+        "b2BSignInActivityMetrics",
+        "billingMetrics",
+        "multiTenantApplicationMetrics"
+      ],
+      "properties": [
+        "createdDateTime"
+      ]
+    },
+    "relatedTenantsRefreshRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "location"
+      ]
+    },
+    "tenantGovernance": {
+      "navigationProperties": [
+        "governanceInvitations",
+        "governancePolicyTemplates",
+        "governanceRelationships",
+        "governanceRequests",
+        "relatedTenants",
+        "settings"
+      ],
+      "properties": []
+    },
+    "tenantGovernanceSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "canReceiveInvitations",
+        "isRelatedTenantsEnabled"
+      ]
+    }
+  },
+  "microsoft.graph.termStore": {
+    "group": {
+      "navigationProperties": [
+        "sets"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "parentSiteId",
+        "scope"
+      ]
+    },
+    "relation": {
+      "navigationProperties": [
+        "fromTerm",
+        "set",
+        "toTerm"
+      ],
+      "properties": [
+        "relationship"
+      ]
+    },
+    "set": {
+      "navigationProperties": [
+        "children",
+        "parentGroup",
+        "relations",
+        "terms"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "localizedNames",
+        "properties"
+      ]
+    },
+    "store": {
+      "navigationProperties": [
+        "groups",
+        "sets"
+      ],
+      "properties": [
+        "defaultLanguageTag",
+        "languageTags"
+      ]
+    },
+    "term": {
+      "navigationProperties": [
+        "children",
+        "relations",
+        "set"
+      ],
+      "properties": [
+        "createdDateTime",
+        "descriptions",
+        "labels",
+        "lastModifiedDateTime",
+        "properties"
+      ]
+    }
+  },
+  "microsoft.graph.windowsUpdates": {
+    "applicableContent": {
+      "navigationProperties": [
+        "catalogEntry",
+        "matchedDevices"
+      ],
+      "properties": [
+        "catalogEntryId"
+      ]
+    },
+    "applicableContentDeviceMatch": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "recommendedBy"
+      ]
+    },
+    "azureADDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "enrollment",
+        "errors"
+      ]
+    },
+    "catalog": {
+      "navigationProperties": [
+        "entries"
+      ],
+      "properties": []
+    },
+    "catalogEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "deployableUntilDateTime",
+        "displayName",
+        "releaseDateTime"
+      ]
+    },
+    "complianceChange": {
+      "navigationProperties": [
+        "updatePolicy"
+      ],
+      "properties": [
+        "createdDateTime",
+        "isRevoked",
+        "revokedDateTime"
+      ]
+    },
+    "contentApproval": {
+      "navigationProperties": [
+        "deployments"
+      ],
+      "properties": [
+        "content",
+        "deploymentSettings"
+      ]
+    },
+    "cveInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "number",
+        "url"
+      ]
+    },
+    "deployment": {
+      "navigationProperties": [
+        "audience"
+      ],
+      "properties": [
+        "content",
+        "createdDateTime",
+        "lastModifiedDateTime",
+        "settings",
+        "state"
+      ]
+    },
+    "deploymentAudience": {
+      "navigationProperties": [
+        "applicableContent",
+        "exclusions",
+        "members"
+      ],
+      "properties": []
+    },
+    "driverUpdateCatalogEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "driverClass",
+        "manufacturer",
+        "provider",
+        "setupInformationFile",
+        "version",
+        "versionDateTime"
+      ]
+    },
+    "edition": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceFamily",
+        "endOfServiceDateTime",
+        "generalAvailabilityDateTime",
+        "isInService",
+        "name",
+        "releasedName",
+        "servicingPeriods"
+      ]
+    },
+    "featureUpdateCatalogEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "buildNumber",
+        "version"
+      ]
+    },
+    "knowledgeBaseArticle": {
+      "navigationProperties": [],
+      "properties": [
+        "url"
+      ]
+    },
+    "knownIssue": {
+      "navigationProperties": [
+        "originatingKnowledgeBaseArticle",
+        "resolvingKnowledgeBaseArticle"
+      ],
+      "properties": [
+        "description",
+        "knownIssueHistories",
+        "lastUpdatedDateTime",
+        "resolvedDateTime",
+        "safeguardHoldIds",
+        "startDateTime",
+        "status",
+        "title",
+        "webViewUrl"
+      ]
+    },
+    "operationalInsightsConnection": {
+      "navigationProperties": [],
+      "properties": [
+        "azureResourceGroupName",
+        "azureSubscriptionId",
+        "workspaceName"
+      ]
+    },
+    "policy": {
+      "navigationProperties": [
+        "applicableContent",
+        "approvals",
+        "rings"
+      ],
+      "properties": [
+        "approvalRules",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime"
+      ]
+    },
+    "policyApproval": {
+      "navigationProperties": [
+        "catalogEntry"
+      ],
+      "properties": [
+        "catalogEntryId",
+        "createdDateTime",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "product": {
+      "navigationProperties": [
+        "editions",
+        "knownIssues",
+        "revisions"
+      ],
+      "properties": [
+        "friendlyNames",
+        "groupName",
+        "name"
+      ]
+    },
+    "productRevision": {
+      "navigationProperties": [
+        "catalogEntry",
+        "knowledgeBaseArticle"
+      ],
+      "properties": [
+        "displayName",
+        "isHotpatchUpdate",
+        "osBuild",
+        "product",
+        "releaseDateTime",
+        "version"
+      ]
+    },
+    "qualityUpdateCatalogEntry": {
+      "navigationProperties": [
+        "productRevisions"
+      ],
+      "properties": [
+        "catalogName",
+        "cveSeverityInformation",
+        "isExpeditable",
+        "qualityUpdateCadence",
+        "qualityUpdateClassification",
+        "shortName"
+      ]
+    },
+    "qualityUpdatePolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "qualityUpdateRing": {
+      "navigationProperties": [],
+      "properties": [
+        "isHotpatchEnabled"
+      ]
+    },
+    "recoveryUpdateCatalogEntry": {
+      "navigationProperties": [
+        "productRevisions"
+      ],
+      "properties": [
+        "catalogName"
+      ]
+    },
+    "resourceConnection": {
+      "navigationProperties": [],
+      "properties": [
+        "state"
+      ]
+    },
+    "ring": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "deferralInDays",
+        "description",
+        "displayName",
+        "excludedGroupAssignment",
+        "includedGroupAssignment",
+        "isPaused",
+        "lastModifiedDateTime"
+      ]
+    },
+    "softwareUpdateCatalogEntry": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "updatableAsset": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "updatableAssetGroup": {
+      "navigationProperties": [
+        "members"
+      ],
+      "properties": []
+    },
+    "updatePolicy": {
+      "navigationProperties": [
+        "audience",
+        "complianceChanges"
+      ],
+      "properties": [
+        "complianceChangeRules",
+        "createdDateTime",
+        "deploymentSettings"
+      ]
+    }
+  }
+}

--- a/schemas/type-mappings/beta-entity-types.json
+++ b/schemas/type-mappings/beta-entity-types.json
@@ -958,6 +958,50 @@
         "hostPrefix"
       ]
     },
+    "alert": {
+      "navigationProperties": [],
+      "properties": [
+        "activityGroupName",
+        "alertDetections",
+        "assignedTo",
+        "azureSubscriptionId",
+        "azureTenantId",
+        "category",
+        "closedDateTime",
+        "cloudAppStates",
+        "comments",
+        "confidence",
+        "createdDateTime",
+        "description",
+        "detectionIds",
+        "eventDateTime",
+        "feedback",
+        "fileStates",
+        "historyStates",
+        "hostStates",
+        "incidentIds",
+        "investigationSecurityStates",
+        "lastEventDateTime",
+        "lastModifiedDateTime",
+        "malwareStates",
+        "messageSecurityStates",
+        "networkConnections",
+        "processes",
+        "recommendedActions",
+        "registryKeyStates",
+        "securityResources",
+        "severity",
+        "sourceMaterials",
+        "status",
+        "tags",
+        "title",
+        "triggers",
+        "uriClickSecurityStates",
+        "userStates",
+        "vendorInformation",
+        "vulnerabilityStates"
+      ]
+    },
     "allowedDataLocation": {
       "navigationProperties": [],
       "properties": [
@@ -4178,6 +4222,28 @@
         "result"
       ]
     },
+    "cloudAppSecurityProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "azureSubscriptionId",
+        "azureTenantId",
+        "createdDateTime",
+        "deploymentPackageUrl",
+        "destinationServiceName",
+        "isSigned",
+        "lastModifiedDateTime",
+        "manifest",
+        "name",
+        "permissionsRequired",
+        "platform",
+        "policyName",
+        "publisher",
+        "riskScore",
+        "tags",
+        "type",
+        "vendorInformation"
+      ]
+    },
     "cloudCertificationAuthority": {
       "navigationProperties": [
         "activeVersion",
@@ -5555,7 +5621,9 @@
       ]
     },
     "crossTenantAccessPolicyConfigurationDefault": {
-      "navigationProperties": [],
+      "navigationProperties": [
+        "m365Capabilities"
+      ],
       "properties": [
         "appServiceConnectInbound",
         "automaticUserConsentSettings",
@@ -5574,7 +5642,8 @@
     },
     "crossTenantAccessPolicyConfigurationPartner": {
       "navigationProperties": [
-        "identitySynchronization"
+        "identitySynchronization",
+        "m365Capabilities"
       ],
       "properties": [
         "appServiceConnectInbound",
@@ -5593,6 +5662,26 @@
         "tenantRestrictions"
       ]
     },
+    "crossTenantCalendarAvailabilityBasic": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "crossTenantCalendarAvailabilityLimitedDetails": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "crossTenantCalendarSharingFreeBusyDetail": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "crossTenantCalendarSharingFreeBusyReviewer": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "crossTenantCalendarSharingFreeBusySimple": {
+      "navigationProperties": [],
+      "properties": []
+    },
     "crossTenantIdentitySyncPolicyPartner": {
       "navigationProperties": [],
       "properties": [
@@ -5602,6 +5691,18 @@
         "tenantId",
         "userSyncInbound"
       ]
+    },
+    "crossTenantMailTipsAll": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "crossTenantMailTipsLimited": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "crossTenantMigration": {
+      "navigationProperties": [],
+      "properties": []
     },
     "crossTenantMigrationJob": {
       "navigationProperties": [
@@ -5631,6 +5732,18 @@
         "lastUpdatedDateTime",
         "taskType"
       ]
+    },
+    "crossTenantOpenProfileCard": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "crossTenantPlacesDeskBooking": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "crossTenantPlacesRoomBooking": {
+      "navigationProperties": [],
+      "properties": []
     },
     "currency": {
       "navigationProperties": [],
@@ -8146,6 +8259,25 @@
         "description"
       ]
     },
+    "domainSecurityProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "activityGroupNames",
+        "azureSubscriptionId",
+        "azureTenantId",
+        "countHits",
+        "countInOrg",
+        "domainCategories",
+        "domainRegisteredDateTime",
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "name",
+        "registrant",
+        "riskScore",
+        "tags",
+        "vendorInformation"
+      ]
+    },
     "drive": {
       "navigationProperties": [
         "activities",
@@ -9493,6 +9625,27 @@
         "sensitiveTypeIds"
       ]
     },
+    "fileSecurityProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "activityGroupNames",
+        "azureSubscriptionId",
+        "azureTenantId",
+        "certificateThumbprint",
+        "extensions",
+        "fileType",
+        "firstSeenDateTime",
+        "hashes",
+        "lastSeenDateTime",
+        "malwareStates",
+        "names",
+        "riskScore",
+        "size",
+        "tags",
+        "vendorInformation",
+        "vulnerabilityStates"
+      ]
+    },
     "fileStorage": {
       "navigationProperties": [
         "containers",
@@ -10378,6 +10531,29 @@
       ],
       "properties": [
         "width"
+      ]
+    },
+    "hostSecurityProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "azureSubscriptionId",
+        "azureTenantId",
+        "firstSeenDateTime",
+        "fqdn",
+        "isAzureAdJoined",
+        "isAzureAdRegistered",
+        "isHybridAzureDomainJoined",
+        "lastSeenDateTime",
+        "logonUsers",
+        "netBiosName",
+        "networkInterfaces",
+        "os",
+        "osVersion",
+        "parentHost",
+        "relatedHostIds",
+        "riskScore",
+        "tags",
+        "vendorInformation"
       ]
     },
     "humanSecurityFraudProtectionProvider": {
@@ -11502,6 +11678,24 @@
         "isTrusted"
       ]
     },
+    "ipSecurityProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "activityGroupNames",
+        "address",
+        "azureSubscriptionId",
+        "azureTenantId",
+        "countHits",
+        "countHosts",
+        "firstSeenDateTime",
+        "ipCategories",
+        "ipReferenceData",
+        "lastSeenDateTime",
+        "riskScore",
+        "tags",
+        "vendorInformation"
+      ]
+    },
     "item": {
       "navigationProperties": [
         "itemCategory",
@@ -11941,6 +12135,7 @@
     "m365CapabilityBase": {
       "navigationProperties": [],
       "properties": [
+        "inboundAccess",
         "lastModifiedDateTime",
         "name"
       ]
@@ -16355,6 +16550,16 @@
         "status"
       ]
     },
+    "providerTenantSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "azureTenantId",
+        "enabled",
+        "lastModifiedDateTime",
+        "provider",
+        "vendor"
+      ]
+    },
     "provisioningObjectSummary": {
       "navigationProperties": [],
       "properties": [
@@ -17625,31 +17830,60 @@
     },
     "security": {
       "navigationProperties": [
+        "alerts",
         "alerts_v2",
         "attackSimulation",
         "auditLog",
         "cases",
+        "cloudAppSecurityProfiles",
         "collaboration",
         "dataDiscovery",
         "dataSecurityAndGovernance",
+        "domainSecurityProfiles",
+        "fileSecurityProfiles",
+        "hostSecurityProfiles",
         "identities",
         "incidents",
         "incidentTasks",
         "informationProtection",
+        "ipSecurityProfiles",
         "labels",
         "partner",
+        "providerTenantSettings",
         "rules",
         "secureScoreControlProfiles",
         "secureScores",
+        "securityActions",
         "securityCopilot",
         "subjectRightsRequests",
         "threatIntelligence",
         "threatSubmission",
+        "tiIndicators",
         "triggers",
         "triggerTypes",
+        "userSecurityProfiles",
         "zones"
       ],
       "properties": []
+    },
+    "securityAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actionReason",
+        "appId",
+        "azureTenantId",
+        "clientContext",
+        "completedDateTime",
+        "createdDateTime",
+        "errorInfo",
+        "lastActionDateTime",
+        "name",
+        "parameters",
+        "states",
+        "status",
+        "user",
+        "vendorInformation"
+      ]
     },
     "securityBaselineCategoryStateSummary": {
       "navigationProperties": [],
@@ -19689,6 +19923,69 @@
         "source"
       ]
     },
+    "tiIndicator": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "activityGroupNames",
+        "additionalInformation",
+        "azureTenantId",
+        "confidence",
+        "description",
+        "diamondModel",
+        "domainName",
+        "emailEncoding",
+        "emailLanguage",
+        "emailRecipient",
+        "emailSenderAddress",
+        "emailSenderName",
+        "emailSourceDomain",
+        "emailSourceIpAddress",
+        "emailSubject",
+        "emailXMailer",
+        "expirationDateTime",
+        "externalId",
+        "fileCompileDateTime",
+        "fileCreatedDateTime",
+        "fileHashType",
+        "fileHashValue",
+        "fileMutexName",
+        "fileName",
+        "filePacker",
+        "filePath",
+        "fileSize",
+        "fileType",
+        "ingestedDateTime",
+        "isActive",
+        "killChain",
+        "knownFalsePositives",
+        "lastReportedDateTime",
+        "malwareFamilyNames",
+        "networkCidrBlock",
+        "networkDestinationAsn",
+        "networkDestinationCidrBlock",
+        "networkDestinationIPv4",
+        "networkDestinationIPv6",
+        "networkDestinationPort",
+        "networkIPv4",
+        "networkIPv6",
+        "networkPort",
+        "networkProtocol",
+        "networkSourceAsn",
+        "networkSourceCidrBlock",
+        "networkSourceIPv4",
+        "networkSourceIPv6",
+        "networkSourcePort",
+        "passiveOnly",
+        "severity",
+        "tags",
+        "targetProduct",
+        "threatType",
+        "tlpLevel",
+        "url",
+        "userAgent"
+      ]
+    },
     "timeCard": {
       "navigationProperties": [],
       "properties": [
@@ -21350,6 +21647,21 @@
         "chat"
       ],
       "properties": []
+    },
+    "userSecurityProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "accounts",
+        "azureSubscriptionId",
+        "azureTenantId",
+        "createdDateTime",
+        "displayName",
+        "lastModifiedDateTime",
+        "riskScore",
+        "tags",
+        "userPrincipalName",
+        "vendorInformation"
+      ]
     },
     "userSettings": {
       "navigationProperties": [
@@ -25045,6 +25357,7 @@
         "completedDateTime",
         "createdDateTime",
         "failureReason",
+        "processingInfo",
         "processingStatus",
         "startedDateTime"
       ]
@@ -26789,6 +27102,7 @@
         "alertPolicyId",
         "alertWebUrl",
         "assignedTo",
+        "categories",
         "category",
         "classification",
         "comments",

--- a/schemas/type-mappings/beta-enum-types.json
+++ b/schemas/type-mappings/beta-enum-types.json
@@ -1,0 +1,15688 @@
+{
+  "microsoft.graph": {
+    "accessDriftReportResourceType": [
+      "application",
+      "group",
+      "unknownFutureValue"
+    ],
+    "accessEntityType": [
+      "group",
+      "unknownFutureValue",
+      "user"
+    ],
+    "accessLevel": [
+      "everyone",
+      "invited",
+      "locked",
+      "sameEnterprise",
+      "sameEnterpriseAndFederated"
+    ],
+    "accessPackageAssignmentFilterByCurrentUserOptions": [
+      "createdBy",
+      "target",
+      "targetAgentIdentitySponsorOrOwner",
+      "targetManager",
+      "unknownFutureValue"
+    ],
+    "accessPackageAssignmentRequestFilterByCurrentUserOptions": [
+      "approver",
+      "createdBy",
+      "requestForOthers",
+      "target",
+      "targetAgentIdentitySponsorOrOwner",
+      "targetManager",
+      "targetOrRequestor",
+      "unknownFutureValue"
+    ],
+    "accessPackageCustomExtensionHandlerStatus": [
+      "requestReceived",
+      "requestSent",
+      "unknownFutureValue"
+    ],
+    "accessPackageCustomExtensionStage": [
+      "assignmentFourteenDaysBeforeExpiration",
+      "assignmentOneDayBeforeExpiration",
+      "assignmentRequestApproved",
+      "assignmentRequestCreated",
+      "assignmentRequestGranted",
+      "assignmentRequestRemoved",
+      "unknownFutureValue"
+    ],
+    "accessPackageFilterByCurrentUserOptions": [
+      "allowedRequestor",
+      "unknownFutureValue"
+    ],
+    "accessPackageSubjectLifecycle": [
+      "governed",
+      "notDefined",
+      "notGoverned",
+      "unknownFutureValue"
+    ],
+    "accessPackageSuggestionFilterByCurrentUserOptions": [
+      "assignmentHistory",
+      "none",
+      "relatedPeopleAssignments",
+      "unknownFutureValue"
+    ],
+    "accessPackageSuggestionRelatedPeopleInsightLevel": [
+      "count",
+      "countAndNames",
+      "disabled",
+      "unknownFutureValue"
+    ],
+    "accessReviewHistoryDecisionFilter": [
+      "approve",
+      "deny",
+      "dontKnow",
+      "notNotified",
+      "notReviewed",
+      "unknownFutureValue"
+    ],
+    "accessReviewHistoryStatus": [
+      "done",
+      "error",
+      "inprogress",
+      "requested",
+      "unknownFutureValue"
+    ],
+    "accessReviewInstanceDecisionItemApplyResult": [
+      "appliedSuccessfully",
+      "appliedSuccessfullyButObjectNotFound",
+      "appliedWithUnknownFailure",
+      "applyNotSupported",
+      "new",
+      "unknownFutureValue"
+    ],
+    "accessReviewInstanceDecisionItemFilterByCurrentUserOptions": [
+      "reviewer",
+      "unknownFutureValue"
+    ],
+    "accessReviewInstanceFilterByCurrentUserOptions": [
+      "reviewer",
+      "unknownFutureValue"
+    ],
+    "accessReviewPrincipalScopeType": [
+      "allUsers",
+      "guestUsers",
+      "inactiveGuestUsers",
+      "inactiveUsers",
+      "unknownFutureValue"
+    ],
+    "accessReviewResourceScopeType": [
+      "accessPackageAssignmentPolicy",
+      "catalog",
+      "directoryRole",
+      "group",
+      "servicePrincipal",
+      "unknownFutureValue"
+    ],
+    "accessReviewReviewerScopeType": [
+      "group",
+      "manager",
+      "managerOrSponsor",
+      "resourceOwner",
+      "self",
+      "sponsor",
+      "unknownFutureValue",
+      "user"
+    ],
+    "accessReviewScheduleDefinitionFilterByCurrentUserOptions": [
+      "reviewer",
+      "unknownFutureValue"
+    ],
+    "accessReviewStageFilterByCurrentUserOptions": [
+      "reviewer",
+      "unknownFutureValue"
+    ],
+    "accessReviewTimeoutBehavior": [
+      "acceptAccessRecommendation",
+      "keepAccess",
+      "removeAccess",
+      "unknownFutureValue"
+    ],
+    "accessType": [
+      "deny",
+      "grant"
+    ],
+    "accountStatus": [
+      "active",
+      "deleted",
+      "staged",
+      "suspended",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "accountTargetContentType": [
+      "addressBook",
+      "includeAll",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "aclType": [
+      "everyone",
+      "everyoneExceptGuests",
+      "externalGroup",
+      "group",
+      "unknownFutureValue",
+      "user"
+    ],
+    "actionCapability": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "actionSource": [
+      "automatic",
+      "default",
+      "manual",
+      "recommended"
+    ],
+    "actionState": [
+      "active",
+      "canceled",
+      "done",
+      "failed",
+      "none",
+      "notSupported",
+      "pending"
+    ],
+    "actionType": [
+      "exclude",
+      "tunnel",
+      "unknownFutureValue"
+    ],
+    "activityDomain": [
+      "personal",
+      "unknown",
+      "unrestricted",
+      "work"
+    ],
+    "activityLogOperationType": [
+      "backupPolicyActivated",
+      "backupPolicyCreated",
+      "backupPolicyModified",
+      "backupPolicyPaused",
+      "backupPolicyRenamed",
+      "dynamicRuleDeletion",
+      "dynamicRuleExecution",
+      "policyLevelOffboarding",
+      "protectionUnitLevelOffboarding",
+      "restoreTaskCompleted",
+      "restoreTaskCreated",
+      "unknownFutureValue"
+    ],
+    "activityLogResultStatus": [
+      "failed",
+      "partiallySucceeded",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "activityLogSeverity": [
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "activityStatus": [
+      "failed",
+      "notStarted",
+      "running",
+      "unknownFutureValue"
+    ],
+    "activityType": [
+      "servicePrincipal",
+      "signin",
+      "unknownFutureValue",
+      "user"
+    ],
+    "adminConsentState": [
+      "granted",
+      "notConfigured",
+      "notGranted"
+    ],
+    "administratorConfiguredDeviceComplianceState": [
+      "basedOnDeviceCompliancePolicy",
+      "nonCompliant"
+    ],
+    "advancedBitLockerState": [
+      "fixedDriveEncryptionMethodMismatch",
+      "fixedDriveNotEncrypted",
+      "loggedOnUserNonAdmin",
+      "networkError",
+      "noUserConsent",
+      "osVolumeEncryptionMethodMismatch",
+      "osVolumeTpmOnlyRequired",
+      "osVolumeTpmPinRequired",
+      "osVolumeTpmPinStartupKeyRequired",
+      "osVolumeTpmRequired",
+      "osVolumeTpmStartupKeyRequired",
+      "osVolumeUnprotected",
+      "recoveryKeyBackupFailed",
+      "success",
+      "tpmNotAvailable",
+      "tpmNotReady",
+      "windowsRecoveryEnvironmentNotConfigured"
+    ],
+    "advancedConfigState": [
+      "default",
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "agentIdentityType": [
+      "agentIdentity",
+      "agentIdentityBlueprintPrincipal",
+      "agentUser",
+      "unknownFutureValue"
+    ],
+    "agentIdRiskLevel": [
+      "high",
+      "low",
+      "medium",
+      "none",
+      "unknownFutureValue"
+    ],
+    "agentStatus": [
+      "active",
+      "inactive"
+    ],
+    "aggregationPeriod": [
+      "d1",
+      "d30",
+      "d7",
+      "unknownFutureValue"
+    ],
+    "aggregationWindow": [
+      "d1",
+      "h1",
+      "h6",
+      "unknownFutureValue"
+    ],
+    "agreementAcceptanceState": [
+      "accepted",
+      "declined",
+      "unknownFutureValue"
+    ],
+    "aiInteractionType": [
+      "aiResponse",
+      "unknownFutureValue",
+      "userPrompt"
+    ],
+    "alertFeedback": [
+      "benignPositive",
+      "falsePositive",
+      "truePositive",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alertSeverity": [
+      "high",
+      "informational",
+      "low",
+      "medium",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alertStatus": [
+      "dismissed",
+      "inProgress",
+      "newAlert",
+      "resolved",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alignment": [
+      "center",
+      "left",
+      "right"
+    ],
+    "allowedAudiences": [
+      "contacts",
+      "everyone",
+      "family",
+      "federatedOrganizations",
+      "groupMembers",
+      "me",
+      "organization",
+      "unknownFutureValue"
+    ],
+    "allowedLobbyAdmitterRoles": [
+      "organizerAndCoOrganizers",
+      "organizerAndCoOrganizersAndPresenters",
+      "unknownFutureValue"
+    ],
+    "allowedRolePrincipalTypes": [
+      "group",
+      "servicePrincipal",
+      "unknownFutureValue",
+      "user"
+    ],
+    "allowInvitesFrom": [
+      "adminsAndGuestInviters",
+      "adminsGuestInvitersAndAllMembers",
+      "everyone",
+      "none",
+      "unknownFutureValue"
+    ],
+    "analyticsActivityType": [
+      "Call",
+      "Chat",
+      "Email",
+      "Focus",
+      "Meeting"
+    ],
+    "androidAppCredentialProviderRoleState": [
+      "allowed",
+      "notConfigured",
+      "unknownFutureValue"
+    ],
+    "androidDeviceOwnerAppAutoUpdatePolicyType": [
+      "always",
+      "never",
+      "notConfigured",
+      "userChoice",
+      "wiFiOnly"
+    ],
+    "androidDeviceOwnerBatteryPluggedMode": [
+      "ac",
+      "notConfigured",
+      "usb",
+      "wireless"
+    ],
+    "androidDeviceOwnerCertificateAccessType": [
+      "specificApps",
+      "unknownFutureValue",
+      "userApproval"
+    ],
+    "androidDeviceOwnerCrossProfileDataSharing": [
+      "crossProfileDataSharingAllowed",
+      "crossProfileDataSharingBlocked",
+      "dataSharingFromWorkToPersonalBlocked",
+      "notConfigured",
+      "unkownFutureValue"
+    ],
+    "androidDeviceOwnerDefaultAppPermissionPolicyType": [
+      "autoDeny",
+      "autoGrant",
+      "deviceDefault",
+      "prompt"
+    ],
+    "androidDeviceOwnerDelegatedAppScopeType": [
+      "captureNetworkActivityLog",
+      "captureSecurityLog",
+      "certificateInstall",
+      "unknownFutureValue",
+      "unspecified"
+    ],
+    "androidDeviceOwnerEnrollmentMode": [
+      "corporateOwnedAOSPUserAssociatedDevice",
+      "corporateOwnedAOSPUserlessDevice",
+      "corporateOwnedDedicatedDevice",
+      "corporateOwnedFullyManaged",
+      "corporateOwnedWorkProfile"
+    ],
+    "androidDeviceOwnerEnrollmentProfileType": [
+      "dedicatedDevice",
+      "fullyManaged",
+      "notConfigured"
+    ],
+    "androidDeviceOwnerEnrollmentTokenType": [
+      "corporateOwnedDedicatedDeviceWithAzureADSharedMode",
+      "default",
+      "deviceStaging"
+    ],
+    "androidDeviceOwnerKioskCustomizationStatusBar": [
+      "notConfigured",
+      "notificationsAndSystemInfoEnabled",
+      "systemInfoOnly"
+    ],
+    "androidDeviceOwnerKioskCustomizationSystemNavigation": [
+      "homeButtonOnly",
+      "navigationEnabled",
+      "notConfigured"
+    ],
+    "androidDeviceOwnerKioskModeFolderIcon": [
+      "darkCircle",
+      "darkSquare",
+      "lightCircle",
+      "lightSquare",
+      "notConfigured"
+    ],
+    "androidDeviceOwnerKioskModeIconSize": [
+      "large",
+      "largest",
+      "notConfigured",
+      "regular",
+      "small",
+      "smallest"
+    ],
+    "androidDeviceOwnerKioskModeScreenOrientation": [
+      "autoRotate",
+      "landscape",
+      "notConfigured",
+      "portrait"
+    ],
+    "androidDeviceOwnerLocationMode": [
+      "disabled",
+      "notConfigured",
+      "unknownFutureValue"
+    ],
+    "androidDeviceOwnerPlayStoreMode": [
+      "allowList",
+      "blockList",
+      "notConfigured"
+    ],
+    "androidDeviceOwnerRequiredPasswordType": [
+      "alphabetic",
+      "alphanumeric",
+      "alphanumericWithSymbols",
+      "customPassword",
+      "deviceDefault",
+      "lowSecurityBiometric",
+      "numeric",
+      "numericComplex",
+      "required"
+    ],
+    "androidDeviceOwnerRequiredPasswordUnlock": [
+      "daily",
+      "deviceDefault",
+      "unkownFutureValue"
+    ],
+    "androidDeviceOwnerSystemUpdateInstallType": [
+      "automatic",
+      "deviceDefault",
+      "postpone",
+      "windowed"
+    ],
+    "androidDeviceOwnerVirtualHomeButtonType": [
+      "floating",
+      "notConfigured",
+      "swipeUp"
+    ],
+    "androidDeviceOwnerWiFiSecurityType": [
+      "open",
+      "wep",
+      "wpaEnterprise",
+      "wpaPersonal"
+    ],
+    "androidEapType": [
+      "eapTls",
+      "eapTtls",
+      "peap"
+    ],
+    "androidForWorkAppConfigurationSchemaItemDataType": [
+      "bool",
+      "bundle",
+      "bundleArray",
+      "choice",
+      "hidden",
+      "integer",
+      "multiselect",
+      "string"
+    ],
+    "androidForWorkBindStatus": [
+      "bound",
+      "boundAndValidated",
+      "notBound",
+      "unbinding"
+    ],
+    "androidForWorkCrossProfileDataSharingType": [
+      "allowPersonalToWork",
+      "deviceDefault",
+      "noRestrictions",
+      "preventAny"
+    ],
+    "androidForWorkDefaultAppPermissionPolicyType": [
+      "autoDeny",
+      "autoGrant",
+      "deviceDefault",
+      "prompt"
+    ],
+    "androidForWorkEnrollmentTarget": [
+      "all",
+      "none",
+      "targeted",
+      "targetedAsEnrollmentRestrictions"
+    ],
+    "androidForWorkRequiredPasswordType": [
+      "alphanumericWithSymbols",
+      "atLeastAlphabetic",
+      "atLeastAlphanumeric",
+      "atLeastNumeric",
+      "deviceDefault",
+      "lowSecurityBiometric",
+      "numericComplex",
+      "required"
+    ],
+    "androidForWorkSyncStatus": [
+      "androidForWorkApiError",
+      "credentialsNotValid",
+      "managementServiceError",
+      "none",
+      "success",
+      "unknownError"
+    ],
+    "androidForWorkVpnConnectionType": [
+      "checkPointCapsuleVpn",
+      "ciscoAnyConnect",
+      "citrix",
+      "dellSonicWallMobileConnect",
+      "f5EdgeClient",
+      "pulseSecure"
+    ],
+    "androidKeyguardFeature": [
+      "allFeatures",
+      "biometrics",
+      "camera",
+      "face",
+      "fingerprint",
+      "iris",
+      "notConfigured",
+      "notifications",
+      "remoteInput",
+      "trustAgents",
+      "unredactedNotifications"
+    ],
+    "androidManagedAppSafetyNetAppsVerificationType": [
+      "enabled",
+      "none"
+    ],
+    "androidManagedAppSafetyNetDeviceAttestationType": [
+      "basicIntegrity",
+      "basicIntegrityAndDeviceCertification",
+      "none"
+    ],
+    "androidManagedAppSafetyNetEvaluationType": [
+      "basic",
+      "hardwareBacked"
+    ],
+    "androidManagedStoreAccountAppSyncStatus": [
+      "androidForWorkApiError",
+      "credentialsNotValid",
+      "managementServiceError",
+      "none",
+      "success",
+      "unknownError"
+    ],
+    "androidManagedStoreAccountBindStatus": [
+      "bound",
+      "boundAndValidated",
+      "notBound",
+      "unbinding"
+    ],
+    "androidManagedStoreAccountEnrollmentTarget": [
+      "all",
+      "none",
+      "targeted",
+      "targetedAsEnrollmentRestrictions"
+    ],
+    "androidManagedStoreAppConfigurationSchemaItemDataType": [
+      "bool",
+      "bundle",
+      "bundleArray",
+      "choice",
+      "hidden",
+      "integer",
+      "multiselect",
+      "string"
+    ],
+    "androidManagedStoreAutoUpdateMode": [
+      "default",
+      "postponed",
+      "priority",
+      "unknownFutureValue"
+    ],
+    "androidManagedStoreLayoutType": [
+      "basic",
+      "custom",
+      "unknownFutureValue"
+    ],
+    "androidPermissionActionType": [
+      "autoDeny",
+      "autoGrant",
+      "prompt"
+    ],
+    "androidProfileApplicability": [
+      "androidDeviceOwner",
+      "androidWorkProfile",
+      "default"
+    ],
+    "androidRequiredPasswordComplexity": [
+      "high",
+      "low",
+      "medium",
+      "none"
+    ],
+    "androidRequiredPasswordType": [
+      "alphabetic",
+      "alphanumeric",
+      "alphanumericWithSymbols",
+      "any",
+      "deviceDefault",
+      "lowSecurityBiometric",
+      "numeric",
+      "numericComplex"
+    ],
+    "androidSafetyNetEvaluationType": [
+      "basic",
+      "hardwareBacked"
+    ],
+    "androidTargetedPlatforms": [
+      "androidDeviceAdministrator",
+      "androidOpenSourceProject",
+      "unknownFutureValue"
+    ],
+    "androidUsernameSource": [
+      "primarySmtpAddress",
+      "samAccountName",
+      "username",
+      "userPrincipalName"
+    ],
+    "androidVpnConnectionType": [
+      "checkPointCapsuleVpn",
+      "ciscoAnyConnect",
+      "citrix",
+      "dellSonicWallMobileConnect",
+      "f5EdgeClient",
+      "microsoftProtect",
+      "microsoftTunnel",
+      "netMotionMobility",
+      "pulseSecure"
+    ],
+    "androidWiFiSecurityType": [
+      "open",
+      "unknownFutureValue",
+      "wep",
+      "wpa2Enterprise",
+      "wpaEnterprise",
+      "wpaPersonal"
+    ],
+    "androidWorkProfileAccountUse": [
+      "allowAll",
+      "allowAllExceptGoogleAccounts",
+      "blockAll",
+      "unknownFutureValue"
+    ],
+    "androidWorkProfileCrossProfileDataSharingType": [
+      "allowPersonalToWork",
+      "deviceDefault",
+      "noRestrictions",
+      "preventAny"
+    ],
+    "androidWorkProfileDefaultAppPermissionPolicyType": [
+      "autoDeny",
+      "autoGrant",
+      "deviceDefault",
+      "prompt"
+    ],
+    "androidWorkProfileRequiredPasswordType": [
+      "alphanumericWithSymbols",
+      "atLeastAlphabetic",
+      "atLeastAlphanumeric",
+      "atLeastNumeric",
+      "deviceDefault",
+      "lowSecurityBiometric",
+      "numericComplex",
+      "required"
+    ],
+    "androidWorkProfileVpnConnectionType": [
+      "checkPointCapsuleVpn",
+      "ciscoAnyConnect",
+      "citrix",
+      "dellSonicWallMobileConnect",
+      "f5EdgeClient",
+      "microsoftProtect",
+      "microsoftTunnel",
+      "netMotionMobility",
+      "paloAltoGlobalProtect",
+      "pulseSecure"
+    ],
+    "answerInputType": [
+      "radioButton",
+      "text",
+      "unknownFutureValue"
+    ],
+    "aospDeviceOwnerWiFiSecurityType": [
+      "open",
+      "wep",
+      "wpaEnterprise",
+      "wpaPersonal"
+    ],
+    "aospWifiSecurityType": [
+      "none",
+      "wep",
+      "wpa"
+    ],
+    "appCredentialRestrictionType": [
+      "customPasswordAddition",
+      "passwordAddition",
+      "passwordLifetime",
+      "symmetricKeyAddition",
+      "symmetricKeyLifetime",
+      "unknownFutureValue"
+    ],
+    "appDevelopmentPlatforms": [
+      "developerPortal",
+      "unknownFutureValue"
+    ],
+    "appInstallControlType": [
+      "anywhere",
+      "notConfigured",
+      "preferStore",
+      "recommendations",
+      "storeOnly"
+    ],
+    "appKeyCredentialRestrictionType": [
+      "asymmetricKeyLifetime",
+      "trustedCertificateAuthority",
+      "unknownFutureValue"
+    ],
+    "appleDeploymentChannel": [
+      "deviceChannel",
+      "unknownFutureValue",
+      "userChannel"
+    ],
+    "appleDeviceDeliveryProtocol": [
+      "declarativeDeviceManagement",
+      "default",
+      "mobileDeviceManagement",
+      "unknownFutureValue"
+    ],
+    "appleSubjectNameFormat": [
+      "commonName",
+      "commonNameAsEmail",
+      "commonNameAsIMEI",
+      "commonNameAsSerialNumber",
+      "commonNameIncludingEmail",
+      "custom"
+    ],
+    "appleUserInitiatedEnrollmentType": [
+      "accountDrivenUserEnrollment",
+      "device",
+      "unknown",
+      "unknownFutureValue",
+      "user",
+      "webDeviceEnrollment"
+    ],
+    "appleVpnConnectionType": [
+      "alwaysOn",
+      "checkPointCapsuleVpn",
+      "ciscoAnyConnect",
+      "ciscoAnyConnectV2",
+      "ciscoIPSec",
+      "citrix",
+      "citrixSso",
+      "customVpn",
+      "dellSonicWallMobileConnect",
+      "f5Access2018",
+      "f5EdgeClient",
+      "ikEv2",
+      "microsoftProtect",
+      "microsoftTunnel",
+      "netMotionMobility",
+      "paloAltoGlobalProtect",
+      "paloAltoGlobalProtectV2",
+      "pulseSecure",
+      "zscalerPrivateAccess"
+    ],
+    "applicationDataType": [
+      "codingFiles",
+      "creditCards",
+      "databaseFiles",
+      "documents",
+      "mediaFiles",
+      "none",
+      "unknownFutureValue"
+    ],
+    "applicationGuardBlockClipboardSharingType": [
+      "blockBoth",
+      "blockContainerToHost",
+      "blockHostToContainer",
+      "blockNone",
+      "notConfigured"
+    ],
+    "applicationGuardBlockFileTransferType": [
+      "blockImageAndTextFile",
+      "blockImageFile",
+      "blockNone",
+      "blockTextFile",
+      "notConfigured"
+    ],
+    "applicationGuardEnabledOptions": [
+      "enabledForEdge",
+      "enabledForEdgeAndOffice",
+      "enabledForOffice",
+      "notConfigured"
+    ],
+    "applicationKeyOrigin": [
+      "application",
+      "servicePrincipal",
+      "unknownFutureValue"
+    ],
+    "applicationKeyType": [
+      "certificate",
+      "clientSecret",
+      "unknownFutureValue"
+    ],
+    "applicationKeyUsage": [
+      "sign",
+      "unknownFutureValue",
+      "verify"
+    ],
+    "applicationMode": [
+      "automatic",
+      "manual",
+      "recommended"
+    ],
+    "applicationPermissionsRequired": [
+      "administrator",
+      "anonymous",
+      "guest",
+      "system",
+      "unknown",
+      "unknownFutureValue",
+      "user"
+    ],
+    "applicationType": [
+      "desktop",
+      "universal"
+    ],
+    "appliedConditionalAccessPolicyResult": [
+      "failure",
+      "notApplied",
+      "notEnabled",
+      "reportOnlyFailure",
+      "reportOnlyInterrupted",
+      "reportOnlyNotApplied",
+      "reportOnlySuccess",
+      "success",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "appListType": [
+      "appsInListCompliant",
+      "appsNotInListCompliant",
+      "none"
+    ],
+    "appLockerApplicationControlType": [
+      "auditComponentsAndStoreApps",
+      "auditComponentsStoreAppsAndSmartlocker",
+      "enforceComponentsAndStoreApps",
+      "enforceComponentsStoreAppsAndSmartlocker",
+      "notConfigured"
+    ],
+    "appLogDecryptionAlgorithm": [
+      "aes256",
+      "unknownFutureValue"
+    ],
+    "appLogUploadState": [
+      "completed",
+      "failed",
+      "pending",
+      "unknownFutureValue"
+    ],
+    "appManagementLevel": [
+      "androidEnterprise",
+      "androidEnterpriseDedicatedDevicesWithAzureAdSharedMode",
+      "androidOpenSourceProjectUserAssociated",
+      "androidOpenSourceProjectUserless",
+      "mdm",
+      "unknownFutureValue",
+      "unmanaged",
+      "unspecified"
+    ],
+    "appManagementRestrictionState": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "approvalFilterByCurrentUserOptions": [
+      "approver",
+      "createdBy",
+      "target",
+      "unknownFutureValue"
+    ],
+    "approvalItemState": [
+      "canceled",
+      "completed",
+      "created",
+      "pending",
+      "unknownFutureValue"
+    ],
+    "approvalItemType": [
+      "basic",
+      "basicAwaitAll",
+      "custom",
+      "customAwaitAll",
+      "unknownFutureValue"
+    ],
+    "approvalOperationStatus": [
+      "failed",
+      "inProgress",
+      "scheduled",
+      "succeeded",
+      "timeout",
+      "unknownFutureValue"
+    ],
+    "approvalState": [
+      "aborted",
+      "approved",
+      "canceled",
+      "denied",
+      "pending"
+    ],
+    "approverInformationVisibility": [
+      "default",
+      "notVisible",
+      "unknownFutureValue",
+      "visible"
+    ],
+    "approverRole": [
+      "approver",
+      "owner",
+      "unknownFutureValue"
+    ],
+    "appsUpdateChannelType": [
+      "current",
+      "monthlyEnterprise",
+      "semiAnnual",
+      "unknownFutureValue"
+    ],
+    "appVulnerabilityTaskMitigationType": [
+      "securityConfiguration",
+      "uninstall",
+      "unknown",
+      "update"
+    ],
+    "artifactRestoreStatus": [
+      "added",
+      "failed",
+      "inProgress",
+      "scheduled",
+      "scheduling",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "artifactType": [
+      "transcript",
+      "unknownFutureValue"
+    ],
+    "assignmentFilterEvaluationResult": [
+      "failure",
+      "inconclusive",
+      "match",
+      "notEvaluated",
+      "notMatch",
+      "unknown"
+    ],
+    "assignmentFilterManagementType": [
+      "apps",
+      "devices",
+      "unknownFutureValue"
+    ],
+    "assignmentFilterOperator": [
+      "contains",
+      "endsWith",
+      "equals",
+      "greaterThan",
+      "greaterThanOrEquals",
+      "in",
+      "lessThan",
+      "lessThanOrEquals",
+      "notContains",
+      "notEndsWith",
+      "notEquals",
+      "notIn",
+      "notSet",
+      "notStartsWith",
+      "startsWith",
+      "unknownFutureValue"
+    ],
+    "assignmentFilterPayloadType": [
+      "enrollmentRestrictions",
+      "notSet"
+    ],
+    "assignmentMethod": [
+      "auto",
+      "privileged",
+      "standard"
+    ],
+    "assignmentScheduleFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "assignmentScheduleInstanceFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "assignmentScheduleRequestFilterByCurrentUserOptions": [
+      "approver",
+      "createdBy",
+      "principal",
+      "unknownFutureValue"
+    ],
+    "assignmentType": [
+      "peerRecommended",
+      "recommended",
+      "required",
+      "unknownFutureValue"
+    ],
+    "associatedAssignmentPayloadType": [
+      "androidEnterpriseApp",
+      "androidEnterpriseConfiguration",
+      "application",
+      "deviceConfigurationAndCompliance",
+      "deviceFirmwareConfigurationInterfacePolicy",
+      "deviceManagmentConfigurationAndCompliancePolicy",
+      "enrollmentConfiguration",
+      "groupPolicyConfiguration",
+      "resourceAccessPolicy",
+      "unknown",
+      "win32app",
+      "zeroTouchDeploymentDeviceConfigProfile"
+    ],
+    "attachmentType": [
+      "file",
+      "item",
+      "reference"
+    ],
+    "attackSimulationOperationType": [
+      "createSimualation",
+      "unknownFutureValue",
+      "updateSimulation"
+    ],
+    "attendeeType": [
+      "optional",
+      "required",
+      "resource"
+    ],
+    "attestationEnforcement": [
+      "disabled",
+      "registrationOnly",
+      "unknownFutureValue"
+    ],
+    "attestationLevel": [
+      "attested",
+      "notAttested",
+      "unknownFutureValue"
+    ],
+    "attributeDefinitionMetadata": [
+      "BaseAttributeName",
+      "ComplexObjectDefinition",
+      "IsContainer",
+      "IsCustomerDefined",
+      "IsDomainQualified",
+      "LinkPropertyNames",
+      "LinkTypeName",
+      "MaximumLength",
+      "ReferencedProperty"
+    ],
+    "attributeFlowBehavior": [
+      "FlowAlways",
+      "FlowWhenChanged"
+    ],
+    "attributeFlowType": [
+      "Always",
+      "AttributeAddOnly",
+      "MultiValueAddOnly",
+      "ObjectAddOnly",
+      "ValueAddOnly"
+    ],
+    "attributeMappingSourceType": [
+      "Attribute",
+      "Constant",
+      "Function"
+    ],
+    "attributeType": [
+      "Binary",
+      "Boolean",
+      "DateTime",
+      "Integer",
+      "Reference",
+      "String"
+    ],
+    "auditIdentityType": [
+      "agent",
+      "servicePrincipal",
+      "unknownFutureValue"
+    ],
+    "auditLogRecordType": [],
+    "auditLogUserType": [],
+    "authenticationAppAdminConfiguration": [
+      "disabled",
+      "enabled",
+      "notApplicable",
+      "unknownFutureValue"
+    ],
+    "authenticationAppEvaluation": [
+      "failure",
+      "success",
+      "unknownFutureValue"
+    ],
+    "authenticationAppPolicyStatus": [
+      "appContextNotShown",
+      "appContextOutOfDate",
+      "appContextShown",
+      "appLockDisabled",
+      "appLockEnabled",
+      "appLockOutOfDate",
+      "locationContextNotShown",
+      "locationContextOutOfDate",
+      "locationContextShown",
+      "numberMatchCorrectNumberEntered",
+      "numberMatchDeny",
+      "numberMatchIncorrectNumberEntered",
+      "numberMatchOutOfDate",
+      "tamperResistantHardwareNotUsed",
+      "tamperResistantHardwareOutOfDate",
+      "tamperResistantHardwareUsed",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "authenticationAttributeCollectionInputType": [
+      "boolean",
+      "checkboxMultiSelect",
+      "radioSingleSelect",
+      "text",
+      "unknownFutureValue"
+    ],
+    "authenticationContextDetail": [
+      "notApplicable",
+      "previouslySatisfied",
+      "required",
+      "unknownFutureValue"
+    ],
+    "authenticationEventType": [
+      "attributeCollectionStart",
+      "attributeCollectionSubmit",
+      "emailOtpSend",
+      "pageRenderStart",
+      "tokenIssuanceStart",
+      "unknownFutureValue"
+    ],
+    "authenticationFailureReasonCode": [
+      "badRequest",
+      "configError",
+      "denied",
+      "incomplete",
+      "other",
+      "systemFailure",
+      "unknownFutureValue",
+      "userError"
+    ],
+    "authenticationMethodFeature": [
+      "mfaCapable",
+      "passwordlessCapable",
+      "ssprCapable",
+      "ssprEnabled",
+      "ssprRegistered",
+      "unknownFutureValue"
+    ],
+    "authenticationMethodKeyStrength": [
+      "normal",
+      "unknown",
+      "weak"
+    ],
+    "authenticationMethodModes": [
+      "deviceBasedPush",
+      "email",
+      "federatedMultiFactor",
+      "federatedSingleFactor",
+      "fido2",
+      "hardwareOath",
+      "microsoftAuthenticatorPush",
+      "password",
+      "qrCodePin",
+      "sms",
+      "softwareOath",
+      "temporaryAccessPassMultiUse",
+      "temporaryAccessPassOneTime",
+      "unknownFutureValue",
+      "voice",
+      "windowsHelloForBusiness",
+      "x509CertificateMultiFactor",
+      "x509CertificateSingleFactor"
+    ],
+    "authenticationMethodPlatform": [
+      "android",
+      "iOS",
+      "linux",
+      "macOS",
+      "unknown",
+      "unknownFutureValue",
+      "windows"
+    ],
+    "authenticationMethodSignInState": [
+      "notAllowedByPolicy",
+      "notConfigured",
+      "notEnabled",
+      "notSupported",
+      "phoneNumberNotUnique",
+      "ready",
+      "unknownFutureValue"
+    ],
+    "authenticationMethodsPolicyMigrationState": [
+      "migrationComplete",
+      "migrationInProgress",
+      "preMigration",
+      "unknownFutureValue"
+    ],
+    "authenticationMethodState": [
+      "disabled",
+      "enabled"
+    ],
+    "authenticationMethodTargetType": [
+      "group",
+      "unknownFutureValue",
+      "user"
+    ],
+    "authenticationPhoneType": [
+      "alternateMobile",
+      "mobile",
+      "office",
+      "unknownFutureValue"
+    ],
+    "authenticationProtocol": [
+      "saml",
+      "unknownFutureValue",
+      "wsFed"
+    ],
+    "authenticationStrengthPolicyType": [
+      "builtIn",
+      "custom",
+      "unknownFutureValue"
+    ],
+    "authenticationStrengthRequirements": [
+      "mfa",
+      "none",
+      "unknownFutureValue"
+    ],
+    "authenticationStrengthResult": [
+      "cannotSatisfy",
+      "cannotSatisfyDueToCombinationConfiguration",
+      "multipleChallengesRequired",
+      "multipleRegistrationsRequired",
+      "notSet",
+      "satisfied",
+      "singleChallengeRequired",
+      "singleRegistrationRequired",
+      "skippedForProofUp",
+      "unknownFutureValue"
+    ],
+    "authenticationTransformConstant": [
+      "aes128Gcm",
+      "aes192Gcm",
+      "aes256Gcm",
+      "md5_96",
+      "sha_256_128",
+      "sha1_96"
+    ],
+    "authMethodsType": [
+      "alternateMobilePhone",
+      "appNotification",
+      "appNotificationAndCode",
+      "appNotificationCode",
+      "appPassword",
+      "email",
+      "externalAuthMethod",
+      "fido",
+      "mobilePhone",
+      "mobilePhoneAndSMS",
+      "mobileSMS",
+      "officePhone",
+      "securityQuestion",
+      "unknownFutureValue"
+    ],
+    "authorizationSystemActionSeverity": [
+      "high",
+      "normal",
+      "unknownFutureValue"
+    ],
+    "authorizationSystemActionType": [
+      "delete",
+      "read",
+      "unknownFutureValue"
+    ],
+    "authorizationSystemType": [
+      "aws",
+      "azure",
+      "gcp",
+      "unknownFutureValue"
+    ],
+    "autoAdmittedUsersType": [
+      "everyone",
+      "everyoneInCompany"
+    ],
+    "automaticRepliesStatus": [
+      "alwaysEnabled",
+      "disabled",
+      "scheduled"
+    ],
+    "automaticUpdateMode": [
+      "autoInstallAndRebootAtMaintenanceTime",
+      "autoInstallAndRebootAtScheduledTime",
+      "autoInstallAndRebootWithoutEndUserControl",
+      "autoInstallAtMaintenanceTime",
+      "notifyDownload",
+      "userDefined",
+      "windowsDefault"
+    ],
+    "autoRestartNotificationDismissalMethod": [
+      "automatic",
+      "notConfigured",
+      "unknownFutureValue",
+      "user"
+    ],
+    "awsAccessType": [
+      "crossAccount",
+      "private",
+      "public",
+      "restricted",
+      "unknownFutureValue"
+    ],
+    "awsPolicyType": [
+      "custom",
+      "system",
+      "unknownFutureValue"
+    ],
+    "awsRoleTrustEntityType": [
+      "crossAccount",
+      "none",
+      "service",
+      "sso",
+      "unknownFutureValue",
+      "webIdentity"
+    ],
+    "awsRoleType": [
+      "custom",
+      "system",
+      "unknownFutureValue"
+    ],
+    "awsSecretInformationWebServices": [
+      "certificateAuthority",
+      "certificateManager",
+      "cloudHsm",
+      "secretsManager",
+      "unknownFutureValue"
+    ],
+    "awsSecurityToolWebServices": [
+      "cloudTrail",
+      "detective",
+      "guardDuty",
+      "inspector",
+      "macie",
+      "securityHub",
+      "unknownFutureValue",
+      "wafShield"
+    ],
+    "awsStatementEffect": [
+      "allow",
+      "deny",
+      "unknownFutureValue"
+    ],
+    "azureAccessType": [
+      "private",
+      "public",
+      "unknownFutureValue"
+    ],
+    "azureAttestationSettingStatus": [
+      "disabled",
+      "enabled",
+      "notApplicable",
+      "unknownFutureValue"
+    ],
+    "azureEncryption": [
+      "customer",
+      "microsoftKeyVault",
+      "microsoftStorage",
+      "unknownFutureValue"
+    ],
+    "azureRoleDefinitionType": [
+      "custom",
+      "system",
+      "unknownFutureValue"
+    ],
+    "b2bIdentityProvidersType": [
+      "azureActiveDirectory",
+      "defaultConfiguredIdp",
+      "emailOneTimePasscode",
+      "externalFederation",
+      "microsoftAccount",
+      "socialIdentityProviders",
+      "unknownFutureValue"
+    ],
+    "BackupPolicyProtectionMode": [
+      "fullServiceBackup",
+      "standard",
+      "unknownFutureValue"
+    ],
+    "backupServiceConsumer": [
+      "firstparty",
+      "thirdparty",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "backupServiceStatus": [
+      "disabled",
+      "enabled",
+      "protectionChangeLocked",
+      "restoreLocked",
+      "unknownFutureValue"
+    ],
+    "baseAuthenticationMethod": [
+      "email",
+      "federation",
+      "fido2",
+      "hardwareOath",
+      "microsoftAuthenticator",
+      "password",
+      "qrCodePin",
+      "sms",
+      "softwareOath",
+      "temporaryAccessPass",
+      "unknownFutureValue",
+      "voice",
+      "windowsHelloForBusiness",
+      "x509Certificate"
+    ],
+    "baselineParameterType": [
+      "boolean",
+      "integer",
+      "string",
+      "unknownFutureValue"
+    ],
+    "binaryOperator": [
+      "and",
+      "or"
+    ],
+    "bitLockerEncryptionMethod": [
+      "aesCbc128",
+      "aesCbc256",
+      "xtsAes128",
+      "xtsAes256"
+    ],
+    "bitLockerRecoveryInformationType": [
+      "passwordAndKey",
+      "passwordOnly"
+    ],
+    "bitLockerRecoveryPasswordRotationType": [
+      "disabled",
+      "enabledForAzureAd",
+      "enabledForAzureAdAndHybrid",
+      "notConfigured"
+    ],
+    "bodyType": [
+      "html",
+      "text"
+    ],
+    "bookingInvoiceStatus": [
+      "canceled",
+      "corrective",
+      "draft",
+      "open",
+      "paid",
+      "reviewing"
+    ],
+    "bookingPageAccessControl": [
+      "restrictedToOrganization",
+      "unknownFutureValue",
+      "unrestricted"
+    ],
+    "bookingPriceType": [
+      "callUs",
+      "fixedPrice",
+      "free",
+      "hourly",
+      "notSet",
+      "priceVaries",
+      "startingAt",
+      "undefined"
+    ],
+    "bookingReminderRecipients": [
+      "allAttendees",
+      "customer",
+      "staff"
+    ],
+    "bookingsAvailabilityStatus": [
+      "available",
+      "busy",
+      "outOfOffice",
+      "slotsAvailable",
+      "unknownFutureValue"
+    ],
+    "bookingsServiceAvailabilityType": [
+      "bookWhenStaffAreFree",
+      "customWeeklyHours",
+      "notBookable",
+      "unknownFutureValue"
+    ],
+    "bookingStaffMembershipStatus": [
+      "active",
+      "pendingAcceptance",
+      "rejectedByStaff",
+      "unknownFutureValue"
+    ],
+    "bookingStaffRole": [
+      "administrator",
+      "externalGuest",
+      "guest",
+      "scheduler",
+      "teamMember",
+      "unknownFutureValue",
+      "viewer"
+    ],
+    "bookingType": [
+      "reserved",
+      "standard",
+      "unknown"
+    ],
+    "broadcastMeetingAudience": [
+      "everyone",
+      "organization",
+      "roleIsAttendee",
+      "unknownFutureValue"
+    ],
+    "browsableResourceType": [
+      "documentLibrary",
+      "folder",
+      "none",
+      "site",
+      "unknownFutureValue"
+    ],
+    "browseQueryOrder": [
+      "nameAsc",
+      "nameDsc",
+      "pathAsc",
+      "pathDsc",
+      "unknownFutureValue"
+    ],
+    "browseQueryResponseItemType": [
+      "documentLibrary",
+      "file",
+      "folder",
+      "none",
+      "site",
+      "unknownFutureValue"
+    ],
+    "browserSharedCookieSourceEnvironment": [
+      "both",
+      "internetExplorer11",
+      "microsoftEdge",
+      "unknownFutureValue"
+    ],
+    "browserSharedCookieStatus": [
+      "pendingAdd",
+      "pendingDelete",
+      "pendingEdit",
+      "published",
+      "unknownFutureValue"
+    ],
+    "browserSiteCompatibilityMode": [
+      "default",
+      "internetExplorer10",
+      "internetExplorer11",
+      "internetExplorer5",
+      "internetExplorer7",
+      "internetExplorer7Enterprise",
+      "internetExplorer8",
+      "internetExplorer8Enterprise",
+      "internetExplorer9",
+      "unknownFutureValue"
+    ],
+    "browserSiteListStatus": [
+      "draft",
+      "pending",
+      "published",
+      "unknownFutureValue"
+    ],
+    "browserSiteMergeType": [
+      "default",
+      "noMerge",
+      "unknownFutureValue"
+    ],
+    "browserSiteStatus": [
+      "pendingAdd",
+      "pendingDelete",
+      "pendingEdit",
+      "published",
+      "unknownFutureValue"
+    ],
+    "browserSiteTargetEnvironment": [
+      "configurable",
+      "internetExplorer11",
+      "internetExplorerMode",
+      "microsoftEdge",
+      "none",
+      "unknownFutureValue"
+    ],
+    "browserSyncSetting": [
+      "blocked",
+      "blockedWithUserOverride",
+      "notConfigured"
+    ],
+    "browseSessionStatus": [
+      "created",
+      "creating",
+      "failed",
+      "unknownFutureValue"
+    ],
+    "bucketAggregationSortProperty": [
+      "count",
+      "keyAsNumber",
+      "keyAsString",
+      "unknownFutureValue"
+    ],
+    "calendarColor": [
+      "auto",
+      "lightBlue",
+      "lightBrown",
+      "lightGray",
+      "lightGreen",
+      "lightOrange",
+      "lightPink",
+      "lightRed",
+      "lightTeal",
+      "lightYellow",
+      "maxColor"
+    ],
+    "calendarRoleType": [
+      "custom",
+      "delegateWithoutPrivateEventAccess",
+      "delegateWithPrivateEventAccess",
+      "freeBusyRead",
+      "limitedRead",
+      "none",
+      "read",
+      "write"
+    ],
+    "calendarSharingAction": [
+      "accept",
+      "acceptAndViewCalendar",
+      "addThisCalendar",
+      "viewCalendar"
+    ],
+    "calendarSharingActionImportance": [
+      "primary",
+      "secondary"
+    ],
+    "calendarSharingActionType": [
+      "accept"
+    ],
+    "callDirection": [
+      "incoming",
+      "outgoing"
+    ],
+    "callDisposition": [
+      "default",
+      "forward",
+      "simultaneousRing"
+    ],
+    "callEventType": [
+      "callEnded",
+      "callStarted",
+      "recordingStateUpdated",
+      "rosterUpdated",
+      "transcriptionStateUpdated",
+      "unknownFutureValue"
+    ],
+    "callRecordingStatus": [
+      "chunkFinished",
+      "failure",
+      "initial",
+      "success",
+      "unknownFutureValue"
+    ],
+    "callState": [
+      "established",
+      "establishing",
+      "hold",
+      "incoming",
+      "redirecting",
+      "ringing",
+      "terminated",
+      "terminating",
+      "transferAccepted",
+      "transferring",
+      "unknownFutureValue"
+    ],
+    "callTranscriptionState": [
+      "active",
+      "inactive",
+      "notStarted",
+      "unknownFutureValue"
+    ],
+    "campaignStatus": [
+      "cancelled",
+      "completed",
+      "deleted",
+      "draft",
+      "excluded",
+      "failed",
+      "inProgress",
+      "scheduled",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "categoryColor": [
+      "none",
+      "preset0",
+      "preset1",
+      "preset10",
+      "preset11",
+      "preset12",
+      "preset13",
+      "preset14",
+      "preset15",
+      "preset16",
+      "preset17",
+      "preset18",
+      "preset19",
+      "preset2",
+      "preset20",
+      "preset21",
+      "preset22",
+      "preset23",
+      "preset24",
+      "preset3",
+      "preset4",
+      "preset5",
+      "preset6",
+      "preset7",
+      "preset8",
+      "preset9"
+    ],
+    "certificateAuthorityType": [
+      "intermediate",
+      "root",
+      "unknownFutureValue"
+    ],
+    "certificateDestinationStore": [
+      "computerCertStoreIntermediate",
+      "computerCertStoreRoot",
+      "userCertStoreIntermediate"
+    ],
+    "certificateIssuanceStates": [
+      "challengeIssued",
+      "challengeIssueFailed",
+      "challengeValidationFailed",
+      "challengeValidationSucceeded",
+      "deleted",
+      "deleteFailed",
+      "enrollmentNotNeeded",
+      "enrollmentSucceeded",
+      "installed",
+      "installFailed",
+      "issued",
+      "issueFailed",
+      "issuePending",
+      "removedFromCollection",
+      "renewalRequested",
+      "renewVerified",
+      "requestCreationFailed",
+      "requested",
+      "requestSubmitFailed",
+      "responsePending",
+      "responseProcessingFailed",
+      "revoked",
+      "unknown"
+    ],
+    "certificateRevocationStatus": [
+      "failed",
+      "issued",
+      "none",
+      "pending",
+      "revoked"
+    ],
+    "certificateStatus": [
+      "notProvisioned",
+      "provisioned"
+    ],
+    "certificateStore": [
+      "machine",
+      "user"
+    ],
+    "certificateValidityPeriodScale": [
+      "days",
+      "months",
+      "years"
+    ],
+    "changeType": [
+      "created",
+      "deleted",
+      "updated"
+    ],
+    "changeUefiSettingsPermission": [
+      "none",
+      "notConfiguredOnly"
+    ],
+    "channelLayoutType": [
+      "chat",
+      "post",
+      "unknownFutureValue"
+    ],
+    "channelMembershipType": [
+      "private",
+      "shared",
+      "standard",
+      "unknownFutureValue"
+    ],
+    "chassisType": [
+      "desktop",
+      "enterpriseServer",
+      "laptop",
+      "mobileOther",
+      "mobileUnknown",
+      "phone",
+      "tablet",
+      "unknown",
+      "worksWorkstation"
+    ],
+    "chatMessageActions": [
+      "actionUndefined",
+      "reactionAdded",
+      "reactionRemoved",
+      "unknownFutureValue"
+    ],
+    "chatMessageImportance": [
+      "high",
+      "normal",
+      "urgent"
+    ],
+    "chatMessagePolicyViolationDlpActionTypes": [
+      "blockAccess",
+      "blockAccessExternal",
+      "none",
+      "notifySender"
+    ],
+    "chatMessagePolicyViolationUserActionTypes": [
+      "none",
+      "override",
+      "reportFalsePositive"
+    ],
+    "chatMessagePolicyViolationVerdictDetailsTypes": [
+      "allowFalsePositiveOverride",
+      "allowOverrideWithJustification",
+      "allowOverrideWithoutJustification",
+      "none"
+    ],
+    "chatMessageType": [
+      "chatEvent",
+      "message",
+      "systemEventMessage",
+      "typing",
+      "unknownFutureValue"
+    ],
+    "chatType": [
+      "group",
+      "meeting",
+      "oneOnOne",
+      "unknownFutureValue"
+    ],
+    "checkInMethod": [
+      "inferred",
+      "manual",
+      "unknownFutureValue",
+      "unspecified",
+      "verified"
+    ],
+    "chromeOSOnboardingStatus": [
+      "failed",
+      "inprogress",
+      "offboarding",
+      "onboarded",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "claimBindingSource": [
+      "directory",
+      "unknownFutureValue"
+    ],
+    "claimConditionUserType": [
+      "aadGuests",
+      "allGuests",
+      "any",
+      "externalGuests",
+      "members",
+      "unknownFutureValue"
+    ],
+    "classificationMethod": [
+      "exactDataMatch",
+      "fingerprint",
+      "machineLearning",
+      "patternMatch"
+    ],
+    "clickSource": [
+      "phishingUrl",
+      "qrCode",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "clientCredentialType": [
+      "certificate",
+      "clientAssertion",
+      "clientSecret",
+      "federatedIdentityCredential",
+      "managedIdentity",
+      "none",
+      "unknownFutureValue"
+    ],
+    "clonableTeamParts": [
+      "apps",
+      "channels",
+      "members",
+      "settings",
+      "tabs"
+    ],
+    "cloudAppSecuritySessionControlType": [
+      "blockDownloads",
+      "mcasConfigured",
+      "monitorOnly",
+      "unknownFutureValue"
+    ],
+    "cloudCertificationAuthorityCertificateKeySize": [
+      "eCP256",
+      "eCP256k",
+      "eCP384",
+      "eCP521",
+      "rsa2048",
+      "rsa3072",
+      "rsa4096",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudCertificationAuthorityHashingAlgorithm": [
+      "sha256",
+      "sha384",
+      "sha512",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudCertificationAuthorityKeyPlatformType": [
+      "hardwareSecurityModule",
+      "software",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudCertificationAuthorityLeafCertificateStatus": [
+      "active",
+      "expired",
+      "revoked",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudCertificationAuthorityStatus": [
+      "active",
+      "expired",
+      "paused",
+      "revoked",
+      "signingPending",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudCertificationAuthorityType": [
+      "issuingCertificationAuthority",
+      "issuingCertificationAuthorityWithExternalRoot",
+      "rootCertificationAuthority",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudCertificationAuthorityVersionStatus": [
+      "active",
+      "decommissioned",
+      "expired",
+      "paused",
+      "retired",
+      "revoked",
+      "signingPending",
+      "staged",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudPcAgentDiagnosticResultType": [
+      "communicationUnhealthy",
+      "functionalityDefect",
+      "healthy",
+      "unknownError",
+      "unknownFutureValue",
+      "versionOutdated"
+    ],
+    "cloudPcAgentHealthCheckErrorType": [
+      "agentCheckHeartbeatLost",
+      "agentCheckNotExisted",
+      "agentCheckNotRunning",
+      "agentCheckOldVersion",
+      "communicationCheckChannelDowngraded",
+      "communicationCheckNotAvailable",
+      "deviceStatusCheckNotAvailable",
+      "deviceStatusCheckNotRunning",
+      "functionalityCheckPowerShellNotRunnable",
+      "healthy",
+      "installationCheckFoundErrors",
+      "installationCheckMsiFileNotExecutable",
+      "installationFailedToDownloadMaterials",
+      "internalAgentUnknownError",
+      "networkAvailabilityCheckRequiredUrlsNotAccessible",
+      "resourceAvailabilityCheckDiskSpaceNotEnough",
+      "unknownFutureValue"
+    ],
+    "cloudPcAgentHealthCheckResultType": [
+      "failed",
+      "succeeded",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "cloudPcAgentHealthCheckState": [
+      "canceled",
+      "conflict",
+      "failed",
+      "pending",
+      "processing",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "cloudPcAgentHealthStatus": [
+      "healthy",
+      "unavailable",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "cloudPcAgentPoolBillingType": [
+      "payAsYouGo",
+      "unknownFutureValue"
+    ],
+    "cloudPcAuditActivityOperationType": [
+      "create",
+      "delete",
+      "patch",
+      "unknownFutureValue"
+    ],
+    "cloudPcAuditActivityResult": [
+      "clientError",
+      "failure",
+      "success",
+      "timeout",
+      "unknownFutureValue"
+    ],
+    "cloudPcAuditActorType": [
+      "application",
+      "itPro",
+      "partner",
+      "unknownFutureValue"
+    ],
+    "cloudPcAuditCategory": [
+      "cloudPC",
+      "unknownFutureValue"
+    ],
+    "cloudPcBlobAccessTier": [
+      "archive",
+      "cold",
+      "cool",
+      "hot",
+      "unknownFutureValue"
+    ],
+    "cloudPcBulkActionStatus": [
+      "failed",
+      "pending",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "cloudPcClientAppUsageReportType": [
+      "microsoftRemoteDesktopClientUsageReport",
+      "unknownFutureValue"
+    ],
+    "cloudPcCloudAppActionFailedErrorCode": [
+      "appDiscoveryFailed",
+      "cloudAppQuotaExceeded",
+      "cloudPcLicenseNotFound",
+      "filePathInvalid",
+      "iconPathInvalid",
+      "internalServerError",
+      "unknownFutureValue"
+    ],
+    "cloudPcCloudAppStatus": [
+      "failed",
+      "preparing",
+      "published",
+      "publishing",
+      "ready",
+      "unknownFutureValue",
+      "unpublishing"
+    ],
+    "cloudPCConnectionQualityReportType": [
+      "regionalConnectionQualityInsightsReport",
+      "regionalConnectionQualityTrendReport",
+      "remoteConnectionQualityReport",
+      "unknownFutureValue"
+    ],
+    "cloudPcConnectivityEventResult": [
+      "failure",
+      "success",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudPcConnectivityEventType": [
+      "deviceHealthCheck",
+      "unknown",
+      "unknownFutureValue",
+      "userConnection",
+      "userTroubleshooting"
+    ],
+    "cloudPcConnectivityStatus": [
+      "available",
+      "availableWithWarning",
+      "inUse",
+      "unavailable",
+      "underServiceMaintenance",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudPcDeviceImageErrorCode": [
+      "fSLogixInstalledSourceImageNotSupported",
+      "internalServerError",
+      "osVersionNotSupported",
+      "paidSourceImageNotSupport",
+      "sourceImageInvalid",
+      "sourceImageNotFound",
+      "sourceImageNotGeneralized",
+      "sourceImageNotSupportCustomizeVMName",
+      "sourceImageSizeExceedsLimitation",
+      "sourceImageWithAzureDiskEncryptionNotSupported",
+      "sourceImageWithDataDiskNotSupported",
+      "sourceImageWithDiskEncryptionSetNotSupported",
+      "startMenuAppLimitExceeded",
+      "unknownFutureValue",
+      "vmAlreadyAzureAdjoined"
+    ],
+    "cloudPcDeviceImageOsStatus": [
+      "supported",
+      "supportedWithWarning",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudPcDeviceImageStatus": [
+      "failed",
+      "pending",
+      "ready",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "cloudPcDeviceImageStatusDetails": [
+      "internalServerError",
+      "osVersionNotSupported",
+      "paidSourceImageNotSupport",
+      "sourceImageInvalid",
+      "sourceImageNotFound",
+      "sourceImageNotGeneralized",
+      "sourceImageNotSupportCustomizeVMName",
+      "sourceImageSizeExceedsLimitation",
+      "unknownFutureValue",
+      "vmAlreadyAzureAdjoined"
+    ],
+    "cloudPcDisasterRecoveryCapabilityType": [
+      "failback",
+      "failover",
+      "none",
+      "unknownFutureValue"
+    ],
+    "cloudPcDisasterRecoveryLicenseType": [
+      "none",
+      "plus",
+      "standard",
+      "unknownFutureValue"
+    ],
+    "cloudPcDisasterRecoveryReportName": [
+      "crossRegionDisasterRecoveryReport",
+      "disasterRecoveryReport",
+      "unknownFutureValue"
+    ],
+    "cloudPcDisasterRecoveryType": [
+      "crossRegion",
+      "notConfigured",
+      "premium",
+      "unknownFutureValue"
+    ],
+    "cloudPcDiskEncryptionState": [
+      "encryptedUsingCustomerManagedKey",
+      "encryptedUsingPlatformManagedKey",
+      "notAvailable",
+      "notEncrypted",
+      "unknownFutureValue"
+    ],
+    "cloudPcDiskEncryptionType": [
+      "customerManagedKey",
+      "platformManagedKey",
+      "unknownFutureValue"
+    ],
+    "cloudPcDomainJoinType": [
+      "azureADJoin",
+      "hybridAzureADJoin",
+      "unknownFutureValue"
+    ],
+    "cloudPcExportJobStatus": [
+      "completed",
+      "failed",
+      "inProgress",
+      "notStarted",
+      "unknownFutureValue"
+    ],
+    "cloudPcExternalPartnerActionErrorCode": [
+      "agentNotFound",
+      "checkDiskSpaceFailed",
+      "checkNetworkConnectionFailed",
+      "deviceNotAvailable",
+      "deviceNotFound",
+      "executeActionFailed",
+      "executeActionTimeout",
+      "invalidAgentChecksum",
+      "invalidAgentFormat",
+      "none",
+      "unknownFutureValue"
+    ],
+    "cloudPcExternalPartnerActionStatus": [
+      "canceled",
+      "created",
+      "failed",
+      "pending",
+      "running",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "cloudPcExternalPartnerActionType": [
+      "configureAgent",
+      "deployAgent",
+      "unknownFutureValue"
+    ],
+    "cloudPcExternalPartnerAuthenticatedMethod": [
+      "appOnly",
+      "dAP",
+      "gDAP",
+      "guestUser",
+      "normalUser",
+      "unknownFutureValue"
+    ],
+    "cloudPcExternalPartnerStatus": [
+      "available",
+      "healthy",
+      "notAvailable",
+      "unhealthy",
+      "unknownFutureValue"
+    ],
+    "cloudPCFrontlineReportType": [
+      "connectedUserRealtimeReport",
+      "licenseHourlyUsageReport",
+      "licenseUsageRealTimeReport",
+      "licenseUsageReport",
+      "noLicenseAvailableConnectivityFailureReport",
+      "unknownFutureValue"
+    ],
+    "cloudPcGalleryImageStatus": [
+      "notSupported",
+      "supported",
+      "supportedWithWarning",
+      "unknownFutureValue"
+    ],
+    "cloudPcGeographicLocationType": [
+      "africa",
+      "asia",
+      "australasia",
+      "canada",
+      "centralAmerica",
+      "default",
+      "europe",
+      "india",
+      "mexico",
+      "middleEast",
+      "southAmerica",
+      "unknownFutureValue",
+      "usCentral",
+      "usEast",
+      "usGovernment",
+      "usWest"
+    ],
+    "cloudPcImportedSnapshotState": [
+      "expired",
+      "inUse",
+      "notUsed",
+      "unknownFutureValue"
+    ],
+    "cloudPCInaccessibleReportName": [
+      "inaccessibleCloudPcReports",
+      "inaccessibleCloudPcTrendReport",
+      "regionalInaccessibleCloudPcTrendReport",
+      "unknownFutureValue"
+    ],
+    "cloudPcManagedLicenseStatus": [
+      "blocked",
+      "deleted",
+      "enabled",
+      "expired",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudPcManagedLicenseType": [
+      "frontline",
+      "reserve",
+      "unknownFutureValue"
+    ],
+    "cloudPcManagementService": [
+      "devBox",
+      "microsoft365BizChat",
+      "microsoft365Opal",
+      "rpaBox",
+      "unknownFutureValue",
+      "windows365"
+    ],
+    "cloudPcOnPremisesConnectionHealthCheckErrorType": [
+      "adJoinCheckAccessDenied",
+      "adJoinCheckAccountLockedOrDisabled",
+      "adJoinCheckAccountQuotaExceeded",
+      "adJoinCheckComputerObjectAlreadyExists",
+      "adJoinCheckCredentialsExpired",
+      "adJoinCheckFqdnNotFound",
+      "adJoinCheckIncorrectCredentials",
+      "adJoinCheckOrganizationalUnitIncorrectFormat",
+      "adJoinCheckOrganizationalUnitNotFound",
+      "adJoinCheckServerNotOperational",
+      "adJoinCheckUnknownError",
+      "azureAdDeviceSyncCheckConnectDisabled",
+      "azureAdDeviceSyncCheckDeviceNotFound",
+      "azureAdDeviceSyncCheckDurationExceeded",
+      "azureAdDeviceSyncCheckLongSyncCircle",
+      "azureAdDeviceSyncCheckScpNotConfigured",
+      "azureAdDeviceSyncCheckTransientServiceError",
+      "azureAdDeviceSyncCheckUnknownError",
+      "dnsCheckFqdnNotFound",
+      "dnsCheckNameWithInvalidCharacter",
+      "dnsCheckUnknownError",
+      "endpointConnectivityCheckAzureADUrlNotAllowListed",
+      "endpointConnectivityCheckCloudPcUrlNotAllowListed",
+      "endpointConnectivityCheckIntuneUrlNotAllowListed",
+      "endpointConnectivityCheckLocaleUrlNotAllowListed",
+      "endpointConnectivityCheckUnknownError",
+      "endpointConnectivityCheckVMAgentEndPointCommunicationError",
+      "endpointConnectivityCheckWVDUrlNotAllowListed",
+      "internalServerErrorAllocateResourceFailed",
+      "internalServerErrorDeploymentCanceled",
+      "internalServerErrorUnableToRunDscScript",
+      "internalServerErrorVMDeploymentTimeout",
+      "internalServerUnknownError",
+      "permissionCheckNoResourceGroupNetworkContributorRole",
+      "permissionCheckNoResourceGroupOwnerRole",
+      "permissionCheckNoSubscriptionReaderRole",
+      "permissionCheckNoVNetContributorRole",
+      "permissionCheckNoWindows365NetworkInterfaceContributorRole",
+      "permissionCheckNoWindows365NetworkUserRole",
+      "permissionCheckTransientServiceError",
+      "permissionCheckUnknownError",
+      "resourceAvailabilityCheckAzurePolicyViolation",
+      "resourceAvailabilityCheckDeploymentQuotaLimitReached",
+      "resourceAvailabilityCheckGeneralSubscriptionError",
+      "resourceAvailabilityCheckIntuneCustomWindowsRestrictionViolation",
+      "resourceAvailabilityCheckIntuneDefaultWindowsRestrictionViolation",
+      "resourceAvailabilityCheckMissingRegistrationForLocation",
+      "resourceAvailabilityCheckNoIntuneReaderRoleError",
+      "resourceAvailabilityCheckNoSubnetIP",
+      "resourceAvailabilityCheckResourceGroupBeingDeleted",
+      "resourceAvailabilityCheckResourceGroupInvalid",
+      "resourceAvailabilityCheckResourceGroupLockedForDelete",
+      "resourceAvailabilityCheckResourceGroupLockedForReadonly",
+      "resourceAvailabilityCheckSubnetDelegationFailed",
+      "resourceAvailabilityCheckSubnetInvalid",
+      "resourceAvailabilityCheckSubnetWithExternalResources",
+      "resourceAvailabilityCheckSubscriptionDisabled",
+      "resourceAvailabilityCheckSubscriptionNotFound",
+      "resourceAvailabilityCheckSubscriptionTransferred",
+      "resourceAvailabilityCheckTransientServiceError",
+      "resourceAvailabilityCheckUnknownError",
+      "resourceAvailabilityCheckUnsupportedVNetRegion",
+      "resourceAvailabilityCheckVNetBeingMoved",
+      "resourceAvailabilityCheckVNetInvalid",
+      "ssoCheckKerberosConfigurationError",
+      "udpConnectivityCheckStunUrlNotAllowListed",
+      "udpConnectivityCheckTurnUrlNotAllowListed",
+      "udpConnectivityCheckUnknownError",
+      "udpConnectivityCheckUrlsNotAllowListed",
+      "unknownFutureValue"
+    ],
+    "cloudPcOnPremisesConnectionStatus": [
+      "failed",
+      "informational",
+      "passed",
+      "pending",
+      "running",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "cloudPcOnPremisesConnectionType": [
+      "azureADJoin",
+      "hybridAzureADJoin",
+      "unknownFutureValue"
+    ],
+    "cloudPcOperatingSystem": [
+      "unknownFutureValue",
+      "windows10",
+      "windows11"
+    ],
+    "cloudPcOrganizationActionStatus": [
+      "failed",
+      "inProgress",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "cloudPcOrganizationActionType": [
+      "activate",
+      "deactivate",
+      "unknownFutureValue"
+    ],
+    "cloudPcPartnerAgentInstallStatus": [
+      "installed",
+      "installFailed",
+      "installing",
+      "licensed",
+      "uninstallFailed",
+      "uninstalling",
+      "unknownFutureValue"
+    ],
+    "cloudPcPartnerAgentName": [
+      "citrix",
+      "hp",
+      "unknownFutureValue",
+      "vMware"
+    ],
+    "cloudPCPerformanceReportName": [
+      "cloudPcInsightReport",
+      "performanceTrendReport",
+      "unknownFutureValue"
+    ],
+    "cloudPcPolicyApplyActionStatus": [
+      "failed",
+      "processing",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "cloudPcPolicySettingType": [
+      "region",
+      "singleSignOn",
+      "unknownFutureValue"
+    ],
+    "cloudPcPolicyTimezone": [
+      "acst",
+      "akst",
+      "art",
+      "ast",
+      "azot",
+      "bit",
+      "bst",
+      "cat",
+      "cet",
+      "cst",
+      "east",
+      "eat",
+      "est",
+      "fjt",
+      "get",
+      "gmt",
+      "gst",
+      "hst",
+      "ist",
+      "jst",
+      "lint",
+      "mit",
+      "mst",
+      "nst",
+      "nut",
+      "pgt",
+      "pkt",
+      "pst",
+      "sbt",
+      "tha",
+      "tot",
+      "unknownFutureValue"
+    ],
+    "cloudPcPowerState": [
+      "poweredOff",
+      "running",
+      "unknownFutureValue"
+    ],
+    "cloudPcProductType": [
+      "business",
+      "devBox",
+      "enterprise",
+      "frontline",
+      "powerAutomate",
+      "unknownFutureValue"
+    ],
+    "cloudPcProvisioningPolicyImageType": [
+      "custom",
+      "gallery",
+      "unknownFutureValue"
+    ],
+    "cloudPcProvisioningSourceType": [
+      "image",
+      "snapshot",
+      "unknownFutureValue"
+    ],
+    "cloudPcProvisioningType": [
+      "dedicated",
+      "reserve",
+      "shared",
+      "sharedByEntraGroup",
+      "sharedByUser",
+      "unknownFutureValue"
+    ],
+    "cloudPcRecommendationReportType": [
+      "cloudPcUsageCategoryReport",
+      "cloudPcUsageCategoryReports",
+      "unknownFutureValue"
+    ],
+    "cloudPcRegionGroup": [
+      "asia",
+      "australasia",
+      "australia",
+      "austria",
+      "automatic",
+      "belgium",
+      "brazil",
+      "canada",
+      "default",
+      "denmark",
+      "euap",
+      "europe",
+      "europeUnion",
+      "france",
+      "germany",
+      "hongKong",
+      "india",
+      "indonesia",
+      "ireland",
+      "israel",
+      "italy",
+      "japan",
+      "kenya",
+      "malaysia",
+      "mexico",
+      "middleEast",
+      "netherlands",
+      "newZealand",
+      "norway",
+      "poland",
+      "singapore",
+      "southAmerica",
+      "southKorea",
+      "spain",
+      "sweden",
+      "switzerland",
+      "taiwan",
+      "unitedKingdom",
+      "unknownFutureValue",
+      "usCentral",
+      "usEast",
+      "usGovernment",
+      "usGovernmentDOD",
+      "usWest"
+    ],
+    "cloudPcRemoteActionName": [
+      "changeUserAccountType",
+      "createSnapshot",
+      "moveRegion",
+      "placeUnderReview",
+      "powerOff",
+      "powerOn",
+      "rename",
+      "reprovision",
+      "resize",
+      "restart",
+      "restore",
+      "troubleshoot",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudPcReportName": [
+      "actionStatusReport",
+      "bulkActionStatusReport",
+      "cloudPcInsightReport",
+      "cloudPCInventoryReport",
+      "cloudPcUsageCategoryReport",
+      "cloudPcUsageCategoryReports",
+      "crossRegionDisasterRecoveryReport",
+      "dailyAggregatedRemoteConnectionReports",
+      "frontlineLicenseHourlyUsageReport",
+      "frontlineLicenseUsageRealTimeReport",
+      "frontlineLicenseUsageReport",
+      "frontlineRealtimeUserConnectionsReport",
+      "inaccessibleCloudPcReports",
+      "inaccessibleCloudPcTrendReport",
+      "noLicenseAvailableConnectivityFailureReport",
+      "performanceTrendReport",
+      "rawRemoteConnectionReports",
+      "regionalConnectionQualityInsightsReport",
+      "regionalConnectionQualityTrendReport",
+      "regionalInaccessibleCloudPcTrendReport",
+      "remoteConnectionHistoricalReports",
+      "remoteConnectionQualityReport",
+      "remoteConnectionQualityReports",
+      "totalAggregatedRemoteConnectionReports",
+      "troubleshootDetailsReport",
+      "troubleshootIssueCountReport",
+      "troubleshootRegionalReport",
+      "troubleshootTrendCountReport",
+      "unknownFutureValue"
+    ],
+    "cloudPcResizeValidationCode": [
+      "cloudPcNotFound",
+      "internalServerError",
+      "operationConflict",
+      "operationNotSupported",
+      "success",
+      "targetLicenseHasAssigned",
+      "unknownFutureValue"
+    ],
+    "cloudPcRestorePointFrequencyType": [
+      "default",
+      "fourHours",
+      "sixHours",
+      "sixteenHours",
+      "twelveHours",
+      "twentyFourHours",
+      "unknownFutureValue"
+    ],
+    "cloudPcServicePlanType": [
+      "business",
+      "enterprise",
+      "unknownFutureValue"
+    ],
+    "cloudPcSnapshotHealthCheckStatus": [
+      "healthy",
+      "unhealthy",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudPcSnapshotImportActionStatus": [
+      "failed",
+      "inProgress",
+      "pending",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "cloudPcSnapshotImportFileType": [
+      "dataFile",
+      "unknownFutureValue",
+      "virtualMachineGuestState"
+    ],
+    "cloudPcSnapshotImportSourceType": [
+      "azureStorageAccount",
+      "sasUrl",
+      "unknownFutureValue"
+    ],
+    "cloudPcSnapshotStatus": [
+      "ready",
+      "unknownFutureValue"
+    ],
+    "cloudPcSnapshotType": [
+      "automatic",
+      "manual",
+      "retention",
+      "unknownFutureValue"
+    ],
+    "cloudPcSourceImageCategory": [
+      "azureComputeGallery",
+      "managedImage",
+      "unknownFutureValue"
+    ],
+    "cloudPcStatus": [
+      "deprovisioning",
+      "failed",
+      "inGracePeriod",
+      "modifyingSingleSignOn",
+      "movingRegion",
+      "notProvisioned",
+      "pendingProvision",
+      "preparing",
+      "provisioned",
+      "provisionedWithWarnings",
+      "provisioning",
+      "refreshPolicyConfiguration",
+      "resizePendingLicense",
+      "resizing",
+      "restoring",
+      "unknownFutureValue",
+      "updatingSingleSignOn"
+    ],
+    "cloudPcStorageAccountAccessTier": [
+      "cold",
+      "cool",
+      "hot",
+      "premium",
+      "unknownFutureValue"
+    ],
+    "cloudPcSupportedRegionStatus": [
+      "available",
+      "restricted",
+      "unavailable",
+      "unknownFutureValue"
+    ],
+    "cloudPCTroubleshootReportType": [
+      "troubleshootDetailsReport",
+      "troubleshootIssueCountReport",
+      "troubleshootRegionalReport",
+      "troubleshootTrendCountReport",
+      "unknownFutureValue"
+    ],
+    "cloudPcUserAccessLevel": [
+      "restricted",
+      "unknownFutureValue",
+      "unrestricted"
+    ],
+    "cloudPcUserAccountType": [
+      "administrator",
+      "standardUser",
+      "unknownFutureValue"
+    ],
+    "cloudPcUserExperienceType": [
+      "cloudApp",
+      "cloudPc",
+      "unknownFutureValue"
+    ],
+    "cloudPCUserSettingsPersistenceProfileStatus": [
+      "connected",
+      "deleting",
+      "notConnected",
+      "unknownFutureValue"
+    ],
+    "cloudPcUserSettingsPersistenceStorageSizeCategory": [
+      "eightGB",
+      "fourGB",
+      "sixteenGB",
+      "sixtyFourGB",
+      "thirtyTwoGB",
+      "unknownFutureValue"
+    ],
+    "coachmarkLocationType": [
+      "displayName",
+      "externalTag",
+      "fromEmail",
+      "messageBody",
+      "subject",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "code": [
+      "datatypeMissing",
+      "datatypeNotSupported",
+      "descriptionInvalid",
+      "descriptionMissing",
+      "descriptionTooLarge",
+      "duplicateLocales",
+      "duplicateRules",
+      "englishLocaleMissing",
+      "jsonFileInvalid",
+      "jsonFileMissing",
+      "jsonFileTooLarge",
+      "moreInfoUriInvalid",
+      "moreInfoUriMissing",
+      "moreInfoUriTooLarge",
+      "none",
+      "operandInvalid",
+      "operandMissing",
+      "operandTooLarge",
+      "operatorDataTypeCombinationNotSupported",
+      "operatorMissing",
+      "operatorNotSupported",
+      "remediationStringsMissing",
+      "rulesMissing",
+      "settingNameInvalid",
+      "settingNameMissing",
+      "settingNameTooLarge",
+      "titleInvalid",
+      "titleMissing",
+      "titleTooLarge",
+      "tooManyRulesSpecified",
+      "unknown",
+      "unrecognizedLocale"
+    ],
+    "columnTypes": [
+      "approvalStatus",
+      "boolean",
+      "calculated",
+      "choice",
+      "currency",
+      "dateTime",
+      "geolocation",
+      "location",
+      "lookup",
+      "multichoice",
+      "multiterm",
+      "note",
+      "number",
+      "term",
+      "text",
+      "thumbnail",
+      "unknownFutureValue",
+      "url",
+      "user"
+    ],
+    "comanagementEligibleType": [
+      "comanaged",
+      "eligible",
+      "eligibleButNotAzureAdJoined",
+      "ineligible",
+      "needsOsUpdate",
+      "scheduledForEnrollment",
+      "unknownFutureValue"
+    ],
+    "communityPrivacy": [
+      "private",
+      "public",
+      "unknownFutureValue"
+    ],
+    "companyPortalAction": [
+      "remove",
+      "reset",
+      "unknown"
+    ],
+    "complianceState": [
+      "compliant",
+      "configManager",
+      "conflict",
+      "error",
+      "inGracePeriod",
+      "noncompliant",
+      "unknown"
+    ],
+    "complianceStatus": [
+      "compliant",
+      "conflict",
+      "error",
+      "nonCompliant",
+      "notApplicable",
+      "notAssigned",
+      "remediated",
+      "unknown"
+    ],
+    "compliantNetworkType": [
+      "allTenantCompliantNetworks",
+      "unknownFutureValue"
+    ],
+    "component": [
+      "Label"
+    ],
+    "conditionalAccessAgentIdRiskLevels": [
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "conditionalAccessClientApp": [
+      "all",
+      "browser",
+      "easSupported",
+      "exchangeActiveSync",
+      "mobileAppsAndDesktopClients",
+      "other",
+      "unknownFutureValue"
+    ],
+    "conditionalAccessConditions": [
+      "application",
+      "authenticationFlows",
+      "client",
+      "clientType",
+      "devicePlatform",
+      "deviceState",
+      "insiderRisk",
+      "ipAddressSeenByAzureAD",
+      "ipAddressSeenByResourceProvider",
+      "location",
+      "none",
+      "servicePrincipalRisk",
+      "servicePrincipals",
+      "signInRisk",
+      "time",
+      "unknownFutureValue",
+      "userRisk",
+      "users"
+    ],
+    "conditionalAccessDevicePlatform": [
+      "all",
+      "android",
+      "iOS",
+      "linux",
+      "macOS",
+      "unknownFutureValue",
+      "windows",
+      "windowsPhone"
+    ],
+    "conditionalAccessExternalTenantsMembershipKind": [
+      "all",
+      "enumerated",
+      "unknownFutureValue"
+    ],
+    "conditionalAccessGrantControl": [
+      "approvedApplication",
+      "block",
+      "compliantApplication",
+      "compliantDevice",
+      "domainJoinedDevice",
+      "mfa",
+      "passwordChange",
+      "riskRemediation",
+      "unknownFutureValue"
+    ],
+    "conditionalAccessGuestOrExternalUserTypes": [
+      "b2bCollaborationGuest",
+      "b2bCollaborationMember",
+      "b2bDirectConnectUser",
+      "internalGuest",
+      "none",
+      "otherExternalUser",
+      "serviceProvider",
+      "unknownFutureValue"
+    ],
+    "conditionalAccessInsiderRiskLevels": [
+      "elevated",
+      "minor",
+      "moderate",
+      "unknownFutureValue"
+    ],
+    "conditionalAccessPolicyState": [
+      "disabled",
+      "enabled",
+      "enabledForReportingButNotEnforced"
+    ],
+    "conditionalAccessRule": [
+      "acr",
+      "allApps",
+      "allDevicePlatforms",
+      "allDevices",
+      "allDeviceStates",
+      "allLocations",
+      "allTrustedLocations",
+      "allUsers",
+      "anonymizedIPAddress",
+      "appFilter",
+      "appId",
+      "authenticationTransfer",
+      "b2bCollaborationGuest",
+      "b2bCollaborationMember",
+      "b2bDirectConnectUser",
+      "deviceCodeFlow",
+      "deviceFilter",
+      "deviceFilterIncludeRuleNotMatched",
+      "devicePlatform",
+      "deviceState",
+      "firstPartyApps",
+      "groupId",
+      "guest",
+      "insideCorpnet",
+      "insiderRisk",
+      "internalGuest",
+      "locationId",
+      "microsoftAdminPortals",
+      "nationStateIPAddress",
+      "office365",
+      "otherExternalUser",
+      "realTimeThreatIntelligence",
+      "roleId",
+      "serviceProvider",
+      "unfamiliarFeatures",
+      "unknownFutureValue",
+      "userId"
+    ],
+    "conditionalAccessStatus": [
+      "failure",
+      "notApplied",
+      "success",
+      "unknownFutureValue"
+    ],
+    "conditionalAccessTransferMethods": [
+      "authenticationTransfer",
+      "deviceCodeFlow",
+      "none",
+      "unknownFutureValue"
+    ],
+    "configurationManagerActionDeliveryStatus": [
+      "deliveredToConnectorService",
+      "deliveredToOnPremisesServer",
+      "failedToDeliverToConnectorService",
+      "pendingDelivery",
+      "unknown"
+    ],
+    "configurationManagerActionType": [
+      "appEvaluation",
+      "fullScan",
+      "quickScan",
+      "refreshMachinePolicy",
+      "refreshUserPolicy",
+      "wakeUpClient",
+      "windowsDefenderUpdateSignatures"
+    ],
+    "configurationManagerClientState": [
+      "communicationError",
+      "healthy",
+      "installed",
+      "installFailed",
+      "unknown",
+      "updateFailed"
+    ],
+    "configurationUsage": [
+      "allowed",
+      "blocked",
+      "notConfigured",
+      "required"
+    ],
+    "confirmedBy": [
+      "manager",
+      "none",
+      "unknownFutureValue",
+      "user"
+    ],
+    "connectedOrganizationState": [
+      "configured",
+      "proposed",
+      "unknownFutureValue"
+    ],
+    "connectionDirection": [
+      "inbound",
+      "outbound",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "connectionOperationStatus": [
+      "completed",
+      "failed",
+      "inprogress",
+      "unspecified"
+    ],
+    "connectionState": [
+      "draft",
+      "limitExceeded",
+      "obsolete",
+      "ready",
+      "unknownFutureValue"
+    ],
+    "connectionStatus": [
+      "attempted",
+      "blocked",
+      "failed",
+      "succeeded",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "connectionType": [
+      "unknownFutureValue",
+      "webSocket"
+    ],
+    "connectorGroupRegion": [
+      "asia",
+      "aus",
+      "eur",
+      "ind",
+      "nam",
+      "unknownFutureValue"
+    ],
+    "connectorGroupType": [
+      "applicationProxy"
+    ],
+    "connectorHealthState": [
+      "healthy",
+      "unhealthy",
+      "unknown",
+      "warning"
+    ],
+    "connectorName": [
+      "appleDepExpirationDateTime",
+      "appleDepLastSyncDateTime",
+      "applePushNotificationServiceExpirationDateTime",
+      "chromebookLastDirectorySyncDateTime",
+      "futureValue",
+      "googlePlayAppLastSyncDateTime",
+      "googlePlayConnectorLastModifiedDateTime",
+      "jamfLastSyncDateTime",
+      "mobileThreatDefenceConnectorLastHeartbeatDateTime",
+      "ndesConnectorLastConnectionDateTime",
+      "onPremConnectorLastSyncDateTime",
+      "vppTokenExpirationDateTime",
+      "vppTokenLastSyncDateTime",
+      "windowsAutopilotLastSyncDateTime",
+      "windowsDefenderATPConnectorLastHeartbeatDateTime",
+      "windowsStoreForBusinessLastSyncDateTime"
+    ],
+    "connectorStatus": [
+      "active",
+      "inactive"
+    ],
+    "connectorType": [
+      "sapAc",
+      "sapIag",
+      "unknownFutureValue"
+    ],
+    "consentRequestFilterByCurrentUserOptions": [
+      "reviewer",
+      "unknownFutureValue"
+    ],
+    "contactRelationship": [
+      "aide",
+      "child",
+      "doctor",
+      "guardian",
+      "other",
+      "parent",
+      "relative",
+      "unknownFutureValue"
+    ],
+    "contentAlignment": [
+      "center",
+      "left",
+      "right"
+    ],
+    "contentCategory": [
+      "ai",
+      "none",
+      "unknownFutureValue"
+    ],
+    "contentFormat": [
+      "default",
+      "email"
+    ],
+    "contentModelType": [
+      "freeformSelectionMethod",
+      "layoutMethod",
+      "prebuiltContractModel",
+      "prebuiltInvoiceModel",
+      "prebuiltReceiptModel",
+      "teachingMethod",
+      "unknownFutureValue"
+    ],
+    "contentProcessingErrorType": [
+      "permanent",
+      "transient",
+      "unknownFutureValue"
+    ],
+    "contentState": [
+      "motion",
+      "rest",
+      "use"
+    ],
+    "continuousAccessEvaluationMode": [
+      "disabled",
+      "strictEnforcement",
+      "strictLocation",
+      "unknownFutureValue"
+    ],
+    "copilotConversationAttributionSource": [
+      "grounding",
+      "model",
+      "unknownFutureValue"
+    ],
+    "copilotConversationAttributionType": [
+      "annotation",
+      "citation",
+      "unknownFutureValue"
+    ],
+    "copilotConversationState": [
+      "active",
+      "disengagedForRai",
+      "unknownFutureValue"
+    ],
+    "copilotSearchResourceType": [
+      "drive",
+      "driveItem",
+      "list",
+      "listItem",
+      "site",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "countryLookupMethodType": [
+      "authenticatorAppGps",
+      "clientIpAddress",
+      "unknownFutureValue"
+    ],
+    "courseStatus": [
+      "completed",
+      "inProgress",
+      "notStarted",
+      "unknownFutureValue"
+    ],
+    "crossTenantAccessPolicyTargetConfigurationAccessType": [
+      "allowed",
+      "blocked",
+      "unknownFutureValue"
+    ],
+    "crossTenantAccessPolicyTargetType": [
+      "application",
+      "group",
+      "unknownFutureValue",
+      "user"
+    ],
+    "crossTenantMigrationJobStatus": [
+      "adminActionRequired",
+      "approved",
+      "cancelled",
+      "completed",
+      "completedWithErrors",
+      "cuttingOver",
+      "deleted",
+      "failed",
+      "inProgress",
+      "pendingCancel",
+      "pendingDelete",
+      "processing",
+      "submitted",
+      "unknownFutureValue",
+      "validateFailed",
+      "validateInProgress",
+      "validatePassed",
+      "validateProcessing",
+      "validateSubmitted"
+    ],
+    "crossTenantMigrationJobType": [
+      "migrate",
+      "unknownFutureValue",
+      "validate"
+    ],
+    "crossTenantMigrationServiceStatus": [
+      "cancelled",
+      "completed",
+      "error",
+      "failed",
+      "finalizing",
+      "forceComplete",
+      "inProgress",
+      "invalid",
+      "notStarted",
+      "pendingCancel",
+      "synced",
+      "syncing",
+      "unknownFutureValue",
+      "valid"
+    ],
+    "csaStarLevel": [
+      "attestation",
+      "certification",
+      "continuousMonitoring",
+      "cStarAssessment",
+      "none",
+      "notSupported",
+      "selfAssessment",
+      "unknownFutureValue"
+    ],
+    "customDataProvidedResourceUploadStatus": [
+      "active",
+      "complete",
+      "expired",
+      "unknownFutureValue"
+    ],
+    "customExtensionCalloutInstanceStatus": [
+      "callbackReceived",
+      "callbackTimedOut",
+      "calloutFailed",
+      "calloutSent",
+      "unknownFutureValue",
+      "waitingForCallback"
+    ],
+    "customSecurityAttributeComparisonOperator": [
+      "equals",
+      "unknownFutureValue"
+    ],
+    "dataCollectionStatus": [
+      "offline",
+      "online",
+      "unknownFutureValue"
+    ],
+    "dataPolicyOperationStatus": [
+      "complete",
+      "failed",
+      "notStarted",
+      "running",
+      "unknownFutureValue"
+    ],
+    "dataProtection": [
+      "impactAssessments",
+      "none",
+      "officers",
+      "secureCrossBorderDataTransfer",
+      "unknownFutureValue"
+    ],
+    "dataRetentionLevel": [
+      "dataRetained",
+      "deletedImmediately",
+      "deletedWithin1Month",
+      "deletedWithin2Weeks",
+      "deletedWithin3Months",
+      "deletedWithinMoreThan3Months",
+      "none",
+      "unknownFutureValue"
+    ],
+    "dataSubjectType": [
+      "currentEmployee",
+      "customer",
+      "faculty",
+      "formerEmployee",
+      "other",
+      "prospectiveEmployee",
+      "student",
+      "teacher",
+      "unknownFutureValue"
+    ],
+    "dataType": [
+      "base64",
+      "boolean",
+      "booleanArray",
+      "dateTime",
+      "dateTimeArray",
+      "double",
+      "doubleArray",
+      "int64",
+      "int64Array",
+      "none",
+      "string",
+      "stringArray",
+      "version",
+      "versionArray",
+      "xml"
+    ],
+    "dayOfWeek": [
+      "friday",
+      "monday",
+      "saturday",
+      "sunday",
+      "thursday",
+      "tuesday",
+      "wednesday"
+    ],
+    "decisionItemPrincipalResourceMembershipType": [
+      "direct",
+      "indirect",
+      "unknownFutureValue"
+    ],
+    "defaultMfaMethodType": [
+      "alternateMobilePhone",
+      "microsoftAuthenticatorPush",
+      "mobilePhone",
+      "none",
+      "officePhone",
+      "softwareOneTimePasscode",
+      "unknownFutureValue"
+    ],
+    "defenderAttackSurfaceType": [
+      "auditMode",
+      "block",
+      "disable",
+      "userDefined",
+      "warn"
+    ],
+    "defenderCloudBlockLevelType": [
+      "high",
+      "highPlus",
+      "notConfigured",
+      "zeroTolerance"
+    ],
+    "defenderMonitorFileActivity": [
+      "disable",
+      "monitorAllFiles",
+      "monitorIncomingFilesOnly",
+      "monitorOutgoingFilesOnly",
+      "userDefined"
+    ],
+    "defenderPotentiallyUnwantedAppAction": [
+      "audit",
+      "block",
+      "deviceDefault"
+    ],
+    "defenderPromptForSampleSubmission": [
+      "alwaysPrompt",
+      "neverSendData",
+      "promptBeforeSendingPersonalData",
+      "sendAllDataWithoutPrompting",
+      "userDefined"
+    ],
+    "defenderProtectionType": [
+      "auditMode",
+      "enable",
+      "notConfigured",
+      "userDefined",
+      "warn"
+    ],
+    "defenderRealtimeScanDirection": [
+      "monitorAllFiles",
+      "monitorIncomingFilesOnly",
+      "monitorOutgoingFilesOnly"
+    ],
+    "defenderScanType": [
+      "disabled",
+      "full",
+      "quick",
+      "userDefined"
+    ],
+    "defenderSecurityCenterITContactDisplayType": [
+      "displayInAppAndInNotifications",
+      "displayOnlyInApp",
+      "displayOnlyInNotifications",
+      "notConfigured"
+    ],
+    "defenderSecurityCenterNotificationsFromAppType": [
+      "blockAllNotifications",
+      "blockNoncriticalNotifications",
+      "notConfigured"
+    ],
+    "defenderSubmitSamplesConsentType": [
+      "alwaysPrompt",
+      "neverSend",
+      "sendAllSamplesAutomatically",
+      "sendSafeSamplesAutomatically"
+    ],
+    "defenderThreatAction": [
+      "allow",
+      "block",
+      "clean",
+      "deviceDefault",
+      "quarantine",
+      "remove",
+      "userDefined"
+    ],
+    "delegatedAdminAccessAssignmentStatus": [
+      "active",
+      "deleted",
+      "deleting",
+      "error",
+      "pending",
+      "unknownFutureValue"
+    ],
+    "delegatedAdminAccessContainerType": [
+      "securityGroup",
+      "unknownFutureValue"
+    ],
+    "delegatedAdminRelationshipOperationType": [
+      "delegatedAdminAccessAssignmentUpdate",
+      "delegatedAdminRelationshipUpdate",
+      "unknownFutureValue"
+    ],
+    "delegatedAdminRelationshipRequestAction": [
+      "approve",
+      "lockForApproval",
+      "reject",
+      "terminate",
+      "unknownFutureValue"
+    ],
+    "delegatedAdminRelationshipRequestStatus": [
+      "created",
+      "failed",
+      "pending",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "delegatedAdminRelationshipStatus": [
+      "activating",
+      "active",
+      "approvalPending",
+      "approved",
+      "created",
+      "expired",
+      "expiring",
+      "terminated",
+      "terminating",
+      "terminationRequested",
+      "unknownFutureValue"
+    ],
+    "delegateMeetingMessageDeliveryOptions": [
+      "sendToDelegateAndInformationToPrincipal",
+      "sendToDelegateAndPrincipal",
+      "sendToDelegateOnly"
+    ],
+    "deliveryOptimizationGroupIdOptionsType": [
+      "adSite",
+      "authenticatedDomainSid",
+      "dhcpUserOption",
+      "dnsSuffix",
+      "notConfigured"
+    ],
+    "deliveryOptimizationRestrictPeerSelectionByOptions": [
+      "notConfigured",
+      "subnetMask"
+    ],
+    "depTokenType": [
+      "appleSchoolManager",
+      "dep",
+      "none"
+    ],
+    "derivedCredentialProviderType": [
+      "entrustDataCard",
+      "intercede",
+      "notConfigured",
+      "purebred",
+      "xTec"
+    ],
+    "destinationType": [
+      "inPlace",
+      "new",
+      "unknownFutureValue"
+    ],
+    "detectedAppPlatformType": [
+      "androidDedicatedAndFullyManaged",
+      "androidDeviceAdministrator",
+      "androidOSP",
+      "androidWorkProfile",
+      "chromeOS",
+      "ios",
+      "macOS",
+      "unknown",
+      "unknownFutureValue",
+      "windows",
+      "windowsHolographic",
+      "windowsMobile"
+    ],
+    "deviceActionCategory": [
+      "bulk",
+      "single"
+    ],
+    "deviceAndAppManagementAssignmentFilterType": [
+      "exclude",
+      "include",
+      "none"
+    ],
+    "deviceAndAppManagementAssignmentSource": [
+      "direct",
+      "policySets"
+    ],
+    "deviceAndAppManagementPayloadType": [
+      "antivirus",
+      "attackSurfaceReduction",
+      "compliancePolicy",
+      "deviceRestrictions",
+      "diskEncryption",
+      "endpointDetectionAndResponse",
+      "firewall",
+      "securityBaseline",
+      "settingsCatalog",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "deviceAppManagementTaskCategory": [
+      "advancedThreatProtection",
+      "unknown"
+    ],
+    "deviceAppManagementTaskPriority": [
+      "high",
+      "low",
+      "none"
+    ],
+    "deviceAppManagementTaskStatus": [
+      "active",
+      "completed",
+      "pending",
+      "rejected",
+      "unknown"
+    ],
+    "deviceAssignmentItemIntent": [
+      "remove",
+      "restore",
+      "unknownFutureValue"
+    ],
+    "deviceAssignmentItemStatus": [
+      "error",
+      "initiated",
+      "inProgress",
+      "removed",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "deviceAssignmentItemType": [
+      "application",
+      "deviceConfiguration",
+      "deviceManagementConfigurationPolicy",
+      "mobileAppConfiguration",
+      "unknownFutureValue"
+    ],
+    "deviceCleanupRulePlatformType": [
+      "all",
+      "androidAOSP",
+      "androidDedicatedAndFullyManagedCorporateOwnedWorkProfile",
+      "androidDeviceAdministrator",
+      "androidPersonallyOwnedWorkProfile",
+      "chromeOS",
+      "ios",
+      "macOS",
+      "tvOS",
+      "unknownFutureValue",
+      "visionOS",
+      "windows",
+      "windowsHolographic"
+    ],
+    "deviceComplianceActionType": [
+      "block",
+      "noAction",
+      "notification",
+      "pushNotification",
+      "remoteLock",
+      "removeResourceAccessProfiles",
+      "retire",
+      "wipe"
+    ],
+    "deviceComplianceScriptRuleDataType": [
+      "base64",
+      "boolean",
+      "booleanArray",
+      "dateTime",
+      "dateTimeArray",
+      "double",
+      "doubleArray",
+      "int64",
+      "int64Array",
+      "none",
+      "string",
+      "stringArray",
+      "version",
+      "versionArray",
+      "xml"
+    ],
+    "deviceComplianceScriptRulesValidationError": [
+      "datatypeMissing",
+      "datatypeNotSupported",
+      "descriptionInvalid",
+      "descriptionMissing",
+      "descriptionTooLarge",
+      "duplicateLocales",
+      "duplicateRules",
+      "englishLocaleMissing",
+      "jsonFileInvalid",
+      "jsonFileMissing",
+      "jsonFileTooLarge",
+      "moreInfoUriInvalid",
+      "moreInfoUriMissing",
+      "moreInfoUriTooLarge",
+      "none",
+      "operandInvalid",
+      "operandMissing",
+      "operandTooLarge",
+      "operatorDataTypeCombinationNotSupported",
+      "operatorMissing",
+      "operatorNotSupported",
+      "remediationStringsMissing",
+      "rulesMissing",
+      "settingNameInvalid",
+      "settingNameMissing",
+      "settingNameTooLarge",
+      "titleInvalid",
+      "titleMissing",
+      "titleTooLarge",
+      "tooManyRulesSpecified",
+      "unknown",
+      "unrecognizedLocale"
+    ],
+    "deviceComplianceScriptRulOperator": [
+      "allOf",
+      "and",
+      "beginsWith",
+      "between",
+      "contains",
+      "dayTimeBetween",
+      "endsWith",
+      "excludesAll",
+      "greaterEquals",
+      "greaterThan",
+      "isEquals",
+      "lessEquals",
+      "lessThan",
+      "none",
+      "noneOf",
+      "notBeginsWith",
+      "notBetween",
+      "notContains",
+      "notEndsWith",
+      "notEquals",
+      "oneOf",
+      "or",
+      "orderedSetEquals",
+      "setEquals",
+      "subsetOf"
+    ],
+    "deviceConfigAssignmentIntent": [
+      "apply",
+      "remove"
+    ],
+    "deviceCustomAttributeValueType": [
+      "dateTime",
+      "integer",
+      "string"
+    ],
+    "deviceEnrollmentConfigurationType": [
+      "defaultLimit",
+      "defaultPlatformRestrictions",
+      "defaultWindows10EnrollmentCompletionPageConfiguration",
+      "defaultWindowsHelloForBusiness",
+      "deviceComanagementAuthorityConfiguration",
+      "enrollmentNotificationsConfiguration",
+      "limit",
+      "platformRestrictions",
+      "singlePlatformRestriction",
+      "unknown",
+      "unknownFutureValue",
+      "windows10EnrollmentCompletionPageConfiguration",
+      "windowsHelloForBusiness",
+      "windowsRestore"
+    ],
+    "deviceEnrollmentFailureReason": [
+      "accountValidation",
+      "authentication",
+      "authorization",
+      "badRequest",
+      "clientDisconnected",
+      "deviceNotSupported",
+      "enrollmentRestrictionsEnforced",
+      "featureNotSupported",
+      "inMaintenance",
+      "unknown",
+      "userAbandonment",
+      "userValidation"
+    ],
+    "deviceEnrollmentType": [
+      "androidAOSPUserlessDeviceEnrollment",
+      "androidAOSPUserOwnedDeviceEnrollment",
+      "androidEnterpriseCorporateWorkProfile",
+      "androidEnterpriseDedicatedDevice",
+      "androidEnterpriseFullyManaged",
+      "appleAccountDrivenUserEnrollment",
+      "appleBulkWithoutUser",
+      "appleBulkWithUser",
+      "appleUserEnrollment",
+      "appleUserEnrollmentWithServiceAccount",
+      "azureAdJoinUsingAzureVmExtension",
+      "deviceEnrollmentManager",
+      "unknown",
+      "unknownFutureValue",
+      "userEnrollment",
+      "windowsAutoEnrollment",
+      "windowsAzureADJoin",
+      "windowsAzureADJoinUsingDeviceAuth",
+      "windowsBulkAzureDomainJoin",
+      "windowsBulkUserless",
+      "windowsCoManagement"
+    ],
+    "deviceEventLevel": [
+      "critical",
+      "error",
+      "information",
+      "none",
+      "unknownFutureValue",
+      "verbose",
+      "warning"
+    ],
+    "deviceGuardLocalSystemAuthorityCredentialGuardState": [
+      "notConfigured",
+      "notLicensed",
+      "rebootRequired",
+      "running",
+      "virtualizationBasedSecurityNotRunning"
+    ],
+    "deviceGuardLocalSystemAuthorityCredentialGuardType": [
+      "disable",
+      "enableWithoutUEFILock",
+      "enableWithUEFILock",
+      "notConfigured"
+    ],
+    "deviceGuardVirtualizationBasedSecurityHardwareRequirementState": [
+      "dmaProtectionRequired",
+      "hyperVNotAvailable",
+      "hyperVNotSupportedForGuestVM",
+      "meetHardwareRequirements",
+      "secureBootRequired"
+    ],
+    "deviceGuardVirtualizationBasedSecurityState": [
+      "doesNotMeetHardwareRequirements",
+      "notConfigured",
+      "notLicensed",
+      "other",
+      "rebootRequired",
+      "require64BitArchitecture",
+      "running"
+    ],
+    "deviceHealthScriptType": [
+      "deviceHealthScript",
+      "managedInstallerScript"
+    ],
+    "deviceIdentityAttestationStatus": [
+      "incompleteData",
+      "notSupported",
+      "trusted",
+      "unknown",
+      "unknownFutureValue",
+      "unTrusted"
+    ],
+    "deviceLicensingStatus": [
+      "acquiringDeviceLicense",
+      "deviceIdentityVerificationFailed",
+      "deviceIsNotAzureActiveDirectoryJoined",
+      "deviceLicenseRefreshFailed",
+      "deviceLicenseRefreshSucceed",
+      "deviceLicenseRemoveFailed",
+      "deviceLicenseRemoveSucceed",
+      "licenseRefreshPending",
+      "licenseRefreshStarted",
+      "microsoftAccountVerificationFailed",
+      "refreshingDeviceLicense",
+      "removingDeviceLicense",
+      "unknown",
+      "unknownFutureValue",
+      "verifyingMicrosoftAccountIdentity",
+      "verifyingMicrosoftDeviceIdentity"
+    ],
+    "deviceLogCollectionTemplateType": [
+      "predefined",
+      "unknownFutureValue"
+    ],
+    "deviceManagementApplicabilityRuleType": [
+      "exclude",
+      "include"
+    ],
+    "deviceManagementAutopilotPolicyComplianceStatus": [
+      "compliant",
+      "error",
+      "installed",
+      "notCompliant",
+      "notInstalled",
+      "unknown"
+    ],
+    "deviceManagementAutopilotPolicyType": [
+      "application",
+      "appModel",
+      "configurationPolicy",
+      "unknown"
+    ],
+    "deviceManagementCertificationAuthority": [
+      "digiCert",
+      "microsoft",
+      "notConfigured"
+    ],
+    "deviceManagementComparisonResult": [
+      "added",
+      "equal",
+      "notEqual",
+      "removed",
+      "unknown"
+    ],
+    "deviceManagementComplianceActionType": [
+      "block",
+      "noAction",
+      "notification",
+      "pushNotification",
+      "remoteLock",
+      "removeResourceAccessProfiles",
+      "retire",
+      "wipe"
+    ],
+    "deviceManagementConfigurationAppleApplicabilityConstraint": [
+      "allowUserEnrollment",
+      "deviceChannel",
+      "notSupported",
+      "requireDepEnrolled",
+      "requireSupervised",
+      "requireUserApproved",
+      "unknownFutureValue",
+      "userChannel"
+    ],
+    "deviceManagementConfigurationAppleApplicabilityDeviceType": [
+      "ios",
+      "macOS",
+      "none",
+      "sharediPad",
+      "unknownFutureValue"
+    ],
+    "deviceManagementConfigurationAzureAdTrustType": [
+      "addWorkAccount",
+      "azureAdJoined",
+      "mdmOnly",
+      "none"
+    ],
+    "deviceManagementConfigurationControlType": [
+      "contextPane",
+      "default",
+      "dropdown",
+      "largeTextBox",
+      "multiheaderGrid",
+      "smallTextBox",
+      "toggle",
+      "unknownFutureValue"
+    ],
+    "deviceManagementConfigurationDeviceMode": [
+      "kiosk",
+      "none"
+    ],
+    "deviceManagementConfigurationPlatforms": [
+      "android",
+      "androidEnterprise",
+      "aosp",
+      "iOS",
+      "linux",
+      "macOS",
+      "none",
+      "tvOS",
+      "unknownFutureValue",
+      "visionOS",
+      "windows10",
+      "windows10X"
+    ],
+    "deviceManagementConfigurationSecretSettingValueState": [
+      "encryptedValueToken",
+      "invalid",
+      "notEncrypted"
+    ],
+    "deviceManagementConfigurationSettingAccessTypes": [
+      "add",
+      "copy",
+      "delete",
+      "execute",
+      "get",
+      "none",
+      "replace"
+    ],
+    "deviceManagementConfigurationSettingRiskLevel": [
+      "high",
+      "low",
+      "medium"
+    ],
+    "deviceManagementConfigurationSettingUsage": [
+      "compliance",
+      "configuration",
+      "none",
+      "reusableSetting",
+      "unknownFutureValue"
+    ],
+    "deviceManagementConfigurationSettingVisibility": [
+      "none",
+      "settingsCatalog",
+      "template",
+      "unknownFutureValue"
+    ],
+    "deviceManagementConfigurationStringFormat": [
+      "base64",
+      "bashScript",
+      "binary",
+      "date",
+      "dateTime",
+      "email",
+      "guid",
+      "ip",
+      "json",
+      "none",
+      "regEx",
+      "surfaceHub",
+      "time",
+      "unknownFutureValue",
+      "url",
+      "version",
+      "xml"
+    ],
+    "deviceManagementConfigurationTechnologies": [
+      "android",
+      "appleRemoteManagement",
+      "configManager",
+      "documentGateway",
+      "endpointPrivilegeManagement",
+      "enrollment",
+      "exchangeOnline",
+      "intuneManagementExtension",
+      "linuxMdm",
+      "mdm",
+      "microsoftSense",
+      "mobileApplicationManagement",
+      "none",
+      "thirdParty",
+      "unknownFutureValue",
+      "windows10XManagement",
+      "windowsOsRecovery"
+    ],
+    "deviceManagementConfigurationTemplateFamily": [
+      "appQuietTime",
+      "baseline",
+      "companyPortal",
+      "deviceConfigurationPolicies",
+      "deviceConfigurationScripts",
+      "endpointSecurityAccountProtection",
+      "endpointSecurityAntivirus",
+      "endpointSecurityApplicationControl",
+      "endpointSecurityAttackSurfaceReduction",
+      "endpointSecurityDiskEncryption",
+      "endpointSecurityEndpointDetectionAndResponse",
+      "endpointSecurityEndpointPrivilegeManagement",
+      "endpointSecurityFirewall",
+      "enrollmentConfiguration",
+      "none",
+      "unknownFutureValue",
+      "windowsOsRecoveryPolicies",
+      "windowsRecoveryAndRemediationConfiguration"
+    ],
+    "deviceManagementConfigurationWindowsSkus": [
+      "holographicForBusiness",
+      "holoLens",
+      "holoLensEnterprise",
+      "iot",
+      "iotEnterprise",
+      "surfaceHub",
+      "unknown",
+      "windowsEducation",
+      "windowsEnterprise",
+      "windowsHome",
+      "windowsMobile",
+      "windowsMobileEnterprise",
+      "windowsMultiSession",
+      "windowsProfessional",
+      "windowsTeamSurface"
+    ],
+    "deviceManagementDerivedCredentialIssuer": [
+      "entrustDatacard",
+      "intercede",
+      "purebred",
+      "xTec"
+    ],
+    "deviceManagementDerivedCredentialNotificationType": [
+      "companyPortal",
+      "email",
+      "none"
+    ],
+    "deviceManagementDomainJoinConnectorState": [
+      "active",
+      "error",
+      "inactive"
+    ],
+    "deviceManagementExchangeAccessLevel": [
+      "allow",
+      "block",
+      "none",
+      "quarantine"
+    ],
+    "deviceManagementExchangeAccessRuleType": [
+      "family",
+      "model"
+    ],
+    "deviceManagementExchangeAccessState": [
+      "allowed",
+      "blocked",
+      "none",
+      "quarantined",
+      "unknown"
+    ],
+    "deviceManagementExchangeAccessStateReason": [
+      "azureADBlockDueToAccessPolicy",
+      "compliant",
+      "compromisedPassword",
+      "deviceNotKnownWithManagedApp",
+      "exchangeDeviceRule",
+      "exchangeGlobalRule",
+      "exchangeIndividualRule",
+      "exchangeMailboxPolicy",
+      "exchangeUpgrade",
+      "mfaRequired",
+      "none",
+      "notCompliant",
+      "notEnrolled",
+      "other",
+      "unknown",
+      "unknownLocation"
+    ],
+    "deviceManagementExchangeConnectorStatus": [
+      "connected",
+      "connectionPending",
+      "disconnected",
+      "none",
+      "unknownFutureValue"
+    ],
+    "deviceManagementExchangeConnectorSyncType": [
+      "deltaSync",
+      "fullSync"
+    ],
+    "deviceManagementExchangeConnectorType": [
+      "dedicated",
+      "hosted",
+      "onPremises",
+      "serviceToService",
+      "unknownFutureValue"
+    ],
+    "deviceManagementExportJobLocalizationType": [
+      "localizedValuesAsAdditionalColumn",
+      "replaceLocalizableValues"
+    ],
+    "deviceManagementPartnerAppType": [
+      "multiTenantApp",
+      "singleTenantApp",
+      "unknown"
+    ],
+    "deviceManagementPartnerTenantState": [
+      "enabled",
+      "rejected",
+      "terminated",
+      "unavailable",
+      "unknown",
+      "unresponsive"
+    ],
+    "deviceManagementReportFileFormat": [
+      "csv",
+      "json",
+      "pdf",
+      "unknownFutureValue"
+    ],
+    "deviceManagementReportStatus": [
+      "completed",
+      "failed",
+      "inProgress",
+      "notStarted",
+      "unknown"
+    ],
+    "deviceManagementResourceAccessProfileIntent": [
+      "apply",
+      "remove"
+    ],
+    "deviceManagementScriptRunState": [
+      "fail",
+      "notApplicable",
+      "pending",
+      "scriptError",
+      "success",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "deviceManagementSubscriptions": [
+      "intune",
+      "intune_EDU",
+      "intune_SMB",
+      "intunePremium",
+      "none",
+      "office365"
+    ],
+    "deviceManagementSubscriptionState": [
+      "active",
+      "blocked",
+      "deleted",
+      "disabled",
+      "lockedOut",
+      "pending",
+      "warning"
+    ],
+    "deviceManagementTemplateLifecycleState": [
+      "active",
+      "deprecated",
+      "draft",
+      "invalid",
+      "retired",
+      "superseded"
+    ],
+    "deviceManagementTemplateSubtype": [
+      "accountProtection",
+      "antivirus",
+      "attackSurfaceReduction",
+      "diskEncryption",
+      "endpointDetectionReponse",
+      "firewall",
+      "firewallSharedAppList",
+      "firewallSharedIpList",
+      "firewallSharedPortlist",
+      "none"
+    ],
+    "deviceManagementTemplateType": [
+      "advancedThreatProtectionSecurityBaseline",
+      "cloudPC",
+      "custom",
+      "deviceCompliance",
+      "deviceConfiguration",
+      "deviceConfigurationForOffice365",
+      "firewallSharedSettings",
+      "microsoftEdgeSecurityBaseline",
+      "microsoftOffice365ProPlusSecurityBaseline",
+      "securityBaseline",
+      "securityTemplate",
+      "specializedDevices"
+    ],
+    "deviceManangementIntentValueType": [
+      "abstractComplex",
+      "boolean",
+      "collection",
+      "complex",
+      "integer",
+      "string"
+    ],
+    "devicePlatformType": [
+      "android",
+      "androidAOSP",
+      "androidForWork",
+      "androidMobileApplicationManagement",
+      "androidWorkProfile",
+      "iOS",
+      "iOSMobileApplicationManagement",
+      "macOS",
+      "unknown",
+      "unknownFutureValue",
+      "windows10AndLater",
+      "windows81AndLater",
+      "windowsMobileApplicationManagement",
+      "windowsPhone81"
+    ],
+    "deviceRegistrationState": [
+      "approvalPending",
+      "certificateReset",
+      "keyConflict",
+      "notRegistered",
+      "notRegisteredPendingEnrollment",
+      "registered",
+      "revoked",
+      "unknown"
+    ],
+    "deviceScopeAction": [],
+    "deviceScopeActionStatus": [
+      "failed",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "deviceScopeOperator": [
+      "equals",
+      "none",
+      "unknownFutureValue"
+    ],
+    "deviceScopeParameter": [
+      "none",
+      "scopeTag",
+      "unknownFutureValue"
+    ],
+    "deviceScopeStatus": [
+      "completed",
+      "computing",
+      "insufficientData",
+      "none",
+      "unknownFutureValue"
+    ],
+    "deviceThreatProtectionLevel": [
+      "high",
+      "low",
+      "medium",
+      "notSet",
+      "secured",
+      "unavailable"
+    ],
+    "deviceType": [
+      "android",
+      "androidEnterprise",
+      "androidForWork",
+      "androidnGMS",
+      "blackberry",
+      "chromeOS",
+      "cloudPC",
+      "desktop",
+      "holoLens",
+      "iPad",
+      "iPhone",
+      "iPod",
+      "iSocConsumer",
+      "linux",
+      "mac",
+      "macMDM",
+      "nokia",
+      "palm",
+      "surfaceHub",
+      "tvOS",
+      "unix",
+      "unknown",
+      "visionOS",
+      "winCE",
+      "windows10x",
+      "windowsPhone",
+      "windowsRT",
+      "winEmbedded",
+      "winMO6"
+    ],
+    "deviceTypes": [
+      "android",
+      "androidEnterprise",
+      "androidForWork",
+      "blackberry",
+      "desktop",
+      "holoLens",
+      "iPad",
+      "iPhone",
+      "iPod",
+      "iSocConsumer",
+      "mac",
+      "macMDM",
+      "nokia",
+      "palm",
+      "surfaceHub",
+      "unix",
+      "unknown",
+      "winCE",
+      "windowsPhone",
+      "windowsRT",
+      "winEmbedded",
+      "winMO6"
+    ],
+    "diagnosticDataSubmissionMode": [
+      "basic",
+      "enhanced",
+      "full",
+      "none",
+      "userDefined"
+    ],
+    "diamondModel": [
+      "adversary",
+      "capability",
+      "infrastructure",
+      "unknown",
+      "unknownFutureValue",
+      "victim"
+    ],
+    "diffieHellmanGroup": [
+      "ecp256",
+      "ecp384",
+      "group1",
+      "group14",
+      "group2",
+      "group24"
+    ],
+    "directoryDefinitionDiscoverabilities": [
+      "AttributeDataTypes",
+      "AttributeNames",
+      "AttributeReadOnly",
+      "None",
+      "ReferenceAttributes",
+      "UnknownFutureValue"
+    ],
+    "disableReason": [
+      "controllerServiceAppDeleted",
+      "invalidBillingProfile",
+      "none",
+      "unknownFutureValue",
+      "userRequested"
+    ],
+    "discoverySource": [
+      "adminImport",
+      "deviceEnrollmentProgram",
+      "unknown"
+    ],
+    "diskType": [
+      "hdd",
+      "ssd",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "dlpAction": [
+      "blockAccess",
+      "browserRestriction",
+      "deviceRestriction",
+      "generateAlert",
+      "generateIncidentReportAction",
+      "notifyUser",
+      "restrictAccess",
+      "restrictWebGrounding",
+      "sPBlockAnonymousAccess",
+      "sPRuntimeAccessControl",
+      "sPSharingGenerateIncidentReport",
+      "sPSharingNotifyUser",
+      "unknownFutureValue"
+    ],
+    "dmaGuardDeviceEnumerationPolicyType": [
+      "allowAll",
+      "blockAll",
+      "deviceDefault"
+    ],
+    "documentProcessingJobStatus": [
+      "completed",
+      "failed",
+      "inProgress",
+      "unknownFutureValue"
+    ],
+    "documentProcessingJobType": [
+      "file",
+      "folder",
+      "unknownFutureValue"
+    ],
+    "domainNameSource": [
+      "fullDomainName",
+      "netBiosDomainName"
+    ],
+    "driftStatus": [
+      "active",
+      "fixed",
+      "unknownFutureValue"
+    ],
+    "driveItemSourceApplication": [
+      "loki",
+      "loop",
+      "office",
+      "oneDrive",
+      "other",
+      "powerPoint",
+      "sharePoint",
+      "stream",
+      "teams",
+      "unknownFutureValue",
+      "yammer"
+    ],
+    "driverApprovalAction": [
+      "approve",
+      "decline",
+      "suspend"
+    ],
+    "driverApprovalStatus": [
+      "approved",
+      "declined",
+      "needsReview",
+      "suspended"
+    ],
+    "driverCategory": [
+      "other",
+      "previouslyApproved",
+      "recommended"
+    ],
+    "driverUpdateProfileApprovalType": [
+      "automatic",
+      "manual"
+    ],
+    "eapFastConfiguration": [
+      "noProtectedAccessCredential",
+      "useProtectedAccessCredential",
+      "useProtectedAccessCredentialAndProvision",
+      "useProtectedAccessCredentialAndProvisionAnonymously"
+    ],
+    "eapType": [
+      "eapFast",
+      "eapSim",
+      "eapTls",
+      "eapTtls",
+      "leap",
+      "peap",
+      "teap"
+    ],
+    "easAuthenticationMethod": [
+      "certificate",
+      "derivedCredential",
+      "usernameAndPassword"
+    ],
+    "easServices": [
+      "calendars",
+      "contacts",
+      "email",
+      "none",
+      "notes",
+      "reminders"
+    ],
+    "edgeCookiePolicy": [
+      "allow",
+      "blockAll",
+      "blockThirdParty",
+      "userDefined"
+    ],
+    "edgeKioskModeRestrictionType": [
+      "digitalSignage",
+      "normalMode",
+      "notConfigured",
+      "publicBrowsingMultiApp",
+      "publicBrowsingSingleApp"
+    ],
+    "edgeOpenOptions": [
+      "newTabPage",
+      "notConfigured",
+      "previousPages",
+      "specificPages",
+      "startPage"
+    ],
+    "edgeSearchEngineType": [
+      "bing",
+      "default"
+    ],
+    "edgeTelemetryMode": [
+      "internet",
+      "intranet",
+      "intranetAndInternet",
+      "notConfigured"
+    ],
+    "editionUpgradeLicenseType": [
+      "licenseFile",
+      "notConfigured",
+      "productKey"
+    ],
+    "educationAddedStudentAction": [
+      "assignIfOpen",
+      "none",
+      "unknownFutureValue"
+    ],
+    "educationAddToCalendarOptions": [
+      "none",
+      "studentsAndPublisher",
+      "studentsAndTeamOwners",
+      "studentsOnly",
+      "unknownFutureValue"
+    ],
+    "educationAssignmentStatus": [
+      "assigned",
+      "draft",
+      "inactive",
+      "published",
+      "unknownFutureValue"
+    ],
+    "educationExternalSource": [
+      "lms",
+      "manual",
+      "sis",
+      "unknownFutureValue"
+    ],
+    "educationFeedbackResourceOutcomeStatus": [
+      "failedPublish",
+      "notPublished",
+      "pendingPublish",
+      "published",
+      "unknownFutureValue"
+    ],
+    "educationGender": [
+      "female",
+      "male",
+      "other",
+      "unknownFutureValue"
+    ],
+    "educationModuleStatus": [
+      "draft",
+      "published",
+      "unknownFutureValue"
+    ],
+    "educationSpeechType": [
+      "informative",
+      "personal",
+      "persuasive",
+      "unknownFutureValue"
+    ],
+    "educationSubmissionStatus": [
+      "excused",
+      "reassigned",
+      "released",
+      "returned",
+      "submitted",
+      "unknownFutureValue",
+      "working"
+    ],
+    "educationUserRole": [
+      "faculty",
+      "none",
+      "student",
+      "teacher",
+      "unknownFutureValue"
+    ],
+    "elevationRequestState": [
+      "approved",
+      "completed",
+      "denied",
+      "expired",
+      "none",
+      "pending",
+      "revoked",
+      "unknownFutureValue"
+    ],
+    "eligibilityFilteringEnabledEntities": [
+      "none",
+      "offerShiftRequest",
+      "swapRequest",
+      "timeOffReason",
+      "unknownFutureValue"
+    ],
+    "eligibilityScheduleFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "eligibilityScheduleInstanceFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "eligibilityScheduleRequestFilterByCurrentUserOptions": [
+      "approver",
+      "createdBy",
+      "principal",
+      "unknownFutureValue"
+    ],
+    "emailCertificateType": [
+      "certificate",
+      "derivedCredential",
+      "none"
+    ],
+    "emailRole": [
+      "recipient",
+      "sender",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "emailSyncDuration": [
+      "oneDay",
+      "oneMonth",
+      "oneWeek",
+      "threeDays",
+      "twoWeeks",
+      "unlimited",
+      "userDefined"
+    ],
+    "emailSyncSchedule": [
+      "asMessagesArrive",
+      "basedOnMyUsage",
+      "fifteenMinutes",
+      "manual",
+      "sixtyMinutes",
+      "thirtyMinutes",
+      "userDefined"
+    ],
+    "emailType": [
+      "main",
+      "other",
+      "personal",
+      "unknown",
+      "work"
+    ],
+    "embeddedSIMDeviceStateValue": [
+      "deleted",
+      "deleting",
+      "error",
+      "failed",
+      "installed",
+      "installing",
+      "notEvaluated",
+      "removedByUser"
+    ],
+    "enablement": [
+      "disabled",
+      "enabled",
+      "notConfigured"
+    ],
+    "encryptionReadinessState": [
+      "notReady",
+      "ready"
+    ],
+    "encryptionState": [
+      "encrypted",
+      "notEncrypted"
+    ],
+    "encryptWith": [
+      "template",
+      "userDefinedRights"
+    ],
+    "endpointSecurityConfigurationApplicablePlatform": [
+      "macOS",
+      "unknown",
+      "windows10AndLater",
+      "windows10AndWindowsServer"
+    ],
+    "endpointSecurityConfigurationProfileType": [
+      "accountProtection",
+      "antivirus",
+      "appAndBrowserIsolation",
+      "applicationControl",
+      "attackSurfaceReductionRules",
+      "bitLocker",
+      "deviceControl",
+      "endpointDetectionAndResponse",
+      "exploitProtection",
+      "fileVault",
+      "firewall",
+      "firewallRules",
+      "unknown",
+      "webProtection",
+      "windowsSecurity"
+    ],
+    "endpointSecurityConfigurationType": [
+      "accountProtection",
+      "antivirus",
+      "attackSurfaceReduction",
+      "diskEncryption",
+      "endpointDetectionAndResponse",
+      "firewall",
+      "unknown"
+    ],
+    "endpointType": [
+      "default",
+      "skypeForBusiness",
+      "skypeForBusinessVoipPhone",
+      "unknownFutureValue",
+      "voicemail"
+    ],
+    "endUserNotificationPreference": [
+      "custom",
+      "microsoft",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "endUserNotificationSettingType": [
+      "noNotification",
+      "noTraining",
+      "trainingSelected",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "endUserNotificationType": [
+      "noTraining",
+      "positiveReinforcement",
+      "trainingAssignment",
+      "trainingReminder",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "enforcementResultStatus": [
+      "agentFailure",
+      "enforcementTimeout",
+      "missingOrInvalidConfiguration",
+      "oSOverride",
+      "other",
+      "processNonExistent",
+      "success",
+      "userOverride"
+    ],
+    "engagementAsyncOperationType": [
+      "createCommunity",
+      "unknownFutureValue"
+    ],
+    "engagementConversationMessageReactionType": [
+      "agree",
+      "angry",
+      "brain",
+      "bullseye",
+      "celebrate",
+      "confirmed",
+      "crying",
+      "excited",
+      "goofy",
+      "happy",
+      "heartBroken",
+      "intenseLaugh",
+      "laugh",
+      "like",
+      "love",
+      "medal",
+      "mindBlown",
+      "praise",
+      "sad",
+      "scared",
+      "shocked",
+      "silly",
+      "smile",
+      "starStruck",
+      "support",
+      "surprised",
+      "takingNotes",
+      "thank",
+      "thinking",
+      "unknownFutureValue",
+      "watching"
+    ],
+    "engagementConversationModerationState": [
+      "dismissed",
+      "pendingReview",
+      "published",
+      "unknownFutureValue"
+    ],
+    "engagementCreationMode": [
+      "migration",
+      "none",
+      "unknownFutureValue"
+    ],
+    "enrollmentAvailabilityOptions": [
+      "availableWithoutPrompts",
+      "availableWithPrompts",
+      "unavailable"
+    ],
+    "enrollmentNotificationBrandingOptions": [
+      "includeCompanyLogo",
+      "includeCompanyName",
+      "includeCompanyPortalLink",
+      "includeContactInformation",
+      "includeDeviceDetails",
+      "none",
+      "unknownFutureValue"
+    ],
+    "enrollmentNotificationTemplateType": [
+      "email",
+      "push",
+      "unknownFutureValue"
+    ],
+    "enrollmentRestrictionPlatformType": [
+      "allPlatforms",
+      "android",
+      "androidForWork",
+      "ios",
+      "linux",
+      "mac",
+      "unknownFutureValue",
+      "windows",
+      "windowsPhone"
+    ],
+    "enrollmentState": [
+      "blocked",
+      "enrolled",
+      "failed",
+      "notContacted",
+      "pendingReset",
+      "unknown"
+    ],
+    "enrollmentTimeDeviceMembershipTargetType": [
+      "staticSecurityGroup",
+      "unknownFutureValue"
+    ],
+    "enrollmentTimeDeviceMembershipTargetValidationErrorCode": [
+      "firstPartyAppNotAnOwner",
+      "notSecurityGroup",
+      "notStaticSecurityGroup",
+      "securityGroupNotFound",
+      "securityGroupNotInCallerScope",
+      "unknownFutureValue"
+    ],
+    "entityType": [
+      "acronym",
+      "bookmark",
+      "chatMessage",
+      "drive",
+      "driveItem",
+      "event",
+      "externalItem",
+      "list",
+      "listItem",
+      "message",
+      "person",
+      "qna",
+      "site",
+      "unknownFutureValue"
+    ],
+    "entryExportStatus": [
+      "Error",
+      "Noop",
+      "PermanentError",
+      "RetryableError",
+      "Success"
+    ],
+    "entrySyncOperation": [
+      "Add",
+      "Delete",
+      "None",
+      "Update"
+    ],
+    "errorCode": [
+      "deleted",
+      "noError",
+      "notFound",
+      "unauthorized"
+    ],
+    "errorCorrectionLevel": [
+      "h",
+      "l",
+      "m",
+      "q",
+      "unknownFutureValue"
+    ],
+    "escrowBehavior": [
+      "Default",
+      "IgnoreLookupReferenceResolutionFailure"
+    ],
+    "eventType": [
+      "exception",
+      "occurrence",
+      "seriesMaster",
+      "singleInstance"
+    ],
+    "exchangeIdFormat": [
+      "entryId",
+      "ewsId",
+      "immutableEntryId",
+      "restId",
+      "restImmutableEntryId"
+    ],
+    "exchangeMessageTraceStatus": [
+      "delivered",
+      "expanded",
+      "failed",
+      "filteredAsSpam",
+      "gettingStatus",
+      "pending",
+      "quarantined",
+      "unknownFutureValue"
+    ],
+    "exclusionUnitBulkJobStatus": [
+      "active",
+      "completed",
+      "completedWithErrors",
+      "created",
+      "unknownFutureValue"
+    ],
+    "executionMode": [
+      "evaluateInline",
+      "evaluateOffline",
+      "unknownFutureValue"
+    ],
+    "expirationPatternType": [
+      "afterDateTime",
+      "afterDuration",
+      "noExpiration",
+      "notSpecified"
+    ],
+    "expirationRequirement": [
+      "audienceTokenLifetimePolicy",
+      "ngcMfa",
+      "rememberMultifactorAuthenticationOnTrustedDevices",
+      "signInFrequencyEveryTime",
+      "signInFrequencyPeriodicReauthentication",
+      "tenantTokenLifetimePolicy",
+      "unknownFutureValue"
+    ],
+    "externalAudienceScope": [
+      "all",
+      "contactsOnly",
+      "none"
+    ],
+    "externalAuthenticationType": [
+      "aadPreAuthentication",
+      "passthru"
+    ],
+    "externalEmailOtpState": [
+      "default",
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "externalItemContentType": [
+      "html",
+      "text",
+      "unknownFutureValue"
+    ],
+    "externalSystemAccessMethods": [
+      "direct",
+      "roleChaining",
+      "unknownFutureValue"
+    ],
+    "featureTargetType": [
+      "administrativeUnit",
+      "group",
+      "role",
+      "unknownFutureValue"
+    ],
+    "featureType": [
+      "registration",
+      "reset",
+      "unknownFutureValue"
+    ],
+    "federatedIdpMfaBehavior": [
+      "acceptIfMfaDoneByFederatedIdp",
+      "enforceMfaByFederatedIdp",
+      "rejectMfaByFederatedIdp",
+      "unknownFutureValue"
+    ],
+    "fedRampLevel": [
+      "high",
+      "liSaas",
+      "low",
+      "moderate",
+      "none",
+      "notSupported",
+      "unknownFutureValue"
+    ],
+    "fido2RestrictionEnforcementType": [
+      "allow",
+      "block",
+      "unknownFutureValue"
+    ],
+    "fileArchiveStatus": [
+      "fullyArchived",
+      "notArchived",
+      "reactivating",
+      "unknownFutureValue"
+    ],
+    "fileHashType": [
+      "authenticodeHash256",
+      "ctph",
+      "lsHash",
+      "md5",
+      "sha1",
+      "sha256",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "fileStorageContainerBillingClassification": [
+      "directToCustomer",
+      "standard",
+      "trial",
+      "unknownFutureValue"
+    ],
+    "fileStorageContainerBillingStatus": [
+      "invalid",
+      "unknownFutureValue",
+      "valid"
+    ],
+    "fileStorageContainerOwnershipType": [
+      "tenantOwned",
+      "unknownFutureValue",
+      "userOwned"
+    ],
+    "fileStorageContainerStatus": [
+      "active",
+      "inactive",
+      "unknownFutureValue"
+    ],
+    "fileStorageContainerTypeAppPermission": [
+      "addPermissions",
+      "create",
+      "delete",
+      "deleteOwnPermission",
+      "deletePermissions",
+      "enumeratePermissions",
+      "full",
+      "manageContent",
+      "managePermissions",
+      "none",
+      "read",
+      "readContent",
+      "unknownFutureValue",
+      "updatePermissions",
+      "write",
+      "writeContent"
+    ],
+    "fileStorageContainerTypeSettingsOverride": [
+      "isDiscoverabilityEnabled",
+      "isItemVersioningEnabled",
+      "isSearchEnabled",
+      "itemMajorVersionLimit",
+      "maxStoragePerContainerInBytes",
+      "unknownFutureValue",
+      "urlTemplate"
+    ],
+    "fileVaultState": [
+      "driveEncryptedByUser",
+      "escrowNotEnabled",
+      "success",
+      "userDeferredEncryption"
+    ],
+    "filterMode": [
+      "exclude",
+      "include"
+    ],
+    "filterType": [
+      "contains",
+      "prefix",
+      "suffix",
+      "unknownFutureValue"
+    ],
+    "firewallCertificateRevocationListCheckMethodType": [
+      "attempt",
+      "deviceDefault",
+      "none",
+      "require"
+    ],
+    "firewallPacketQueueingMethodType": [
+      "deviceDefault",
+      "disabled",
+      "queueBoth",
+      "queueInbound",
+      "queueOutbound"
+    ],
+    "firewallPreSharedKeyEncodingMethodType": [
+      "deviceDefault",
+      "none",
+      "utF8"
+    ],
+    "firmwareProtectionType": [
+      "disabled",
+      "firmwareAttackSurfaceReduction",
+      "notApplicable",
+      "systemGuardSecureLaunch",
+      "unknownFutureValue"
+    ],
+    "folderProtectionType": [
+      "auditDiskModification",
+      "auditMode",
+      "blockDiskModification",
+      "enable",
+      "userDefined"
+    ],
+    "followupFlagStatus": [
+      "complete",
+      "flagged",
+      "notFlagged"
+    ],
+    "fotaRegistrationState": [
+      "completed",
+      "failed",
+      "inProgress",
+      "pending",
+      "requested",
+      "unknownFutureValue"
+    ],
+    "freeBusyStatus": [
+      "busy",
+      "free",
+      "oof",
+      "tentative",
+      "unknown",
+      "workingElsewhere"
+    ],
+    "frontlineCloudPcAccessState": [
+      "activating",
+      "activationFailed",
+      "active",
+      "noLicensesAvailable",
+      "standbyMode",
+      "unassigned",
+      "unknownFutureValue"
+    ],
+    "frontlineCloudPcAvailability": [
+      "available",
+      "notApplicable",
+      "notAvailable",
+      "unknownFutureValue"
+    ],
+    "gcpAccessType": [
+      "private",
+      "public",
+      "subjectToObjectAcls",
+      "unknownFutureValue"
+    ],
+    "gcpEncryption": [
+      "customer",
+      "google",
+      "unknownFutureValue"
+    ],
+    "gcpRoleType": [
+      "custom",
+      "system",
+      "unknownFutureValue"
+    ],
+    "genmojiIosManagedAppConfigurationState": [
+      "blocked",
+      "notBlocked",
+      "unknownFutureValue"
+    ],
+    "giphyRatingType": [
+      "moderate",
+      "strict",
+      "unknownFutureValue"
+    ],
+    "globalDeviceHealthScriptState": [
+      "enabled",
+      "notConfigured",
+      "pending"
+    ],
+    "groundingEntityType": [
+      "drive",
+      "driveItem",
+      "list",
+      "listItem",
+      "site",
+      "unknownFutureValue"
+    ],
+    "groupAccessType": [
+      "none",
+      "private",
+      "public",
+      "secret"
+    ],
+    "groupPolicyConfigurationIngestionType": [
+      "builtIn",
+      "custom",
+      "mixed",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "groupPolicyConfigurationType": [
+      "policy",
+      "preference"
+    ],
+    "groupPolicyDefinitionClassType": [
+      "machine",
+      "user"
+    ],
+    "groupPolicyMigrationReadiness": [
+      "complete",
+      "error",
+      "none",
+      "notApplicable",
+      "partial"
+    ],
+    "groupPolicyOperationStatus": [
+      "failed",
+      "inProgress",
+      "success",
+      "unknown"
+    ],
+    "groupPolicyOperationType": [
+      "addLanguageFiles",
+      "none",
+      "remove",
+      "removeLanguageFiles",
+      "updateLanguageFiles",
+      "upload",
+      "uploadNewVersion"
+    ],
+    "groupPolicySettingScope": [
+      "device",
+      "unknown",
+      "user"
+    ],
+    "groupPolicySettingType": [
+      "account",
+      "appLockerRuleCollection",
+      "auditSetting",
+      "dataSourcesSettings",
+      "devicesSettings",
+      "driveMapSettings",
+      "environmentVariables",
+      "filesSettings",
+      "folderOptions",
+      "folders",
+      "iniFiles",
+      "internetOptions",
+      "localUsersAndGroups",
+      "networkOptions",
+      "networkShares",
+      "ntServices",
+      "policy",
+      "powerOptions",
+      "printers",
+      "regionalOptionsSettings",
+      "registrySettings",
+      "scheduledTasks",
+      "securityOptions",
+      "shortcutSettings",
+      "startMenuSettings",
+      "unknown",
+      "userRightsAssignment",
+      "windowsFirewallSettings"
+    ],
+    "groupPolicyType": [
+      "admxBacked",
+      "admxIngested"
+    ],
+    "groupPolicyUploadedDefinitionFileStatus": [
+      "assigned",
+      "available",
+      "none",
+      "removalFailed",
+      "removalInProgress",
+      "uploadFailed",
+      "uploadInProgress"
+    ],
+    "groupPrivacy": [
+      "private",
+      "public",
+      "unknownFutureValue",
+      "unspecified"
+    ],
+    "groupType": [
+      "azureAD",
+      "unifiedGroups",
+      "unknownFutureValue"
+    ],
+    "hardwareConfigurationFormat": [
+      "dell",
+      "surface",
+      "surfaceDock"
+    ],
+    "hardwareOathTokenHashFunction": [
+      "hmacsha1",
+      "hmacsha256",
+      "unknownFutureValue"
+    ],
+    "hardwareOathTokenStatus": [
+      "activated",
+      "assigned",
+      "available",
+      "failedActivation",
+      "unknownFutureValue"
+    ],
+    "hashAlgorithms": [
+      "sha1",
+      "sha2"
+    ],
+    "healthState": [
+      "healthy",
+      "unhealthy",
+      "unknown"
+    ],
+    "holdType": [
+      "none",
+      "private",
+      "public",
+      "unknownFutureValue"
+    ],
+    "horizontalSectionLayoutType": [
+      "fullWidth",
+      "none",
+      "oneColumn",
+      "oneThirdLeftColumn",
+      "oneThirdRightColumn",
+      "threeColumns",
+      "twoColumns",
+      "unknownFutureValue"
+    ],
+    "iamStatus": [
+      "active",
+      "disabled",
+      "inactive",
+      "unknownFutureValue"
+    ],
+    "identityProviderState": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "identitySourceType": [
+      "azureActiveDirectory",
+      "external"
+    ],
+    "identityUserFlowAttributeDataType": [
+      "boolean",
+      "dateTime",
+      "int64",
+      "string",
+      "stringCollection",
+      "unknownFutureValue"
+    ],
+    "identityUserFlowAttributeInputType": [
+      "checkboxMultiSelect",
+      "dateTimeDropdown",
+      "dropdownSingleSelect",
+      "emailBox",
+      "radioSingleSelect",
+      "textBox"
+    ],
+    "identityUserFlowAttributeType": [
+      "builtIn",
+      "custom",
+      "required",
+      "unknownFutureValue"
+    ],
+    "imageTaggingChoice": [
+      "basic",
+      "disabled",
+      "enhanced",
+      "unknownFutureValue"
+    ],
+    "importance": [
+      "high",
+      "low",
+      "normal"
+    ],
+    "importedDeviceIdentityType": [
+      "imei",
+      "manufacturerModelSerial",
+      "serialNumber",
+      "unknown"
+    ],
+    "importedWindowsAutopilotDeviceIdentityImportStatus": [
+      "complete",
+      "error",
+      "partial",
+      "pending",
+      "unknown"
+    ],
+    "importedWindowsAutopilotDeviceIdentityUploadStatus": [
+      "complete",
+      "error",
+      "noUpload",
+      "pending"
+    ],
+    "includedUserRoles": [
+      "admin",
+      "all",
+      "privilegedAdmin",
+      "unknownFutureValue",
+      "user"
+    ],
+    "includedUserTypes": [
+      "all",
+      "guest",
+      "member",
+      "unknownFutureValue"
+    ],
+    "incomingTokenType": [
+      "none",
+      "primaryRefreshToken",
+      "refreshToken",
+      "remoteDesktopToken",
+      "saml11",
+      "saml20",
+      "unknownFutureValue"
+    ],
+    "incompatiblePrinterSettings": [
+      "hide",
+      "show",
+      "unknownFutureValue"
+    ],
+    "inferenceClassificationType": [
+      "focused",
+      "other"
+    ],
+    "informationBarrierMode": [
+      "explicit",
+      "open",
+      "ownerModerated",
+      "unknownFutureValue"
+    ],
+    "ingestionSource": [
+      "builtIn",
+      "custom",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "initiatorType": [
+      "application",
+      "system",
+      "unknownFutureValue",
+      "user"
+    ],
+    "inkAccessSetting": [
+      "disabled",
+      "enabled",
+      "notConfigured"
+    ],
+    "insiderRiskLevel": [
+      "elevated",
+      "minor",
+      "moderate",
+      "none",
+      "unknownFutureValue"
+    ],
+    "installIntent": [
+      "available",
+      "availableWithoutEnrollment",
+      "required",
+      "uninstall"
+    ],
+    "installState": [
+      "failed",
+      "installed",
+      "notApplicable",
+      "notInstalled",
+      "uninstallFailed",
+      "unknown"
+    ],
+    "intelligentInsightConfidence": [
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "intelligentInsightRecommendation": [
+      "approve",
+      "deny",
+      "unknownFutureValue"
+    ],
+    "intendedPurpose": [
+      "smimeEncryption",
+      "smimeSigning",
+      "unassigned",
+      "vpn",
+      "wifi"
+    ],
+    "internetExplorerMessageSetting": [
+      "disabled",
+      "enabled",
+      "keepGoing",
+      "notConfigured"
+    ],
+    "internetSiteSecurityLevel": [
+      "high",
+      "medium",
+      "mediumHigh",
+      "userDefined"
+    ],
+    "iosKioskModeAppType": [
+      "appStoreApp",
+      "builtInApp",
+      "managedApp",
+      "notConfigured"
+    ],
+    "iosNotificationAlertType": [
+      "banner",
+      "deviceDefault",
+      "modal",
+      "none"
+    ],
+    "iosNotificationPreviewVisibility": [
+      "alwaysShow",
+      "hideWhenLocked",
+      "neverShow",
+      "notConfigured"
+    ],
+    "iosSoftwareUpdateScheduleType": [
+      "alwaysUpdate",
+      "updateDuringTimeWindows",
+      "updateOutsideOfActiveHours",
+      "updateOutsideOfTimeWindows"
+    ],
+    "iosUpdatesInstallStatus": [
+      "available",
+      "deviceOsHigherThanDesiredOsVersion",
+      "downloadFailed",
+      "downloading",
+      "downloadInsufficientNetwork",
+      "downloadInsufficientPower",
+      "downloadInsufficientSpace",
+      "downloadRequiresComputer",
+      "idle",
+      "installFailed",
+      "installing",
+      "installInsufficientPower",
+      "installInsufficientSpace",
+      "installPhoneCallInProgress",
+      "mdmClientCrashed",
+      "notSupportedOperation",
+      "sharedDeviceUserLoggedInError",
+      "success",
+      "timeout",
+      "unknown",
+      "updateError",
+      "updateScanFailed"
+    ],
+    "iosWallpaperDisplayLocation": [
+      "homeScreen",
+      "lockAndHomeScreens",
+      "lockScreen",
+      "notConfigured"
+    ],
+    "iosWiredNetworkEapType": [
+      "eapAka",
+      "eapFast",
+      "eapTls",
+      "eapTtls",
+      "peap",
+      "unknownFutureValue"
+    ],
+    "iTunesPairingMode": [
+      "allow",
+      "disallow",
+      "requiresCertificate"
+    ],
+    "joinType": [
+      "azureADJoined",
+      "azureADRegistered",
+      "hybridAzureADJoined",
+      "unknown"
+    ],
+    "kerberosSignOnMappingAttributeType": [
+      "onPremisesSAMAccountName",
+      "onPremisesUserPrincipalName",
+      "onPremisesUserPrincipalUsername",
+      "userPrincipalName",
+      "userPrincipalUsername"
+    ],
+    "keySize": [
+      "size1024",
+      "size2048",
+      "size4096"
+    ],
+    "keyStorageProviderOption": [
+      "usePassportForWorkKspOtherwiseFail",
+      "useSoftwareKsp",
+      "useTpmKspOtherwiseFail",
+      "useTpmKspOtherwiseUseSoftwareKsp"
+    ],
+    "keyUsages": [
+      "digitalSignature",
+      "keyEncipherment"
+    ],
+    "kind": [
+      "allowedTenants",
+      "unknownFutureValue",
+      "unrestricted"
+    ],
+    "kioskModeManagedHomeScreenPinComplexity": [
+      "complex",
+      "notConfigured",
+      "simple"
+    ],
+    "kioskModeType": [
+      "multiAppMode",
+      "notConfigured",
+      "singleAppMode"
+    ],
+    "label": [
+      "authors",
+      "createdBy",
+      "createdDateTime",
+      "fileExtension",
+      "fileName",
+      "lastModifiedBy",
+      "lastModifiedDateTime",
+      "title",
+      "url"
+    ],
+    "labelActionSource": [
+      "automatic",
+      "manual",
+      "none",
+      "recommended",
+      "unknownFutureValue"
+    ],
+    "labelKind": [
+      "all",
+      "enumerated",
+      "unknownFutureValue"
+    ],
+    "languageProficiencyLevel": [
+      "conversational",
+      "elementary",
+      "fullProfessional",
+      "limitedWorking",
+      "nativeOrBilingual",
+      "professionalWorking",
+      "unknownFutureValue"
+    ],
+    "lanManagerAuthenticationLevel": [
+      "lmAndNltm",
+      "lmAndNtlmOnly",
+      "lmAndNtlmV2",
+      "lmNtlmAndNtlmV2",
+      "lmNtlmV2AndNotLm",
+      "lmNtlmV2AndNotLmOrNtm"
+    ],
+    "layoutTemplateType": [
+      "default",
+      "unknownFutureValue",
+      "verticalSplit"
+    ],
+    "level": [
+      "advanced",
+      "beginner",
+      "intermediate",
+      "unknownFutureValue"
+    ],
+    "licenseType": [
+      "notPaid",
+      "paid",
+      "trial",
+      "unknownFutureValue"
+    ],
+    "lifecycleEventType": [
+      "missed",
+      "reauthorizationRequired",
+      "subscriptionRemoved"
+    ],
+    "lobbyBypassScope": [
+      "everyone",
+      "invited",
+      "organization",
+      "organizationAndFederated",
+      "organizationExcludingGuests",
+      "organizer",
+      "unknownFutureValue"
+    ],
+    "localSecurityOptionsAdministratorElevationPromptBehaviorType": [
+      "elevateWithoutPrompting",
+      "notConfigured",
+      "promptForConsent",
+      "promptForConsentForNonWindowsBinaries",
+      "promptForConsentOnTheSecureDesktop",
+      "promptForCredentials",
+      "promptForCredentialsOnTheSecureDesktop"
+    ],
+    "localSecurityOptionsFormatAndEjectOfRemovableMediaAllowedUserType": [
+      "administrators",
+      "administratorsAndInteractiveUsers",
+      "administratorsAndPowerUsers",
+      "notConfigured"
+    ],
+    "localSecurityOptionsInformationDisplayedOnLockScreenType": [
+      "administrators",
+      "administratorsAndInteractiveUsers",
+      "administratorsAndPowerUsers",
+      "notConfigured"
+    ],
+    "localSecurityOptionsInformationShownOnLockScreenType": [
+      "doNotDisplayUser",
+      "notConfigured",
+      "userDisplayNameDomainUser",
+      "userDisplayNameOnly"
+    ],
+    "localSecurityOptionsMinimumSessionSecurity": [
+      "none",
+      "ntlmV2And128BitEncryption",
+      "require128BitEncryption",
+      "requireNtmlV2SessionSecurity"
+    ],
+    "localSecurityOptionsSmartCardRemovalBehaviorType": [
+      "disconnectRemoteDesktopSession",
+      "forceLogoff",
+      "lockWorkstation",
+      "noAction"
+    ],
+    "localSecurityOptionsStandardUserElevationPromptBehaviorType": [
+      "automaticallyDenyElevationRequests",
+      "notConfigured",
+      "promptForCredentials",
+      "promptForCredentialsOnTheSecureDesktop"
+    ],
+    "locationType": [
+      "businessAddress",
+      "conferenceRoom",
+      "default",
+      "geoCoordinates",
+      "homeAddress",
+      "hotel",
+      "localBusiness",
+      "postalAddress",
+      "restaurant",
+      "streetAddress"
+    ],
+    "locationUniqueIdType": [
+      "bing",
+      "directory",
+      "locationStore",
+      "private",
+      "unknown"
+    ],
+    "logonType": [
+      "batch",
+      "interactive",
+      "network",
+      "remoteInteractive",
+      "service",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "longRunningOperationStatus": [
+      "failed",
+      "notStarted",
+      "running",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "lostModeState": [
+      "disabled",
+      "enabled"
+    ],
+    "m365ResourceType": [
+      "group",
+      "none",
+      "unknownFutureValue",
+      "user"
+    ],
+    "macAddressRandomizationMode": [
+      "automatic",
+      "hardware",
+      "unknownFutureValue"
+    ],
+    "macOSContentCachingClientPolicy": [
+      "clientsInCustomLocalNetworks",
+      "clientsInCustomLocalNetworksWithFallback",
+      "clientsInLocalNetwork",
+      "clientsWithSamePublicIpAddress",
+      "notConfigured"
+    ],
+    "macOSContentCachingParentSelectionPolicy": [
+      "firstAvailable",
+      "notConfigured",
+      "random",
+      "roundRobin",
+      "stickyAvailable",
+      "urlPathHash"
+    ],
+    "macOSContentCachingPeerPolicy": [
+      "notConfigured",
+      "peersInCustomLocalNetworks",
+      "peersInLocalNetwork",
+      "peersWithSamePublicIpAddress"
+    ],
+    "macOSContentCachingType": [
+      "notConfigured",
+      "sharedContentOnly",
+      "userContentOnly"
+    ],
+    "macOSFileVaultRecoveryKeyTypes": [
+      "institutionalRecoveryKey",
+      "notConfigured",
+      "personalRecoveryKey"
+    ],
+    "macOSGatekeeperAppSources": [
+      "anywhere",
+      "macAppStore",
+      "macAppStoreAndIdentifiedDevelopers",
+      "notConfigured"
+    ],
+    "macOSPriority": [
+      "high",
+      "low",
+      "unknownFutureValue"
+    ],
+    "macOSProcessIdentifierType": [
+      "bundleID",
+      "path"
+    ],
+    "macOSSoftwareUpdateBehavior": [
+      "default",
+      "downloadOnly",
+      "installASAP",
+      "installLater",
+      "notConfigured",
+      "notifyOnly"
+    ],
+    "macOSSoftwareUpdateCategory": [
+      "configurationDataFile",
+      "critical",
+      "firmware",
+      "other"
+    ],
+    "macOSSoftwareUpdateDelayPolicy": [
+      "delayAppUpdateVisibility",
+      "delayMajorOsUpdateVisibility",
+      "delayOSUpdateVisibility",
+      "none",
+      "unknownFutureValue"
+    ],
+    "macOSSoftwareUpdateScheduleType": [
+      "alwaysUpdate",
+      "updateDuringTimeWindows",
+      "updateOutsideOfTimeWindows"
+    ],
+    "macOSSoftwareUpdateState": [
+      "available",
+      "commandFailed",
+      "downloaded",
+      "downloadFailed",
+      "downloading",
+      "downloadInsufficientNetwork",
+      "downloadInsufficientPower",
+      "downloadInsufficientSpace",
+      "idle",
+      "installFailed",
+      "installing",
+      "installInsufficientPower",
+      "installInsufficientSpace",
+      "scheduled",
+      "success"
+    ],
+    "macOSSystemExtensionType": [
+      "driverExtensionsAllowed",
+      "endpointSecurityExtensionsAllowed",
+      "networkExtensionsAllowed"
+    ],
+    "mailboxRecipientType": [
+      "equipment",
+      "linked",
+      "others",
+      "room",
+      "shared",
+      "unknown",
+      "user"
+    ],
+    "mailboxType": [
+      "shared",
+      "unknown",
+      "unknownFutureValue",
+      "user"
+    ],
+    "mailDestinationRoutingReason": [
+      "advancedSpamFiltering",
+      "autoPurgeToDeleted",
+      "autoPurgeToInbox",
+      "autoPurgeToJunk",
+      "blockedSender",
+      "domainAllowList",
+      "domainBlockList",
+      "firstTimeSender",
+      "junk",
+      "mailFlowRule",
+      "none",
+      "notInAddressBook",
+      "notJunk",
+      "outbound",
+      "safeSender",
+      "unknownFutureValue"
+    ],
+    "mailFolderOperationStatus": [
+      "failed",
+      "notStarted",
+      "running",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "mailTipsType": [
+      "automaticReplies",
+      "customMailTip",
+      "deliveryRestriction",
+      "externalMemberCount",
+      "mailboxFullStatus",
+      "maxMessageSize",
+      "moderationStatus",
+      "recipientScope",
+      "recipientSuggestions",
+      "totalMemberCount"
+    ],
+    "managedAppAvailability": [
+      "global",
+      "lineOfBusiness"
+    ],
+    "managedAppClipboardSharingLevel": [
+      "allApps",
+      "blocked",
+      "managedApps",
+      "managedAppsWithPasteIn"
+    ],
+    "managedAppDataEncryptionType": [
+      "afterDeviceRestart",
+      "useDeviceSettings",
+      "whenDeviceLocked",
+      "whenDeviceLockedExceptOpenFiles"
+    ],
+    "managedAppDataIngestionLocation": [
+      "camera",
+      "oneDriveForBusiness",
+      "photoLibrary",
+      "sharePoint"
+    ],
+    "managedAppDataStorageLocation": [
+      "box",
+      "egnyte",
+      "iManage",
+      "localStorage",
+      "oneDriveForBusiness",
+      "photoLibrary",
+      "sharePoint",
+      "unknownFutureValue"
+    ],
+    "managedAppDataTransferLevel": [
+      "allApps",
+      "managedApps",
+      "none"
+    ],
+    "managedAppDeviceThreatLevel": [
+      "high",
+      "low",
+      "medium",
+      "notConfigured",
+      "secured"
+    ],
+    "managedAppFlaggedReason": [
+      "androidBootloaderUnlocked",
+      "androidFactoryRomModified",
+      "none",
+      "rootedDevice"
+    ],
+    "managedAppLogUploadConsent": [
+      "accepted",
+      "declined",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "managedAppLogUploadState": [
+      "completed",
+      "declinedByUser",
+      "failed",
+      "inProgress",
+      "pending",
+      "timedOut",
+      "unknownFutureValue"
+    ],
+    "managedAppNotificationRestriction": [
+      "allow",
+      "block",
+      "blockOrganizationalData"
+    ],
+    "managedAppPhoneNumberRedirectLevel": [
+      "allApps",
+      "blocked",
+      "customApp",
+      "managedApps"
+    ],
+    "managedAppPinCharacterSet": [
+      "alphanumericAndSymbol",
+      "numeric"
+    ],
+    "managedAppRemediationAction": [
+      "block",
+      "blockWhenSettingIsSupported",
+      "warn",
+      "wipe"
+    ],
+    "managedBrowserType": [
+      "microsoftEdge",
+      "notConfigured"
+    ],
+    "managedDeviceArchitecture": [
+      "arm",
+      "arM64",
+      "unknown",
+      "x64",
+      "x86"
+    ],
+    "managedDeviceManagementFeatures": [
+      "microsoftManagedDesktop",
+      "none"
+    ],
+    "managedDeviceOwnerType": [
+      "company",
+      "personal",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "managedDevicePartnerReportedHealthState": [
+      "activated",
+      "compromised",
+      "deactivated",
+      "highSeverity",
+      "lowSeverity",
+      "mediumSeverity",
+      "misconfigured",
+      "secured",
+      "unknown",
+      "unresponsive"
+    ],
+    "managedDeviceRemoteAction": [
+      "activateDeviceEsim",
+      "collectDiagnostics",
+      "customTextNotification",
+      "delete",
+      "deprovision",
+      "disable",
+      "fullScan",
+      "initiateDeviceAttestation",
+      "initiateMobileDeviceManagementKeyRecovery",
+      "initiateOnDemandProactiveRemediation",
+      "moveDeviceToOrganizationalUnit",
+      "quickScan",
+      "rebootNow",
+      "reenable",
+      "retire",
+      "setDeviceName",
+      "signatureUpdate",
+      "syncDevice",
+      "unknownFutureValue",
+      "wipe"
+    ],
+    "managedDeviceWindowsOperatingSystemEditionType": [
+      "education",
+      "educationN",
+      "enterprise",
+      "enterpriseN",
+      "proEducation",
+      "proEducationN",
+      "professional",
+      "professionalN",
+      "proWorkstation",
+      "proWorkstationN",
+      "unknownFutureValue"
+    ],
+    "managedGooglePlayEnterpriseType": [
+      "enterpriseTypeUnspecified",
+      "managedGoogleDomain",
+      "managedGooglePlayAccountsEnterprise",
+      "unknownFutureValue"
+    ],
+    "managedInstallerStatus": [
+      "disabled",
+      "enabled"
+    ],
+    "managementAgentType": [
+      "configurationManagerClient",
+      "configurationManagerClientMdm",
+      "configurationManagerClientMdmEas",
+      "eas",
+      "easIntuneClient",
+      "easMdm",
+      "google",
+      "googleCloudDevicePolicyController",
+      "intuneAosp",
+      "intuneClient",
+      "jamf",
+      "mdm",
+      "microsoft365ManagedMdm",
+      "msSense",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "managementState": [
+      "deletePending",
+      "discovered",
+      "managed",
+      "retireCanceled",
+      "retireFailed",
+      "retireIssued",
+      "retirePending",
+      "unhealthy",
+      "unknownFutureValue",
+      "wipeCanceled",
+      "wipeFailed",
+      "wipeIssued",
+      "wipePending"
+    ],
+    "matchOn": [
+      "displayName",
+      "samAccountName",
+      "unknownFutureValue"
+    ],
+    "maxWorkLocationDetails": [
+      "approximate",
+      "none",
+      "specific",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "mdmAppConfigKeyType": [
+      "booleanType",
+      "integerType",
+      "realType",
+      "stringType",
+      "tokenType"
+    ],
+    "mdmAuthority": [
+      "intune",
+      "office365",
+      "sccm",
+      "unknown"
+    ],
+    "mdmSupportedState": [
+      "deprecated",
+      "supported",
+      "unknown",
+      "unsupported"
+    ],
+    "mediaDirection": [
+      "inactive",
+      "receiveOnly",
+      "sendOnly",
+      "sendReceive"
+    ],
+    "mediaSourceContentCategory": [
+      "chat",
+      "comment",
+      "liveStream",
+      "meeting",
+      "note",
+      "presentation",
+      "profile",
+      "screenRecording",
+      "story",
+      "unknownFutureValue"
+    ],
+    "mediaState": [
+      "active",
+      "inactive",
+      "unknownFutureValue"
+    ],
+    "meetingAudience": [
+      "everyone",
+      "organization",
+      "unknownFutureValue"
+    ],
+    "meetingCapabilities": [
+      "questionAndAnswer",
+      "unknownFutureValue"
+    ],
+    "meetingChatHistoryDefaultMode": [
+      "all",
+      "none",
+      "unknownFutureValue"
+    ],
+    "meetingChatMode": [
+      "disabled",
+      "enabled",
+      "limited",
+      "unknownFutureValue"
+    ],
+    "meetingLiveShareOptions": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "meetingMessageType": [
+      "meetingAccepted",
+      "meetingCancelled",
+      "meetingDeclined",
+      "meetingRequest",
+      "meetingTentativelyAccepted",
+      "none"
+    ],
+    "meetingRegistrantStatus": [
+      "canceled",
+      "processing",
+      "registered",
+      "unknownFutureValue"
+    ],
+    "meetingRequestType": [
+      "fullUpdate",
+      "informationalUpdate",
+      "newMeetingRequest",
+      "none",
+      "outdated",
+      "principalWantsCopy",
+      "silentUpdate"
+    ],
+    "MembershipRuleProcessingStatusDetails": [
+      "Failed",
+      "NotStarted",
+      "Running",
+      "Succeeded",
+      "UnsupportedFutureValue"
+    ],
+    "messageActionFlag": [
+      "any",
+      "call",
+      "doNotForward",
+      "followUp",
+      "forward",
+      "fyi",
+      "noResponseNecessary",
+      "read",
+      "reply",
+      "replyToAll",
+      "review"
+    ],
+    "messageEventType": [
+      "delayed",
+      "delivered",
+      "distributionGroupExpanded",
+      "dlpRuleTriggered",
+      "dropped",
+      "failed",
+      "journaled",
+      "malwareDetected",
+      "malwareDetectedInAttachment",
+      "malwareDetectedInMessage",
+      "processingFailed",
+      "received",
+      "recipientsAdded",
+      "redirected",
+      "resolved",
+      "sent",
+      "spamDetected",
+      "submitted",
+      "transportRuleTriggered",
+      "ttDelivered",
+      "ttZapped",
+      "unknownFutureValue"
+    ],
+    "messageStatus": [
+      "delivered",
+      "expanded",
+      "failed",
+      "filteredAsSpam",
+      "gettingStatus",
+      "pending",
+      "quarantined",
+      "unknownFutureValue"
+    ],
+    "messagingRedirectAppType": [
+      "anyApp",
+      "anyManagedApp",
+      "blocked",
+      "specificApps"
+    ],
+    "meteredConnectionLimitType": [
+      "fixed",
+      "unrestricted",
+      "variable"
+    ],
+    "mfaFailureReasonCode": [
+      "badRequest",
+      "mfaDenied",
+      "mfaIncomplete",
+      "other",
+      "systemFailure",
+      "unknownFutureValue"
+    ],
+    "mfaType": [
+      "certificate",
+      "eotp",
+      "fido",
+      "oneWaySms",
+      "other",
+      "phoneAppNotification",
+      "phoneAppOtp",
+      "twoWaySms",
+      "twoWaySmsOtherMobile",
+      "twoWayVoiceMobile",
+      "twoWayVoiceOffice",
+      "twoWayVoiceOtherMobile",
+      "unknownFutureValue"
+    ],
+    "microsoftAuthenticatorAuthenticationMethodClientAppName": [
+      "microsoftAuthenticator",
+      "outlookMobile",
+      "unknownFutureValue"
+    ],
+    "microsoftAuthenticatorAuthenticationMode": [
+      "any",
+      "deviceBasedPush",
+      "push"
+    ],
+    "microsoftEdgeChannel": [
+      "beta",
+      "dev",
+      "stable",
+      "unknownFutureValue"
+    ],
+    "microsoftLauncherDockPresence": [
+      "disabled",
+      "hide",
+      "notConfigured",
+      "show"
+    ],
+    "microsoftLauncherSearchBarPlacement": [
+      "bottom",
+      "hide",
+      "notConfigured",
+      "top"
+    ],
+    "microsoftManagedDesktopType": [
+      "notManaged",
+      "premiumManaged",
+      "standardManaged",
+      "starterManaged",
+      "unknownFutureValue"
+    ],
+    "microsoftStoreForBusinessLicenseType": [
+      "offline",
+      "online"
+    ],
+    "microsoftStoreForBusinessPortalSelectionOptions": [
+      "companyPortal",
+      "none",
+      "privateStore"
+    ],
+    "microsoftTunnelDeploymentMode": [
+      "podRootful",
+      "podRootless",
+      "standaloneRootful",
+      "standaloneRootless",
+      "unknownFutureValue"
+    ],
+    "microsoftTunnelLogCollectionStatus": [
+      "completed",
+      "failed",
+      "pending",
+      "unknownFutureValue"
+    ],
+    "microsoftTunnelServerHealthStatus": [
+      "healthy",
+      "offline",
+      "unhealthy",
+      "unknown",
+      "unknownFutureValue",
+      "upgradeFailed",
+      "upgradeInProgress",
+      "warning"
+    ],
+    "migrationMode": [
+      "completed",
+      "inProgress",
+      "unknownFutureValue"
+    ],
+    "migrationStatus": [
+      "additionalStepsRequired",
+      "needsReview",
+      "ready",
+      "unknownFutureValue"
+    ],
+    "miracastChannel": [
+      "eight",
+      "eleven",
+      "five",
+      "forty",
+      "fortyEight",
+      "fortyFour",
+      "four",
+      "nine",
+      "one",
+      "oneHundredFiftySeven",
+      "oneHundredFiftyThree",
+      "oneHundredFortyNine",
+      "oneHundredSixtyFive",
+      "oneHundredSixtyOne",
+      "seven",
+      "six",
+      "ten",
+      "thirtySix",
+      "three",
+      "two",
+      "userDefined"
+    ],
+    "mlClassificationMatchTolerance": [
+      "exact",
+      "near"
+    ],
+    "mobileAppActionType": [
+      "installCommandSent",
+      "installed",
+      "uninstalled",
+      "unknown",
+      "userRequestedInstall"
+    ],
+    "mobileAppContentFileUploadState": [
+      "azureStorageUriRenewalFailed",
+      "azureStorageUriRenewalPending",
+      "azureStorageUriRenewalSuccess",
+      "azureStorageUriRenewalTimedOut",
+      "azureStorageUriRequestFailed",
+      "azureStorageUriRequestPending",
+      "azureStorageUriRequestSuccess",
+      "azureStorageUriRequestTimedOut",
+      "commitFileFailed",
+      "commitFilePending",
+      "commitFileSuccess",
+      "commitFileTimedOut",
+      "error",
+      "success",
+      "transientError",
+      "unknown"
+    ],
+    "mobileAppContentScriptState": [
+      "commitFailed",
+      "commitPending",
+      "commitSuccess",
+      "unknownFutureValue"
+    ],
+    "mobileAppDependencyType": [
+      "autoInstall",
+      "detect",
+      "unknownFutureValue"
+    ],
+    "mobileAppIntent": [
+      "available",
+      "availableInstallWithoutEnrollment",
+      "exclude",
+      "notAvailable",
+      "requiredAndAvailableInstall",
+      "requiredInstall",
+      "requiredUninstall"
+    ],
+    "mobileAppPublishingState": [
+      "notPublished",
+      "processing",
+      "published"
+    ],
+    "mobileAppRelationshipType": [
+      "child",
+      "parent",
+      "unknownFutureValue"
+    ],
+    "mobileAppSupersedenceType": [
+      "replace",
+      "unknownFutureValue",
+      "update"
+    ],
+    "mobileThreatDefensePartnerPriority": [
+      "defenderOverThirdPartyPartner",
+      "thirdPartyPartnerOverDefender",
+      "unknownFutureValue"
+    ],
+    "mobileThreatPartnerTenantState": [
+      "available",
+      "enabled",
+      "error",
+      "notSetUp",
+      "unavailable",
+      "unknownFutureValue",
+      "unresponsive"
+    ],
+    "modality": [
+      "audio",
+      "data",
+      "unknown",
+      "unknownFutureValue",
+      "video",
+      "videoBasedScreenSharing"
+    ],
+    "monitorMode": [
+      "monitorOnly",
+      "unknownFutureValue"
+    ],
+    "monitorRunStatus": [
+      "failed",
+      "partiallySuccessful",
+      "successful",
+      "unknownFutureValue"
+    ],
+    "monitorStatus": [
+      "active",
+      "inactive",
+      "unknownFutureValue"
+    ],
+    "msiType": [
+      "none",
+      "systemAssigned",
+      "unknownFutureValue",
+      "userAssigned"
+    ],
+    "multiFactorAuthConfiguration": [
+      "notRequired",
+      "required",
+      "unknownFutureValue"
+    ],
+    "multiTenantOrganizationMemberProcessingStatus": [
+      "failed",
+      "notStarted",
+      "running",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "multiTenantOrganizationMemberRole": [
+      "member",
+      "owner",
+      "unknownFutureValue"
+    ],
+    "multiTenantOrganizationMemberState": [
+      "active",
+      "pending",
+      "removed",
+      "unknownFutureValue"
+    ],
+    "multiTenantOrganizationState": [
+      "active",
+      "inactive",
+      "unknownFutureValue"
+    ],
+    "mutability": [
+      "Immutable",
+      "ReadOnly",
+      "ReadWrite",
+      "WriteOnly"
+    ],
+    "nativeAuthenticationApisEnabled": [
+      "all",
+      "none",
+      "unknownFutureValue"
+    ],
+    "ndesConnectorState": [
+      "active",
+      "inactive",
+      "none"
+    ],
+    "networkSingleSignOnType": [
+      "disabled",
+      "postlogon",
+      "prelogon"
+    ],
+    "networkType": [
+      "extranet",
+      "intranet",
+      "namedNetwork",
+      "trusted",
+      "trustedNamedLocation",
+      "unknownFutureValue"
+    ],
+    "nonAdminSetting": [
+      "false",
+      "true",
+      "unknownFutureValue"
+    ],
+    "nonEapAuthenticationMethodForEapTtlsType": [
+      "challengeHandshakeAuthenticationProtocol",
+      "microsoftChap",
+      "microsoftChapVersionTwo",
+      "unencryptedPassword"
+    ],
+    "nonEapAuthenticationMethodForPeap": [
+      "microsoftChapVersionTwo",
+      "none"
+    ],
+    "notificationDeliveryFrequency": [
+      "biWeekly",
+      "unknown",
+      "unknownFutureValue",
+      "weekly"
+    ],
+    "notificationDeliveryPreference": [
+      "deliverAfterCampaignEnd",
+      "deliverImmedietly",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "notificationEventsType": [
+      "none",
+      "restoreAndPolicyUpdates",
+      "unknownFutureValue"
+    ],
+    "notificationRecipientsType": [
+      "allAdmins",
+      "backupAdmins",
+      "custom",
+      "globalAdmins",
+      "none",
+      "unknownFutureValue"
+    ],
+    "notificationTemplateBrandingOptions": [
+      "includeCompanyLogo",
+      "includeCompanyName",
+      "includeCompanyPortalLink",
+      "includeContactInformation",
+      "includeDeviceDetails",
+      "none",
+      "unknownFutureValue"
+    ],
+    "notifyMembers": [
+      "all",
+      "allowSelected",
+      "blockSelected",
+      "unknownFutureValue"
+    ],
+    "oAuthAppScope": [
+      "readAllChat",
+      "readAllFile",
+      "readAndWriteMail",
+      "readCalendar",
+      "readContact",
+      "readMail",
+      "sendMail",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "objectDefinitionMetadata": [
+      "BaseObjectName",
+      "ConnectorDataStorageRequired",
+      "Extensions",
+      "IsSoftDeletionSupported",
+      "IsSynchronizeAllSupported",
+      "PropertyNameAccountEnabled",
+      "PropertyNameSoftDeleted"
+    ],
+    "objectFlowTypes": [
+      "Add",
+      "Delete",
+      "None",
+      "Update"
+    ],
+    "objectMappingMetadata": [
+      "DisableMonitoringForChanges",
+      "Disposition",
+      "EscrowBehavior",
+      "ExcludeFromReporting",
+      "IsCustomerDefined",
+      "OriginalJoiningProperty",
+      "Unsynchronized"
+    ],
+    "obliterationBehavior": [
+      "always",
+      "default",
+      "doNotObliterate",
+      "obliterateWithWarning",
+      "unknownFutureValue"
+    ],
+    "officeProductId": [
+      "o365BusinessRetail",
+      "o365ProPlusRetail",
+      "projectProRetail",
+      "visioProRetail"
+    ],
+    "officeSuiteDefaultFileFormatType": [
+      "notConfigured",
+      "officeOpenDocumentFormat",
+      "officeOpenXMLFormat",
+      "unknownFutureValue"
+    ],
+    "officeSuiteInstallProgressDisplayLevel": [
+      "full",
+      "none"
+    ],
+    "officeUpdateChannel": [
+      "current",
+      "deferred",
+      "firstReleaseCurrent",
+      "firstReleaseDeferred",
+      "monthlyEnterprise",
+      "none"
+    ],
+    "oidcResponseType": [
+      "code",
+      "id_token",
+      "token",
+      "unknownFutureValue"
+    ],
+    "onboardingStatus": [
+      "failed",
+      "inprogress",
+      "offboarding",
+      "onboarded",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "onenotePatchActionType": [
+      "Append",
+      "Delete",
+      "Insert",
+      "Prepend",
+      "Replace"
+    ],
+    "onenotePatchInsertPosition": [
+      "After",
+      "Before"
+    ],
+    "onenoteSourceService": [
+      "OneDrive",
+      "OneDriveForBusiness",
+      "OnPremOneDriveForBusiness",
+      "Unknown"
+    ],
+    "onenoteUserRole": [
+      "Contributor",
+      "None",
+      "Owner",
+      "Reader"
+    ],
+    "onlineMeetingContentSharingDisabledReason": [
+      "unknownFutureValue",
+      "watermarkProtection"
+    ],
+    "onlineMeetingForwarders": [
+      "everyone",
+      "organizer",
+      "unknownFutureValue"
+    ],
+    "onlineMeetingPresenters": [
+      "everyone",
+      "organization",
+      "organizer",
+      "roleIsPresenter",
+      "unknownFutureValue"
+    ],
+    "onlineMeetingProviderType": [
+      "skypeForBusiness",
+      "skypeForConsumer",
+      "teamsForBusiness",
+      "unknown"
+    ],
+    "onlineMeetingRole": [
+      "attendee",
+      "coorganizer",
+      "presenter",
+      "producer",
+      "unknownFutureValue"
+    ],
+    "onlineMeetingVideoDisabledReason": [
+      "unknownFutureValue",
+      "watermarkProtection"
+    ],
+    "onPremisesDirectorySynchronizationDeletionPreventionType": [
+      "disabled",
+      "enabledForCount",
+      "enabledForPercentage",
+      "unknownFutureValue"
+    ],
+    "onPremisesPublishingType": [
+      "applicationProxy",
+      "authentication",
+      "exchangeOnline",
+      "intunePfx",
+      "oflineDomainJoin",
+      "privateAccess",
+      "provisioning",
+      "unknownFutureValue"
+    ],
+    "openIdConnectResponseMode": [
+      "form_post",
+      "query",
+      "unknownFutureValue"
+    ],
+    "openIdConnectResponseTypes": [
+      "code",
+      "id_token",
+      "token"
+    ],
+    "operatingSystemUpgradeEligibility": [
+      "capable",
+      "notCapable",
+      "unknown",
+      "unknownFutureValue",
+      "upgraded"
+    ],
+    "operationApprovalPolicyPlatform": [
+      "androidDeviceAdministrator",
+      "androidEnterprise",
+      "iOSiPadOS",
+      "macOS",
+      "notApplicable",
+      "unknownFutureValue",
+      "windows10AndLater",
+      "windows10X",
+      "windows81AndLater"
+    ],
+    "operationApprovalPolicyType": [
+      "app",
+      "deviceDelete",
+      "deviceRetire",
+      "deviceWipe",
+      "role",
+      "script",
+      "tenantConfiguration",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "operationApprovalRequestStatus": [
+      "approved",
+      "cancelled",
+      "completed",
+      "expired",
+      "needsApproval",
+      "rejected",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "operationApprovalSource": [
+      "adminConsole",
+      "email",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "operationResult": [
+      "failure",
+      "success",
+      "timeout",
+      "unknownFutureValue"
+    ],
+    "operationStatus": [
+      "Completed",
+      "Failed",
+      "NotStarted",
+      "Running"
+    ],
+    "operator": [
+      "allOf",
+      "and",
+      "beginsWith",
+      "between",
+      "contains",
+      "dayTimeBetween",
+      "endsWith",
+      "excludesAll",
+      "greaterEquals",
+      "greaterThan",
+      "isEquals",
+      "lessEquals",
+      "lessThan",
+      "none",
+      "noneOf",
+      "notBeginsWith",
+      "notBetween",
+      "notContains",
+      "notEndsWith",
+      "notEquals",
+      "oneOf",
+      "or",
+      "orderedSetEquals",
+      "setEquals",
+      "subsetOf"
+    ],
+    "originalTransferMethods": [
+      "authenticationTransfer",
+      "deviceCodeFlow",
+      "none",
+      "unknownFutureValue"
+    ],
+    "outlierContainerType": [
+      "group",
+      "unknownFutureValue"
+    ],
+    "outlierMemberType": [
+      "unknownFutureValue",
+      "user"
+    ],
+    "ownerType": [
+      "company",
+      "personal",
+      "unknown"
+    ],
+    "packageStatus": [
+      "all",
+      "none",
+      "some",
+      "unknownFutureValue"
+    ],
+    "packageType": [
+      "custom",
+      "external",
+      "microsoft",
+      "shared",
+      "unknownFutureValue"
+    ],
+    "pageLayoutType": [
+      "article",
+      "home",
+      "microsoftReserved",
+      "newsLink",
+      "unknownFutureValue",
+      "videoNewsLink"
+    ],
+    "pageOrientation": [
+      "diagonal",
+      "horizontal"
+    ],
+    "pagePromotionType": [
+      "microsoftReserved",
+      "newsPost",
+      "page",
+      "unknownFutureValue"
+    ],
+    "partnerTenantType": [
+      "breadthPartner",
+      "breadthPartnerDelegatedAdmin",
+      "microsoftSupport",
+      "resellerPartnerDelegatedAdmin",
+      "syndicatePartner",
+      "unknownFutureValue",
+      "valueAddedResellerPartnerDelegatedAdmin"
+    ],
+    "passkeyType": [
+      "deviceBound",
+      "synced",
+      "unknownFutureValue"
+    ],
+    "passkeyTypes": [
+      "deviceBound",
+      "synced",
+      "unknownFutureValue"
+    ],
+    "passwordPolicy": [
+      "changePasswordPeriod",
+      "charactersCombination",
+      "none",
+      "passwordHistoryAndReuse",
+      "passwordLengthLimit",
+      "personalInformationUse",
+      "unknownFutureValue"
+    ],
+    "payloadBrand": [
+      "adobe",
+      "americanExpress",
+      "capitalOne",
+      "dhl",
+      "docuSign",
+      "dropbox",
+      "facebook",
+      "firstAmerican",
+      "microsoft",
+      "netflix",
+      "other",
+      "scotiabank",
+      "sendGrid",
+      "stewartTitle",
+      "syrinxCloud",
+      "teams",
+      "tesco",
+      "unknown",
+      "unknownFutureValue",
+      "wellsFargo",
+      "zoom"
+    ],
+    "payloadComplexity": [
+      "high",
+      "low",
+      "medium",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "payloadDeliveryPlatform": [
+      "email",
+      "sms",
+      "teams",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "payloadIndustry": [
+      "banking",
+      "businessServices",
+      "construction",
+      "consulting",
+      "consumerServices",
+      "courierServices",
+      "education",
+      "energy",
+      "financialServices",
+      "government",
+      "healthcare",
+      "hospitality",
+      "insurance",
+      "IT",
+      "legal",
+      "manufacturing",
+      "other",
+      "realEstate",
+      "retail",
+      "telecom",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "payloadTheme": [
+      "accountActivation",
+      "accountVerification",
+      "advertisement",
+      "billing",
+      "cleanUpMail",
+      "controversial",
+      "documentReceived",
+      "employeeEngagement",
+      "expense",
+      "fax",
+      "financeReport",
+      "incomingMessages",
+      "invoice",
+      "itemReceived",
+      "loginAlert",
+      "mailReceived",
+      "other",
+      "password",
+      "payment",
+      "payroll",
+      "personalizedOffer",
+      "quarantine",
+      "remoteWork",
+      "reviewMessage",
+      "securityUpdate",
+      "serviceSuspended",
+      "signatureRequired",
+      "unknown",
+      "unknownFutureValue",
+      "upgradeMailboxStorage",
+      "verifyMailbox",
+      "voicemail"
+    ],
+    "pciVersion": [
+      "none",
+      "notSupported",
+      "unknownFutureValue",
+      "v3_2_1",
+      "v4"
+    ],
+    "perfectForwardSecrecyGroup": [
+      "ecp256",
+      "ecp384",
+      "pfs1",
+      "pfs2",
+      "pfs2048",
+      "pfs24",
+      "pfsMM"
+    ],
+    "permissionClassificationType": [
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "permissionKind": [
+      "all",
+      "allPermissionsOnResourceApp",
+      "enumerated",
+      "unknownFutureValue"
+    ],
+    "permissionsDefinitionIdentityType": [
+      "application",
+      "managedIdentity",
+      "role",
+      "serviceAccount",
+      "unknownFutureValue",
+      "user"
+    ],
+    "permissionsModificationCapability": [
+      "enabled",
+      "noRecentDataCollected",
+      "notConfigured",
+      "unknownFutureValue"
+    ],
+    "permissionsRequestOccurrenceStatus": [
+      "granted",
+      "granting",
+      "grantingFailed",
+      "revoked",
+      "revoking",
+      "revokingFailed",
+      "unknownFutureValue"
+    ],
+    "permissionType": [
+      "application",
+      "delegated",
+      "delegatedUserConsentable"
+    ],
+    "persistentBrowserSessionMode": [
+      "always",
+      "never"
+    ],
+    "personalProfilePersonalPlayStoreMode": [
+      "allowedApps",
+      "blockedApps",
+      "notConfigured"
+    ],
+    "personAnnualEventType": [
+      "birthday",
+      "other",
+      "unknownFutureValue",
+      "wedding",
+      "work"
+    ],
+    "personRelationship": [
+      "alternateContact",
+      "assistant",
+      "child",
+      "colleague",
+      "directReport",
+      "dotLineManager",
+      "dotLineReport",
+      "emergencyContact",
+      "friend",
+      "manager",
+      "other",
+      "parent",
+      "sibling",
+      "sponsor",
+      "spouse",
+      "unknownFutureValue"
+    ],
+    "perUserMfaState": [
+      "disabled",
+      "enabled",
+      "enforced",
+      "unknownFutureValue"
+    ],
+    "phoneType": [
+      "assistant",
+      "business",
+      "businessFax",
+      "home",
+      "homeFax",
+      "mobile",
+      "other",
+      "otherFax",
+      "pager",
+      "radio"
+    ],
+    "physicalAddressType": [
+      "business",
+      "home",
+      "other",
+      "unknown"
+    ],
+    "placeFeatureEnablement": [
+      "disabled",
+      "enabled",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "placeOperationStatus": [
+      "created",
+      "expired",
+      "failed",
+      "inProgress",
+      "partiallySucceeded",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "plannerApprovalStatus": [
+      "approved",
+      "cancelled",
+      "rejected",
+      "requested",
+      "unknownFutureValue"
+    ],
+    "plannerContainerType": [
+      "driveItem",
+      "group",
+      "onlineMeeting",
+      "plannerTask",
+      "project",
+      "roster",
+      "teamsChannel",
+      "unknownFutureValue",
+      "user"
+    ],
+    "plannerContextState": [
+      "active",
+      "delinked",
+      "unknownFutureValue"
+    ],
+    "plannerCreationSourceKind": [
+      "external",
+      "none",
+      "publication",
+      "unknownFutureValue"
+    ],
+    "plannerExternalTaskSourceDisplayType": [
+      "default",
+      "none",
+      "unknownFutureValue"
+    ],
+    "plannerPlanAccessLevel": [
+      "fullAccess",
+      "readAccess",
+      "readWriteAccess",
+      "unknownFutureValue"
+    ],
+    "plannerPlanContextType": [
+      "loopPage",
+      "meetingNotes",
+      "other",
+      "project",
+      "sharePointPage",
+      "teamsTab",
+      "unknownFutureValue"
+    ],
+    "plannerPreviewType": [
+      "automatic",
+      "checklist",
+      "description",
+      "noPreview",
+      "reference"
+    ],
+    "plannerRelationshipUserRoles": [
+      "applications",
+      "defaultRules",
+      "groupMembers",
+      "groupOwners",
+      "taskAssignees",
+      "unknownFutureValue"
+    ],
+    "plannerRuleKind": [
+      "bucketRule",
+      "planRule",
+      "taskRule",
+      "unknownFutureValue"
+    ],
+    "plannerTaskChatMentionType": [
+      "application",
+      "unknownFutureValue",
+      "user"
+    ],
+    "plannerTaskChatMessageType": [
+      "plainText",
+      "richTextHtml",
+      "unknownFutureValue"
+    ],
+    "plannerTaskCompletionRequirements": [
+      "approvalCompletion",
+      "checklistCompletion",
+      "completionInHostedApp",
+      "formCompletion",
+      "none",
+      "unknownFutureValue"
+    ],
+    "plannerTaskTargetKind": [
+      "group",
+      "unknownFutureValue"
+    ],
+    "plannerUserRoleKind": [
+      "relationship",
+      "unknownFutureValue"
+    ],
+    "platform": [
+      "android",
+      "ios",
+      "macOS",
+      "tvOS",
+      "unknown",
+      "unknownFutureValue",
+      "visionOS",
+      "windows",
+      "windowsMobile"
+    ],
+    "playPromptCompletionReason": [
+      "completedSuccessfully",
+      "mediaOperationCanceled",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "policyFileStatus": [
+      "modified",
+      "noContent",
+      "notModified",
+      "unknownFutureValue"
+    ],
+    "policyFileType": [
+      "dataCollectionPolicy",
+      "dlpPolicy",
+      "dlpSensitiveInformationType",
+      "unknownFutureValue"
+    ],
+    "policyPivotProperty": [
+      "activity",
+      "location",
+      "none",
+      "unknownFutureValue"
+    ],
+    "policyPlatformType": [
+      "all",
+      "android",
+      "androidAOSP",
+      "androidForWork",
+      "androidWorkProfile",
+      "iOS",
+      "macOS",
+      "windows10AndLater",
+      "windows10XProfile",
+      "windows81AndLater",
+      "windowsPhone81"
+    ],
+    "policyScope": [
+      "all",
+      "none",
+      "selected",
+      "unknownFutureValue"
+    ],
+    "policySetStatus": [
+      "error",
+      "notAssigned",
+      "partialSuccess",
+      "success",
+      "unknown",
+      "validating"
+    ],
+    "postType": [
+      "quick",
+      "regular",
+      "strategic",
+      "unknownFutureValue"
+    ],
+    "powerActionType": [
+      "hibernate",
+      "noAction",
+      "notConfigured",
+      "shutdown",
+      "sleep"
+    ],
+    "prereleaseFeatures": [
+      "notAllowed",
+      "settingsAndExperimentations",
+      "settingsOnly",
+      "userDefined"
+    ],
+    "principalType": [
+      "entraIdUser",
+      "unknownFutureValue"
+    ],
+    "printColorConfiguration": [
+      "auto",
+      "blackAndWhite",
+      "color",
+      "grayscale"
+    ],
+    "printColorMode": [
+      "auto",
+      "blackAndWhite",
+      "color",
+      "grayscale",
+      "unknownFutureValue"
+    ],
+    "printDuplexConfiguration": [
+      "oneSided",
+      "twoSidedLongEdge",
+      "twoSidedShortEdge"
+    ],
+    "printDuplexMode": [
+      "flipOnLongEdge",
+      "flipOnShortEdge",
+      "oneSided",
+      "unknownFutureValue"
+    ],
+    "printerFeedDirection": [
+      "longEdgeFirst",
+      "shortEdgeFirst"
+    ],
+    "printerFeedOrientation": [
+      "longEdgeFirst",
+      "shortEdgeFirst"
+    ],
+    "printerProcessingState": [
+      "idle",
+      "processing",
+      "stopped",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "printerProcessingStateDetail": [
+      "alertRemovalOfBinaryChangeEntry",
+      "banderAdded",
+      "banderAlmostEmpty",
+      "banderAlmostFull",
+      "banderAtLimit",
+      "banderClosed",
+      "banderConfigurationChange",
+      "banderCoverClosed",
+      "banderCoverOpen",
+      "banderEmpty",
+      "banderFull",
+      "banderInterlockClosed",
+      "banderInterlockOpen",
+      "banderJam",
+      "banderLifeAlmostOver",
+      "banderLifeOver",
+      "banderMemoryExhausted",
+      "banderMissing",
+      "banderMotorFailure",
+      "banderNearLimit",
+      "banderOffline",
+      "banderOpened",
+      "banderOverTemperature",
+      "banderPowerSaver",
+      "banderRecoverableFailure",
+      "banderRecoverableStorage",
+      "banderRemoved",
+      "banderResourceAdded",
+      "banderResourceRemoved",
+      "banderThermistorFailure",
+      "banderTimingFailure",
+      "banderTurnedOff",
+      "banderTurnedOn",
+      "banderUnderTemperature",
+      "banderUnrecoverableFailure",
+      "banderUnrecoverableStorageError",
+      "banderWarmingUp",
+      "binderAdded",
+      "binderAlmostEmpty",
+      "binderAlmostFull",
+      "binderAtLimit",
+      "binderClosed",
+      "binderConfigurationChange",
+      "binderCoverClosed",
+      "binderCoverOpen",
+      "binderEmpty",
+      "binderFull",
+      "binderInterlockClosed",
+      "binderInterlockOpen",
+      "binderJam",
+      "binderLifeAlmostOver",
+      "binderLifeOver",
+      "binderMemoryExhausted",
+      "binderMissing",
+      "binderMotorFailure",
+      "binderNearLimit",
+      "binderOffline",
+      "binderOpened",
+      "binderOverTemperature",
+      "binderPowerSaver",
+      "binderRecoverableFailure",
+      "binderRecoverableStorage",
+      "binderRemoved",
+      "binderResourceAdded",
+      "binderResourceRemoved",
+      "binderThermistorFailure",
+      "binderTimingFailure",
+      "binderTurnedOff",
+      "binderTurnedOn",
+      "binderUnderTemperature",
+      "binderUnrecoverableFailure",
+      "binderUnrecoverableStorageError",
+      "binderWarmingUp",
+      "cameraFailure",
+      "chamberCooling",
+      "chamberFailure",
+      "chamberHeating",
+      "chamberTemperatureHigh",
+      "chamberTemperatureLow",
+      "cleanerLifeAlmostOver",
+      "cleanerLifeOver",
+      "configurationChange",
+      "connectingToDevice",
+      "coverOpen",
+      "deactivated",
+      "deleted",
+      "developerEmpty",
+      "developerLow",
+      "dieCutterAdded",
+      "dieCutterAlmostEmpty",
+      "dieCutterAlmostFull",
+      "dieCutterAtLimit",
+      "dieCutterClosed",
+      "dieCutterConfigurationChange",
+      "dieCutterCoverClosed",
+      "dieCutterCoverOpen",
+      "dieCutterEmpty",
+      "dieCutterFull",
+      "dieCutterInterlockClosed",
+      "dieCutterInterlockOpen",
+      "dieCutterJam",
+      "dieCutterLifeAlmostOver",
+      "dieCutterLifeOver",
+      "dieCutterMemoryExhausted",
+      "dieCutterMissing",
+      "dieCutterMotorFailure",
+      "dieCutterNearLimit",
+      "dieCutterOffline",
+      "dieCutterOpened",
+      "dieCutterOverTemperature",
+      "dieCutterPowerSaver",
+      "dieCutterRecoverableFailure",
+      "dieCutterRecoverableStorage",
+      "dieCutterRemoved",
+      "dieCutterResourceAdded",
+      "dieCutterResourceRemoved",
+      "dieCutterThermistorFailure",
+      "dieCutterTimingFailure",
+      "dieCutterTurnedOff",
+      "dieCutterTurnedOn",
+      "dieCutterUnderTemperature",
+      "dieCutterUnrecoverableFailure",
+      "dieCutterUnrecoverableStorageError",
+      "dieCutterWarmingUp",
+      "doorOpen",
+      "extruderCooling",
+      "extruderFailure",
+      "extruderHeating",
+      "extruderJam",
+      "extruderTemperatureHigh",
+      "extruderTemperatureLow",
+      "fanFailure",
+      "faxModemLifeAlmostOver",
+      "faxModemLifeOver",
+      "faxModemMissing",
+      "faxModemTurnedOff",
+      "faxModemTurnedOn",
+      "folderAdded",
+      "folderAlmostEmpty",
+      "folderAlmostFull",
+      "folderAtLimit",
+      "folderClosed",
+      "folderConfigurationChange",
+      "folderCoverClosed",
+      "folderCoverOpen",
+      "folderEmpty",
+      "folderFull",
+      "folderInterlockClosed",
+      "folderInterlockOpen",
+      "folderJam",
+      "folderLifeAlmostOver",
+      "folderLifeOver",
+      "folderMemoryExhausted",
+      "folderMissing",
+      "folderMotorFailure",
+      "folderNearLimit",
+      "folderOffline",
+      "folderOpened",
+      "folderOverTemperature",
+      "folderPowerSaver",
+      "folderRecoverableFailure",
+      "folderRecoverableStorage",
+      "folderRemoved",
+      "folderResourceAdded",
+      "folderResourceRemoved",
+      "folderThermistorFailure",
+      "folderTimingFailure",
+      "folderTurnedOff",
+      "folderTurnedOn",
+      "folderUnderTemperature",
+      "folderUnrecoverableFailure",
+      "folderUnrecoverableStorageError",
+      "folderWarmingUp",
+      "fuserOverTemp",
+      "fuserUnderTemp",
+      "hibernate",
+      "holdNewJobs",
+      "identifyPrinterRequested",
+      "imprinterAdded",
+      "imprinterAlmostEmpty",
+      "imprinterAlmostFull",
+      "imprinterAtLimit",
+      "imprinterClosed",
+      "imprinterConfigurationChange",
+      "imprinterCoverClosed",
+      "imprinterCoverOpen",
+      "imprinterEmpty",
+      "imprinterFull",
+      "imprinterInterlockClosed",
+      "imprinterInterlockOpen",
+      "imprinterJam",
+      "imprinterLifeAlmostOver",
+      "imprinterLifeOver",
+      "imprinterMemoryExhausted",
+      "imprinterMissing",
+      "imprinterMotorFailure",
+      "imprinterNearLimit",
+      "imprinterOffline",
+      "imprinterOpened",
+      "imprinterOverTemperature",
+      "imprinterPowerSaver",
+      "imprinterRecoverableFailure",
+      "imprinterRecoverableStorage",
+      "imprinterRemoved",
+      "imprinterResourceAdded",
+      "imprinterResourceRemoved",
+      "imprinterThermistorFailure",
+      "imprinterTimingFailure",
+      "imprinterTurnedOff",
+      "imprinterTurnedOn",
+      "imprinterUnderTemperature",
+      "imprinterUnrecoverableFailure",
+      "imprinterUnrecoverableStorageError",
+      "imprinterWarmingUp",
+      "inputCannotFeedSizeSelected",
+      "inputManualInputRequest",
+      "inputMediaColorChange",
+      "inputMediaFormPartsChange",
+      "inputMediaSizeChange",
+      "inputMediaTrayFailure",
+      "inputMediaTrayFeedError",
+      "inputMediaTrayJam",
+      "inputMediaTypeChange",
+      "inputMediaWeightChange",
+      "inputPickRollerFailure",
+      "inputPickRollerLifeOver",
+      "inputPickRollerLifeWarn",
+      "inputPickRollerMissing",
+      "inputTrayElevationFailure",
+      "inputTrayMissing",
+      "inputTrayPositionFailure",
+      "inserterAdded",
+      "inserterAlmostEmpty",
+      "inserterAlmostFull",
+      "inserterAtLimit",
+      "inserterClosed",
+      "inserterConfigurationChange",
+      "inserterCoverClosed",
+      "inserterCoverOpen",
+      "inserterEmpty",
+      "inserterFull",
+      "inserterInterlockClosed",
+      "inserterInterlockOpen",
+      "inserterJam",
+      "inserterLifeAlmostOver",
+      "inserterLifeOver",
+      "inserterMemoryExhausted",
+      "inserterMissing",
+      "inserterMotorFailure",
+      "inserterNearLimit",
+      "inserterOffline",
+      "inserterOpened",
+      "inserterOverTemperature",
+      "inserterPowerSaver",
+      "inserterRecoverableFailure",
+      "inserterRecoverableStorage",
+      "inserterRemoved",
+      "inserterResourceAdded",
+      "inserterResourceRemoved",
+      "inserterThermistorFailure",
+      "inserterTimingFailure",
+      "inserterTurnedOff",
+      "inserterTurnedOn",
+      "inserterUnderTemperature",
+      "inserterUnrecoverableFailure",
+      "inserterUnrecoverableStorageError",
+      "inserterWarmingUp",
+      "interlockClosed",
+      "interlockOpen",
+      "interpreterCartridgeAdded",
+      "interpreterCartridgeDeleted",
+      "interpreterComplexPageEncountered",
+      "interpreterMemoryDecrease",
+      "interpreterMemoryIncrease",
+      "interpreterResourceAdded",
+      "interpreterResourceDeleted",
+      "interpreterResourceUnavailable",
+      "lampAtEol",
+      "lampFailure",
+      "lampNearEol",
+      "laserAtEol",
+      "laserFailure",
+      "laserNearEol",
+      "makeEnvelopeAdded",
+      "makeEnvelopeAlmostEmpty",
+      "makeEnvelopeAlmostFull",
+      "makeEnvelopeAtLimit",
+      "makeEnvelopeClosed",
+      "makeEnvelopeConfigurationChange",
+      "makeEnvelopeCoverClosed",
+      "makeEnvelopeCoverOpen",
+      "makeEnvelopeEmpty",
+      "makeEnvelopeFull",
+      "makeEnvelopeInterlockClosed",
+      "makeEnvelopeInterlockOpen",
+      "makeEnvelopeJam",
+      "makeEnvelopeLifeAlmostOver",
+      "makeEnvelopeLifeOver",
+      "makeEnvelopeMemoryExhausted",
+      "makeEnvelopeMissing",
+      "makeEnvelopeMotorFailure",
+      "makeEnvelopeNearLimit",
+      "makeEnvelopeOffline",
+      "makeEnvelopeOpened",
+      "makeEnvelopeOverTemperature",
+      "makeEnvelopePowerSaver",
+      "makeEnvelopeRecoverableFailure",
+      "makeEnvelopeRecoverableStorage",
+      "makeEnvelopeRemoved",
+      "makeEnvelopeResourceAdded",
+      "makeEnvelopeResourceRemoved",
+      "makeEnvelopeThermistorFailure",
+      "makeEnvelopeTimingFailure",
+      "makeEnvelopeTurnedOff",
+      "makeEnvelopeTurnedOn",
+      "makeEnvelopeUnderTemperature",
+      "makeEnvelopeUnrecoverableFailure",
+      "makeEnvelopeUnrecoverableStorageError",
+      "makeEnvelopeWarmingUp",
+      "markerAdjustingPrintQuality",
+      "markerCleanerMissing",
+      "markerDeveloperAlmostEmpty",
+      "markerDeveloperEmpty",
+      "markerDeveloperMissing",
+      "markerFuserMissing",
+      "markerFuserThermistorFailure",
+      "markerFuserTimingFailure",
+      "markerInkAlmostEmpty",
+      "markerInkEmpty",
+      "markerInkMissing",
+      "markerOpcMissing",
+      "markerPrintRibbonAlmostEmpty",
+      "markerPrintRibbonEmpty",
+      "markerPrintRibbonMissing",
+      "markerSupplyAlmostEmpty",
+      "markerSupplyEmpty",
+      "markerSupplyLow",
+      "markerSupplyMissing",
+      "markerTonerCartridgeMissing",
+      "markerTonerMissing",
+      "markerWasteAlmostFull",
+      "markerWasteFull",
+      "markerWasteInkReceptacleAlmostFull",
+      "markerWasteInkReceptacleFull",
+      "markerWasteInkReceptacleMissing",
+      "markerWasteMissing",
+      "markerWasteTonerReceptacleAlmostFull",
+      "markerWasteTonerReceptacleFull",
+      "markerWasteTonerReceptacleMissing",
+      "materialEmpty",
+      "materialLow",
+      "materialNeeded",
+      "mediaDrying",
+      "mediaEmpty",
+      "mediaJam",
+      "mediaLow",
+      "mediaNeeded",
+      "mediaPathCannotDuplexMediaSelected",
+      "mediaPathFailure",
+      "mediaPathInputEmpty",
+      "mediaPathInputFeedError",
+      "mediaPathInputJam",
+      "mediaPathInputRequest",
+      "mediaPathJam",
+      "mediaPathMediaTrayAlmostFull",
+      "mediaPathMediaTrayFull",
+      "mediaPathMediaTrayMissing",
+      "mediaPathOutputFeedError",
+      "mediaPathOutputFull",
+      "mediaPathOutputJam",
+      "mediaPathPickRollerFailure",
+      "mediaPathPickRollerLifeOver",
+      "mediaPathPickRollerLifeWarn",
+      "mediaPathPickRollerMissing",
+      "motorFailure",
+      "movingToPaused",
+      "none",
+      "opticalPhotoConductorLifeOver",
+      "opticalPhotoConductorNearEndOfLife",
+      "other",
+      "outputAreaAlmostFull",
+      "outputAreaFull",
+      "outputMailboxSelectFailure",
+      "outputMediaTrayFailure",
+      "outputMediaTrayFeedError",
+      "outputMediaTrayJam",
+      "outputTrayMissing",
+      "paused",
+      "perforaterAdded",
+      "perforaterAlmostEmpty",
+      "perforaterAlmostFull",
+      "perforaterAtLimit",
+      "perforaterClosed",
+      "perforaterConfigurationChange",
+      "perforaterCoverClosed",
+      "perforaterCoverOpen",
+      "perforaterEmpty",
+      "perforaterFull",
+      "perforaterInterlockClosed",
+      "perforaterInterlockOpen",
+      "perforaterJam",
+      "perforaterLifeAlmostOver",
+      "perforaterLifeOver",
+      "perforaterMemoryExhausted",
+      "perforaterMissing",
+      "perforaterMotorFailure",
+      "perforaterNearLimit",
+      "perforaterOffline",
+      "perforaterOpened",
+      "perforaterOverTemperature",
+      "perforaterPowerSaver",
+      "perforaterRecoverableFailure",
+      "perforaterRecoverableStorage",
+      "perforaterRemoved",
+      "perforaterResourceAdded",
+      "perforaterResourceRemoved",
+      "perforaterThermistorFailure",
+      "perforaterTimingFailure",
+      "perforaterTurnedOff",
+      "perforaterTurnedOn",
+      "perforaterUnderTemperature",
+      "perforaterUnrecoverableFailure",
+      "perforaterUnrecoverableStorageError",
+      "perforaterWarmingUp",
+      "platformCooling",
+      "platformFailure",
+      "platformHeating",
+      "platformTemperatureHigh",
+      "platformTemperatureLow",
+      "powerDown",
+      "powerUp",
+      "printerManualReset",
+      "printerNmsReset",
+      "printerReadyToPrint",
+      "puncherAdded",
+      "puncherAlmostEmpty",
+      "puncherAlmostFull",
+      "puncherAtLimit",
+      "puncherClosed",
+      "puncherConfigurationChange",
+      "puncherCoverClosed",
+      "puncherCoverOpen",
+      "puncherEmpty",
+      "puncherFull",
+      "puncherInterlockClosed",
+      "puncherInterlockOpen",
+      "puncherJam",
+      "puncherLifeAlmostOver",
+      "puncherLifeOver",
+      "puncherMemoryExhausted",
+      "puncherMissing",
+      "puncherMotorFailure",
+      "puncherNearLimit",
+      "puncherOffline",
+      "puncherOpened",
+      "puncherOverTemperature",
+      "puncherPowerSaver",
+      "puncherRecoverableFailure",
+      "puncherRecoverableStorage",
+      "puncherRemoved",
+      "puncherResourceAdded",
+      "puncherResourceRemoved",
+      "puncherThermistorFailure",
+      "puncherTimingFailure",
+      "puncherTurnedOff",
+      "puncherTurnedOn",
+      "puncherUnderTemperature",
+      "puncherUnrecoverableFailure",
+      "puncherUnrecoverableStorageError",
+      "puncherWarmingUp",
+      "resuming",
+      "scanMediaPathFailure",
+      "scanMediaPathInputEmpty",
+      "scanMediaPathInputFeedError",
+      "scanMediaPathInputJam",
+      "scanMediaPathInputRequest",
+      "scanMediaPathJam",
+      "scanMediaPathOutputFeedError",
+      "scanMediaPathOutputFull",
+      "scanMediaPathOutputJam",
+      "scanMediaPathPickRollerFailure",
+      "scanMediaPathPickRollerLifeOver",
+      "scanMediaPathPickRollerLifeWarn",
+      "scanMediaPathPickRollerMissing",
+      "scanMediaPathTrayAlmostFull",
+      "scanMediaPathTrayFull",
+      "scanMediaPathTrayMissing",
+      "scannerLightFailure",
+      "scannerLightLifeAlmostOver",
+      "scannerLightLifeOver",
+      "scannerLightMissing",
+      "scannerSensorFailure",
+      "scannerSensorLifeAlmostOver",
+      "scannerSensorLifeOver",
+      "scannerSensorMissing",
+      "separationCutterAdded",
+      "separationCutterAlmostEmpty",
+      "separationCutterAlmostFull",
+      "separationCutterAtLimit",
+      "separationCutterClosed",
+      "separationCutterConfigurationChange",
+      "separationCutterCoverClosed",
+      "separationCutterCoverOpen",
+      "separationCutterEmpty",
+      "separationCutterFull",
+      "separationCutterInterlockClosed",
+      "separationCutterInterlockOpen",
+      "separationCutterJam",
+      "separationCutterLifeAlmostOver",
+      "separationCutterLifeOver",
+      "separationCutterMemoryExhausted",
+      "separationCutterMissing",
+      "separationCutterMotorFailure",
+      "separationCutterNearLimit",
+      "separationCutterOffline",
+      "separationCutterOpened",
+      "separationCutterOverTemperature",
+      "separationCutterPowerSaver",
+      "separationCutterRecoverableFailure",
+      "separationCutterRecoverableStorage",
+      "separationCutterRemoved",
+      "separationCutterResourceAdded",
+      "separationCutterResourceRemoved",
+      "separationCutterThermistorFailure",
+      "separationCutterTimingFailure",
+      "separationCutterTurnedOff",
+      "separationCutterTurnedOn",
+      "separationCutterUnderTemperature",
+      "separationCutterUnrecoverableFailure",
+      "separationCutterUnrecoverableStorageError",
+      "separationCutterWarmingUp",
+      "sheetRotatorAdded",
+      "sheetRotatorAlmostEmpty",
+      "sheetRotatorAlmostFull",
+      "sheetRotatorAtLimit",
+      "sheetRotatorClosed",
+      "sheetRotatorConfigurationChange",
+      "sheetRotatorCoverClosed",
+      "sheetRotatorCoverOpen",
+      "sheetRotatorEmpty",
+      "sheetRotatorFull",
+      "sheetRotatorInterlockClosed",
+      "sheetRotatorInterlockOpen",
+      "sheetRotatorJam",
+      "sheetRotatorLifeAlmostOver",
+      "sheetRotatorLifeOver",
+      "sheetRotatorMemoryExhausted",
+      "sheetRotatorMissing",
+      "sheetRotatorMotorFailure",
+      "sheetRotatorNearLimit",
+      "sheetRotatorOffline",
+      "sheetRotatorOpened",
+      "sheetRotatorOverTemperature",
+      "sheetRotatorPowerSaver",
+      "sheetRotatorRecoverableFailure",
+      "sheetRotatorRecoverableStorage",
+      "sheetRotatorRemoved",
+      "sheetRotatorResourceAdded",
+      "sheetRotatorResourceRemoved",
+      "sheetRotatorThermistorFailure",
+      "sheetRotatorTimingFailure",
+      "sheetRotatorTurnedOff",
+      "sheetRotatorTurnedOn",
+      "sheetRotatorUnderTemperature",
+      "sheetRotatorUnrecoverableFailure",
+      "sheetRotatorUnrecoverableStorageError",
+      "sheetRotatorWarmingUp",
+      "shutdown",
+      "slitterAdded",
+      "slitterAlmostEmpty",
+      "slitterAlmostFull",
+      "slitterAtLimit",
+      "slitterClosed",
+      "slitterConfigurationChange",
+      "slitterCoverClosed",
+      "slitterCoverOpen",
+      "slitterEmpty",
+      "slitterFull",
+      "slitterInterlockClosed",
+      "slitterInterlockOpen",
+      "slitterJam",
+      "slitterLifeAlmostOver",
+      "slitterLifeOver",
+      "slitterMemoryExhausted",
+      "slitterMissing",
+      "slitterMotorFailure",
+      "slitterNearLimit",
+      "slitterOffline",
+      "slitterOpened",
+      "slitterOverTemperature",
+      "slitterPowerSaver",
+      "slitterRecoverableFailure",
+      "slitterRecoverableStorage",
+      "slitterRemoved",
+      "slitterResourceAdded",
+      "slitterResourceRemoved",
+      "slitterThermistorFailure",
+      "slitterTimingFailure",
+      "slitterTurnedOff",
+      "slitterTurnedOn",
+      "slitterUnderTemperature",
+      "slitterUnrecoverableFailure",
+      "slitterUnrecoverableStorageError",
+      "slitterWarmingUp",
+      "spoolAreaFull",
+      "stackerAdded",
+      "stackerAlmostEmpty",
+      "stackerAlmostFull",
+      "stackerAtLimit",
+      "stackerClosed",
+      "stackerConfigurationChange",
+      "stackerCoverClosed",
+      "stackerCoverOpen",
+      "stackerEmpty",
+      "stackerFull",
+      "stackerInterlockClosed",
+      "stackerInterlockOpen",
+      "stackerJam",
+      "stackerLifeAlmostOver",
+      "stackerLifeOver",
+      "stackerMemoryExhausted",
+      "stackerMissing",
+      "stackerMotorFailure",
+      "stackerNearLimit",
+      "stackerOffline",
+      "stackerOpened",
+      "stackerOverTemperature",
+      "stackerPowerSaver",
+      "stackerRecoverableFailure",
+      "stackerRecoverableStorage",
+      "stackerRemoved",
+      "stackerResourceAdded",
+      "stackerResourceRemoved",
+      "stackerThermistorFailure",
+      "stackerTimingFailure",
+      "stackerTurnedOff",
+      "stackerTurnedOn",
+      "stackerUnderTemperature",
+      "stackerUnrecoverableFailure",
+      "stackerUnrecoverableStorageError",
+      "stackerWarmingUp",
+      "standby",
+      "staplerAdded",
+      "staplerAlmostEmpty",
+      "staplerAlmostFull",
+      "staplerAtLimit",
+      "staplerClosed",
+      "staplerConfigurationChange",
+      "staplerCoverClosed",
+      "staplerCoverOpen",
+      "staplerEmpty",
+      "staplerFull",
+      "staplerInterlockClosed",
+      "staplerInterlockOpen",
+      "staplerJam",
+      "staplerLifeAlmostOver",
+      "staplerLifeOver",
+      "staplerMemoryExhausted",
+      "staplerMissing",
+      "staplerMotorFailure",
+      "staplerNearLimit",
+      "staplerOffline",
+      "staplerOpened",
+      "staplerOverTemperature",
+      "staplerPowerSaver",
+      "staplerRecoverableFailure",
+      "staplerRecoverableStorage",
+      "staplerRemoved",
+      "staplerResourceAdded",
+      "staplerResourceRemoved",
+      "staplerThermistorFailure",
+      "staplerTimingFailure",
+      "staplerTurnedOff",
+      "staplerTurnedOn",
+      "staplerUnderTemperature",
+      "staplerUnrecoverableFailure",
+      "staplerUnrecoverableStorageError",
+      "staplerWarmingUp",
+      "stitcherAdded",
+      "stitcherAlmostEmpty",
+      "stitcherAlmostFull",
+      "stitcherAtLimit",
+      "stitcherClosed",
+      "stitcherConfigurationChange",
+      "stitcherCoverClosed",
+      "stitcherCoverOpen",
+      "stitcherEmpty",
+      "stitcherFull",
+      "stitcherInterlockClosed",
+      "stitcherInterlockOpen",
+      "stitcherJam",
+      "stitcherLifeAlmostOver",
+      "stitcherLifeOver",
+      "stitcherMemoryExhausted",
+      "stitcherMissing",
+      "stitcherMotorFailure",
+      "stitcherNearLimit",
+      "stitcherOffline",
+      "stitcherOpened",
+      "stitcherOverTemperature",
+      "stitcherPowerSaver",
+      "stitcherRecoverableFailure",
+      "stitcherRecoverableStorage",
+      "stitcherRemoved",
+      "stitcherResourceAdded",
+      "stitcherResourceRemoved",
+      "stitcherThermistorFailure",
+      "stitcherTimingFailure",
+      "stitcherTurnedOff",
+      "stitcherTurnedOn",
+      "stitcherUnderTemperature",
+      "stitcherUnrecoverableFailure",
+      "stitcherUnrecoverableStorageError",
+      "stitcherWarmingUp",
+      "stoppedPartially",
+      "stopping",
+      "subunitAdded",
+      "subunitAlmostEmpty",
+      "subunitAlmostFull",
+      "subunitAtLimit",
+      "subunitClosed",
+      "subunitCoolingDown",
+      "subunitEmpty",
+      "subunitFull",
+      "subunitLifeAlmostOver",
+      "subunitLifeOver",
+      "subunitMemoryExhausted",
+      "subunitMissing",
+      "subunitMotorFailure",
+      "subunitNearLimit",
+      "subunitOffline",
+      "subunitOpened",
+      "subunitOverTemperature",
+      "subunitPowerSaver",
+      "subunitRecoverableFailure",
+      "subunitRecoverableStorage",
+      "subunitRemoved",
+      "subunitResourceAdded",
+      "subunitResourceRemoved",
+      "subunitThermistorFailure",
+      "subunitTimingFailure",
+      "subunitTurnedOff",
+      "subunitTurnedOn",
+      "subunitUnderTemperature",
+      "subunitUnrecoverableFailure",
+      "subunitUnrecoverableStorage",
+      "subunitWarmingUp",
+      "suspend",
+      "testing",
+      "timedOut",
+      "tonerEmpty",
+      "tonerLow",
+      "trimmerAdded",
+      "trimmerAlmostEmpty",
+      "trimmerAlmostFull",
+      "trimmerAtLimit",
+      "trimmerClosed",
+      "trimmerConfigurationChange",
+      "trimmerCoverClosed",
+      "trimmerCoverOpen",
+      "trimmerEmpty",
+      "trimmerFull",
+      "trimmerInterlockClosed",
+      "trimmerInterlockOpen",
+      "trimmerJam",
+      "trimmerLifeAlmostOver",
+      "trimmerLifeOver",
+      "trimmerMemoryExhausted",
+      "trimmerMissing",
+      "trimmerMotorFailure",
+      "trimmerNearLimit",
+      "trimmerOffline",
+      "trimmerOpened",
+      "trimmerOverTemperature",
+      "trimmerPowerSaver",
+      "trimmerRecoverableFailure",
+      "trimmerRecoverableStorage",
+      "trimmerRemoved",
+      "trimmerResourceAdded",
+      "trimmerResourceRemoved",
+      "trimmerThermistorFailure",
+      "trimmerTimingFailure",
+      "trimmerTurnedOff",
+      "trimmerTurnedOn",
+      "trimmerUnderTemperature",
+      "trimmerUnrecoverableFailure",
+      "trimmerUnrecoverableStorageError",
+      "trimmerWarmingUp",
+      "unknown",
+      "unknownFutureValue",
+      "wrapperAdded",
+      "wrapperAlmostEmpty",
+      "wrapperAlmostFull",
+      "wrapperAtLimit",
+      "wrapperClosed",
+      "wrapperConfigurationChange",
+      "wrapperCoverClosed",
+      "wrapperCoverOpen",
+      "wrapperEmpty",
+      "wrapperFull",
+      "wrapperInterlockClosed",
+      "wrapperInterlockOpen",
+      "wrapperJam",
+      "wrapperLifeAlmostOver",
+      "wrapperLifeOver",
+      "wrapperMemoryExhausted",
+      "wrapperMissing",
+      "wrapperMotorFailure",
+      "wrapperNearLimit",
+      "wrapperOffline",
+      "wrapperOpened",
+      "wrapperOverTemperature",
+      "wrapperPowerSaver",
+      "wrapperRecoverableFailure",
+      "wrapperRecoverableStorage",
+      "wrapperRemoved",
+      "wrapperResourceAdded",
+      "wrapperResourceRemoved",
+      "wrapperThermistorFailure",
+      "wrapperTimingFailure",
+      "wrapperTurnedOff",
+      "wrapperTurnedOn",
+      "wrapperUnderTemperature",
+      "wrapperUnrecoverableFailure",
+      "wrapperUnrecoverableStorageError",
+      "wrapperWarmingUp"
+    ],
+    "printerProcessingStateReason": [
+      "connectingToDevice",
+      "coverOpen",
+      "developerEmpty",
+      "developerLow",
+      "doorOpen",
+      "fuserOverTemp",
+      "fuserUnderTemp",
+      "inputTrayMissing",
+      "interlockOpen",
+      "interpreterResourceUnavailable",
+      "markerSupplyEmpty",
+      "markerSupplyLow",
+      "markerWasteAlmostFull",
+      "markerWasteFull",
+      "mediaEmpty",
+      "mediaJam",
+      "mediaLow",
+      "mediaNeeded",
+      "movingToPaused",
+      "none",
+      "opticalPhotoConductorLifeOver",
+      "opticalPhotoConductorNearEndOfLife",
+      "other",
+      "outputAreaAlmostFull",
+      "outputAreaFull",
+      "outputTrayMissing",
+      "paused",
+      "shutdown",
+      "spoolAreaFull",
+      "stoppedPartially",
+      "stopping",
+      "timedOut",
+      "tonerEmpty",
+      "tonerLow",
+      "unknownFutureValue"
+    ],
+    "printEvent": [
+      "jobStarted",
+      "unknownFutureValue"
+    ],
+    "printFinishing": [
+      "bale",
+      "bind",
+      "bindBottom",
+      "bindLeft",
+      "bindRight",
+      "bindTop",
+      "bookletMaker",
+      "coat",
+      "cover",
+      "fold",
+      "foldAccordion",
+      "foldDoubleGate",
+      "foldEngineeringZ",
+      "foldGate",
+      "foldHalf",
+      "foldHalfZ",
+      "foldLeftGate",
+      "foldLetter",
+      "foldParallel",
+      "foldPoster",
+      "foldRightGate",
+      "foldZ",
+      "laminate",
+      "none",
+      "punch",
+      "punchBottomLeft",
+      "punchBottomRight",
+      "punchDualBottom",
+      "punchDualLeft",
+      "punchDualRight",
+      "punchDualTop",
+      "punchQuadBottom",
+      "punchQuadLeft",
+      "punchQuadRight",
+      "punchQuadTop",
+      "punchTopLeft",
+      "punchTopRight",
+      "punchTripleBottom",
+      "punchTripleLeft",
+      "punchTripleRight",
+      "punchTripleTop",
+      "saddleStitch",
+      "staple",
+      "stapleBottomLeft",
+      "stapleBottomRight",
+      "stapleDualBottom",
+      "stapleDualLeft",
+      "stapleDualRight",
+      "stapleDualTop",
+      "stapleTopLeft",
+      "stapleTopRight",
+      "stapleTripleBottom",
+      "stapleTripleLeft",
+      "stapleTripleRight",
+      "stapleTripleTop",
+      "stitchBottomEdge",
+      "stitchEdge",
+      "stitchLeftEdge",
+      "stitchRightEdge",
+      "stitchTopEdge",
+      "trim",
+      "trimAfterCopies",
+      "trimAfterDocuments",
+      "trimAfterJob",
+      "trimAfterPages",
+      "unknownFutureValue"
+    ],
+    "printJobProcessingState": [
+      "aborted",
+      "canceled",
+      "completed",
+      "paused",
+      "pending",
+      "processing",
+      "stopped",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "printJobStateDetail": [
+      "completedSuccessfully",
+      "completedWithErrors",
+      "completedWithWarnings",
+      "interpreting",
+      "releaseWait",
+      "transforming",
+      "unknownFutureValue",
+      "uploadPending"
+    ],
+    "printMediaType": [
+      "continuous",
+      "continuousLong",
+      "continuousShort",
+      "envelope",
+      "envelopePlain",
+      "envelopeWindow",
+      "labels",
+      "multiLayer",
+      "multiPartForm",
+      "screen",
+      "screenPaged",
+      "stationery",
+      "transparency"
+    ],
+    "printMultipageLayout": [
+      "clockwiseFromBottomLeft",
+      "clockwiseFromBottomRight",
+      "clockwiseFromTopLeft",
+      "clockwiseFromTopRight",
+      "counterclockwiseFromBottomLeft",
+      "counterclockwiseFromBottomRight",
+      "counterclockwiseFromTopLeft",
+      "counterclockwiseFromTopRight",
+      "unknownFutureValue"
+    ],
+    "printOperationProcessingState": [
+      "failed",
+      "notStarted",
+      "running",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "printOrientation": [
+      "landscape",
+      "portrait",
+      "reverseLandscape",
+      "reversePortrait",
+      "unknownFutureValue"
+    ],
+    "printPresentationDirection": [
+      "clockwiseFromBottomLeft",
+      "clockwiseFromBottomRight",
+      "clockwiseFromTopLeft",
+      "clockwiseFromTopRight",
+      "counterClockwiseFromBottomLeft",
+      "counterClockwiseFromBottomRight",
+      "counterClockwiseFromTopLeft",
+      "counterClockwiseFromTopRight"
+    ],
+    "printQuality": [
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "printScaling": [
+      "auto",
+      "fill",
+      "fit",
+      "none",
+      "shrinkToFit",
+      "unknownFutureValue"
+    ],
+    "printTaskProcessingState": [
+      "aborted",
+      "completed",
+      "pending",
+      "processing",
+      "unknownFutureValue"
+    ],
+    "priority": [
+      "High",
+      "Low",
+      "None"
+    ],
+    "privateNetworkDestinationType": [
+      "dnsSuffix",
+      "fqdn",
+      "ipAddress",
+      "ipRange",
+      "ipRangeCidr",
+      "servicePrincipalName",
+      "unknownFutureValue"
+    ],
+    "privateNetworkProtocol": [
+      "tcp",
+      "udp",
+      "unknownFutureValue"
+    ],
+    "privilegedAccessGroupAssignmentType": [
+      "activated",
+      "assigned",
+      "unknownFutureValue"
+    ],
+    "privilegedAccessGroupMemberType": [
+      "direct",
+      "group",
+      "unknownFutureValue"
+    ],
+    "privilegedAccessGroupRelationships": [
+      "member",
+      "owner",
+      "unknownFutureValue"
+    ],
+    "privilegeLevel": [
+      "privileged",
+      "standard",
+      "unknownFutureValue"
+    ],
+    "privilegeManagementElevationType": [
+      "supportApprovedElevation",
+      "undetermined",
+      "unknownFutureValue",
+      "unmanagedElevation",
+      "userConfirmedElevation",
+      "zeroTouchElevation"
+    ],
+    "privilegeManagementEndUserType": [
+      "azureAd",
+      "hybrid",
+      "local",
+      "undetermined",
+      "unknownFutureValue"
+    ],
+    "privilegeManagementProcessType": [
+      "child",
+      "parent",
+      "undefined",
+      "unknownFutureValue"
+    ],
+    "processIntegrityLevel": [
+      "high",
+      "low",
+      "medium",
+      "system",
+      "unknown",
+      "unknownFutureValue",
+      "untrusted"
+    ],
+    "promptLoginBehavior": [
+      "disabled",
+      "nativeSupport",
+      "translateToFreshPasswordAuthentication",
+      "unknownFutureValue"
+    ],
+    "propertyType": [
+      "boolean",
+      "dateTime",
+      "dateTimeCollection",
+      "double",
+      "doubleCollection",
+      "int64",
+      "int64Collection",
+      "string",
+      "stringCollection"
+    ],
+    "protectionPolicyStatus": [
+      "active",
+      "activeWithErrors",
+      "inactive",
+      "offboarded",
+      "offboardRequested",
+      "unknownFutureValue",
+      "updating"
+    ],
+    "protectionRuleStatus": [
+      "active",
+      "completed",
+      "completedWithErrors",
+      "deleteRequested",
+      "draft",
+      "unknownFutureValue",
+      "updateRequested"
+    ],
+    "protectionScopeState": [
+      "modified",
+      "notModified",
+      "unknownFutureValue"
+    ],
+    "protectionSource": [
+      "dynamicRule",
+      "manual",
+      "none",
+      "unknownFutureValue"
+    ],
+    "protectionUnitsBulkJobStatus": [
+      "active",
+      "completed",
+      "completedWithErrors",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "protectionUnitStatus": [
+      "cancelOffboardRequested",
+      "offboarded",
+      "offboardRequested",
+      "protected",
+      "protectRequested",
+      "removeRequested",
+      "unknownFutureValue",
+      "unprotected",
+      "unprotectRequested"
+    ],
+    "protocolType": [
+      "authenticationTransfer",
+      "authorizationCodeWithoutPkce",
+      "authorizationCodeWithPkce",
+      "clientCredentials",
+      "deviceCode",
+      "directUserGrant",
+      "encryptedAuthorizeResponse",
+      "implicitAccessTokenAndGetResponseMode",
+      "implicitAccessTokenAndPostResponseMode",
+      "implicitIdTokenAndGetResponseMode",
+      "implicitIdTokenAndPostResponseMode",
+      "kerberos",
+      "nativeAuth",
+      "none",
+      "oAuth2",
+      "officeS2S",
+      "onBehalfOf",
+      "prtBrokerBased",
+      "prtGrant",
+      "prtNonBrokerBased",
+      "refreshTokenGrant",
+      "ropc",
+      "saml20",
+      "samlOnBehalfOf",
+      "seamlessSso",
+      "unknownFutureValue",
+      "wsFederation",
+      "wsTrust"
+    ],
+    "provisioningAction": [
+      "create",
+      "delete",
+      "disable",
+      "other",
+      "stagedDelete",
+      "unknownFutureValue",
+      "update"
+    ],
+    "provisioningResult": [
+      "failure",
+      "skipped",
+      "success",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "provisioningStatusErrorCategory": [
+      "failure",
+      "nonServiceFailure",
+      "success",
+      "unknownFutureValue"
+    ],
+    "provisioningStepType": [
+      "export",
+      "import",
+      "matching",
+      "processing",
+      "referenceResolution",
+      "scoping",
+      "unknownFutureValue"
+    ],
+    "provisionState": [
+      "notProvisioned",
+      "provisioningCompleted",
+      "provisioningFailed",
+      "provisioningInProgress",
+      "unknownFutureValue"
+    ],
+    "purviewInsiderRiskManagementLevel": [
+      "elevated",
+      "minor",
+      "moderate",
+      "none",
+      "unknownFutureValue"
+    ],
+    "quarantineReason": [
+      "EncounteredBaseEscrowThreshold",
+      "EncounteredEscrowProportionThreshold",
+      "EncounteredQuarantineException",
+      "EncounteredTotalEscrowThreshold",
+      "IngestionInterrupted",
+      "QuarantinedOnDemand",
+      "TooManyDeletes",
+      "Unknown"
+    ],
+    "ratingAppsType": [
+      "agesAbove12",
+      "agesAbove17",
+      "agesAbove4",
+      "agesAbove9",
+      "allAllowed",
+      "allBlocked"
+    ],
+    "ratingAustraliaMoviesType": [
+      "agesAbove15",
+      "agesAbove18",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "mature",
+      "parentalGuidance"
+    ],
+    "ratingAustraliaTelevisionType": [
+      "agesAbove15",
+      "agesAbove15AdultViolence",
+      "allAllowed",
+      "allBlocked",
+      "children",
+      "general",
+      "mature",
+      "parentalGuidance",
+      "preschoolers"
+    ],
+    "ratingCanadaMoviesType": [
+      "agesAbove14",
+      "agesAbove18",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "parentalGuidance",
+      "restricted"
+    ],
+    "ratingCanadaTelevisionType": [
+      "agesAbove14",
+      "agesAbove18",
+      "allAllowed",
+      "allBlocked",
+      "children",
+      "childrenAbove8",
+      "general",
+      "parentalGuidance"
+    ],
+    "ratingFranceMoviesType": [
+      "agesAbove10",
+      "agesAbove12",
+      "agesAbove16",
+      "agesAbove18",
+      "allAllowed",
+      "allBlocked"
+    ],
+    "ratingFranceTelevisionType": [
+      "agesAbove10",
+      "agesAbove12",
+      "agesAbove16",
+      "agesAbove18",
+      "allAllowed",
+      "allBlocked"
+    ],
+    "ratingGermanyMoviesType": [
+      "adults",
+      "agesAbove12",
+      "agesAbove16",
+      "agesAbove6",
+      "allAllowed",
+      "allBlocked",
+      "general"
+    ],
+    "ratingGermanyTelevisionType": [
+      "adults",
+      "agesAbove12",
+      "agesAbove16",
+      "agesAbove6",
+      "allAllowed",
+      "allBlocked",
+      "general"
+    ],
+    "ratingIrelandMoviesType": [
+      "adults",
+      "agesAbove12",
+      "agesAbove15",
+      "agesAbove16",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "parentalGuidance"
+    ],
+    "ratingIrelandTelevisionType": [
+      "allAllowed",
+      "allBlocked",
+      "children",
+      "general",
+      "mature",
+      "parentalSupervision",
+      "youngAdults"
+    ],
+    "ratingJapanMoviesType": [
+      "agesAbove15",
+      "agesAbove18",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "parentalGuidance"
+    ],
+    "ratingJapanTelevisionType": [
+      "allAllowed",
+      "allBlocked",
+      "explicitAllowed"
+    ],
+    "ratingNewZealandMoviesType": [
+      "agesAbove13",
+      "agesAbove15",
+      "agesAbove16",
+      "agesAbove16Restricted",
+      "agesAbove18",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "mature",
+      "parentalGuidance",
+      "restricted"
+    ],
+    "ratingNewZealandTelevisionType": [
+      "adults",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "parentalGuidance"
+    ],
+    "ratingUnitedKingdomMoviesType": [
+      "adults",
+      "agesAbove12Cinema",
+      "agesAbove12Video",
+      "agesAbove15",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "parentalGuidance",
+      "universalChildren"
+    ],
+    "ratingUnitedKingdomTelevisionType": [
+      "allAllowed",
+      "allBlocked",
+      "caution"
+    ],
+    "ratingUnitedStatesMoviesType": [
+      "adults",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "parentalGuidance",
+      "parentalGuidance13",
+      "restricted"
+    ],
+    "ratingUnitedStatesTelevisionType": [
+      "adults",
+      "allAllowed",
+      "allBlocked",
+      "childrenAbove14",
+      "childrenAbove7",
+      "childrenAll",
+      "general",
+      "parentalGuidance"
+    ],
+    "readingCoachStoryType": [
+      "aiGenerated",
+      "readWorks",
+      "unknownFutureValue",
+      "userProvided"
+    ],
+    "recipientScopeType": [
+      "external",
+      "externalNonPartner",
+      "externalPartner",
+      "internal",
+      "none"
+    ],
+    "recommendationCategory": [
+      "identityBestPractice",
+      "identitySecureScore",
+      "mdiSecureScore",
+      "unknownFutureValue"
+    ],
+    "recommendationFeatureAreas": [
+      "accessReviews",
+      "applications",
+      "conditionalAccess",
+      "devices",
+      "governance",
+      "groups",
+      "unknownFutureValue",
+      "users"
+    ],
+    "recommendationPriority": [
+      "high",
+      "low",
+      "medium"
+    ],
+    "recommendationStatus": [
+      "active",
+      "alternateMitigation",
+      "completedBySystem",
+      "completedByUser",
+      "dismissed",
+      "planned",
+      "postponed",
+      "riskAccepted",
+      "thirdParty",
+      "unknownFutureValue"
+    ],
+    "recommendationType": [
+      "aadConnectDeprecated",
+      "aadGraphDeprecationApplication",
+      "aadGraphDeprecationServicePrincipal",
+      "adalToMsalMigration",
+      "adfsAppsMigration",
+      "adminMFAV2",
+      "applicationCredentialExpiry",
+      "appRoleAssignmentsGroups",
+      "appRoleAssignmentsUsers",
+      "blockLegacyAuthentication",
+      "enableDesktopSSO",
+      "enablePHS",
+      "enableProvisioning",
+      "inactiveGuests",
+      "integratedApps",
+      "longLivedCredentials",
+      "managedIdentity",
+      "mfaRegistrationV2",
+      "mfaServerDeprecation",
+      "oneAdmin",
+      "overprivilegedApps",
+      "ownerlessApps",
+      "passwordHashSync",
+      "privateLinkForAAD",
+      "pwagePolicyNew",
+      "roleOverlap",
+      "selfServicePasswordReset",
+      "servicePrincipalKeyExpiry",
+      "signinRiskPolicy",
+      "staleAppCreds",
+      "staleApps",
+      "switchFromPerUserMFA",
+      "tenantMFA",
+      "thirdPartyApps",
+      "turnOffPerUserMFA",
+      "unknownFutureValue",
+      "useAuthenticatorApp",
+      "useMyApps",
+      "userRiskPolicy",
+      "verifyAppPublisher"
+    ],
+    "recordCompletionReason": [
+      "initialSilenceTimeout",
+      "maxRecordDurationReached",
+      "maxSilenceTimeout",
+      "mediaReceiveTimeout",
+      "operationCanceled",
+      "playBeepFailed",
+      "playPromptFailed",
+      "stopToneDetected",
+      "unspecifiedError"
+    ],
+    "recordingStatus": [
+      "failed",
+      "notRecording",
+      "recording",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "recurrencePatternType": [
+      "absoluteMonthly",
+      "absoluteYearly",
+      "daily",
+      "relativeMonthly",
+      "relativeYearly",
+      "weekly"
+    ],
+    "recurrenceRangeType": [
+      "endDate",
+      "noEnd",
+      "numbered"
+    ],
+    "referenceAttachmentPermission": [
+      "anonymousEdit",
+      "anonymousView",
+      "edit",
+      "organizationEdit",
+      "organizationView",
+      "other",
+      "view"
+    ],
+    "referenceAttachmentProvider": [
+      "dropbox",
+      "oneDriveBusiness",
+      "oneDriveConsumer",
+      "other"
+    ],
+    "registrationAuthMethod": [
+      "alternateMobilePhone",
+      "appCode",
+      "appNotification",
+      "appPassword",
+      "email",
+      "externalAuthMethod",
+      "fido",
+      "mobilePhone",
+      "officePhone",
+      "securityQuestion",
+      "unknownFutureValue"
+    ],
+    "registrationStatusType": [
+      "capable",
+      "enabled",
+      "mfaRegistered",
+      "registered",
+      "unknownFutureValue"
+    ],
+    "registryHive": [
+      "currentConfig",
+      "currentUser",
+      "localMachineSam",
+      "localMachineSecurity",
+      "localMachineSoftware",
+      "localMachineSystem",
+      "unknown",
+      "unknownFutureValue",
+      "usersDefault"
+    ],
+    "registryOperation": [
+      "create",
+      "delete",
+      "modify",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "registryValueType": [
+      "binary",
+      "dword",
+      "dwordBigEndian",
+      "dwordLittleEndian",
+      "expandSz",
+      "link",
+      "multiSz",
+      "none",
+      "qword",
+      "qwordlittleEndian",
+      "sz",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "rejectReason": [
+      "busy",
+      "forbidden",
+      "none",
+      "unknownFutureValue"
+    ],
+    "releaseType": [
+      "generallyAvailable",
+      "preview",
+      "unknownFutureValue"
+    ],
+    "remediationState": [
+      "remediationFailed",
+      "scriptError",
+      "skipped",
+      "success",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "remindBeforeTimeInMinutesType": [
+      "mins15",
+      "unknownFutureValue"
+    ],
+    "remoteAction": [
+      "activateDeviceEsim",
+      "automaticRedeployment",
+      "changeAssignments",
+      "cleanWindowsDevice",
+      "delete",
+      "deprovision",
+      "disable",
+      "disableLostMode",
+      "enableLostMode",
+      "factoryReset",
+      "factoryResetKeepEnrollmentData",
+      "fullScan",
+      "getFileVaultKey",
+      "initiateDeviceAttestation",
+      "initiateMobileDeviceManagementKeyRecovery",
+      "initiateOnDemandProactiveRemediation",
+      "launchRemoteHelp",
+      "locateDevice",
+      "logoutSharedAppleDeviceActiveUser",
+      "moveDeviceToOrganizationalUnit",
+      "pauseConfigurationRefresh",
+      "quickScan",
+      "rebootNow",
+      "recoverPasscode",
+      "reenable",
+      "remoteLock",
+      "removeCompanyData",
+      "removeDeviceFirmwareConfigurationInterfaceManagement",
+      "resetPasscode",
+      "restoreManagedHomeScreen",
+      "revokeAppleVppLicenses",
+      "rotateBitLockerKeys",
+      "rotateFileVaultKey",
+      "rotateLocalAdminPassword",
+      "setDeviceName",
+      "shutDown",
+      "suspendManagedHomeScreen",
+      "unknown",
+      "unknownFutureValue",
+      "updateDeviceAccount",
+      "windowsDefenderUpdateSignatures"
+    ],
+    "remoteAssistanceOnboardingStatus": [
+      "notOnboarded",
+      "onboarded",
+      "onboarding"
+    ],
+    "remoteAssistanceState": [
+      "disabled",
+      "enabled"
+    ],
+    "replyRestriction": [
+      "authorAndModerators",
+      "everyone",
+      "unknownFutureValue"
+    ],
+    "reportAction": [
+      "junk",
+      "notJunk",
+      "phish",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "requiredLicenses": [
+      "aatp",
+      "microsoftEntraIdFree",
+      "microsoftEntraIdGovernance",
+      "microsoftEntraIdP1",
+      "microsoftEntraIdP2",
+      "microsoftEntraWorkloadId",
+      "notApplicable",
+      "unknownFutureValue"
+    ],
+    "requiredPasswordType": [
+      "alphanumeric",
+      "deviceDefault",
+      "numeric"
+    ],
+    "requirementProvider": [
+      "accountCompromisePolicies",
+      "authenticationStrengths",
+      "baselineProtection",
+      "crossTenantOutboundRule",
+      "enforcedForCspAdmins",
+      "gpsLocationCondition",
+      "mfaRegistrationRequiredByBaselineProtection",
+      "mfaRegistrationRequiredByIdentityProtectionPolicy",
+      "mfaRegistrationRequiredByMultiConditionalAccess",
+      "mfaRegistrationRequiredBySecurityDefaults",
+      "multiConditionalAccess",
+      "proofUpCodeRequest",
+      "request",
+      "riskBasedPolicy",
+      "scopeBasedAuthRequirementPolicy",
+      "securityDefaults",
+      "servicePrincipal",
+      "tenantSessionRiskPolicy",
+      "unknownFutureValue",
+      "user",
+      "v1ConditionalAccess",
+      "v1ConditionalAccessDependency",
+      "v1ConditionalAccessPolicyIdRequested"
+    ],
+    "resourceAccessStatus": [
+      "failure",
+      "none",
+      "success",
+      "unknownFutureValue"
+    ],
+    "resourceAccessType": [
+      "create",
+      "none",
+      "read",
+      "unknownFutureValue",
+      "write"
+    ],
+    "resourceLinkType": [
+      "unknownFutureValue",
+      "url"
+    ],
+    "resourceScopeType": [
+      "chat",
+      "group",
+      "team",
+      "tenant",
+      "unknownFutureValue"
+    ],
+    "responseEmotionType": [
+      "ambitious",
+      "angry",
+      "annoyed",
+      "anxious",
+      "apathetic",
+      "ashamed",
+      "awed",
+      "bored",
+      "calm",
+      "cheerful",
+      "comfortable",
+      "concerned",
+      "confident",
+      "confused",
+      "content",
+      "creative",
+      "curious",
+      "depressed",
+      "determined",
+      "disappointed",
+      "energized",
+      "excited",
+      "exhausted",
+      "focused",
+      "frightened",
+      "frustrated",
+      "fulfilled",
+      "glad",
+      "grateful",
+      "happy",
+      "hopeless",
+      "hurt",
+      "included",
+      "inspired",
+      "jealous",
+      "lonely",
+      "miserable",
+      "motivated",
+      "nervous",
+      "none",
+      "optimistic",
+      "overwhelmed",
+      "peaceful",
+      "pensive",
+      "proud",
+      "reserved",
+      "restless",
+      "sad",
+      "sensitive",
+      "shocked",
+      "skeptical",
+      "stressed",
+      "stuck",
+      "successful",
+      "tired",
+      "unknownFutureValue",
+      "valuable",
+      "worthless"
+    ],
+    "responseFeedbackType": [
+      "neutral",
+      "none",
+      "notDetected",
+      "pleasant",
+      "unknownFutureValue",
+      "unpleasant",
+      "veryPleasant",
+      "veryUnpleasant"
+    ],
+    "responseType": [
+      "accepted",
+      "declined",
+      "none",
+      "notResponded",
+      "organizer",
+      "tentativelyAccepted"
+    ],
+    "restEncryptionType": [
+      "aes",
+      "bitlocker",
+      "blowfish",
+      "des",
+      "none",
+      "notSupported",
+      "rc4",
+      "rsa",
+      "unknownFutureValue"
+    ],
+    "restorableArtifact": [
+      "message",
+      "unknownFutureValue"
+    ],
+    "restoreArtifactsBulkRequestStatus": [
+      "active",
+      "completed",
+      "completedWithErrors",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "restoreJobType": [
+      "bulk",
+      "granular",
+      "standard",
+      "unknownFutureValue"
+    ],
+    "restorePointPreference": [
+      "latest",
+      "oldest",
+      "unknownFutureValue"
+    ],
+    "restorePointTags": [
+      "fastRestore",
+      "includeNewerItems",
+      "none",
+      "unknownFutureValue"
+    ],
+    "restoreSessionStatus": [
+      "activating",
+      "active",
+      "completed",
+      "completedWithError",
+      "draft",
+      "failed",
+      "unknownFutureValue"
+    ],
+    "restoreTimeRange": [
+      "after",
+      "before",
+      "beforeOrAfter",
+      "unknownFutureValue"
+    ],
+    "restrictedAppsState": [
+      "notApprovedApps",
+      "prohibitedApps"
+    ],
+    "restrictionAction": [
+      "audit",
+      "block",
+      "warn"
+    ],
+    "restrictionTrigger": [
+      "cloudEgress",
+      "copyPaste",
+      "copyToNetworkShare",
+      "copyToRemovableMedia",
+      "print",
+      "screenCapture",
+      "unallowedApps"
+    ],
+    "resultantAppState": [
+      "failed",
+      "installed",
+      "notApplicable",
+      "notInstalled",
+      "pendingInstall",
+      "uninstallFailed",
+      "unknown"
+    ],
+    "resultantAppStateDetail": [
+      "appRemovedBySupersedence",
+      "autoInstallDisabled",
+      "contentDownloaded",
+      "dependencyFailedToInstall",
+      "dependencyPendingReboot",
+      "dependencyWithAutoInstallDisabled",
+      "dependencyWithRequirementsNotMet",
+      "fileSystemRequirementNotMet",
+      "installingDependencies",
+      "iosAppStoreUpdateFailedToInstall",
+      "managedAppNoLongerPresent",
+      "minimumCpuSpeedNotMet",
+      "minimumDiskSpaceNotMet",
+      "minimumLogicalProcessorCountNotMet",
+      "minimumOsVersionNotMet",
+      "minimumPhysicalMemoryNotMet",
+      "noAdditionalDetails",
+      "pendingReboot",
+      "platformNotApplicable",
+      "powerShellScriptRequirementNotMet",
+      "processorArchitectureNotApplicable",
+      "registryRequirementNotMet",
+      "removingSupersededApps",
+      "seeInstallErrorCode",
+      "seeUninstallErrorCode",
+      "supersededAppsDetected",
+      "supersededAppUninstallFailed",
+      "supersededAppUninstallPendingReboot",
+      "supersedingAppsDetected",
+      "supersedingAppsNotApplicable",
+      "uninstallPendingReboot",
+      "untargetedSupersedingAppsDetected",
+      "userIsNotLoggedIntoAppStore",
+      "userRejectedInstall",
+      "userRejectedUpdate",
+      "vppAppHasUpdateAvailable"
+    ],
+    "retrievalDataSource": [
+      "externalItem",
+      "oneDriveBusiness",
+      "sharePoint",
+      "unknownFutureValue"
+    ],
+    "retrievalEntityType": [
+      "drive",
+      "driveItem",
+      "externalItem",
+      "list",
+      "listItem",
+      "site",
+      "unknownFutureValue"
+    ],
+    "riskDetail": [
+      "adminConfirmedAccountSafe",
+      "adminConfirmedAgentCompromised",
+      "adminConfirmedAgentSafe",
+      "adminConfirmedServicePrincipalCompromised",
+      "adminConfirmedSigninCompromised",
+      "adminConfirmedSigninSafe",
+      "adminConfirmedUserCompromised",
+      "adminDismissedAllRiskForServicePrincipal",
+      "adminDismissedAllRiskForUser",
+      "adminDismissedRiskForAgent",
+      "adminDismissedRiskForSignIn",
+      "adminGeneratedTemporaryPassword",
+      "aiConfirmedSigninSafe",
+      "hidden",
+      "m365DAdminDismissedDetection",
+      "microsoftRevokedSessions",
+      "none",
+      "unknownFutureValue",
+      "userChangedPasswordOnPremises",
+      "userPassedMFADrivenByRiskBasedPolicy",
+      "userPerformedSecuredPasswordChange",
+      "userPerformedSecuredPasswordReset"
+    ],
+    "riskDetectionTimingType": [
+      "nearRealtime",
+      "notDefined",
+      "offline",
+      "realtime",
+      "unknownFutureValue"
+    ],
+    "riskEventType": [
+      "adminConfirmedUserCompromised",
+      "anonymizedIPAddress",
+      "generic",
+      "investigationsThreatIntelligence",
+      "investigationsThreatIntelligenceSigninLinked",
+      "leakedCredentials",
+      "maliciousIPAddress",
+      "maliciousIPAddressValidCredentialsBlockedIP",
+      "malwareInfectedIPAddress",
+      "mcasImpossibleTravel",
+      "mcasSuspiciousInboxManipulationRules",
+      "suspiciousIPAddress",
+      "unfamiliarFeatures",
+      "unknownFutureValue",
+      "unlikelyTravel"
+    ],
+    "riskLevel": [
+      "hidden",
+      "high",
+      "low",
+      "medium",
+      "none",
+      "unknownFutureValue"
+    ],
+    "riskState": [
+      "atRisk",
+      "confirmedCompromised",
+      "confirmedSafe",
+      "dismissed",
+      "none",
+      "remediated",
+      "unknownFutureValue"
+    ],
+    "roleAssignmentScheduleFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "roleAssignmentScheduleInstanceFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "roleAssignmentScheduleRequestFilterByCurrentUserOptions": [
+      "approver",
+      "createdBy",
+      "principal",
+      "unknownFutureValue"
+    ],
+    "roleAssignmentScopeType": [
+      "allDevices",
+      "allDevicesAndLicensedUsers",
+      "allLicensedUsers",
+      "resourceScope",
+      "unknownFutureValue"
+    ],
+    "roleEligibilityScheduleFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "roleEligibilityScheduleInstanceFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "roleEligibilityScheduleRequestFilterByCurrentUserOptions": [
+      "approver",
+      "createdBy",
+      "principal",
+      "unknownFutureValue"
+    ],
+    "roleSummaryStatus": [
+      "bad",
+      "ok"
+    ],
+    "rootDomains": [
+      "all",
+      "allFederated",
+      "allManaged",
+      "allManagedAndEnumeratedFederated",
+      "enumerated",
+      "none",
+      "unknownFutureValue"
+    ],
+    "routingMode": [
+      "multicast",
+      "oneToOne"
+    ],
+    "routingPolicy": [
+      "disableForwarding",
+      "disableForwardingExceptPhone",
+      "noMissedCall",
+      "none",
+      "preferSkypeForBusiness",
+      "unknownFutureValue"
+    ],
+    "routingType": [
+      "forwarded",
+      "lookup",
+      "selfFork",
+      "unknownFutureValue"
+    ],
+    "ruleMode": [
+      "audit",
+      "auditAndNotify",
+      "enforce",
+      "pendingDeletion",
+      "test"
+    ],
+    "runAsAccountType": [
+      "system",
+      "user"
+    ],
+    "runState": [
+      "fail",
+      "notApplicable",
+      "pending",
+      "scriptError",
+      "success",
+      "unknown"
+    ],
+    "safeSearchFilterType": [
+      "moderate",
+      "strict",
+      "userDefined"
+    ],
+    "samlAttributeNameFormat": [
+      "basic",
+      "unknownFutureValue",
+      "unspecified",
+      "uri"
+    ],
+    "samlNameIDFormat": [
+      "default",
+      "emailAddress",
+      "persistent",
+      "unknownFutureValue",
+      "unspecified",
+      "windowsDomainQualifiedName"
+    ],
+    "samlSLOBindingType": [
+      "httpPost",
+      "httpRedirect",
+      "unknownFutureValue"
+    ],
+    "scheduleChangeRequestActor": [
+      "manager",
+      "recipient",
+      "sender",
+      "system",
+      "unknownFutureValue"
+    ],
+    "scheduleChangeState": [
+      "approved",
+      "declined",
+      "pending",
+      "unknownFutureValue"
+    ],
+    "scheduledPermissionsRequestFilterByCurrentUserOptions": [
+      "approver",
+      "createdBy",
+      "principal",
+      "unknownFutureValue"
+    ],
+    "scheduledRetireState": [
+      "cancelRetire",
+      "confirmRetire",
+      "unknownFutureValue"
+    ],
+    "scheduleEntityTheme": [
+      "blue",
+      "darkBlue",
+      "darkGreen",
+      "darkPink",
+      "darkPurple",
+      "darkYellow",
+      "gray",
+      "green",
+      "pink",
+      "purple",
+      "unknownFutureValue",
+      "white",
+      "yellow"
+    ],
+    "scheduleRequestActions": [
+      "adminAssign",
+      "adminExtend",
+      "adminRemove",
+      "adminRenew",
+      "adminUpdate",
+      "selfActivate",
+      "selfDeactivate",
+      "selfExtend",
+      "selfRenew",
+      "unknownFutureValue"
+    ],
+    "scopeCollectionKind": [
+      "allAllowed",
+      "enumerated",
+      "none",
+      "scopeKindNotSet",
+      "unknownFutureValue"
+    ],
+    "scopeOperatorMultiValuedComparisonType": [
+      "All",
+      "Any"
+    ],
+    "scopeOperatorType": [
+      "Binary",
+      "Unary"
+    ],
+    "screenCaptureIosManagedAppConfigurationState": [
+      "blocked",
+      "notBlocked",
+      "unknownFutureValue"
+    ],
+    "screenSharingRole": [
+      "sharer",
+      "viewer"
+    ],
+    "searchAlterationType": [
+      "modification",
+      "suggestion",
+      "unknownFutureValue"
+    ],
+    "searchContent": [
+      "privateContent",
+      "sharedContent",
+      "unknownFutureValue"
+    ],
+    "sectionEmphasisType": [
+      "neutral",
+      "none",
+      "soft",
+      "strong",
+      "unknownFutureValue"
+    ],
+    "sectionIconSkinTone": [
+      "dark",
+      "light",
+      "medium",
+      "mediumDark",
+      "mediumLight",
+      "unknownFutureValue"
+    ],
+    "sectionItemType": [
+      "channel",
+      "chat",
+      "community",
+      "meeting",
+      "unknownFutureValue"
+    ],
+    "sectionSortType": [
+      "mostRecent",
+      "nameAlphabetical",
+      "unknownFutureValue",
+      "unreadThenMostRecent",
+      "userDefinedCustomOrder"
+    ],
+    "sectionType": [
+      "systemDefined",
+      "unknownFutureValue",
+      "userDefined"
+    ],
+    "secureAssessmentAccountType": [
+      "azureADAccount",
+      "domainAccount",
+      "localAccount",
+      "localGuestAccount"
+    ],
+    "secureBootWithDMAType": [
+      "notConfigured",
+      "withDMA",
+      "withoutDMA"
+    ],
+    "securityBaselineComplianceState": [
+      "conflict",
+      "error",
+      "notApplicable",
+      "notSecure",
+      "secure",
+      "unknown"
+    ],
+    "securityBaselinePolicySourceType": [
+      "deviceConfiguration",
+      "deviceIntent"
+    ],
+    "securityNetworkProtocol": [
+      "ggp",
+      "icmp",
+      "icmpV6",
+      "idp",
+      "igmp",
+      "ip",
+      "ipSecAuthenticationHeader",
+      "ipSecEncapsulatingSecurityPayload",
+      "ipv4",
+      "ipv6",
+      "ipv6DestinationOptions",
+      "ipv6FragmentHeader",
+      "ipv6NoNextHeader",
+      "ipv6RoutingHeader",
+      "ipx",
+      "nd",
+      "pup",
+      "raw",
+      "spx",
+      "spxII",
+      "tcp",
+      "udp",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "securityQuestionType": [
+      "custom",
+      "predefined"
+    ],
+    "securityResourceType": [
+      "attacked",
+      "related",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "sendDtmfCompletionReason": [
+      "completedSuccessfully",
+      "mediaOperationCanceled",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "sensitiveTypeScope": [
+      "fullDocument",
+      "partialDocument"
+    ],
+    "sensitiveTypeSource": [
+      "outOfBox",
+      "tenant"
+    ],
+    "sensitivity": [
+      "confidential",
+      "normal",
+      "personal",
+      "private"
+    ],
+    "sensitivityLabelAssignmentMethod": [
+      "auto",
+      "privileged",
+      "standard",
+      "unknownFutureValue"
+    ],
+    "sensitivityLabelTarget": [
+      "email",
+      "site",
+      "teamwork",
+      "unifiedGroup",
+      "unknownFutureValue"
+    ],
+    "sensorStatus": [
+      "active",
+      "inactive",
+      "unknownFutureValue"
+    ],
+    "serviceAppStatus": [
+      "active",
+      "inactive",
+      "pendingActive",
+      "pendingInactive",
+      "unknownFutureValue"
+    ],
+    "serviceHealthClassificationType": [
+      "advisory",
+      "incident",
+      "unknownFutureValue"
+    ],
+    "serviceHealthOrigin": [
+      "customer",
+      "microsoft",
+      "thirdParty",
+      "unknownFutureValue"
+    ],
+    "serviceHealthStatus": [
+      "confirmed",
+      "extendedRecovery",
+      "falsePositive",
+      "investigating",
+      "investigationSuspended",
+      "mitigated",
+      "mitigatedExternal",
+      "postIncidentReviewPublished",
+      "reported",
+      "resolved",
+      "resolvedExternal",
+      "restoringService",
+      "serviceDegradation",
+      "serviceInterruption",
+      "serviceOperational",
+      "serviceRestored",
+      "unknownFutureValue",
+      "verifyingService"
+    ],
+    "serviceNowConnectionStatus": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "serviceStartType": [
+      "automatic",
+      "disabled",
+      "manual"
+    ],
+    "serviceType": [
+      "exchange",
+      "oneDriveForBusiness",
+      "sharePoint",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "serviceUpdateCategory": [
+      "planForChange",
+      "preventOrFixIssue",
+      "stayInformed",
+      "unknownFutureValue"
+    ],
+    "serviceUpdateSeverity": [
+      "critical",
+      "high",
+      "normal",
+      "unknownFutureValue"
+    ],
+    "settingSourceType": [
+      "deviceConfiguration",
+      "deviceIntent"
+    ],
+    "setupStatus": [
+      "disabled",
+      "notRegisteredYet",
+      "registeredSetupInProgress",
+      "registeredSetupNotStarted",
+      "registrationAndSetupCompleted",
+      "registrationFailed",
+      "registrationTimedOut",
+      "unknown"
+    ],
+    "sharedPCAccountDeletionPolicyType": [
+      "diskSpaceThreshold",
+      "diskSpaceThresholdOrInactiveThreshold",
+      "immediate"
+    ],
+    "sharedPCAllowedAccountType": [
+      "domain",
+      "guest",
+      "notConfigured"
+    ],
+    "sharePointIdentityMappingGroupType": [
+      "m365Group",
+      "none",
+      "regularGroup",
+      "unknownFutureValue"
+    ],
+    "sharePointIdentityMappingUserType": [
+      "adminUser",
+      "guestUser",
+      "none",
+      "regularUser",
+      "unknownFutureValue"
+    ],
+    "sharePointMigrationJobErrorLevel": [
+      "error",
+      "fatalError",
+      "important",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "sharePointMigrationObjectType": [
+      "alert",
+      "file",
+      "folder",
+      "invalid",
+      "list",
+      "listItem",
+      "sharedWithObject",
+      "site",
+      "unknownFutureValue",
+      "web"
+    ],
+    "sharePointMigrationTaskStatus": [
+      "cancelled",
+      "completed",
+      "failed",
+      "inProgress",
+      "notStarted",
+      "unknownFutureValue"
+    ],
+    "sharingCapabilities": [
+      "disabled",
+      "existingExternalUserSharingOnly",
+      "externalUserAndGuestSharing",
+      "externalUserSharingOnly",
+      "unknownFutureValue"
+    ],
+    "sharingDomainRestrictionMode": [
+      "allowList",
+      "blockList",
+      "none",
+      "unknownFutureValue"
+    ],
+    "sharingRole": [
+      "edit",
+      "manageList",
+      "none",
+      "restrictedView",
+      "review",
+      "submitOnly",
+      "unknownFutureValue",
+      "view"
+    ],
+    "sharingScope": [
+      "anonymous",
+      "anyone",
+      "organization",
+      "specificPeople",
+      "unknownFutureValue",
+      "users"
+    ],
+    "sharingVariant": [
+      "addressBar",
+      "embed",
+      "none",
+      "passwordProtected",
+      "requiresAuthentication",
+      "unknownFutureValue"
+    ],
+    "signInAccessType": [
+      "b2bCollaboration",
+      "b2bDirectConnect",
+      "microsoftSupport",
+      "none",
+      "passthrough",
+      "serviceProvider",
+      "unknownFutureValue"
+    ],
+    "signInAssistantOptions": [
+      "disabled",
+      "notConfigured"
+    ],
+    "signInFrequencyAuthenticationType": [
+      "primaryAndSecondaryAuthentication",
+      "secondaryAuthentication",
+      "unknownFutureValue"
+    ],
+    "signInFrequencyInterval": [
+      "everyTime",
+      "timeBased",
+      "unknownFutureValue"
+    ],
+    "signinFrequencyType": [
+      "days",
+      "hours"
+    ],
+    "signInIdentifierType": [
+      "onPremisesUserPrincipalName",
+      "phoneNumber",
+      "proxyAddress",
+      "qrCode",
+      "unknownFutureValue",
+      "userPrincipalName"
+    ],
+    "signInUserType": [
+      "guest",
+      "member",
+      "unknownFutureValue"
+    ],
+    "signUpIdentifierType": [
+      "emailAddress",
+      "federation",
+      "unknownFutureValue"
+    ],
+    "signUpStage": [
+      "attributeCollectionAndValidation",
+      "consent",
+      "credentialCollection",
+      "credentialFederation",
+      "credentialValidation",
+      "tenantConsent",
+      "unknownFutureValue",
+      "userCreation"
+    ],
+    "simulationAttackTechnique": [
+      "attachmentMalware",
+      "credentialHarvesting",
+      "driveByUrl",
+      "linkInAttachment",
+      "linkToMalwareFile",
+      "oAuthConsentGrant",
+      "phishTraining",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "simulationAttackType": [
+      "cloud",
+      "endpoint",
+      "social",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "simulationAutomationRunStatus": [
+      "failed",
+      "running",
+      "skipped",
+      "succeeded",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "simulationAutomationStatus": [
+      "completed",
+      "draft",
+      "notRunning",
+      "running",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "simulationContentSource": [
+      "global",
+      "tenant",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "simulationContentStatus": [
+      "archive",
+      "delete",
+      "draft",
+      "ready",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "simulationStatus": [
+      "cancelled",
+      "draft",
+      "excluded",
+      "failed",
+      "running",
+      "scheduled",
+      "succeeded",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "singleSignOnMode": [
+      "aadHeaderBased",
+      "none",
+      "oAuthToken",
+      "onPremisesKerberos",
+      "pingHeaderBased",
+      "saml",
+      "unknownFutureValue"
+    ],
+    "siteAccessType": [
+      "block",
+      "full",
+      "limited"
+    ],
+    "siteArchiveStatus": [
+      "fullyArchived",
+      "reactivating",
+      "recentlyArchived",
+      "unknownFutureValue"
+    ],
+    "siteLockState": [
+      "lockedNoAccess",
+      "lockedNoAdditions",
+      "lockedReadOnly",
+      "unknownFutureValue",
+      "unlocked"
+    ],
+    "siteSecurityLevel": [
+      "high",
+      "low",
+      "medium",
+      "mediumHigh",
+      "mediumLow",
+      "userDefined"
+    ],
+    "siteTemplateType": [
+      "sitepagepublishing",
+      "sts",
+      "unknownFutureValue"
+    ],
+    "skillProficiencyLevel": [
+      "advancedProfessional",
+      "elementary",
+      "expert",
+      "generalProfessional",
+      "limitedWorking",
+      "unknownFutureValue"
+    ],
+    "snapshotJobStatus": [
+      "failed",
+      "notStarted",
+      "partiallySuccessful",
+      "running",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "socialIdentitySourceType": [
+      "facebook",
+      "unknownFutureValue"
+    ],
+    "sslVersion": [
+      "none",
+      "notSupported",
+      "ssl3_0",
+      "tls1_0",
+      "tls1_1",
+      "tls1_2",
+      "tls1_3",
+      "unknownFutureValue"
+    ],
+    "stagedFeatureName": [
+      "certificateBasedAuthentication",
+      "emailAsAlternateId",
+      "passthroughAuthentication",
+      "passwordHashSync",
+      "seamlessSso",
+      "unknownFutureValue"
+    ],
+    "stateManagementSetting": [
+      "allowed",
+      "blocked",
+      "notConfigured"
+    ],
+    "status": [
+      "active",
+      "deleted",
+      "ignored",
+      "unknownFutureValue",
+      "updated"
+    ],
+    "statusDetail": [
+      "approved",
+      "canceled",
+      "completed",
+      "rejected",
+      "submitted",
+      "unknownFutureValue"
+    ],
+    "structuredDataEntryValueType": [
+      "boolean",
+      "byte",
+      "byteArray",
+      "dateTime",
+      "integer32",
+      "integer64",
+      "string",
+      "stringArray",
+      "unknownFutureValue",
+      "unsignedInteger32",
+      "unsignedInteger64"
+    ],
+    "subjectAlternativeNameType": [
+      "customAzureADAttribute",
+      "domainNameService",
+      "emailAddress",
+      "none",
+      "universalResourceIdentifier",
+      "userPrincipalName"
+    ],
+    "subjectNameFormat": [
+      "commonName",
+      "commonNameAsAadDeviceId",
+      "commonNameAsDurableDeviceId",
+      "commonNameAsEmail",
+      "commonNameAsIMEI",
+      "commonNameAsIntuneDeviceId",
+      "commonNameAsSerialNumber",
+      "commonNameIncludingEmail",
+      "custom"
+    ],
+    "subjectRightsRequestStage": [
+      "approval",
+      "caseResolved",
+      "contentDeletion",
+      "contentEstimate",
+      "contentRetrieval",
+      "contentReview",
+      "generateReport",
+      "unknownFutureValue"
+    ],
+    "subjectRightsRequestStageStatus": [
+      "completed",
+      "current",
+      "failed",
+      "notStarted",
+      "unknownFutureValue"
+    ],
+    "subjectRightsRequestStatus": [
+      "active",
+      "closed",
+      "unknownFutureValue"
+    ],
+    "subjectRightsRequestType": [
+      "access",
+      "delete",
+      "export",
+      "tagForAction",
+      "unknownFutureValue"
+    ],
+    "synchronizationDisposition": [
+      "Discard",
+      "Escrow",
+      "Normal"
+    ],
+    "synchronizationJobRestartScope": [
+      "ConnectorDataStore",
+      "Escrows",
+      "ForceDeletes",
+      "Full",
+      "None",
+      "QuarantineState",
+      "Watermark"
+    ],
+    "synchronizationMetadata": [
+      "configurationFields",
+      "galleryApplicationIdentifier",
+      "galleryApplicationKey",
+      "isOAuthEnabled",
+      "IsSynchronizationAgentAssignmentRequired",
+      "isSynchronizationAgentRequired",
+      "isSynchronizationInPreview",
+      "oAuthSettings",
+      "synchronizationLearnMoreIbizaFwLink"
+    ],
+    "synchronizationScheduleState": [
+      "Active",
+      "Disabled",
+      "Paused"
+    ],
+    "synchronizationSecret": [
+      "AppKey",
+      "ApplicationTemplateIdentifier",
+      "AuthenticationType",
+      "BaseAddress",
+      "ClientIdentifier",
+      "ClientSecret",
+      "CompanyId",
+      "ConnectionString",
+      "ConsumerKey",
+      "ConsumerSecret",
+      "Domain",
+      "EnforceDomain",
+      "HardDeletesEnabled",
+      "InstanceName",
+      "None",
+      "Oauth2AccessToken",
+      "Oauth2AccessTokenCreationTime",
+      "Oauth2AuthorizationCode",
+      "Oauth2AuthorizationUri",
+      "Oauth2ClientId",
+      "Oauth2ClientSecret",
+      "Oauth2RedirectUri",
+      "Oauth2RefreshToken",
+      "Oauth2TokenExchangeUri",
+      "Password",
+      "PerformInboundEntitlementGrants",
+      "Sandbox",
+      "SandboxName",
+      "SecretToken",
+      "Server",
+      "SingleSignOnType",
+      "SkipOutOfScopeDeletions",
+      "SyncAgentADContainer",
+      "SyncAgentCompatibilityKey",
+      "SyncAll",
+      "SynchronizationSchedule",
+      "SyncNotificationSettings",
+      "SystemOfRecord",
+      "TestReferences",
+      "TokenExpiration",
+      "TokenKey",
+      "UpdateKeyOnSoftDelete",
+      "Url",
+      "UserName",
+      "ValidateDomain"
+    ],
+    "synchronizationStatusCode": [
+      "Active",
+      "NotConfigured",
+      "NotRun",
+      "Paused",
+      "Quarantine"
+    ],
+    "synchronizationTaskExecutionResult": [
+      "EntryLevelErrors",
+      "Failed",
+      "Succeeded"
+    ],
+    "systemManagementModeLevel": [
+      "level1",
+      "level2",
+      "level3",
+      "notApplicable",
+      "unknownFutureValue"
+    ],
+    "targetedManagedAppGroupType": [
+      "allApps",
+      "allCoreMicrosoftApps",
+      "allMicrosoftApps",
+      "selectedPublicApps"
+    ],
+    "targettedUserType": [
+      "allUsers",
+      "clicked",
+      "compromised",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "taskStatus": [
+      "completed",
+      "deferred",
+      "inProgress",
+      "notStarted",
+      "waitingOnOthers"
+    ],
+    "teamsAppDashboardCardSize": [
+      "large",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "teamsAppDashboardCardSourceType": [
+      "bot",
+      "unknownFutureValue"
+    ],
+    "teamsAppDistributionMethod": [
+      "organization",
+      "sideloaded",
+      "store",
+      "unknownFutureValue"
+    ],
+    "teamsAppInstallationScopes": [
+      "groupChat",
+      "personal",
+      "team",
+      "unknownFutureValue"
+    ],
+    "teamsAppPublishingState": [
+      "published",
+      "rejected",
+      "submitted",
+      "unknownFutureValue"
+    ],
+    "teamsAppResourceSpecificPermissionType": [
+      "application",
+      "delegated",
+      "unknownFutureValue"
+    ],
+    "teamsAsyncOperationStatus": [
+      "failed",
+      "inProgress",
+      "invalid",
+      "notStarted",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "teamsAsyncOperationType": [
+      "archiveChannel",
+      "archiveTeam",
+      "cloneTeam",
+      "createChannel",
+      "createChat",
+      "createTeam",
+      "invalid",
+      "teamifyGroup",
+      "unarchiveChannel",
+      "unarchiveTeam",
+      "unknownFutureValue"
+    ],
+    "teamSpecialization": [
+      "educationClass",
+      "educationProfessionalLearningCommunity",
+      "educationStaff",
+      "educationStandard",
+      "healthcareCareCoordination",
+      "healthcareStandard",
+      "none",
+      "unknownFutureValue"
+    ],
+    "teamTemplateAudience": [
+      "organization",
+      "public",
+      "unknownFutureValue",
+      "user"
+    ],
+    "teamVisibilityType": [
+      "hiddenMembership",
+      "private",
+      "public",
+      "unknownFutureValue"
+    ],
+    "teamworkActivityTopicSource": [
+      "entityUrl",
+      "text"
+    ],
+    "teamworkApplicationIdentityType": [
+      "aadApplication",
+      "bot",
+      "office365Connector",
+      "outgoingWebhook",
+      "tenantBot",
+      "unknownFutureValue"
+    ],
+    "teamworkCallEventType": [
+      "call",
+      "meeting",
+      "screenShare",
+      "unknownFutureValue"
+    ],
+    "teamworkConnectionStatus": [
+      "connected",
+      "disconnected",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "teamworkConversationIdentityType": [
+      "channel",
+      "chat",
+      "team",
+      "unknownFutureValue"
+    ],
+    "teamworkDeviceActivityState": [
+      "busy",
+      "idle",
+      "unavailable",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "teamworkDeviceHealthStatus": [
+      "critical",
+      "healthy",
+      "nonUrgent",
+      "offline",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "teamworkDeviceOperationType": [
+      "configUpdate",
+      "deviceDiagnostics",
+      "deviceManagementAgentConfigUpdate",
+      "deviceRestart",
+      "remoteLogin",
+      "remoteLogout",
+      "softwareUpdate",
+      "unknownFutureValue"
+    ],
+    "teamworkDeviceType": [
+      "collaborationBar",
+      "ipPhone",
+      "lowCostPhone",
+      "sip",
+      "surfaceHub",
+      "teamsDisplay",
+      "teamsPanel",
+      "teamsRoom",
+      "touchConsole",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "teamworkInteractionType": [
+      "createChat",
+      "unknownFutureValue"
+    ],
+    "teamworkSoftwareFreshness": [
+      "latest",
+      "unknown",
+      "unknownFutureValue",
+      "updateAvailable"
+    ],
+    "teamworkSoftwareType": [
+      "adminAgent",
+      "companyPortal",
+      "firmware",
+      "operatingSystem",
+      "partnerAgent",
+      "teamsClient",
+      "unknownFutureValue"
+    ],
+    "teamworkSupportedClient": [
+      "skypeDefaultAndTeams",
+      "skypeOnly",
+      "teamsDefaultAndSkype",
+      "teamsOnly",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "teamworkTagType": [
+      "standard",
+      "unknownFutureValue"
+    ],
+    "teamworkUserIdentityType": [
+      "aadUser",
+      "anonymousGuest",
+      "azureCommunicationServicesUser",
+      "emailUser",
+      "federatedUser",
+      "onPremiseAadUser",
+      "personalMicrosoftAccountUser",
+      "phoneUser",
+      "skypeUser",
+      "unknownFutureValue"
+    ],
+    "templateApplicationLevel": [
+      "existingPartners",
+      "newPartners",
+      "none",
+      "unknownFutureValue"
+    ],
+    "templateScenarios": [
+      "emergingThreats",
+      "new",
+      "protectAdmins",
+      "remoteWork",
+      "secureFoundation",
+      "unknownFutureValue",
+      "zeroTrust"
+    ],
+    "threatAssessmentContentType": [
+      "file",
+      "mail",
+      "url"
+    ],
+    "threatAssessmentRequestPivotProperty": [
+      "mailDestinationRoutingReason",
+      "threatCategory"
+    ],
+    "threatAssessmentRequestSource": [
+      "administrator",
+      "undefined",
+      "user"
+    ],
+    "threatAssessmentResultType": [
+      "checkPolicy",
+      "rescan",
+      "unknownFutureValue"
+    ],
+    "threatAssessmentStatus": [
+      "completed",
+      "pending"
+    ],
+    "threatCategory": [
+      "malware",
+      "phishing",
+      "spam",
+      "undefined",
+      "unknownFutureValue"
+    ],
+    "threatExpectedAssessment": [
+      "block",
+      "unblock"
+    ],
+    "tiAction": [
+      "alert",
+      "allow",
+      "block",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "timeCardState": [
+      "clockedIn",
+      "clockedOut",
+      "onBreak",
+      "unknownFutureValue"
+    ],
+    "timeOffReasonIconType": [
+      "cake",
+      "calendar",
+      "car",
+      "clock",
+      "cup",
+      "doctor",
+      "dog",
+      "firstAid",
+      "globe",
+      "juryDuty",
+      "none",
+      "notWorking",
+      "phone",
+      "piggyBank",
+      "pin",
+      "plane",
+      "running",
+      "sunny",
+      "trafficCone",
+      "umbrella",
+      "unknownFutureValue",
+      "weather"
+    ],
+    "timeZoneStandard": [
+      "iana",
+      "windows"
+    ],
+    "titleAreaLayoutType": [
+      "colorBlock",
+      "imageAndTitle",
+      "overlap",
+      "plain",
+      "unknownFutureValue"
+    ],
+    "titleAreaTextAlignmentType": [
+      "center",
+      "left",
+      "unknownFutureValue"
+    ],
+    "tlpLevel": [
+      "amber",
+      "green",
+      "red",
+      "unknown",
+      "unknownFutureValue",
+      "white"
+    ],
+    "tlsClientRegistrationMetadata": [
+      "tls_client_auth_san_dns",
+      "tls_client_auth_san_email",
+      "tls_client_auth_san_ip",
+      "tls_client_auth_san_uri",
+      "tls_client_auth_subject_dn",
+      "unknownFutureValue"
+    ],
+    "tokenFormat": [
+      "jwt",
+      "saml",
+      "unknownFutureValue"
+    ],
+    "tokenIssuerType": [
+      "ADFederationServices",
+      "ADFederationServicesMFAAdapter",
+      "AzureAD",
+      "AzureADBackupAuth",
+      "NPSExtension",
+      "UnknownFutureValue"
+    ],
+    "tokenProtectionStatus": [
+      "bound",
+      "none",
+      "unbound",
+      "unknownFutureValue"
+    ],
+    "tone": [
+      "a",
+      "b",
+      "c",
+      "d",
+      "flash",
+      "pound",
+      "star",
+      "tone0",
+      "tone1",
+      "tone2",
+      "tone3",
+      "tone4",
+      "tone5",
+      "tone6",
+      "tone7",
+      "tone8",
+      "tone9"
+    ],
+    "trafficRoutingMethod": [
+      "none",
+      "performance",
+      "random",
+      "sessionPersistence",
+      "unknownFutureValue"
+    ],
+    "trainingAssignedTo": [
+      "allUsers",
+      "clickedPayload",
+      "compromised",
+      "didNothing",
+      "none",
+      "readButNotClicked",
+      "reportedPhish",
+      "unknownFutureValue"
+    ],
+    "trainingAvailabilityStatus": [
+      "archive",
+      "available",
+      "delete",
+      "notAvailable",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "trainingCompletionDuration": [
+      "fortnite",
+      "month",
+      "unknownFutureValue",
+      "week"
+    ],
+    "trainingSettingType": [
+      "custom",
+      "microsoftCustom",
+      "microsoftManaged",
+      "noTraining",
+      "unknownFutureValue"
+    ],
+    "trainingStatus": [
+      "assigned",
+      "completed",
+      "inProgress",
+      "overdue",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "trainingType": [
+      "phishing",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "transformationExtractType": [
+      "prefix",
+      "suffix",
+      "unknownFutureValue"
+    ],
+    "transformationTrimType": [
+      "leading",
+      "leadingAndTrailing",
+      "trailing",
+      "unknownFutureValue"
+    ],
+    "translationBehavior": [
+      "Ask",
+      "No",
+      "Yes"
+    ],
+    "trustFrameworkKeyStatus": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "unifiedRoleScheduleRequestActions": [
+      "adminAssign",
+      "adminExtend",
+      "adminRemove",
+      "adminRenew",
+      "adminUpdate",
+      "selfActivate",
+      "selfDeactivate",
+      "selfExtend",
+      "selfRenew",
+      "unknownFutureValue"
+    ],
+    "updateClassification": [
+      "important",
+      "none",
+      "recommendedAndImportant",
+      "userDefined"
+    ],
+    "uriUsageType": [
+      "identifierUri",
+      "loginUrl",
+      "logoutUrl",
+      "redirectUri",
+      "unknownFutureValue"
+    ],
+    "usageAuthMethod": [
+      "alternateMobileCall",
+      "alternateMobilePhone",
+      "appCode",
+      "appNotification",
+      "appPassword",
+      "email",
+      "externalAuthMethod",
+      "fido",
+      "fido2SecurityKey",
+      "hardwareOneTimePasscode",
+      "macOsSecureEnclaveKey",
+      "microsoftAuthenticatorPasswordless",
+      "microsoftAuthenticatorPush",
+      "mobileCall",
+      "mobilePhone",
+      "mobileSMS",
+      "officePhone",
+      "oneTimePasscode",
+      "passKeyDeviceBound",
+      "passKeyDeviceBoundAuthenticator",
+      "passKeyDeviceBoundWindowsHello",
+      "passKeySynced",
+      "qrCode",
+      "securityQuestion",
+      "sms",
+      "softwareOneTimePasscode",
+      "temporaryAccessPass",
+      "unknownFutureValue",
+      "windowsHelloForBusiness"
+    ],
+    "usageRights": [
+      "accessDenied",
+      "comment",
+      "docEdit",
+      "edit",
+      "editRightsData",
+      "encryptedProtectionTypeNotSupportedException",
+      "exception",
+      "export",
+      "extract",
+      "forward",
+      "labelNotFoundException",
+      "objModel",
+      "owner",
+      "print",
+      "purviewClaimsChallengeNotSupportedException",
+      "reply",
+      "replyAll",
+      "unknown",
+      "unknownFutureValue",
+      "userDefinedProtectionTypeNotSupportedException",
+      "view",
+      "viewRightsData"
+    ],
+    "usageRightState": [
+      "active",
+      "inactive",
+      "suspended",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "userAccountSecurityType": [
+      "administrator",
+      "power",
+      "standard",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "userAction": [
+      "registerOrJoinDevices",
+      "registerSecurityInformation",
+      "unknownFutureValue"
+    ],
+    "userActivityType": [
+      "downloadFile",
+      "downloadText",
+      "unknownFutureValue",
+      "uploadFile",
+      "uploadText"
+    ],
+    "userActivityTypes": [
+      "downloadFile",
+      "downloadText",
+      "none",
+      "unknownFutureValue",
+      "uploadFile",
+      "uploadText"
+    ],
+    "userDefaultAuthenticationMethod": [
+      "none",
+      "oath",
+      "push",
+      "sms",
+      "unknownFutureValue",
+      "voiceAlternateMobile",
+      "voiceMobile",
+      "voiceOffice"
+    ],
+    "userDefaultAuthenticationMethodType": [
+      "oath",
+      "push",
+      "sms",
+      "unknownFutureValue",
+      "voiceAlternateMobile",
+      "voiceMobile",
+      "voiceOffice"
+    ],
+    "userEmailSource": [
+      "primarySmtpAddress",
+      "userPrincipalName"
+    ],
+    "userExperienceAnalyticsAnomalyCorrelationGroupPrevalence": [
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "userExperienceAnalyticsAnomalyDeviceFeatureType": [
+      "application",
+      "driver",
+      "manufacturer",
+      "model",
+      "osVersion",
+      "unknownFutureValue"
+    ],
+    "userExperienceAnalyticsAnomalySeverity": [
+      "high",
+      "informational",
+      "low",
+      "medium",
+      "other",
+      "unknownFutureValue"
+    ],
+    "userExperienceAnalyticsAnomalyState": [
+      "active",
+      "disabled",
+      "new",
+      "other",
+      "removed",
+      "unknownFutureValue"
+    ],
+    "userExperienceAnalyticsAnomalyType": [
+      "application",
+      "device",
+      "driver",
+      "other",
+      "stopError",
+      "unknownFutureValue"
+    ],
+    "userExperienceAnalyticsDeviceStatus": [
+      "affected",
+      "anomalous",
+      "atRisk",
+      "unknownFutureValue"
+    ],
+    "userExperienceAnalyticsHealthState": [
+      "insufficientData",
+      "meetingGoals",
+      "needsAttention",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "userExperienceAnalyticsInsightSeverity": [
+      "error",
+      "informational",
+      "none",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "userExperienceAnalyticsMachineType": [
+      "physical",
+      "unknown",
+      "unknownFutureValue",
+      "virtual"
+    ],
+    "userExperienceAnalyticsOperatingSystemRestartCategory": [
+      "blueScreen",
+      "bootError",
+      "longPowerButtonPress",
+      "restartWithoutUpdate",
+      "restartWithUpdate",
+      "shutdownWithoutUpdate",
+      "shutdownWithUpdate",
+      "unknown",
+      "unknownFutureValue",
+      "update"
+    ],
+    "userExperienceAnalyticsSummarizedBy": [
+      "allRegressions",
+      "manufacturerRegression",
+      "model",
+      "modelRegression",
+      "none",
+      "operatingSystemVersionRegression",
+      "unknownFutureValue"
+    ],
+    "userFlowType": [
+      "passwordReset",
+      "profileUpdate",
+      "resourceOwner",
+      "signIn",
+      "signUp",
+      "signUpOrSignIn",
+      "unknownFutureValue"
+    ],
+    "usernameSource": [
+      "primarySmtpAddress",
+      "samAccountName",
+      "userPrincipalName"
+    ],
+    "userNewMessageRestriction": [
+      "everyone",
+      "everyoneExceptGuests",
+      "moderators",
+      "unknownFutureValue"
+    ],
+    "userOwnership": [
+      "lawfulBasisForProcessing",
+      "none",
+      "rightsRelatedToAutomatedDecisionMaking",
+      "rightToAccess",
+      "rightToBeInformed",
+      "rightToDataPortability",
+      "rightToObject",
+      "rightToRectification",
+      "rightToRestrictionOfProcessing",
+      "unknownFutureValue"
+    ],
+    "userPersona": [
+      "externalGuest",
+      "externalMember",
+      "internalGuest",
+      "internalMember",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "userPfxIntendedPurpose": [
+      "smimeEncryption",
+      "smimeSigning",
+      "unassigned",
+      "vpn",
+      "wifi"
+    ],
+    "userPfxPaddingScheme": [
+      "none",
+      "oaepSha1",
+      "oaepSha256",
+      "oaepSha384",
+      "oaepSha512",
+      "pkcs1"
+    ],
+    "userPurpose": [
+      "equipment",
+      "linked",
+      "others",
+      "room",
+      "shared",
+      "unknown",
+      "unknownFutureValue",
+      "user"
+    ],
+    "userScopeType": [
+      "group",
+      "tenant",
+      "unknownFutureValue",
+      "user"
+    ],
+    "userSignInRecommendationScope": [
+      "application",
+      "tenant",
+      "unknownFutureValue"
+    ],
+    "userType": [
+      "guest",
+      "member",
+      "unknownFutureValue"
+    ],
+    "verifiableCredentialPresentationStatusCode": [
+      "presentation_verified",
+      "request_retrieved",
+      "unknownFutureValue"
+    ],
+    "verifiedIdProfileState": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "verifiedIdUsageConfigurationPurpose": [
+      "all",
+      "onboarding",
+      "recovery",
+      "unknownFutureValue"
+    ],
+    "virtualAppointmentMessageType": [
+      "cancellation",
+      "confirmation",
+      "reschedule",
+      "unknownFutureValue"
+    ],
+    "virtualEventAttendeeRegistrationStatus": [
+      "canceled",
+      "pendingApproval",
+      "registered",
+      "rejectedByOrganizer",
+      "unknownFutureValue",
+      "waitlisted"
+    ],
+    "virtualEventRegistrationPredefinedQuestionLabel": [
+      "city",
+      "countryOrRegion",
+      "industry",
+      "jobTitle",
+      "organization",
+      "postalCode",
+      "state",
+      "street",
+      "unknownFutureValue"
+    ],
+    "virtualEventRegistrationQuestionAnswerInputType": [
+      "boolean",
+      "multiChoice",
+      "multilineText",
+      "singleChoice",
+      "text",
+      "unknownFutureValue"
+    ],
+    "virtualEventStatus": [
+      "canceled",
+      "draft",
+      "published",
+      "unknownFutureValue"
+    ],
+    "visibilitySetting": [
+      "hide",
+      "notConfigured",
+      "show"
+    ],
+    "volumeType": [
+      "fixedDataVolume",
+      "operatingSystemVolume",
+      "removableDataVolume",
+      "unknownFutureValue"
+    ],
+    "vpnAuthenticationMethod": [
+      "azureAD",
+      "certificate",
+      "derivedCredential",
+      "sharedSecret",
+      "usernameAndPassword"
+    ],
+    "vpnClientAuthenticationType": [
+      "deviceAuthentication",
+      "userAuthentication"
+    ],
+    "vpnDeadPeerDetectionRate": [
+      "high",
+      "low",
+      "medium",
+      "none"
+    ],
+    "vpnEncryptionAlgorithmType": [
+      "aes128",
+      "aes128Gcm",
+      "aes192",
+      "aes192Gcm",
+      "aes256",
+      "aes256Gcm",
+      "chaCha20Poly1305",
+      "des",
+      "tripleDes"
+    ],
+    "vpnIntegrityAlgorithmType": [
+      "md5",
+      "sha1_160",
+      "sha1_96",
+      "sha2_256",
+      "sha2_384",
+      "sha2_512"
+    ],
+    "vpnLocalIdentifier": [
+      "clientCertificateSubjectName",
+      "deviceFQDN",
+      "empty"
+    ],
+    "vpnOnDemandRuleConnectionAction": [
+      "connect",
+      "disconnect",
+      "evaluateConnection",
+      "ignore"
+    ],
+    "vpnOnDemandRuleConnectionDomainAction": [
+      "connectIfNeeded",
+      "neverConnect"
+    ],
+    "vpnOnDemandRuleInterfaceTypeMatch": [
+      "cellular",
+      "ethernet",
+      "notConfigured",
+      "wiFi"
+    ],
+    "vpnProviderType": [
+      "appProxy",
+      "notConfigured",
+      "packetTunnel"
+    ],
+    "vpnServerCertificateType": [
+      "ecdsa256",
+      "ecdsa384",
+      "ecdsa521",
+      "rsa"
+    ],
+    "vpnServiceExceptionAction": [
+      "allowTrafficOutside",
+      "dropTraffic",
+      "forceTrafficViaVPN"
+    ],
+    "vpnTrafficDirection": [
+      "inbound",
+      "outbound",
+      "unknownFutureValue"
+    ],
+    "vpnTrafficRuleAppType": [
+      "desktop",
+      "none",
+      "universal"
+    ],
+    "vpnTrafficRuleRoutingPolicyType": [
+      "forceTunnel",
+      "none",
+      "splitTunnel"
+    ],
+    "vpnTunnelConfigurationType": [
+      "cellular",
+      "wifi",
+      "wifiAndCellular"
+    ],
+    "vppTokenAccountType": [
+      "business",
+      "education"
+    ],
+    "vppTokenActionFailureReason": [
+      "appleFailure",
+      "expiredApplePushNotificationCertificate",
+      "expiredVppToken",
+      "internalError",
+      "none"
+    ],
+    "vppTokenState": [
+      "assignedToExternalMDM",
+      "duplicateLocationId",
+      "expired",
+      "invalid",
+      "unknown",
+      "valid"
+    ],
+    "vppTokenSyncStatus": [
+      "completed",
+      "failed",
+      "inProgress",
+      "none"
+    ],
+    "watermarkLayout": [
+      "diagonal",
+      "horizontal"
+    ],
+    "weakAlgorithms": [
+      "rsaSha1",
+      "unknownFutureValue"
+    ],
+    "webApplicationFirewallDnsRecordType": [
+      "cname",
+      "unknownFutureValue"
+    ],
+    "webApplicationFirewallProviderType": [
+      "akamai",
+      "cloudflare",
+      "unknownFutureValue"
+    ],
+    "webApplicationFirewallVerificationStatus": [
+      "failure",
+      "success",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "webBrowserCookieSettings": [
+      "allowAlways",
+      "allowCurrentWebSite",
+      "allowFromWebsitesVisited",
+      "blockAlways",
+      "browserDefault"
+    ],
+    "websiteType": [
+      "blog",
+      "home",
+      "other",
+      "profile",
+      "work"
+    ],
+    "weekIndex": [
+      "first",
+      "fourth",
+      "last",
+      "second",
+      "third"
+    ],
+    "weeklySchedule": [
+      "everyday",
+      "friday",
+      "monday",
+      "noScheduledScan",
+      "saturday",
+      "sunday",
+      "thursday",
+      "tuesday",
+      "userDefined",
+      "wednesday"
+    ],
+    "welcomeScreenMeetingInformation": [
+      "showOrganizerAndTimeAndSubject",
+      "showOrganizerAndTimeOnly",
+      "userDefined"
+    ],
+    "wellknownListName": [
+      "defaultList",
+      "flaggedEmails",
+      "none",
+      "unknownFutureValue"
+    ],
+    "whatIfAnalysisReasons": [
+      "agentIdentities",
+      "agentIdRisk",
+      "application",
+      "authenticationContext",
+      "authenticationFlow",
+      "clientApps",
+      "devicePlatform",
+      "devices",
+      "emptyPolicy",
+      "insiderRisk",
+      "invalidCondition",
+      "invalidPolicy",
+      "location",
+      "notEnoughInformation",
+      "notSet",
+      "policyNotEnabled",
+      "signInRisk",
+      "time",
+      "unknownFutureValue",
+      "userActions",
+      "userRisk",
+      "users",
+      "workloadIdentities"
+    ],
+    "wiFiAuthenticationMethod": [
+      "certificate",
+      "derivedCredential",
+      "usernameAndPassword"
+    ],
+    "wifiAuthenticationType": [
+      "guest",
+      "machine",
+      "machineOrUser",
+      "none",
+      "user"
+    ],
+    "wiFiProxySetting": [
+      "automatic",
+      "manual",
+      "none",
+      "unknownFutureValue"
+    ],
+    "wiFiSecurityType": [
+      "open",
+      "unknownFutureValue",
+      "wep",
+      "wpa2Enterprise",
+      "wpa2Personal",
+      "wpa3Personal",
+      "wpaEnterprise",
+      "wpaPersonal"
+    ],
+    "win32LobAppDeliveryOptimizationPriority": [
+      "foreground",
+      "notConfigured"
+    ],
+    "win32LobAppDetectionOperator": [
+      "equal",
+      "greaterThan",
+      "greaterThanOrEqual",
+      "lessThan",
+      "lessThanOrEqual",
+      "notConfigured",
+      "notEqual"
+    ],
+    "win32LobAppFileSystemDetectionType": [
+      "createdDate",
+      "doesNotExist",
+      "exists",
+      "modifiedDate",
+      "notConfigured",
+      "sizeInMB",
+      "version"
+    ],
+    "win32LobAppFileSystemOperationType": [
+      "appVersion",
+      "createdDate",
+      "doesNotExist",
+      "exists",
+      "modifiedDate",
+      "notConfigured",
+      "sizeInBytes",
+      "sizeInMB",
+      "unknownFutureValue",
+      "version"
+    ],
+    "win32LobAppMsiPackageType": [
+      "dualPurpose",
+      "perMachine",
+      "perUser"
+    ],
+    "win32LobAppNotification": [
+      "hideAll",
+      "showAll",
+      "showReboot"
+    ],
+    "win32LobAppPowerShellScriptDetectionType": [
+      "boolean",
+      "dateTime",
+      "float",
+      "integer",
+      "notConfigured",
+      "string",
+      "version"
+    ],
+    "win32LobAppPowerShellScriptRuleOperationType": [
+      "boolean",
+      "dateTime",
+      "float",
+      "integer",
+      "notConfigured",
+      "string",
+      "version"
+    ],
+    "win32LobAppRegistryDetectionType": [
+      "doesNotExist",
+      "exists",
+      "integer",
+      "notConfigured",
+      "string",
+      "version"
+    ],
+    "win32LobAppRegistryRuleOperationType": [
+      "appVersion",
+      "doesNotExist",
+      "exists",
+      "integer",
+      "notConfigured",
+      "string",
+      "unknownFutureValue",
+      "version"
+    ],
+    "win32LobAppRestartBehavior": [
+      "allow",
+      "basedOnReturnCode",
+      "force",
+      "suppress"
+    ],
+    "win32LobAppReturnCodeType": [
+      "failed",
+      "hardReboot",
+      "retry",
+      "softReboot",
+      "success"
+    ],
+    "win32LobAppRuleOperator": [
+      "equal",
+      "greaterThan",
+      "greaterThanOrEqual",
+      "lessThan",
+      "lessThanOrEqual",
+      "notConfigured",
+      "notEqual"
+    ],
+    "win32LobAppRuleType": [
+      "detection",
+      "requirement"
+    ],
+    "win32LobAutoUpdateSupersededAppsState": [
+      "enabled",
+      "notConfigured",
+      "unknownFutureValue"
+    ],
+    "windows10AppsUpdateRecurrence": [
+      "daily",
+      "monthly",
+      "none",
+      "weekly"
+    ],
+    "windows10AppType": [
+      "desktop",
+      "universal"
+    ],
+    "windows10DeviceModeType": [
+      "sModeConfiguration",
+      "standardConfiguration"
+    ],
+    "windows10EditionType": [
+      "notConfigured",
+      "windows10Education",
+      "windows10EducationN",
+      "windows10Enterprise",
+      "windows10EnterpriseN",
+      "windows10HolographicEnterprise",
+      "windows10Home",
+      "windows10HomeChina",
+      "windows10HomeN",
+      "windows10HomeSingleLanguage",
+      "windows10IoTCore",
+      "windows10IoTCoreCommercial",
+      "windows10Mobile",
+      "windows10MobileEnterprise",
+      "windows10Professional",
+      "windows10ProfessionalEducation",
+      "windows10ProfessionalEducationN",
+      "windows10ProfessionalN",
+      "windows10ProfessionalWorkstation",
+      "windows10ProfessionalWorkstationN"
+    ],
+    "windows10VpnAuthenticationMethod": [
+      "certificate",
+      "customEapXml",
+      "derivedCredential",
+      "usernameAndPassword"
+    ],
+    "windows10VpnConnectionType": [
+      "automatic",
+      "checkPointCapsuleVpn",
+      "ciscoAnyConnect",
+      "citrix",
+      "dellSonicWallMobileConnect",
+      "f5EdgeClient",
+      "ikEv2",
+      "l2tp",
+      "microsoftTunnel",
+      "paloAltoGlobalProtect",
+      "pptp",
+      "pulseSecure",
+      "unknownFutureValue"
+    ],
+    "windows10VpnProfileTarget": [
+      "autoPilotDevice",
+      "device",
+      "user"
+    ],
+    "windows365SwitchCompatibilityFailureReasonType": [
+      "hardwareNotSupported",
+      "osVersionNotSupported",
+      "unknownFutureValue"
+    ],
+    "windowsAppStartLayoutTileSize": [
+      "hidden",
+      "large",
+      "medium",
+      "small",
+      "wide"
+    ],
+    "windowsArchitecture": [
+      "arm",
+      "arm64",
+      "neutral",
+      "none",
+      "x64",
+      "x86"
+    ],
+    "windowsAutopilotDeploymentState": [
+      "disabled",
+      "failure",
+      "inProgress",
+      "notAttempted",
+      "success",
+      "successOnRetry",
+      "successWithTimeout",
+      "unknown"
+    ],
+    "windowsAutopilotDeviceRemediationState": [
+      "automaticRemediationRequired",
+      "manualRemediationRequired",
+      "noRemediationRequired",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "windowsAutopilotDeviceType": [
+      "holoLens",
+      "surfaceHub2",
+      "surfaceHub2S",
+      "unknownFutureValue",
+      "virtualMachine",
+      "windowsPc"
+    ],
+    "windowsAutopilotEnrollmentType": [
+      "azureADJoinedUsingDeviceAuthWithAutopilotProfile",
+      "azureADJoinedUsingDeviceAuthWithoutAutopilotProfile",
+      "azureADJoinedWithAutopilotProfile",
+      "azureADJoinedWithOfflineAutopilotProfile",
+      "azureADJoinedWithWhiteGlove",
+      "offlineDomainJoined",
+      "offlineDomainJoinedWithOfflineAutopilotProfile",
+      "offlineDomainJoinedWithWhiteGlove",
+      "unknown"
+    ],
+    "windowsAutopilotProfileAssignmentDetailedStatus": [
+      "hardwareRequirementsNotMet",
+      "holoLensProfileNotSupported",
+      "none",
+      "surfaceHub2SProfileNotSupported",
+      "surfaceHubProfileNotSupported",
+      "unknownFutureValue",
+      "windowsPcProfileNotSupported"
+    ],
+    "windowsAutopilotProfileAssignmentStatus": [
+      "assignedInSync",
+      "assignedOutOfSync",
+      "assignedUnkownSyncState",
+      "failed",
+      "notAssigned",
+      "pending",
+      "unknown"
+    ],
+    "windowsAutopilotSyncStatus": [
+      "completed",
+      "failed",
+      "inProgress",
+      "unknown"
+    ],
+    "windowsAutopilotUserlessEnrollmentStatus": [
+      "allowed",
+      "blocked",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "windowsAutoUpdateCatalogAppDeliveryOptimizationPriority": [
+      "foreground",
+      "notConfigured",
+      "unknownFutureValue"
+    ],
+    "windowsAutoUpdateCatalogAppNotificationType": [
+      "hideAll",
+      "showAll",
+      "showReboot",
+      "unknownFutureValue"
+    ],
+    "windowsAutoUpdateCatalogAppRestartBehavior": [
+      "allow",
+      "basedOnReturnCode",
+      "force",
+      "suppress",
+      "unknownFutureValue"
+    ],
+    "windowsDefenderApplicationControlSupplementalPolicyStatuses": [
+      "notAuthorizedByToken",
+      "policyNotFound",
+      "success",
+      "tokenError",
+      "unknown"
+    ],
+    "windowsDefenderProductStatus": [
+      "asSignaturesOutOfDate",
+      "avSignaturesOutOfDate",
+      "noFullScanHappenedForSpecifiedPeriod",
+      "noQuickScanHappenedForSpecifiedPeriod",
+      "noStatus",
+      "noStatusFlagsSet",
+      "offlineScanRequired",
+      "pendingFullScanDueToThreatAction",
+      "pendingManualStepsDueToThreatAction",
+      "pendingRebootDueToThreatAction",
+      "platformAboutToBeOutdated",
+      "platformOutOfDate",
+      "platformUpdateInProgress",
+      "productExpired",
+      "productRunningInEvaluationMode",
+      "productRunningInNonGenuineMode",
+      "samplesPendingSubmission",
+      "serviceNotRunning",
+      "serviceShutdownAsPartOfSystemShutdown",
+      "serviceStartedWithoutMalwareProtection",
+      "signatureOrPlatformEndOfLifeIsPastOrIsImpending",
+      "systemInitiatedCleanInProgress",
+      "systemInitiatedScanInProgress",
+      "threatRemediationFailedCritically",
+      "threatRemediationFailedNonCritically",
+      "windowsSModeSignaturesInUseOnNonWin10SInstall"
+    ],
+    "windowsDefenderTamperProtectionOptions": [
+      "disable",
+      "enable",
+      "notConfigured"
+    ],
+    "windowsDeliveryOptimizationMode": [
+      "bypassMode",
+      "httpOnly",
+      "httpWithInternetPeering",
+      "httpWithPeeringNat",
+      "httpWithPeeringPrivateGroup",
+      "simpleDownload",
+      "userDefined"
+    ],
+    "windowsDeviceHealthState": [
+      "clean",
+      "critical",
+      "fullScanPending",
+      "manualStepsPending",
+      "offlineScanPending",
+      "rebootPending"
+    ],
+    "windowsDeviceType": [
+      "desktop",
+      "holographic",
+      "mobile",
+      "none",
+      "team",
+      "unknownFutureValue"
+    ],
+    "windowsDeviceUsageType": [
+      "shared",
+      "singleUser",
+      "unknownFutureValue"
+    ],
+    "windowsDriverUpdateProfileInventorySyncState": [
+      "failure",
+      "pending",
+      "success"
+    ],
+    "windowsEdgeKioskType": [
+      "fullScreen",
+      "publicBrowsing"
+    ],
+    "windowsFirewallRuleInterfaceTypes": [
+      "lan",
+      "notConfigured",
+      "remoteAccess",
+      "wireless"
+    ],
+    "windowsFirewallRuleNetworkProfileTypes": [
+      "domain",
+      "notConfigured",
+      "private",
+      "public"
+    ],
+    "windowsFirewallRuleTrafficDirectionType": [
+      "in",
+      "notConfigured",
+      "out"
+    ],
+    "windowsHealthMonitoringScope": [
+      "bootPerformance",
+      "healthMonitoring",
+      "privilegeManagement",
+      "undefined",
+      "windowsUpdates"
+    ],
+    "windowsHelloForBusinessPinUsage": [
+      "allowed",
+      "disallowed",
+      "required"
+    ],
+    "windowsInformationProtectionEnforcementLevel": [
+      "encryptAndAuditOnly",
+      "encryptAuditAndBlock",
+      "encryptAuditAndPrompt",
+      "noProtection"
+    ],
+    "windowsInformationProtectionPinCharacterRequirements": [
+      "allow",
+      "notAllow",
+      "requireAtLeastOne"
+    ],
+    "windowsKioskAppType": [
+      "aumId",
+      "desktop",
+      "store",
+      "unknown"
+    ],
+    "windowsMalwareCategory": [
+      "adware",
+      "aolExploit",
+      "backdoor",
+      "behavior",
+      "browserModifier",
+      "browserPlugin",
+      "cookie",
+      "dialer",
+      "emailFlooder",
+      "enterpriseUnwantedSoftware",
+      "exploit",
+      "filesharingProgram",
+      "hipsRule",
+      "hostileActiveXControl",
+      "icqExploit",
+      "invalid",
+      "jokeProgram",
+      "keylogger",
+      "known",
+      "malwareCreationTool",
+      "monitoringSoftware",
+      "nuker",
+      "passwordStealer",
+      "policy",
+      "potentialUnwantedSoftware",
+      "ransom",
+      "remote_Control_Software",
+      "remoteAccessTrojan",
+      "remoteControlSoftware",
+      "securityDisabler",
+      "settingsModifier",
+      "softwareBundler",
+      "spp",
+      "spyware",
+      "stealthNotifier",
+      "tool",
+      "toolBar",
+      "trojan",
+      "trojanDenialOfService",
+      "trojanDownloader",
+      "trojanDropper",
+      "trojanFtp",
+      "trojanMassMailer",
+      "trojanMonitoringSoftware",
+      "trojanProxyServer",
+      "trojanTelnet",
+      "unknown",
+      "virus",
+      "vulnerability",
+      "worm"
+    ],
+    "windowsMalwareExecutionState": [
+      "allowed",
+      "blocked",
+      "notRunning",
+      "running",
+      "unknown"
+    ],
+    "windowsMalwareSeverity": [
+      "high",
+      "low",
+      "moderate",
+      "severe",
+      "unknown"
+    ],
+    "windowsMalwareState": [
+      "abandoned",
+      "allowed",
+      "allowFailed",
+      "blocked",
+      "blockFailed",
+      "cleaned",
+      "cleanFailed",
+      "detected",
+      "quarantined",
+      "quarantineFailed",
+      "removed",
+      "removeFailed",
+      "unknown"
+    ],
+    "windowsMalwareThreatState": [
+      "actionFailed",
+      "active",
+      "allowed",
+      "cleaned",
+      "fullScanRequired",
+      "manualStepsRequired",
+      "noStatusCleared",
+      "quarantined",
+      "rebootRequired",
+      "remediatedWithNonCriticalFailures",
+      "removed"
+    ],
+    "windowsManagedAppClipboardSharingLevel": [
+      "anyDestinationAnySource",
+      "none",
+      "unknownFutureValue"
+    ],
+    "windowsManagedAppDataTransferLevel": [
+      "allApps",
+      "none"
+    ],
+    "windowsPrivacyDataAccessLevel": [
+      "forceAllow",
+      "forceDeny",
+      "notConfigured",
+      "userInControl"
+    ],
+    "windowsPrivacyDataCategory": [
+      "accountInfo",
+      "appsRunInBackground",
+      "calendar",
+      "callHistory",
+      "camera",
+      "contacts",
+      "diagnosticsInfo",
+      "email",
+      "location",
+      "messaging",
+      "microphone",
+      "motion",
+      "notConfigured",
+      "notifications",
+      "phone",
+      "radios",
+      "syncWithDevices",
+      "tasks",
+      "trustedDevices"
+    ],
+    "windowsQualityUpdateApprovalStatus": [
+      "approved",
+      "suspended",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "windowsQualityUpdateCadence": [
+      "monthly",
+      "outOfBand",
+      "unknownFutureValue"
+    ],
+    "windowsQualityUpdateCategory": [
+      "all",
+      "nonSecurity",
+      "quickMachineRecovery",
+      "security",
+      "unknownFutureValue"
+    ],
+    "windowsQualityUpdatePolicyActionType": [
+      "approve",
+      "suspend",
+      "unknownFutureValue"
+    ],
+    "windowsQualityUpdatePolicyApprovalMethodType": [
+      "automatic",
+      "manual",
+      "unknownFutureValue"
+    ],
+    "windowsSettingType": [
+      "backup",
+      "roaming",
+      "unknownFutureValue"
+    ],
+    "windowsSModeConfiguration": [
+      "block",
+      "noRestriction",
+      "unlock"
+    ],
+    "windowsSpotlightEnablementSettings": [
+      "disabled",
+      "enabled",
+      "notConfigured"
+    ],
+    "windowsStartMenuAppListVisibilityType": [
+      "collapse",
+      "disableSettingsApp",
+      "remove",
+      "userDefined"
+    ],
+    "windowsStartMenuModeType": [
+      "fullScreen",
+      "nonFullScreen",
+      "userDefined"
+    ],
+    "windowsUpdateCveSeverityLevel": [
+      "critical",
+      "important",
+      "moderate",
+      "unknownFutureValue"
+    ],
+    "windowsUpdateForBusinessUpdateWeeks": [
+      "everyWeek",
+      "firstWeek",
+      "fourthWeek",
+      "secondWeek",
+      "thirdWeek",
+      "unknownFutureValue",
+      "userDefined"
+    ],
+    "windowsUpdateNotificationDisplayOption": [
+      "defaultNotifications",
+      "disableAllNotifications",
+      "notConfigured",
+      "restartWarningsOnly",
+      "unknownFutureValue"
+    ],
+    "windowsUpdateStatus": [
+      "failed",
+      "pendingInstallation",
+      "pendingReboot",
+      "upToDate"
+    ],
+    "windowsUpdateType": [
+      "all",
+      "businessReadyOnly",
+      "userDefined",
+      "windowsInsiderBuildFast",
+      "windowsInsiderBuildRelease",
+      "windowsInsiderBuildSlow"
+    ],
+    "windowsUserAccountControlSettings": [
+      "alwaysNotify",
+      "neverNotify",
+      "notifyOnAppChanges",
+      "notifyOnAppChangesWithoutDimming",
+      "userDefined"
+    ],
+    "windowsUserType": [
+      "administrator",
+      "standard",
+      "unknownFutureValue"
+    ],
+    "windowsVpnConnectionType": [
+      "checkPointCapsuleVpn",
+      "dellSonicWallMobileConnect",
+      "f5EdgeClient",
+      "pulseSecure"
+    ],
+    "winGetAppNotification": [
+      "hideAll",
+      "showAll",
+      "showReboot",
+      "unknownFutureValue"
+    ],
+    "wiredNetworkAuthenticationMethod": [
+      "certificate",
+      "derivedCredential",
+      "unknownFutureValue",
+      "usernameAndPassword"
+    ],
+    "wiredNetworkAuthenticationType": [
+      "guest",
+      "machine",
+      "machineOrUser",
+      "none",
+      "unknownFutureValue",
+      "user"
+    ],
+    "wiredNetworkInterface": [
+      "anyEthernet",
+      "firstActiveEthernet",
+      "firstEthernet",
+      "secondActiveEthernet",
+      "secondEthernet",
+      "thirdActiveEthernet",
+      "thirdEthernet"
+    ],
+    "workbookOperationStatus": [
+      "failed",
+      "notStarted",
+      "running",
+      "succeeded"
+    ],
+    "workforceIntegrationEncryptionProtocol": [
+      "sharedSecret",
+      "unknownFutureValue"
+    ],
+    "workforceIntegrationSupportedEntities": [
+      "none",
+      "offerShiftRequest",
+      "openShift",
+      "openShiftRequest",
+      "shift",
+      "swapRequest",
+      "timeCard",
+      "timeOff",
+      "timeOffReason",
+      "timeOffRequest",
+      "unknownFutureValue",
+      "userShiftPreferences"
+    ],
+    "workLocationSource": [
+      "automatic",
+      "manual",
+      "none",
+      "scheduled",
+      "unknownFutureValue"
+    ],
+    "workLocationType": [
+      "office",
+      "remote",
+      "timeOff",
+      "unknownFutureValue",
+      "unspecified"
+    ],
+    "workLocationUpdateScope": [
+      "currentDay",
+      "currentSegment",
+      "unknownFutureValue"
+    ],
+    "workplaceSensorEventType": [
+      "badgeIn",
+      "badgeOut",
+      "unknownFutureValue"
+    ],
+    "workplaceSensorType": [
+      "badge",
+      "heartbeat",
+      "inferredOccupancy",
+      "occupancy",
+      "peopleCount",
+      "unknownFutureValue",
+      "wifi"
+    ],
+    "writingToolsIosManagedAppConfigurationState": [
+      "blocked",
+      "notBlocked",
+      "unknownFutureValue"
+    ],
+    "x509CertificateAffinityLevel": [
+      "high",
+      "low",
+      "unknownFutureValue"
+    ],
+    "x509CertificateAuthenticationMode": [
+      "unknownFutureValue",
+      "x509CertificateMultiFactor",
+      "x509CertificateSingleFactor"
+    ],
+    "x509CertificateIssuerHintsState": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "x509CertificateRuleType": [
+      "issuerSubject",
+      "issuerSubjectAndPolicyOID",
+      "policyOID",
+      "unknownFutureValue"
+    ],
+    "zebraFotaConnectorState": [
+      "connected",
+      "disconnected",
+      "none",
+      "unknownFutureValue"
+    ],
+    "zebraFotaDeploymentState": [
+      "canceled",
+      "completed",
+      "created",
+      "createFailed",
+      "inProgress",
+      "pendingCancel",
+      "pendingCreation",
+      "unknownFutureValue"
+    ],
+    "zebraFotaErrorCode": [
+      "noDevicesFoundInSelectedAadGroups",
+      "noIntuneDevicesFoundInSelectedAadGroups",
+      "noZebraFotaDevicesFoundForSelectedDeviceModel",
+      "noZebraFotaEnrolledDevicesFoundForCurrentTenant",
+      "noZebraFotaEnrolledDevicesFoundInSelectedAadGroups",
+      "success",
+      "unknownFutureValue",
+      "zebraFotaCreateDeploymentRequestFailure"
+    ],
+    "zebraFotaNetworkType": [
+      "any",
+      "cellular",
+      "unknownFutureValue",
+      "wifi",
+      "wifiAndCellular"
+    ],
+    "zebraFotaScheduleMode": [
+      "installNow",
+      "scheduled",
+      "unknownFutureValue"
+    ],
+    "zebraFotaUpdateType": [
+      "auto",
+      "custom",
+      "latest",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.agentic": {
+    "agentType": [
+      "agenticApp",
+      "agenticAppInstance",
+      "agentIdentityBlueprintPrincipal",
+      "agentIDuser",
+      "notAgentic",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.callRecords": {
+    "audioCodec": [
+      "amrWide",
+      "cn",
+      "g722",
+      "g7221",
+      "g7221c",
+      "g729",
+      "invalid",
+      "muchv2",
+      "multiChannelAudio",
+      "opus",
+      "pcma",
+      "pcmu",
+      "rtAudio16",
+      "rtAudio8",
+      "satin",
+      "satinFullband",
+      "silk",
+      "silkNarrow",
+      "silkWide",
+      "siren",
+      "unknown",
+      "unknownFutureValue",
+      "xmsRta"
+    ],
+    "callType": [
+      "groupCall",
+      "peerToPeer",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "clientPlatform": [
+      "android",
+      "holoLens",
+      "iOS",
+      "ipPhone",
+      "macOS",
+      "roomSystem",
+      "surfaceHub",
+      "unknown",
+      "unknownFutureValue",
+      "web",
+      "windows"
+    ],
+    "failureStage": [
+      "callSetup",
+      "midcall",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "mediaStreamDirection": [
+      "calleeToCaller",
+      "callerToCallee"
+    ],
+    "modality": [
+      "audio",
+      "data",
+      "screenSharing",
+      "unknownFutureValue",
+      "video",
+      "videoBasedScreenSharing"
+    ],
+    "networkConnectionType": [
+      "mobile",
+      "tunnel",
+      "unknown",
+      "unknownFutureValue",
+      "wifi",
+      "wired"
+    ],
+    "networkTransportProtocol": [
+      "tcp",
+      "udp",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "productFamily": [
+      "azureCommunicationServices",
+      "lync",
+      "skypeForBusiness",
+      "teams",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "pstnCallDurationSource": [
+      "microsoft",
+      "operator"
+    ],
+    "pstnUserBlockMode": [
+      "blocked",
+      "unblocked",
+      "unknownFutureValue"
+    ],
+    "serviceRole": [
+      "audioTeleconferencerController",
+      "conferencingAnnouncementService",
+      "conferencingAttendant",
+      "customBot",
+      "exchangeUnifiedMessagingService",
+      "gateway",
+      "mediaController",
+      "mediationServer",
+      "mediationServerCloudConnectorEdition",
+      "responseGroupService",
+      "responseGroupServiceAnnouncementService",
+      "skypeForBusinessApplicationSharingMcu",
+      "skypeForBusinessAttendant",
+      "skypeForBusinessAudioVideoMcu",
+      "skypeForBusinessAutoAttendant",
+      "skypeForBusinessCallQueues",
+      "skypeForBusinessMicrosoftTeamsGateway",
+      "skypeForBusinessUnifiedCommunicationApplicationPlatform",
+      "skypeTranslator",
+      "unknown",
+      "unknownFutureValue",
+      "voicemail"
+    ],
+    "userFeedbackRating": [
+      "bad",
+      "excellent",
+      "fair",
+      "good",
+      "notRated",
+      "poor",
+      "unknownFutureValue"
+    ],
+    "videoCodec": [
+      "av1",
+      "h263",
+      "h264",
+      "h264s",
+      "h264uc",
+      "h265",
+      "invalid",
+      "rtvc1",
+      "rtVideo",
+      "unknown",
+      "unknownFutureValue",
+      "xrtvc1"
+    ],
+    "wifiBand": [
+      "frequency24GHz",
+      "frequency50GHz",
+      "frequency60GHz",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "wifiRadioType": [
+      "unknown",
+      "unknownFutureValue",
+      "wifi80211a",
+      "wifi80211ac",
+      "wifi80211ax",
+      "wifi80211b",
+      "wifi80211g",
+      "wifi80211n"
+    ]
+  },
+  "microsoft.graph.cloudLicensing": {
+    "assigneeTypes": [
+      "device",
+      "group",
+      "none",
+      "unknownFutureValue",
+      "user"
+    ],
+    "subscriptionState": [
+      "active",
+      "deleted",
+      "lockedOut",
+      "suspended",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "subscriptionTags": [
+      "none",
+      "trial",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.deviceManagement": {
+    "aggregationType": [
+      "affectedCloudPcCount",
+      "affectedCloudPcPercentage",
+      "count",
+      "durationInMinutes",
+      "percentage",
+      "unknownFutureValue"
+    ],
+    "alertRuleTemplate": [
+      "cloudPcDeprovisionFailedScenario",
+      "cloudPcFrontlineConcurrencyScenario",
+      "cloudPcFrontlineInsufficientLicensesScenario",
+      "cloudPcImageUploadScenario",
+      "cloudPcInaccessibleScenario",
+      "cloudPcInGracePeriodScenario",
+      "cloudPcOnPremiseNetworkConnectionCheckScenario",
+      "cloudPcProvisionScenario",
+      "cloudPcUserSettingsPersistenceScenario",
+      "unknownFutureValue"
+    ],
+    "alertStatusType": [
+      "active",
+      "resolved",
+      "unknownFutureValue"
+    ],
+    "conditionCategory": [
+      "azureNetworkConnectionCheckFailures",
+      "cloudPcConnectionErrors",
+      "cloudPcDeprovisionedThreshold",
+      "cloudPcHostHealthCheckFailures",
+      "cloudPcInGracePeriod",
+      "cloudPcReserveDeprovisionFailedThreshold",
+      "cloudPcUserSettingsPersistenceUsageThreshold",
+      "cloudPcZoneOutage",
+      "frontlineBufferUsageDuration",
+      "frontlineBufferUsageThreshold",
+      "frontlineInsufficientLicenses",
+      "imageUploadFailures",
+      "provisionFailures",
+      "unknownFutureValue"
+    ],
+    "notificationChannelType": [
+      "email",
+      "phoneCall",
+      "portal",
+      "sms",
+      "unknownFutureValue"
+    ],
+    "operatorType": [
+      "equal",
+      "greater",
+      "greaterOrEqual",
+      "less",
+      "lessOrEqual",
+      "notEqual",
+      "unknownFutureValue"
+    ],
+    "relationshipType": [
+      "and",
+      "or",
+      "unknownFutureValue"
+    ],
+    "ruleSeverityType": [
+      "critical",
+      "informational",
+      "unknown",
+      "unknownFutureValue",
+      "warning"
+    ]
+  },
+  "microsoft.graph.ediscovery": {
+    "additionalDataOptions": [
+      "allVersions",
+      "linkedFiles",
+      "unknownFutureValue"
+    ],
+    "caseAction": [
+      "addToReviewSet",
+      "applyTags",
+      "contentExport",
+      "convertToPdf",
+      "estimateStatistics",
+      "holdUpdate",
+      "index",
+      "purgeData",
+      "unknownFutureValue"
+    ],
+    "caseOperationStatus": [
+      "failed",
+      "notStarted",
+      "partiallySucceeded",
+      "running",
+      "submissionFailed",
+      "succeeded"
+    ],
+    "caseStatus": [
+      "active",
+      "closed",
+      "closedWithError",
+      "closing",
+      "pendingDelete",
+      "unknown"
+    ],
+    "childSelectability": [
+      "Many",
+      "One"
+    ],
+    "custodianStatus": [
+      "active",
+      "released"
+    ],
+    "dataSourceContainerStatus": [
+      "Active",
+      "Released",
+      "UnknownFutureValue"
+    ],
+    "dataSourceHoldStatus": [
+      "applied",
+      "applying",
+      "notApplied",
+      "partial",
+      "removing",
+      "unknownFutureValue"
+    ],
+    "dataSourceScopes": [
+      "allCaseCustodians",
+      "allCaseNoncustodialDataSources",
+      "allTenantMailboxes",
+      "allTenantSites",
+      "none",
+      "unknownFutureValue"
+    ],
+    "exportFileStructure": [
+      "directory",
+      "none",
+      "pst",
+      "unknownFutureValue"
+    ],
+    "exportOptions": [
+      "fileInfo",
+      "originalFiles",
+      "pdfReplacement",
+      "tags",
+      "text",
+      "unknownFutureValue"
+    ],
+    "legalHoldStatus": [
+      "Error",
+      "Pending",
+      "Success",
+      "UnknownFutureValue"
+    ],
+    "sourceType": [
+      "mailbox",
+      "site"
+    ]
+  },
+  "microsoft.graph.entraRecoveryServices": {
+    "recoveryAction": [
+      "restore",
+      "softDelete",
+      "unknownFutureValue",
+      "update"
+    ],
+    "recoveryStatus": [
+      "abandoned",
+      "calculating",
+      "failed",
+      "initialized",
+      "loadingData",
+      "running",
+      "successful",
+      "unknownFutureValue"
+    ],
+    "resourceTypeName": [
+      "application",
+      "appRoleAssignment",
+      "authenticationMethodPolicy",
+      "authenticationStrengthPolicy",
+      "authorizationPolicy",
+      "conditionalAccessPolicy",
+      "group",
+      "namedLocationPolicy",
+      "oAuth2PermissionGrant",
+      "organization",
+      "servicePrincipal",
+      "unknownFutureValue",
+      "user"
+    ]
+  },
+  "microsoft.graph.externalConnectors": {
+    "accessType": [
+      "deny",
+      "grant",
+      "unknownFutureValue"
+    ],
+    "aclType": [
+      "everyone",
+      "everyoneExceptGuests",
+      "externalGroup",
+      "group",
+      "unknownFutureValue",
+      "user"
+    ],
+    "connectionOperationStatus": [
+      "completed",
+      "failed",
+      "inprogress",
+      "unknownFutureValue",
+      "unspecified"
+    ],
+    "connectionState": [
+      "draft",
+      "limitExceeded",
+      "obsolete",
+      "ready",
+      "unknownFutureValue"
+    ],
+    "contentCategory": [
+      "crm",
+      "dashboard",
+      "email",
+      "fileRepository",
+      "knowledgeBase",
+      "learningManagement",
+      "media",
+      "meetingTranscripts",
+      "messaging",
+      "people",
+      "qna",
+      "taskManagement",
+      "uncategorized",
+      "unknownFutureValue",
+      "wikis"
+    ],
+    "contentExperienceType": [
+      "compliance",
+      "search",
+      "unknownFutureValue"
+    ],
+    "externalActivityType": [
+      "commented",
+      "created",
+      "modified",
+      "unknownFutureValue",
+      "viewed"
+    ],
+    "externalItemContentType": [
+      "html",
+      "text",
+      "unknownFutureValue"
+    ],
+    "identitySourceType": [
+      "azureActiveDirectory",
+      "external",
+      "unknownFutureValue"
+    ],
+    "identityType": [
+      "externalGroup",
+      "group",
+      "unknownFutureValue",
+      "user"
+    ],
+    "importanceScore": [
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue",
+      "veryHigh"
+    ],
+    "label": [
+      "assignedToPeople",
+      "authors",
+      "closedBy",
+      "closedDate",
+      "containerName",
+      "containerUrl",
+      "createdBy",
+      "createdDateTime",
+      "dueDate",
+      "fileExtension",
+      "fileName",
+      "iconUrl",
+      "itemParentId",
+      "itemPath",
+      "itemType",
+      "lastModifiedBy",
+      "lastModifiedDateTime",
+      "numberOfReactions",
+      "parentUrl",
+      "personAccount",
+      "personAddresses",
+      "personAlternateContacts",
+      "personAnniversaries",
+      "personAssistants",
+      "personAwards",
+      "personCertifications",
+      "personColleagues",
+      "personCurrentPosition",
+      "personEducationalActivities",
+      "personEmails",
+      "personEmergencyContacts",
+      "personInterests",
+      "personLanguages",
+      "personManager",
+      "personName",
+      "personNote",
+      "personPatents",
+      "personPhones",
+      "personProjects",
+      "personPublications",
+      "personSkills",
+      "personWebAccounts",
+      "personWebSite",
+      "priority",
+      "priorityNormalized",
+      "reportedBy",
+      "secondaryId",
+      "severity",
+      "sprintName",
+      "state",
+      "tags",
+      "title",
+      "unknownFutureValue",
+      "url"
+    ],
+    "propertyType": [
+      "boolean",
+      "dateTime",
+      "dateTimeCollection",
+      "double",
+      "doubleCollection",
+      "int64",
+      "int64Collection",
+      "principal",
+      "principalCollection",
+      "string",
+      "stringCollection",
+      "unknownFutureValue"
+    ],
+    "ruleOperation": [
+      "contains",
+      "equals",
+      "greaterThan",
+      "lessThan",
+      "notContains",
+      "notEquals",
+      "null",
+      "startsWith",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.healthMonitoring": {
+    "alertState": [
+      "active",
+      "resolved",
+      "unknownFutureValue"
+    ],
+    "alertType": [
+      "compliantDeviceSignInFailure",
+      "conditionalAccessBlockedSignIn",
+      "managedDeviceSignInFailure",
+      "mfaSignInFailure",
+      "samlSignInFailure",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "category": [
+      "authentication",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "enrichmentState": [
+      "enriched",
+      "inProgress",
+      "none",
+      "unknownFutureValue"
+    ],
+    "scenario": [
+      "conditionalAccess",
+      "devices",
+      "mfa",
+      "saml",
+      "unknown",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.identityGovernance": {
+    "activationTaskScopeType": [
+      "allTasks",
+      "failedTasks",
+      "unknownFutureValue"
+    ],
+    "activationUserScopeType": [
+      "allUsers",
+      "failedUsers",
+      "unknownFutureValue"
+    ],
+    "customTaskExtensionOperationStatus": [
+      "completed",
+      "failed",
+      "unknownFutureValue"
+    ],
+    "lifecycleTaskCategory": [
+      "joiner",
+      "leaver",
+      "mover",
+      "unknownFutureValue"
+    ],
+    "lifecycleWorkflowCategory": [
+      "joiner",
+      "leaver",
+      "mover",
+      "unknownFutureValue"
+    ],
+    "lifecycleWorkflowProcessingStatus": [
+      "canceled",
+      "canceling",
+      "completed",
+      "completedWithErrors",
+      "failed",
+      "inProgress",
+      "queued",
+      "unknownFutureValue"
+    ],
+    "membershipChangeType": [
+      "add",
+      "remove",
+      "unknownFutureValue"
+    ],
+    "valueType": [
+      "bool",
+      "enum",
+      "int",
+      "string",
+      "unknownFutureValue"
+    ],
+    "workflowExecutionType": [
+      "activatedWithScope",
+      "onDemand",
+      "preview",
+      "scheduled",
+      "unknownFutureValue"
+    ],
+    "workflowTriggerTimeBasedAttribute": [
+      "createdDateTime",
+      "employeeHireDate",
+      "employeeLeaveDateTime",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.industryData": {
+    "additionalClassGroupAttributes": [
+      "academicSessionExternalId",
+      "academicSessionTitle",
+      "classCode",
+      "courseCode",
+      "courseExternalId",
+      "courseGradeLevel",
+      "courseSubject",
+      "courseTitle",
+      "unknownFutureValue"
+    ],
+    "additionalUserAttributes": [
+      "unknownFutureValue",
+      "userGradeLevel",
+      "userNumber"
+    ],
+    "apiFormat": [
+      "oneRoster",
+      "unknownFutureValue"
+    ],
+    "filterOptions": [
+      "orgExternalId",
+      "unknownFutureValue"
+    ],
+    "inboundDomain": [
+      "educationRostering",
+      "unknownFutureValue"
+    ],
+    "industryDataActivityStatus": [
+      "completed",
+      "completedWithErrors",
+      "completedWithWarnings",
+      "failed",
+      "inProgress",
+      "skipped",
+      "unknownFutureValue"
+    ],
+    "industryDataRunStatus": [
+      "completed",
+      "completedWithErrors",
+      "completedWithWarnings",
+      "failed",
+      "running",
+      "unknownFutureValue"
+    ],
+    "readinessStatus": [
+      "disabled",
+      "expired",
+      "failed",
+      "notReady",
+      "ready",
+      "unknownFutureValue"
+    ],
+    "studentAgeGroup": [
+      "adult",
+      "minor",
+      "notAdult",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.managedTenants": {
+    "alertSeverity": [
+      "high",
+      "informational",
+      "low",
+      "medium",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alertStatus": [
+      "dismissed",
+      "inProgress",
+      "newAlert",
+      "resolved",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "delegatedPrivilegeStatus": [
+      "delegatedAdminPrivileges",
+      "delegatedAndGranularDelegetedAdminPrivileges",
+      "granularDelegatedAdminPrivileges",
+      "none",
+      "unknownFutureValue"
+    ],
+    "managementActionStatus": [
+      "completed",
+      "error",
+      "inProgress",
+      "planned",
+      "resolvedBy3rdParty",
+      "resolvedThroughAlternateMitigation",
+      "riskAccepted",
+      "timeOut",
+      "toAddress",
+      "unknownFutureValue"
+    ],
+    "managementCategory": [
+      "custom",
+      "data",
+      "devices",
+      "identity",
+      "unknownFutureValue"
+    ],
+    "managementParameterValueType": [
+      "boolean",
+      "booleanCollection",
+      "guid",
+      "guidCollection",
+      "integer",
+      "integerCollection",
+      "string",
+      "stringCollection",
+      "unknownFutureValue"
+    ],
+    "managementProvider": [
+      "community",
+      "indirectProvider",
+      "microsoft",
+      "self",
+      "unknownFutureValue"
+    ],
+    "managementTemplateDeploymentStatus": [
+      "completed",
+      "failed",
+      "ineligible",
+      "inProgress",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "notificationDestination": [
+      "api",
+      "email",
+      "none",
+      "sms",
+      "unknownFutureValue"
+    ],
+    "tenantOnboardingEligibilityReason": [
+      "contractType",
+      "delegatedAdminPrivileges",
+      "license",
+      "none",
+      "unknownFutureValue",
+      "usersCount"
+    ],
+    "tenantOnboardingStatus": [
+      "active",
+      "disabled",
+      "inactive",
+      "ineligible",
+      "inProcess",
+      "unknownFutureValue"
+    ],
+    "workloadActionCategory": [
+      "automated",
+      "manual",
+      "unknownFutureValue"
+    ],
+    "workloadActionStatus": [
+      "completed",
+      "error",
+      "inProgress",
+      "timeOut",
+      "toAddress",
+      "unknownFutureValue"
+    ],
+    "workloadOnboardingStatus": [
+      "notOnboarded",
+      "onboarded",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.networkaccess": {
+    "accessType": [
+      "appAccess",
+      "privateAccess",
+      "quickAccess",
+      "unknownFutureValue"
+    ],
+    "aggregationFilter": [
+      "bytesReceived",
+      "bytesSent",
+      "connections",
+      "devices",
+      "totalBytes",
+      "transactions",
+      "unknownFutureValue",
+      "users"
+    ],
+    "alertSeverity": [
+      "high",
+      "informational",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "alertType": [
+      "crossTenantAnomaly",
+      "deviceTokenInconsistency",
+      "dlp",
+      "malware",
+      "patientZero",
+      "suspiciousProcess",
+      "threatIntelligenceTransactions",
+      "unhealthyConnectors",
+      "unhealthyRemoteNetworks",
+      "unknownFutureValue",
+      "webContentBlocked"
+    ],
+    "algorithm": [
+      "md5",
+      "sha1",
+      "sha256",
+      "sha256ac",
+      "unknownFutureValue"
+    ],
+    "applicationActivity": [
+      "mcp",
+      "none",
+      "prompt",
+      "unknownFutureValue"
+    ],
+    "bandwidthCapacityInMbps": [
+      "mbps1000",
+      "mbps250",
+      "mbps500",
+      "mbps750",
+      "unknownFutureValue"
+    ],
+    "clientFallbackAction": [
+      "block",
+      "bypass",
+      "unknownFutureValue"
+    ],
+    "cloudFirewallAction": [
+      "allow",
+      "block",
+      "unknownFutureValue"
+    ],
+    "cloudFirewallProtocol": [
+      "tcp",
+      "udp",
+      "unknownFutureValue"
+    ],
+    "confidenceLevel": [
+      "high",
+      "low",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "connectionStatus": [
+      "active",
+      "closed",
+      "open",
+      "unknownFutureValue"
+    ],
+    "connectivityState": [
+      "connected",
+      "error",
+      "inactive",
+      "pending",
+      "unknownFutureValue"
+    ],
+    "crossTenantAccessType": [
+      "b2bCollaboration",
+      "none",
+      "unknownFutureValue"
+    ],
+    "deviceCategory": [
+      "branch",
+      "client",
+      "remoteNetwork",
+      "unknownFutureValue"
+    ],
+    "deviceJoinType": [
+      "microsoftEntraJoined",
+      "microsoftEntraRegistered",
+      "none",
+      "unknownFutureValue"
+    ],
+    "deviceVendor": [
+      "aristaNetworks",
+      "aristaVeloCloud",
+      "aviatrix",
+      "barracudaNetworks",
+      "checkPoint",
+      "ciscoCatalyst",
+      "ciscoMeraki",
+      "citrix",
+      "fortinet",
+      "hpeAruba",
+      "juniperNetworks",
+      "netFoundry",
+      "netskope",
+      "nuage",
+      "openSystems",
+      "other",
+      "paloAltoNetworks",
+      "riverbedTechnology",
+      "silverPeak",
+      "teridion",
+      "unknownFutureValue",
+      "versa",
+      "vmWareSdWan"
+    ],
+    "dhGroup": [
+      "dhGroup14",
+      "dhGroup2048",
+      "dhGroup24",
+      "ecp256",
+      "ecp384",
+      "unknownFutureValue"
+    ],
+    "filteringPolicyAction": [
+      "alert",
+      "allow",
+      "block",
+      "bypass",
+      "unknownFutureValue"
+    ],
+    "forwardingCategory": [
+      "allow",
+      "default",
+      "optimized",
+      "unknownFutureValue"
+    ],
+    "forwardingRuleAction": [
+      "bypass",
+      "forward",
+      "unknownFutureValue"
+    ],
+    "httpMethod": [
+      "connect",
+      "delete",
+      "get",
+      "head",
+      "options",
+      "patch",
+      "post",
+      "put",
+      "trace",
+      "unknownFutureValue"
+    ],
+    "ikeEncryption": [
+      "aes128",
+      "aes192",
+      "aes256",
+      "gcmAes128",
+      "gcmAes256",
+      "unknownFutureValue"
+    ],
+    "ikeIntegrity": [
+      "gcmAes128",
+      "gcmAes256",
+      "sha256",
+      "sha384",
+      "unknownFutureValue"
+    ],
+    "intentCategory": [
+      "collection",
+      "commandAndControl",
+      "credentialAccess",
+      "defenseEvasion",
+      "discovery",
+      "evasion",
+      "execution",
+      "exfiltration",
+      "impact",
+      "impairProcessControl",
+      "inhibitResponseFunction",
+      "initialAccess",
+      "lateralMovement",
+      "persistence",
+      "privilegeEscalation",
+      "reconnaissance",
+      "resourceDevelopment",
+      "unknownFutureValue"
+    ],
+    "ipSecEncryption": [
+      "gcmAes128",
+      "gcmAes192",
+      "gcmAes256",
+      "none",
+      "unknownFutureValue"
+    ],
+    "ipSecIntegrity": [
+      "gcmAes128",
+      "gcmAes192",
+      "gcmAes256",
+      "sha256",
+      "unknownFutureValue"
+    ],
+    "malwareCategory": [
+      "adware",
+      "backdoor",
+      "behavior",
+      "bot",
+      "browserModifier",
+      "constructor",
+      "cryptojacking",
+      "ddos",
+      "dropper",
+      "dropperMalware",
+      "exploit",
+      "filelessMalware",
+      "hackTool",
+      "hybridMalware",
+      "joke",
+      "keylogger",
+      "misleading",
+      "monitoringTool",
+      "passwordStealer",
+      "polymorphicMalware",
+      "program",
+      "ransomware",
+      "remoteAccess",
+      "rogue",
+      "rootkit",
+      "settingsModifier",
+      "softwareBundler",
+      "spammer",
+      "spoofer",
+      "spyware",
+      "tool",
+      "trojan",
+      "trojanClicker",
+      "trojanDownloader",
+      "trojanNotifier",
+      "trojanProxy",
+      "trojanSpy",
+      "unknownFutureValue",
+      "virus",
+      "wiperMalware",
+      "worm"
+    ],
+    "networkDestinationType": [
+      "fqdn",
+      "ipAddress",
+      "ipRange",
+      "ipSubnet",
+      "unknownFutureValue",
+      "url",
+      "webCategory"
+    ],
+    "networkingProtocol": [
+      "ggp",
+      "icmp",
+      "icmpV6",
+      "idp",
+      "igmp",
+      "ip",
+      "ipSecAuthenticationHeader",
+      "ipSecEncapsulatingSecurityPayload",
+      "ipv4",
+      "ipv6",
+      "ipv6DestinationOptions",
+      "ipv6FragmentHeader",
+      "ipv6NoNextHeader",
+      "ipv6RoutingHeader",
+      "ipx",
+      "nd",
+      "pup",
+      "raw",
+      "spx",
+      "spxII",
+      "tcp",
+      "udp",
+      "unknownFutureValue"
+    ],
+    "networkTrafficOperationStatus": [
+      "failure",
+      "success",
+      "unknownFutureValue"
+    ],
+    "onboardingStatus": [
+      "offboarded",
+      "offboardingErrorOccurred",
+      "offboardingInProgress",
+      "onboarded",
+      "onboardingErrorOccurred",
+      "onboardingInProgress",
+      "unknownFutureValue"
+    ],
+    "pfsGroup": [
+      "ecp256",
+      "ecp384",
+      "none",
+      "pfs1",
+      "pfs14",
+      "pfs2",
+      "pfs2048",
+      "pfs24",
+      "pfsmm",
+      "unknownFutureValue"
+    ],
+    "redundancyTier": [
+      "noRedundancy",
+      "unknownFutureValue",
+      "zoneRedundancy"
+    ],
+    "region": [
+      "australiaEast",
+      "australiaSouthEast",
+      "brazilSouth",
+      "brazilSouthEast",
+      "canadaCentral",
+      "canadaEast",
+      "centralIndia",
+      "centralUS",
+      "eastUS",
+      "eastUS2",
+      "franceCentral",
+      "franceSouth",
+      "germanyWestCentral",
+      "israelCentral",
+      "italyNorth",
+      "japanEast",
+      "japanWest",
+      "jioIndiaCentral",
+      "koreaCentral",
+      "koreaSouth",
+      "mexicoCentral",
+      "northCentralUS",
+      "northEurope",
+      "polandCentral",
+      "southAfricaNorth",
+      "southAfricaWest",
+      "southCentralUS",
+      "southEastAsia",
+      "southIndia",
+      "spainCentral",
+      "swedenCentral",
+      "switzerlandNorth",
+      "taiwanNorth",
+      "uaeNorth",
+      "ukSouth",
+      "unknownFutureValue",
+      "westCentralUS",
+      "westEurope",
+      "westUS",
+      "westUS2",
+      "westUS3"
+    ],
+    "remoteNetworkStatus": [
+      "bgpConnected",
+      "bgpDisconnected",
+      "remoteNetworkAlive",
+      "tunnelConnected",
+      "tunnelDisconnected",
+      "unknownFutureValue"
+    ],
+    "securityRuleStatus": [
+      "disabled",
+      "enabled",
+      "reportOnly",
+      "unknownFutureValue"
+    ],
+    "status": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "threatIntelligenceAction": [
+      "allow",
+      "block",
+      "unknownFutureValue"
+    ],
+    "threatIntelligenceSeverity": [
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "threatSeverity": [
+      "critical",
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "tlsAction": [
+      "bypassed",
+      "intercepted",
+      "unknownFutureValue"
+    ],
+    "tlsCertificateStatus": [
+      "active",
+      "csrGenerated",
+      "disabled",
+      "enabled",
+      "enrolling",
+      "expired",
+      "expiring",
+      "unknownFutureValue"
+    ],
+    "tlsStatus": [
+      "failure",
+      "success",
+      "unknownFutureValue"
+    ],
+    "trafficForwardingType": [
+      "internet",
+      "m365",
+      "private",
+      "unknownFutureValue"
+    ],
+    "trafficType": [
+      "all",
+      "internet",
+      "microsoft365",
+      "private",
+      "unknownFutureValue"
+    ],
+    "usageStatus": [
+      "frequentlyUsed",
+      "rarelyUsed",
+      "unknownFutureValue"
+    ],
+    "userType": [
+      "guest",
+      "member",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.partner.security": {
+    "complianceStatus": [
+      "compliant",
+      "noncomplaint",
+      "unknownFutureValue"
+    ],
+    "policyStatus": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "securityAlertConfidence": [
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "securityAlertResolvedReason": [
+      "fraud",
+      "ignore",
+      "legitimate",
+      "unknownFutureValue"
+    ],
+    "securityAlertSeverity": [
+      "high",
+      "informational",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "securityAlertStatus": [
+      "active",
+      "investigating",
+      "resolved",
+      "unknownFutureValue"
+    ],
+    "securityRequirementState": [
+      "active",
+      "preview",
+      "unknownFutureValue"
+    ],
+    "securityRequirementType": [
+      "mfaEnforcedForAdmins",
+      "mfaEnforcedForAdminsOfCustomers",
+      "securityAlertsPromptlyResolved",
+      "securityContactProvided",
+      "spendingBudgetSetForCustomerAzureSubscriptions",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.partners.billing": {
+    "attributeSet": [
+      "basic",
+      "full",
+      "unknownFutureValue"
+    ],
+    "billingPeriod": [
+      "current",
+      "last",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.search": {
+    "answerState": [
+      "draft",
+      "excluded",
+      "published",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.security": {
+    "action": [
+      "disable",
+      "enable",
+      "forcePasswordReset",
+      "markUserAsCompromised",
+      "requireUserToSignInAgain",
+      "revokeAllSessions",
+      "unknownFutureValue"
+    ],
+    "actionAfterRetentionPeriod": [
+      "delete",
+      "none",
+      "relabel",
+      "startDispositionReview",
+      "unknownFutureValue"
+    ],
+    "actionSource": [
+      "automatic",
+      "default",
+      "manual",
+      "recommended"
+    ],
+    "additionalDataOptions": [
+      "advancedIndexing",
+      "allItemsInFolder",
+      "allVersions",
+      "htmlTranscripts",
+      "linkedFiles",
+      "listAttachments",
+      "locationsWithoutHits",
+      "messageConversationExpansion",
+      "unknownFutureValue"
+    ],
+    "additionalOptions": [
+      "advancedIndexing",
+      "allDocumentVersions",
+      "allItemsInFolder",
+      "cloudAttachments",
+      "condensePaths",
+      "friendlyName",
+      "htmlTranscripts",
+      "includeFolderAndPath",
+      "includeReport",
+      "listAttachments",
+      "none",
+      "splitSource",
+      "subfolderContents",
+      "teamsAndYammerConversations",
+      "unknownFutureValue"
+    ],
+    "aiAgentPlatform": [
+      "azureAIFoundry",
+      "copilot",
+      "copilotStudio",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alertClassification": [
+      "falsePositive",
+      "informationalExpectedActivity",
+      "truePositive",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alertDetermination": [
+      "apt",
+      "compromisedAccount",
+      "confirmedActivity",
+      "lineOfBusinessApplication",
+      "maliciousUserActivity",
+      "malware",
+      "multiStagedAttack",
+      "notEnoughDataToValidate",
+      "notMalicious",
+      "other",
+      "phishing",
+      "securityPersonnel",
+      "securityTesting",
+      "unknown",
+      "unknownFutureValue",
+      "unwantedSoftware"
+    ],
+    "alertSeverity": [
+      "high",
+      "informational",
+      "low",
+      "medium",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alertStatus": [
+      "inProgress",
+      "new",
+      "resolved",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "antispamDirectionality": [
+      "inbound",
+      "intraOrg",
+      "outbound",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "antispamTeamsDirection": [
+      "inbound",
+      "intraorg",
+      "outbound",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "appCategory": [
+      "accountingAndFinance",
+      "advertising",
+      "aiModelProvider",
+      "businessIntelligence",
+      "businessManagement",
+      "clientAiApp",
+      "cloudComputingPlatform",
+      "cloudStorage",
+      "codeHosting",
+      "collaboration",
+      "communications",
+      "contentManagement",
+      "contentSharing",
+      "crm",
+      "customerSupport",
+      "dataAnalytics",
+      "developmentTools",
+      "eCommerce",
+      "education",
+      "forums",
+      "generativeAi",
+      "health",
+      "hostingServices",
+      "humanResourceManagement",
+      "internetOfThings",
+      "itServices",
+      "marketing",
+      "mcpServer",
+      "newsAndEntertainment",
+      "onlineMeetings",
+      "operationsManagement",
+      "personalInstantMessaging",
+      "productDesign",
+      "productivity",
+      "projectManagement",
+      "propertyManagement",
+      "sales",
+      "security",
+      "socialNetwork",
+      "supplyChainAndLogistics",
+      "transportationAndTravel",
+      "unknown",
+      "unknownFutureValue",
+      "vendorManagementSystems",
+      "webAnalytics",
+      "webemail",
+      "websiteMonitoring"
+    ],
+    "appInfoCsaStarLevel": [
+      "attestation",
+      "certification",
+      "continuousMonitoring",
+      "cStarAssessment",
+      "selfAssessment",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "appInfoDataAtRestEncryptionMethod": [
+      "aes",
+      "bitLocker",
+      "blowfish",
+      "des",
+      "des3",
+      "notSupported",
+      "rc4",
+      "rsA",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "appInfoDataRetentionPolicy": [
+      "dataRetained",
+      "deletedImmediately",
+      "deletedWithinMoreThanThreeMonths",
+      "deletedWithinOneMonth",
+      "deletedWithinThreeMonths",
+      "deletedWithinTwoWeeks",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "appInfoEncryptionProtocol": [
+      "notApplicable",
+      "notSupported",
+      "ssl3",
+      "tls1_0",
+      "tls1_1",
+      "tls1_2",
+      "tls1_3",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "appInfoFedRampLevel": [
+      "high",
+      "liSaaS",
+      "low",
+      "moderate",
+      "notSupported",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "appInfoHolding": [
+      "private",
+      "public",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "appInfoPciDssVersion": [
+      "notSupported",
+      "unknown",
+      "unknownFutureValue",
+      "v1",
+      "v2",
+      "v3",
+      "v3_1",
+      "v3_2",
+      "v3_2_1",
+      "v4"
+    ],
+    "appInfoUploadedDataTypes": [
+      "codingFiles",
+      "creditCards",
+      "databaseFiles",
+      "documents",
+      "mediaFiles",
+      "none",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "assignmentMethod": [
+      "auto",
+      "privileged",
+      "standard"
+    ],
+    "auditLogQueryStatus": [
+      "cancelled",
+      "failed",
+      "notStarted",
+      "running",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "auditLogRecordType": [
+      "A365AIExecuteTool",
+      "A365AIInferenceCall",
+      "A365AIInvokeAgent",
+      "A365AIRunSummary",
+      "A365SpanOutputs",
+      "AadRiskDetection",
+      "AeD",
+      "AgentAdminActivity",
+      "AgentSettingsAdminActivity",
+      "AIAppInteraction",
+      "AIExecuteTool",
+      "AIInferenceCall",
+      "AIInteractionsChangeNotification",
+      "AIInteractionsExport",
+      "AIInteractionsSubscription",
+      "AIInvokeAgent",
+      "AipDiscover",
+      "AipFileDeleted",
+      "AipHeartBeat",
+      "AipProtectionAction",
+      "AipScannerDiscoverEvent",
+      "AipSensitivityLabelAction",
+      "AirAdminActionInvestigation",
+      "AirInvestigation",
+      "AirManualInvestigation",
+      "Alert",
+      "AlertIncident",
+      "AlertStatus",
+      "AppAdminActivity",
+      "ApplicationAudit",
+      "AppSettingsAdminActivity",
+      "AttackSim",
+      "AttackSimAdmin",
+      "AuditConfig",
+      "AuditRetentionPolicy",
+      "AuditSearch",
+      "AZFWApplicationRuleAggregation",
+      "AZFWDnsQuery",
+      "AZFWNetworkRule",
+      "AzureActiveDirectory",
+      "AzureActiveDirectoryAccountLogon",
+      "AzureActiveDirectoryStsLogon",
+      "CallActivityEvent",
+      "Campaign",
+      "Case",
+      "CaseInvestigation",
+      "CCRAIPolicyViolation",
+      "CDPClassificationDocument",
+      "CDPClassificationMailItem",
+      "CdpClassifierHealthRecord",
+      "CdpColdCrawlStatus",
+      "CdpComplianceDLPExchangeClassification",
+      "CdpComplianceDLPSharePointClassification",
+      "CDPCompliancePolicyExecution",
+      "CDPCompliancePolicyUserFeedback",
+      "CdpConsumptionResource",
+      "CdpContentExplorerAggregateRecord",
+      "CDPDLMAIInteractionInsights",
+      "CdpDlpSensitive",
+      "CDPEdgeBlockedMessage",
+      "CDPEmailFeatures",
+      "CDPHygieneAttachmentInfo",
+      "CDPHygieneSummary",
+      "CDPHygieneUrlInfo",
+      "CDPMlInferencingResult",
+      "CdpOcrBillingRecord",
+      "CdpOcrCostEstimatorRecord",
+      "CDPPackageManagerHygieneEvent",
+      "CDPPostMailDeliveryAction",
+      "CDPPredictiveCodingLabel",
+      "CdpResourceScopeChangeEvent",
+      "CDPUnifiedFeedback",
+      "CDPUrlClick",
+      "CloudUpdateDeviceConfig",
+      "CloudUpdateProfileConfig",
+      "CloudUpdateTenantConfig",
+      "CMImprovementActionChange",
+      "ComplianceCCExchangeExecutionResult",
+      "ComplianceConnector",
+      "ComplianceDLMExchange",
+      "ComplianceDLMSharePoint",
+      "ComplianceDLPApplications",
+      "ComplianceDLPApplicationsClassification",
+      "ComplianceDLPEndpoint",
+      "ComplianceDLPEndpointDiscovery",
+      "ComplianceDLPEnforcement",
+      "ComplianceDLPExchange",
+      "ComplianceDLPExchangeClassification",
+      "ComplianceDLPExchangeDiscovery",
+      "ComplianceDLPSharePoint",
+      "ComplianceDLPSharePointClassification",
+      "ComplianceDLPSharePointClassificationExtended",
+      "ComplianceSettingsChange",
+      "ComplianceSupervisionExchange",
+      "ConnectedAIAppInteraction",
+      "ConsumptionResource",
+      "ContentStoreMetadata",
+      "CopilotActions",
+      "CopilotAgentManagement",
+      "CopilotForSecurityLogging",
+      "CopilotForSecurityTrigger",
+      "CopilotInteraction",
+      "CoreReportingSettings",
+      "CortanaBriefing",
+      "CPSOperation",
+      "CreateCopilotPlugin",
+      "CreateCopilotPromptBook",
+      "CreateCopilotWorkspace",
+      "CriticalAssetManagementClassification",
+      "CRM",
+      "CrossTenantAccessPolicy",
+      "CustomerKeyServiceEncryption",
+      "DataCatalogAccessRequests",
+      "DataCenterSecurityCmdlet",
+      "DataGovernance",
+      "DataInsightsRestApiAudit",
+      "DataSecurityInvestigation",
+      "DataShareOperation",
+      "DefenderCaseManagement",
+      "DefenderExpertsforXDRAdmin",
+      "DefenderPreviewFeatures",
+      "DeleteCopilotPlugin",
+      "DeleteCopilotPromptBook",
+      "DeleteCopilotWorkspace",
+      "DeployFeatureActivity",
+      "DeviceDiscoverySettings",
+      "DeviceDiscoverySettingsAuthenticatedScans",
+      "DeviceDiscoverySettingsExclusion",
+      "DisableCopilotPlugin",
+      "DisableCopilotPromptBook",
+      "DisableCopilotWorkspace",
+      "Discovery",
+      "DLPEndpoint",
+      "DlpImportResult",
+      "DlpSensitiveInformationType",
+      "Dynamics365BusinessCentral",
+      "EduDataLakeDownloadOperation",
+      "EHRConnector",
+      "EnableCopilotPlugin",
+      "EnableCopilotPromptBook",
+      "EnableCopilotWorkspace",
+      "ExchangeAdmin",
+      "ExchangeAggregatedOperation",
+      "ExchangeItem",
+      "ExchangeItemAggregated",
+      "ExchangeItemGroup",
+      "ExchangeSearch",
+      "FabricAudit",
+      "FilteringAtpDetonationInfo",
+      "FilteringAttachmentInfo",
+      "FilteringBulkSenderInsightData",
+      "FilteringBulkThresholdInsightData",
+      "FilteringDelistingMetadata",
+      "FilteringDocMetadata",
+      "FilteringDocScan",
+      "FilteringEmailContentFeatures",
+      "FilteringEmailFeatures",
+      "FilteringEntityEvent",
+      "FilteringMailGradingResult",
+      "FilteringMailMetadata",
+      "FilteringMailMetadataExtended",
+      "FilteringMailSubmission",
+      "FilteringPostMailDeliveryAction",
+      "FilteringRuleHits",
+      "FilteringRuntimeInfo",
+      "FilteringTeamsMetadata",
+      "FilteringTeamsPostDeliveryAction",
+      "FilteringTeamsUrlInfo",
+      "FilteringTimeTravelDocMetadata",
+      "FilteringUrlClick",
+      "FilteringUrlInfo",
+      "FilteringUrlPostClickAction",
+      "HealthcareSignal",
+      "HostedRpa",
+      "HRSignal",
+      "HygieneEvent",
+      "IncidentStatus",
+      "InformationBarrierPolicyApplication",
+      "InformationWorkerProtection",
+      "InsiderRiskScopedUserInsights",
+      "InsiderRiskScopedUsers",
+      "IRMActivityAuditTrail",
+      "IRMSecurityAlert",
+      "IrmUserDefinedDetectionSignal",
+      "Kaizala",
+      "LabelAnalyticsAggregate",
+      "LabelContentExplorer",
+      "LabelExplorer",
+      "LargeContentMetadata",
+      "M365ComplianceConnector",
+      "M365DAAD",
+      "M365ODSPAssetMetadata",
+      "M365SearchSections",
+      "MailSubmission",
+      "ManagedTenants",
+      "MAPGAlerts",
+      "MAPGOnboard",
+      "MAPGPolicy",
+      "MAPGRemediation",
+      "MCASAlerts",
+      "MDAAudit",
+      "MDADataSecuritySignal",
+      "MDATPAudit",
+      "MDCAssessments",
+      "MDCConfigurationEvent",
+      "MDCRegulatoryComplianceAssessments",
+      "MDCRegulatoryComplianceControls",
+      "MDCRegulatoryComplianceStandards",
+      "MDCSecurityConnectors",
+      "MDCUsageEvent",
+      "MeshWorlds",
+      "Microsoft365BackupBackupItem",
+      "Microsoft365BackupBackupPolicy",
+      "Microsoft365BackupGranularBrowseTask",
+      "Microsoft365BackupRestoreItem",
+      "Microsoft365BackupRestoreTask",
+      "Microsoft365CopilotScheduledPrompt",
+      "Microsoft365Group",
+      "MicrosoftDefenderForIdentityAudit",
+      "MicrosoftFlow",
+      "MicrosoftForms",
+      "MicrosoftGraphDataConnectConsent",
+      "MicrosoftGraphDataConnectOperation",
+      "MicrosoftManagedServicePlatform",
+      "MicrosoftPurview",
+      "MicrosoftStream",
+      "MicrosoftTeams",
+      "MicrosoftTeamsAdmin",
+      "MicrosoftTeamsAnalytics",
+      "MicrosoftTeamsDevice",
+      "MicrosoftTeamsRetentionLabelAction",
+      "MicrosoftTeamsSensitivityLabelAction",
+      "MicrosoftTeamsShifts",
+      "MicrosoftTodoAudit",
+      "MipAutoLabelExchangeItem",
+      "MipAutoLabelProgressFeedback",
+      "MipAutoLabelSharePointItem",
+      "MipAutoLabelSharePointPolicyLocation",
+      "MipAutoLabelSimulationCompletion",
+      "MipAutoLabelSimulationProgress",
+      "MipAutoLabelSimulationStatistics",
+      "MipExactDataMatch",
+      "MIPLabel",
+      "MipLabelAnalyticsAuditRecord",
+      "MosAgentInfoRecord",
+      "MS365DCustomDetection",
+      "MS365DIncident",
+      "MS365DSuppressionRule",
+      "MSDECustomCollection",
+      "MSDEGeneralSettings",
+      "MSDEIndicatorsSettings",
+      "MSDEResponseActions",
+      "MSDERolesSettings",
+      "MSTIC",
+      "MultiStageDisposition",
+      "MyAnalyticsSettings",
+      "NoisyAlertPolicy",
+      "OfficeClientRestrictedModeAction",
+      "OfficeNative",
+      "OfficeRestrictedModeAction",
+      "OfficeScriptsRunAction",
+      "OMEPortal",
+      "OnDemandSharePointClassification",
+      "OneDrive",
+      "OnPremisesFileShareScannerDlp",
+      "OnPremisesSharePointScannerDlp",
+      "OpticalCharacterRecognition",
+      "OrganizationalDataInM365",
+      "OutlookCopilotAutomation",
+      "OWAAuth",
+      "P4AIAssessmentCategoryRecord",
+      "P4AIAssessmentFabricScannerRecord",
+      "P4AIAssessmentLocationResultRecord",
+      "P4AIAssessmentRecord",
+      "PeopleAdminSettings",
+      "PhysicalBadgingSignal",
+      "PlacesDirectory",
+      "PlannerChatMessage",
+      "PlannerChatMessageList",
+      "PlannerCopyPlan",
+      "PlannerGoal",
+      "PlannerGoalList",
+      "PlannerPlan",
+      "PlannerPlanList",
+      "PlannerPlanSensitivityLabel",
+      "PlannerRoster",
+      "PlannerRosterSensitivityLabel",
+      "PlannerTask",
+      "PlannerTaskList",
+      "PlannerTenantSettings",
+      "PowerAppsApp",
+      "PowerAppsPlan",
+      "PowerAppsResource",
+      "PowerBIAudit",
+      "PowerBIDlp",
+      "PowerPagesSite",
+      "PowerPlatformAdminDlp",
+      "PowerPlatformAdminEnvironment",
+      "PowerPlatformAdministratorActivity",
+      "PowerPlatformLockboxResourceAccessRequest",
+      "PowerPlatformLockboxResourceCommand",
+      "PowerPlatformServiceActivity",
+      "PowerPlatformTenantIsolation",
+      "PrivacyDataMatch",
+      "PrivacyDataMinimization",
+      "PrivacyDigestEmail",
+      "PrivacyOpenAccess",
+      "PrivacyPortal",
+      "PrivacyRemediation",
+      "PrivacyRemediationAction",
+      "PrivacyTenantAuditHistoryRecord",
+      "PrivaPrivacyAssessmentOperation",
+      "PrivaPrivacyConsentOperation",
+      "Project",
+      "ProjectForTheWebAssignedToMeSettings",
+      "ProjectForTheWebProject",
+      "ProjectForTheWebProjectSettings",
+      "ProjectForTheWebRoadmap",
+      "ProjectForTheWebRoadmapItem",
+      "ProjectForTheWebRoadmapSettings",
+      "ProjectForTheWebTask",
+      "PublicFolder",
+      "PurviewDataMapOperation",
+      "PurviewInsiderRiskAlerts",
+      "PurviewInsiderRiskCases",
+      "PurviewMCRecommendation",
+      "PurviewMetadataPolicyOperation",
+      "PurviewPolicyOperation",
+      "PurviewPostureAgent",
+      "Quarantine",
+      "QuarantineMetadata",
+      "RecordsManagement",
+      "ReportSubmission",
+      "ReportSubmissionResultDetail",
+      "RTIOperationsAgent",
+      "ScorePlatformGenericAuditRecord",
+      "SCPConfigurationEvent",
+      "SCPUsageEvent",
+      "Search",
+      "SecureScore",
+      "SecurityComplianceAlerts",
+      "SecurityComplianceCenterEOPCmdlet",
+      "SecurityComplianceInsights",
+      "SecurityComplianceRBAC",
+      "SecurityComplianceUserChange",
+      "SensitiveInfoRemediationAgentData",
+      "SensitivityLabelAction",
+      "SensitivityLabeledFileAction",
+      "SensitivityLabelPolicyMatch",
+      "SentinelAITool",
+      "SentinelGraph",
+      "SentinelJob",
+      "SentinelKQLOnLake",
+      "SentinelLakeDataOnboarding",
+      "SentinelLakeEncryption",
+      "SentinelLakeOnboarding",
+      "SentinelNotebookOnLake",
+      "SentinelPackage",
+      "SharePoint",
+      "SharePointAppPermissionOperation",
+      "SharePointCommentOperation",
+      "SharePointContentSecurityPolicy",
+      "SharePointContentTypeOperation",
+      "SharePointESignature",
+      "SharePointFieldOperation",
+      "SharePointFileOperation",
+      "SharePointListItemOperation",
+      "SharePointListOperation",
+      "SharePointSearch",
+      "SharePointSharingOperation",
+      "SkypeForBusinessCmdlets",
+      "SkypeForBusinessPSTNUsage",
+      "SkypeForBusinessUsersBlocked",
+      "SonarDetonationContentMetadata",
+      "SubmissionAgenticGradingResult",
+      "SupervisoryReviewDayXInsight",
+      "Sway",
+      "SyntheticProbe",
+      "TeamCopilotInteraction",
+      "TeamsEasyApprovals",
+      "TeamsEvalDataHubAdminOperation",
+      "TeamsEvalDataHubDataAccess",
+      "TeamsEvalDataHubPermissionChange",
+      "TeamsHealthcare",
+      "TeamsQuarantineMetadata",
+      "TeamsUpdates",
+      "TenantAllowBlockList",
+      "ThreatFinder",
+      "ThreatIntelligence",
+      "ThreatIntelligenceAtpContent",
+      "ThreatIntelligenceExport",
+      "ThreatIntelligenceObject",
+      "ThreatIntelligenceUrl",
+      "TimeTravelFilteringDocMetadata",
+      "TimeTravelFilteringDocScan",
+      "TrainableClassifier",
+      "UAMOperation",
+      "UnifiedCatalogConceptAction",
+      "UnifiedSimulationMatchedItem",
+      "UnifiedSimulationSummary",
+      "UniversalPrintManagement",
+      "UniversalPrintPrintJob",
+      "unknownFutureValue",
+      "UpdateCopilotPlugin",
+      "UpdateCopilotPromptBook",
+      "UpdateCopilotSettings",
+      "UpdateCopilotWorkspace",
+      "UpdateQuarantineMetadata",
+      "URBACAssignment",
+      "URBACEnableState",
+      "URBACRole",
+      "UserTraining",
+      "USXWorkspaceOnboarding",
+      "VfamCreatePolicy",
+      "VfamDeletePolicy",
+      "VfamUpdatePolicy",
+      "VivaAmplifyOutlookSensitivityLabel",
+      "VivaEngageEvents",
+      "VivaEngageNetworkAssociation",
+      "VivaEngageSegment",
+      "VivaGlintAdvancedConfiguration",
+      "VivaGlintFeedbackProgram",
+      "VivaGlintOrganizationalData",
+      "VivaGlintPulseProgram",
+      "VivaGlintPulseProgramRespondentRate",
+      "VivaGlintQuestion",
+      "VivaGlintRole",
+      "VivaGlintRubicon",
+      "VivaGlintSupportAccess",
+      "VivaGlintSystem",
+      "VivaGlintUser",
+      "VivaGlintUserGroup",
+      "VivaGoals",
+      "VivaLearning",
+      "VivaLearningAdmin",
+      "VivaPulseAdmin",
+      "VivaPulseOrganizer",
+      "VivaPulseReport",
+      "VivaPulseResponse",
+      "WDATPAlerts",
+      "WebContentFiltering",
+      "WebpageActivityEndpoint",
+      "Windows365CustomerLockbox",
+      "WorkplaceAnalytics",
+      "Yammer",
+      "YammerUserHiding"
+    ],
+    "auditLogUserType": [
+      "Admin",
+      "Application",
+      "CustomPolicy",
+      "DcAdmin",
+      "Guest",
+      "PartnerTechnician",
+      "Regular",
+      "Reserved",
+      "ServicePrincipal",
+      "System",
+      "SystemPolicy",
+      "unknownFutureValue"
+    ],
+    "behaviorDuringRetentionPeriod": [
+      "doNotRetain",
+      "retain",
+      "retainAsRecord",
+      "retainAsRegulatoryRecord",
+      "unknownFutureValue"
+    ],
+    "caseAction": [
+      "addToReviewSet",
+      "applyTags",
+      "contentExport",
+      "convertToPdf",
+      "estimateStatistics",
+      "exportReport",
+      "exportResult",
+      "holdPolicySync",
+      "holdUpdate",
+      "index",
+      "purgeData",
+      "unknownFutureValue"
+    ],
+    "caseOperationStatus": [
+      "failed",
+      "notStarted",
+      "partiallySucceeded",
+      "running",
+      "submissionFailed",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "caseStatus": [
+      "active",
+      "closed",
+      "closedWithError",
+      "closing",
+      "pendingDelete",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "caseType": [
+      "premium",
+      "standard",
+      "unknownFutureValue"
+    ],
+    "childSelectability": [
+      "Many",
+      "One",
+      "unknownFutureValue"
+    ],
+    "cloudAppInfoState": [
+      "false",
+      "true",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudAttachmentVersion": [
+      "all",
+      "latest",
+      "recent10",
+      "recent100",
+      "unknownFutureValue"
+    ],
+    "containerPortProtocol": [
+      "sctp",
+      "tcp",
+      "udp",
+      "unknownFutureValue"
+    ],
+    "contentAlignment": [
+      "center",
+      "left",
+      "right"
+    ],
+    "contentFormat": [
+      "html",
+      "markdown",
+      "text",
+      "unknownFutureValue"
+    ],
+    "contentState": [
+      "motion",
+      "rest",
+      "use"
+    ],
+    "correlationReason": [
+      "eventCasualSequence",
+      "eventSequence",
+      "lateralMovementPath",
+      "networkProximity",
+      "repeatedAlertOccurrence",
+      "sameActor",
+      "sameAsset",
+      "sameCampaign",
+      "sameGeography",
+      "sameNetworkSegment",
+      "sameTargetedAsset",
+      "sameThreatSource",
+      "sharedIndicators",
+      "similarArtifacts",
+      "similarTTPsOrBehavior",
+      "temporalProximity",
+      "timeFrame",
+      "unknownFutureValue"
+    ],
+    "dataSourceContainerStatus": [
+      "active",
+      "released",
+      "unknownFutureValue"
+    ],
+    "dataSourceHoldStatus": [
+      "applied",
+      "applying",
+      "notApplied",
+      "partial",
+      "removing",
+      "unknownFutureValue"
+    ],
+    "dataSourceScopes": [
+      "allCaseCustodians",
+      "allCaseNoncustodialDataSources",
+      "allTenantMailboxes",
+      "allTenantSites",
+      "none",
+      "unknownFutureValue"
+    ],
+    "defaultRecordBehavior": [
+      "startLocked",
+      "startUnlocked",
+      "unknownFutureValue"
+    ],
+    "defenderAvStatus": [
+      "disabled",
+      "notReporting",
+      "notSupported",
+      "notUpdated",
+      "unknown",
+      "unknownFutureValue",
+      "updated"
+    ],
+    "deliveryAction": [
+      "blocked",
+      "delivered",
+      "deliveredToJunk",
+      "replaced",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "deliveryLocation": [
+      "deletedFolder",
+      "dropped",
+      "failed",
+      "inbox_folder",
+      "junkFolder",
+      "onprem_external",
+      "others",
+      "quarantine",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "deploymentStatus": [
+      "disconnected",
+      "notConfigured",
+      "outdated",
+      "startFailure",
+      "syncing",
+      "unknownFutureValue",
+      "unreachable",
+      "updateFailed",
+      "updating",
+      "upToDate"
+    ],
+    "detectionSource": [
+      "antivirus",
+      "appGovernanceDetection",
+      "appGovernancePolicy",
+      "automatedInvestigation",
+      "azureAdIdentityProtection",
+      "builtInMl",
+      "cloudAppSecurity",
+      "customDetection",
+      "customTi",
+      "manual",
+      "microsoft365Defender",
+      "microsoftDataLossPrevention",
+      "microsoftDefenderForAIServices",
+      "microsoftDefenderForApiManagement",
+      "microsoftDefenderForAppService",
+      "microsoftDefenderForCloud",
+      "microsoftDefenderForContainers",
+      "microsoftDefenderForDatabases",
+      "microsoftDefenderForDNS",
+      "microsoftDefenderForEndpoint",
+      "microsoftDefenderForIdentity",
+      "microsoftDefenderForIoT",
+      "microsoftDefenderForKeyVault",
+      "microsoftDefenderForNetwork",
+      "microsoftDefenderForOffice365",
+      "microsoftDefenderForResourceManager",
+      "microsoftDefenderForServers",
+      "microsoftDefenderForStorage",
+      "microsoftDefenderThreatIntelligenceAnalytics",
+      "microsoftInsiderRiskManagement",
+      "microsoftSentinel",
+      "microsoftThreatExperts",
+      "microsoftThreatIntelligence",
+      "nrtAlerts",
+      "scheduledAlerts",
+      "securityCopilot",
+      "smartScreen",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "detectionStatus": [
+      "blocked",
+      "detected",
+      "prevented",
+      "unknownFutureValue"
+    ],
+    "deviceAssetIdentifier": [
+      "destinationDeviceName",
+      "deviceId",
+      "deviceName",
+      "remoteDeviceName",
+      "targetDeviceName",
+      "unknownFutureValue"
+    ],
+    "deviceHealthStatus": [
+      "active",
+      "impairedCommunication",
+      "inactive",
+      "noSensorData",
+      "noSensorDataImpairedCommunication",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "deviceIdEntityIdentifier": [
+      "deviceId",
+      "unknownFutureValue"
+    ],
+    "deviceRiskScore": [
+      "high",
+      "informational",
+      "low",
+      "medium",
+      "none",
+      "unknownFutureValue"
+    ],
+    "deviceType": [
+      "adcs",
+      "adfs",
+      "domainController",
+      "entraConnect",
+      "unknownFutureValue"
+    ],
+    "disableUserEntityIdentifier": [
+      "accountSid",
+      "initiatingProcessAccountSid",
+      "onPremSid",
+      "requestAccountSid",
+      "unknownFutureValue"
+    ],
+    "documentVersion": [
+      "all",
+      "latest",
+      "recent10",
+      "recent100",
+      "unknownFutureValue"
+    ],
+    "emailEntityIdentifier": [
+      "networkMessageId",
+      "recipientEmailAddress",
+      "unknownFutureValue"
+    ],
+    "entityType": [
+      "ipAddress",
+      "machineName",
+      "other",
+      "unknown",
+      "unknownFutureValue",
+      "userName"
+    ],
+    "environmentKind": [
+      "awsAccount",
+      "awsOrganization",
+      "azureDevOpsOrganization",
+      "azureSubscription",
+      "devOpsConnection",
+      "dockersHubOrganization",
+      "gcpOrganization",
+      "gcpProject",
+      "gitHubOrganization",
+      "gitLabGroup",
+      "jFrogArtifactory",
+      "unknownFutureValue"
+    ],
+    "eventPropagationStatus": [
+      "failed",
+      "inProcessing",
+      "none",
+      "success",
+      "unknownFutureValue"
+    ],
+    "eventSource": [
+      "admin",
+      "system",
+      "unknownFutureValue",
+      "user"
+    ],
+    "eventStatusType": [
+      "error",
+      "notAvaliable",
+      "pending",
+      "success",
+      "unknownFutureValue"
+    ],
+    "evidenceRemediationStatus": [
+      "active",
+      "blocked",
+      "declined",
+      "none",
+      "notFound",
+      "partiallyRemediated",
+      "pendingApproval",
+      "prevented",
+      "remediated",
+      "running",
+      "unknownFutureValue",
+      "unremediated"
+    ],
+    "evidenceRole": [
+      "added",
+      "attacked",
+      "attacker",
+      "commandAndControl",
+      "compromised",
+      "contextual",
+      "created",
+      "destination",
+      "edited",
+      "loaded",
+      "policyViolator",
+      "scanned",
+      "source",
+      "suspicious",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "evidenceVerdict": [
+      "malicious",
+      "noThreatsFound",
+      "suspicious",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "exportCriteria": [
+      "partiallyIndexed",
+      "searchHits",
+      "unknownFutureValue"
+    ],
+    "exportFileStructure": [
+      "directory",
+      "msg",
+      "none",
+      "pst",
+      "unknownFutureValue"
+    ],
+    "exportFormat": [
+      "eml",
+      "msg",
+      "pst",
+      "unknownFutureValue"
+    ],
+    "exportLocation": [
+      "nonresponsiveLocations",
+      "responsiveLocations",
+      "unknownFutureValue"
+    ],
+    "exportOptions": [
+      "condensePaths",
+      "fileInfo",
+      "friendlyName",
+      "includeFolderAndPath",
+      "originalFiles",
+      "pdfReplacement",
+      "splitSource",
+      "tags",
+      "text",
+      "unknownFutureValue"
+    ],
+    "fileEntityIdentifier": [
+      "initiatingProcessSHA1",
+      "initiatingProcessSHA256",
+      "sha1",
+      "sha256",
+      "unknownFutureValue"
+    ],
+    "fileHashAlgorithm": [
+      "md5",
+      "sha1",
+      "sha256",
+      "sha256ac",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "fileProcessingStatus": [
+      "extractionException",
+      "fileBodyIsTooLong",
+      "fileDepthLimitExceeded",
+      "fileSizeIsTooLarge",
+      "fileSizeIsZero",
+      "fileTypeIsNotSupported",
+      "fileTypeIsUnknown",
+      "internalError",
+      "invalidFileId",
+      "malformedFile",
+      "noReviewSetSummaryGenerated",
+      "ocrFileSizeExceedsLimit",
+      "ocrProcessingTimeout",
+      "poisonFile",
+      "processingTimeout",
+      "protectedFile",
+      "success",
+      "unknownError",
+      "unknownFutureValue"
+    ],
+    "forceUserPasswordResetEntityIdentifier": [
+      "accountSid",
+      "initiatingProcessAccountSid",
+      "onPremSid",
+      "requestAccountSid",
+      "unknownFutureValue"
+    ],
+    "googleCloudLocationType": [
+      "global",
+      "regional",
+      "unknown",
+      "unknownFutureValue",
+      "zonal"
+    ],
+    "healthIssueSeverity": [
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "healthIssueStatus": [
+      "closed",
+      "open",
+      "suppressed",
+      "unknownFutureValue"
+    ],
+    "healthIssueType": [
+      "global",
+      "sensor",
+      "unknownFutureValue"
+    ],
+    "hostPortProtocol": [
+      "tcp",
+      "udp",
+      "unknownFutureValue"
+    ],
+    "hostPortStatus": [
+      "closed",
+      "filtered",
+      "open",
+      "unknownFutureValue"
+    ],
+    "hostReputationClassification": [
+      "malicious",
+      "neutral",
+      "suspicious",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "hostReputationRuleSeverity": [
+      "high",
+      "low",
+      "medium",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "huntingRuleErrorCode": [
+      "alertCreationFailed",
+      "alertReportNotFound",
+      "noImpactedEntity",
+      "partialRowsFailed",
+      "queryExceededResultSize",
+      "queryExecutionFailed",
+      "queryExecutionThrottling",
+      "queryLimitsExceeded",
+      "queryTimeout",
+      "unknownFutureValue"
+    ],
+    "huntingRuleRunStatus": [
+      "completed",
+      "failed",
+      "partiallyFailed",
+      "running",
+      "unknownFutureValue"
+    ],
+    "identityProvider": [
+      "activeDirectory",
+      "entraID",
+      "okta",
+      "unknownFutureValue"
+    ],
+    "incidentStatus": [
+      "active",
+      "awaitingAction",
+      "inProgress",
+      "redirected",
+      "resolved",
+      "unknownFutureValue"
+    ],
+    "incidentTaskActionStatus": [
+      "completed",
+      "failed",
+      "inProgress",
+      "notStarted",
+      "partiallyCompleted",
+      "unknownFutureValue"
+    ],
+    "incidentTaskActionType": [
+      "collectInvestigationPackage",
+      "disableUser",
+      "enableUser",
+      "forceUserPasswordReset",
+      "hardDeleteEmail",
+      "isolateDevice",
+      "markUserAsCompromised",
+      "requireSignIn",
+      "restrictAppExecution",
+      "runAntiVirusScan",
+      "softDeleteEmail",
+      "stopAndQuarantineFile",
+      "submitIocRule",
+      "text",
+      "unIsolateDevice",
+      "unknownFutureValue",
+      "unRestrictAppExecution"
+    ],
+    "incidentTaskSource": [
+      "defenderExpertsGuidedResponse",
+      "defenderExpertsManagedResponse",
+      "unknownFutureValue"
+    ],
+    "incidentTaskStatus": [
+      "completed",
+      "failed",
+      "inProgress",
+      "notRelevant",
+      "open",
+      "unknownFutureValue"
+    ],
+    "indicatorSource": [
+      "microsoft",
+      "osint",
+      "public",
+      "unknownFutureValue"
+    ],
+    "intelligenceProfileKind": [
+      "actor",
+      "tool",
+      "unknownFutureValue"
+    ],
+    "investigationState": [
+      "benign",
+      "failed",
+      "innerFailure",
+      "partiallyInvestigated",
+      "partiallyRemediated",
+      "pendingApproval",
+      "pendingResource",
+      "preexistingAlert",
+      "queued",
+      "running",
+      "successfullyRemediated",
+      "suppressedAlert",
+      "terminated",
+      "terminatedBySystem",
+      "terminatedByUser",
+      "unknown",
+      "unknownFutureValue",
+      "unsupportedAlertType",
+      "unsupportedOs"
+    ],
+    "ioTDeviceImportanceType": [
+      "high",
+      "low",
+      "normal",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "isolationType": [
+      "full",
+      "selective",
+      "unknownFutureValue"
+    ],
+    "itemsToInclude": [
+      "partiallyIndexed",
+      "searchHits",
+      "unknownFutureValue"
+    ],
+    "kubernetesPlatform": [
+      "aks",
+      "arc",
+      "eks",
+      "gke",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "kubernetesServiceType": [
+      "clusterIP",
+      "externalName",
+      "loadBalancer",
+      "nodePort",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "logDataProvider": [
+      "barracuda",
+      "barracudaNextGenFw",
+      "barracudaNextGenFwWeblog",
+      "bluecoat",
+      "checkpoint",
+      "checkpointCef",
+      "checkpointSmartViewTracker",
+      "checkpointXml",
+      "ciscoAsa",
+      "ciscoAsaFirepower",
+      "ciscoFirepowerV6",
+      "ciscoFwsm",
+      "ciscoIronportProxy",
+      "ciscoIronportWsaIi",
+      "ciscoIronportWsaIii",
+      "ciscoScanSafe",
+      "clavister",
+      "contentkeeper",
+      "corrata",
+      "customParser",
+      "forcepoint",
+      "forcepointLeef",
+      "fortigate",
+      "fortios",
+      "genericCef",
+      "genericLeef",
+      "genericW3C",
+      "iboss",
+      "iFilter",
+      "juniperSrx",
+      "juniperSrxSd",
+      "juniperSrxWelf",
+      "juniperSsg",
+      "machineZoneMeraki",
+      "mcafeeSwg",
+      "menloSecurityCef",
+      "microsoftConditionalAppAccess",
+      "microsoftDefenderForEndpoint",
+      "microsoftIsaW3C",
+      "openSystemsSecureWebGateway",
+      "paloAlto",
+      "paloAltoLeef",
+      "sonicwall",
+      "sophosCyberoam",
+      "sophosSg",
+      "sophosXg",
+      "squid",
+      "squidNative",
+      "stormshield",
+      "unknownFutureValue",
+      "wandera",
+      "watchguardXtm",
+      "websenseSiemCef",
+      "websenseV75",
+      "zscaler",
+      "zscalerCef",
+      "zscalerQradar"
+    ],
+    "longRunningOperationStatus": [
+      "failed",
+      "notStarted",
+      "running",
+      "skipped",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "mailboxAssetIdentifier": [
+      "accountUpn",
+      "fileOwnerUpn",
+      "initiatingProcessAccountUpn",
+      "lastModifyingAccountUpn",
+      "recipientEmailAddress",
+      "senderDisplayName",
+      "senderFromAddress",
+      "senderMailFromAddress",
+      "targetAccountUpn",
+      "unknownFutureValue"
+    ],
+    "mailboxConfigurationType": [
+      "ewsSettings",
+      "mailDelegation",
+      "mailForwardingRule",
+      "owaSettings",
+      "unknownFutureValue",
+      "userInboxRule"
+    ],
+    "markUserAsCompromisedEntityIdentifier": [
+      "accountObjectId",
+      "initiatingProcessAccountObjectId",
+      "recipientObjectId",
+      "servicePrincipalId",
+      "unknownFutureValue"
+    ],
+    "migrationState": [
+      "migrating",
+      "migrationFailed",
+      "notReadyForMigration",
+      "readyForMigration",
+      "unknownFutureValue",
+      "upToDate"
+    ],
+    "onboardingStatus": [
+      "canBeOnboarded",
+      "insufficientInfo",
+      "onboarded",
+      "unknownFutureValue",
+      "unsupported"
+    ],
+    "policyStatus": [
+      "error",
+      "pending",
+      "success",
+      "unknownFutureValue"
+    ],
+    "protocolType": [
+      "tcp",
+      "udp",
+      "unknownFutureValue"
+    ],
+    "purgeAreas": [
+      "mailboxes",
+      "teamsMessages",
+      "unknownFutureValue"
+    ],
+    "purgeType": [
+      "permanentlyDelete",
+      "recoverable",
+      "unknownFutureValue"
+    ],
+    "queryType": [
+      "files",
+      "messages",
+      "unknownFutureValue"
+    ],
+    "receiverProtocol": [
+      "ftp",
+      "ftps",
+      "syslogTcp",
+      "syslogTls",
+      "syslogUdp",
+      "unknownFutureValue"
+    ],
+    "recipientType": [
+      "roleGroup",
+      "unknownFutureValue",
+      "user"
+    ],
+    "remediationAction": [
+      "hardDelete",
+      "moveToDeletedItems",
+      "moveToInbox",
+      "moveToJunk",
+      "moveToQuarantine",
+      "softDelete",
+      "unknownFutureValue"
+    ],
+    "remediationSeverity": [
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "retentionTrigger": [
+      "dateCreated",
+      "dateLabeled",
+      "dateModified",
+      "dateOfEvent",
+      "unknownFutureValue"
+    ],
+    "reviewSetSettings": [
+      "disableGrouping",
+      "none",
+      "unknownFutureValue"
+    ],
+    "scopeType": [
+      "deviceGroup",
+      "unknownFutureValue"
+    ],
+    "sensorCandidateActivationMode": [
+      "automated",
+      "manual",
+      "unknownFutureValue"
+    ],
+    "sensorHealthStatus": [
+      "healthy",
+      "notHealthyHigh",
+      "notHealthyLow",
+      "notHealthyMedium",
+      "unknownFutureValue"
+    ],
+    "sensorType": [
+      "adConnectIntegrated",
+      "adcsIntegrated",
+      "adfsIntegrated",
+      "domainControllerIntegrated",
+      "domainControllerStandalone",
+      "unknownFutureValue"
+    ],
+    "servicePrincipalType": [
+      "application",
+      "legacy",
+      "managedIdentity",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "serviceSource": [
+      "azureAdIdentityProtection",
+      "dataLossPrevention",
+      "microsoft365Defender",
+      "microsoftAppGovernance",
+      "microsoftDefenderForCloud",
+      "microsoftDefenderForCloudApps",
+      "microsoftDefenderForEndpoint",
+      "microsoftDefenderForIdentity",
+      "microsoftDefenderForOffice365",
+      "microsoftInsiderRiskManagement",
+      "microsoftSentinel",
+      "microsoftThreatIntelligence",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "serviceStatus": [
+      "disabled",
+      "onboarding",
+      "running",
+      "starting",
+      "stopped",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "sourceType": [
+      "mailbox",
+      "site",
+      "unknownFutureValue"
+    ],
+    "statisticsOptions": [
+      "advancedIndexing",
+      "includeQueryStats",
+      "includeRefiners",
+      "includeUnindexedStats",
+      "locationsWithoutHits",
+      "unknownFutureValue"
+    ],
+    "stopAndQuarantineFileEntityIdentifier": [
+      "deviceId",
+      "initiatingProcessSHA1",
+      "sha1",
+      "unknownFutureValue"
+    ],
+    "submissionCategory": [
+      "malware",
+      "notJunk",
+      "phishing",
+      "spam",
+      "unknownFutureValue"
+    ],
+    "submissionClientSource": [
+      "microsoft",
+      "other",
+      "unknownFutureValue"
+    ],
+    "submissionContentType": [
+      "app",
+      "email",
+      "file",
+      "unknownFutureValue",
+      "url"
+    ],
+    "submissionResultCategory": [
+      "allowedByPolicy",
+      "allowedDueToOrganizationOverride",
+      "allowedDueToUserOverride",
+      "authenticationFailure",
+      "beingAnalyzed",
+      "blockedByPolicy",
+      "blockedDueToOrganizationOverride",
+      "blockedDueToUserOverride",
+      "brandImpersonation",
+      "bulk",
+      "domainImpersonation",
+      "itemNotfound",
+      "malware",
+      "noResultAvailable",
+      "noThreatsFound",
+      "notJunk",
+      "notSubmittedToMicrosoft",
+      "phishing",
+      "phishingSimulation",
+      "reasonLostInTransit",
+      "spam",
+      "spoof",
+      "spoofedAllowed",
+      "spoofedBlocked",
+      "threatsFound",
+      "unknown",
+      "unknownFutureValue",
+      "userImpersonation"
+    ],
+    "submissionResultDetail": [
+      "allowedByAdvancedDelivery",
+      "allowedByConnection",
+      "allowedByEnhancedFiltering",
+      "allowedByExchangeTransportRule",
+      "allowedBySecOps",
+      "allowedByTenant",
+      "allowedByTenantAllowBlockList",
+      "allowedByThirdPartyFilters",
+      "allowedByUserSetting",
+      "allowedFileByTenantAllowBlockList",
+      "allowedRecipientByTenantAllowBlockList",
+      "allowedSenderByTenantAllowBlockList",
+      "allowedUrlByTenantAllowBlockList",
+      "associatedWithBrand",
+      "badReclassifiedAsBad",
+      "badReclassifiedAsBulk",
+      "badReclassifiedAsCannotMakeDecision",
+      "badReclassifiedAsGood",
+      "blockedByConnection",
+      "blockedByExchangeTransportRule",
+      "blockedByTenant",
+      "blockedByTenantAllowBlockList",
+      "blockedByUserSetting",
+      "blockedFileByTenantAllowBlockList",
+      "blockedRecipientByTenantAllowBlockList",
+      "blockedSenderByTenantAllowBlockList",
+      "blockedUrlByTenantAllowBlockList",
+      "brandImpersonation",
+      "checkUserReportedSettings",
+      "domainImpersonation",
+      "domainResembledYourOrganization",
+      "endUserBeingImpersonated",
+      "endUserBeingSpoofed",
+      "goodReclassifiedAsBad",
+      "goodReclassifiedAsBulk",
+      "goodReclassifiedAsCannotMakeDecision",
+      "goodReclassifiedAsGood",
+      "invalidFalseNegative",
+      "invalidFalsePositive",
+      "itemDeleted",
+      "itemFoundBulk",
+      "itemFoundClean",
+      "itemFoundMalicious",
+      "itemFoundSpam",
+      "itemNotReceivedByService",
+      "junkMailRuleDisabled",
+      "messageNotFound",
+      "none",
+      "onPremisesSkip",
+      "outboundBulk",
+      "outboundCannotMakeDecision",
+      "outboundNotRescanned",
+      "outboundShouldBeBlocked",
+      "outboundShouldNotBeBlocked",
+      "partOfEducationCampaign",
+      "quarantineReleased",
+      "quarantineReleasedThenBlocked",
+      "senderFailedAuthentication",
+      "simulatedThreat",
+      "spoofBlocked",
+      "unableToMakeDecision",
+      "underInvestigation",
+      "unknownFutureValue",
+      "urlFileCannotMakeDecision",
+      "urlFileShouldBeBlocked",
+      "urlFileShouldNotBeBlocked",
+      "userImpersonation",
+      "willNotifyOnceDone",
+      "zeroHourAutoPurgeAllowed",
+      "zeroHourAutoPurgeBlocked",
+      "zeroHourAutoPurgeQuarantineReleased"
+    ],
+    "submissionSource": [
+      "administrator",
+      "unknownFutureValue",
+      "user"
+    ],
+    "teamsDeliveryLocation": [
+      "failed",
+      "quarantine",
+      "teams",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "teamsMessageDeliveryAction": [
+      "blocked",
+      "delivered",
+      "deliveredAsSpam",
+      "replaced",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "tenantAllowBlockListAction": [
+      "allow",
+      "block",
+      "unknownFutureValue"
+    ],
+    "tenantAllowBlockListEntryType": [
+      "fileHash",
+      "recipient",
+      "sender",
+      "unknownFutureValue",
+      "url"
+    ],
+    "threatType": [
+      "malware",
+      "none",
+      "phish",
+      "spam",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "timelineEventType": [
+      "air",
+      "dynamicDelivery",
+      "originalDelivery",
+      "quarantineRelease",
+      "reprocessed",
+      "systemTimeTravel",
+      "unknown",
+      "unknownFutureValue",
+      "userUrlClick",
+      "zap"
+    ],
+    "trafficType": [
+      "downloadedBytes",
+      "unknown",
+      "unknownFutureValue",
+      "uploadedBytes"
+    ],
+    "userAssetIdentifier": [
+      "accountDomain",
+      "accountId",
+      "accountName",
+      "accountObjectId",
+      "accountSid",
+      "accountUpn",
+      "initiatingAccountDomain",
+      "initiatingAccountName",
+      "initiatingAccountSid",
+      "initiatingProcessAccountUpn",
+      "processAccountObjectId",
+      "recipientObjectId",
+      "requestAccountDomain",
+      "requestAccountName",
+      "requestAccountSid",
+      "servicePrincipalId",
+      "servicePrincipalName",
+      "targetAccountUpn",
+      "unknownFutureValue"
+    ],
+    "userMailboxSetting": [
+      "customRule",
+      "exclusive",
+      "fromFirstTimeSender",
+      "isFromAddressInAddressBlockList",
+      "isFromAddressInAddressBook",
+      "isFromAddressInAddressImplicitJunkList",
+      "isFromAddressInAddressImplicitSafeList",
+      "isFromAddressInAddressSafeList",
+      "isFromDomainInDomainBlockList",
+      "isFromDomainInDomainSafeList",
+      "isJunkMailRuleEnabled",
+      "isRecipientInRecipientSafeList",
+      "junkMailDeletion",
+      "junkMailRule",
+      "none",
+      "priorSeenPass",
+      "senderAuthenticationSucceeded",
+      "senderPraPresent",
+      "unknownFutureValue"
+    ],
+    "verdictCategory": [
+      "decryptionFailed",
+      "malware",
+      "none",
+      "phish",
+      "siteUnavailable",
+      "spam",
+      "undefined",
+      "unknownFutureValue",
+      "unsupportedFileType",
+      "unsupportedUriScheme"
+    ],
+    "vmCloudProvider": [
+      "azure",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "vulnerabilitySeverity": [
+      "critical",
+      "high",
+      "low",
+      "medium",
+      "none",
+      "unknownFutureValue"
+    ],
+    "watermarkLayout": [
+      "diagonal",
+      "horizontal"
+    ],
+    "whoisDomainStatus": [
+      "clientDeleteProhibited",
+      "clientHold",
+      "clientRenewProhibited",
+      "clientTransferProhibited",
+      "clientUpdateProhibited",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.security.dlp": {
+    "auditRecordType": [
+      "complianceDlpApplications",
+      "complianceDlpEndpoint",
+      "complianceDlpExchange",
+      "complianceDlpSharePoint",
+      "dlpEndpoint",
+      "powerBiDlp",
+      "sharePointFileOperation",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "enforcementType": [
+      "combined",
+      "separate",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "purposeType": [
+      "audit",
+      "di",
+      "unknownFutureValue"
+    ],
+    "remediationActivityType": [
+      "iwUnableToTakeAction",
+      "templateTriggered",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "userType": [
+      "admin",
+      "regular",
+      "system",
+      "unknownFutureValue"
+    ],
+    "workloadType": [
+      "endpoint",
+      "exchange",
+      "oneDrive",
+      "powerBi",
+      "sharePoint",
+      "unknown",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.security.securityCopilot": {
+    "evaluationResultType": [
+      "capacityExceeded",
+      "error",
+      "needAdditionalClaims",
+      "rejected",
+      "success",
+      "timedOut",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "evaluationState": [
+      "cancelled",
+      "completed",
+      "created",
+      "deferred",
+      "pending",
+      "running",
+      "unknown",
+      "unknownFutureValue",
+      "waitingForInput"
+    ],
+    "pluginAuthTypes": [
+      "aad",
+      "aadDelegated",
+      "aPIKey",
+      "basic",
+      "none",
+      "oAuthAuthorizationCodeFlow",
+      "oAuthClientCredentialsFlow",
+      "oAuthPasswordGrantFlow",
+      "serviceHttp",
+      "unknownFutureValue"
+    ],
+    "pluginCatalogScope": [
+      "geoGlobal",
+      "global",
+      "none",
+      "tenant",
+      "unknownFutureValue",
+      "user",
+      "userWorkspace",
+      "workspace"
+    ],
+    "pluginCategory": [
+      "hidden",
+      "microsoft",
+      "microsoftConnectors",
+      "other",
+      "plugin",
+      "testing",
+      "unknownFutureValue",
+      "web"
+    ],
+    "pluginPreviewStates": [
+      "ga",
+      "private",
+      "public",
+      "unknownFutureValue"
+    ],
+    "pluginSettingDisplayType": [
+      "checkbox",
+      "dropdown",
+      "none",
+      "textbox",
+      "unknownFutureValue"
+    ],
+    "pluginSettingType": [
+      "array",
+      "bool",
+      "enum",
+      "secretString",
+      "string",
+      "unknownFutureValue"
+    ],
+    "promptType": [
+      "context",
+      "feedback",
+      "prompt",
+      "skill",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "skillPreviewState": [
+      "ga",
+      "private",
+      "public",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.teamsAdministration": {
+    "accountType": [
+      "guest",
+      "ineligibleUser",
+      "resourceAccount",
+      "sfbOnPremUser",
+      "unknown",
+      "unknownFutureValue",
+      "user"
+    ],
+    "activationState": [
+      "activated",
+      "assignmentFailed",
+      "assignmentPending",
+      "unknownFutureValue",
+      "updateFailed",
+      "updatePending"
+    ],
+    "assignmentCategory": [
+      "alternate",
+      "primary",
+      "private",
+      "unknownFutureValue"
+    ],
+    "assignmentStatus": [
+      "conferenceAssigned",
+      "internalError",
+      "policyAssigned",
+      "thirdPartyAppAssigned",
+      "unassigned",
+      "unknownFutureValue",
+      "userAssigned",
+      "voiceApplicationAssigned"
+    ],
+    "assignmentType": [
+      "direct",
+      "group",
+      "unknownFutureValue"
+    ],
+    "customerAction": [
+      "locationUpdate",
+      "release",
+      "unknownFutureValue"
+    ],
+    "numberCapability": [
+      "conferenceAssignment",
+      "teamsPhoneMobile",
+      "unknownFutureValue",
+      "userAssignment",
+      "voiceApplicationAssignment"
+    ],
+    "numberSource": [
+      "online",
+      "onPremises",
+      "unknownFutureValue"
+    ],
+    "numberType": [
+      "callingPlan",
+      "directRouting",
+      "internalError",
+      "operatorConnect",
+      "unknownFutureValue"
+    ],
+    "portInStatus": [
+      "completed",
+      "firmOrderCommitmentAccepted",
+      "unknownFutureValue"
+    ],
+    "reverseNumberLookupOption": [
+      "skipInternalVoip",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.tenantGovernanceServices": {
+    "longRunningOperationStatus": [
+      "failed",
+      "notStarted",
+      "running",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "permissionType": [
+      "role",
+      "scope",
+      "unknownFutureValue"
+    ],
+    "relationshipCreationType": [
+      "addOnTenant",
+      "approvedByAdmin",
+      "unknownFutureValue"
+    ],
+    "relationshipStatus": [
+      "active",
+      "terminated",
+      "terminationRequestedByGoverningTenant",
+      "unknownFutureValue"
+    ],
+    "requestStatus": [
+      "accepted",
+      "pending",
+      "rejected",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.termStore": {
+    "relationType": [
+      "pin",
+      "reuse"
+    ],
+    "termGroupScope": [
+      "global",
+      "siteCollection",
+      "system"
+    ]
+  },
+  "microsoft.graph.windowsUpdates": {
+    "approvalStatus": [
+      "approved",
+      "suspended",
+      "unknownFutureValue"
+    ],
+    "azureADDeviceRegistrationErrorReason": [
+      "invalidAzureADDeviceId",
+      "invalidAzureADJoin",
+      "invalidGlobalDeviceId",
+      "missingTrustType",
+      "unknownFutureValue"
+    ],
+    "bodyType": [
+      "html",
+      "text",
+      "unknownFutureValue"
+    ],
+    "cveSeverityLevel": [
+      "critical",
+      "important",
+      "moderate",
+      "unknownFutureValue"
+    ],
+    "deploymentStateReasonValue": [
+      "faultedByContentOutdated",
+      "offeringByRequest",
+      "pausedByMonitoring",
+      "pausedByRequest",
+      "scheduledByOfferWindow",
+      "unknownFutureValue"
+    ],
+    "deploymentStateValue": [
+      "archived",
+      "faulted",
+      "offering",
+      "paused",
+      "scheduled",
+      "unknownFutureValue"
+    ],
+    "enrollmentState": [
+      "enrolled",
+      "enrolledWithPolicy",
+      "enrolling",
+      "notEnrolled",
+      "unenrolling",
+      "unknownFutureValue"
+    ],
+    "monitoringAction": [
+      "alertError",
+      "offerFallback",
+      "pauseDeployment",
+      "unknownFutureValue"
+    ],
+    "monitoringSignal": [
+      "ineligible",
+      "rollback",
+      "unknownFutureValue"
+    ],
+    "qualityUpdateCadence": [
+      "monthly",
+      "outOfBand",
+      "unknownFutureValue"
+    ],
+    "qualityUpdateClassification": [
+      "all",
+      "nonSecurity",
+      "security",
+      "unknownFutureValue"
+    ],
+    "remediationType": [
+      "inPlaceUpgrade",
+      "unknownFutureValue"
+    ],
+    "requestedDeploymentStateValue": [
+      "archived",
+      "none",
+      "paused",
+      "unknownFutureValue"
+    ],
+    "resourceConnectionState": [
+      "connected",
+      "notAuthorized",
+      "notFound",
+      "unknownFutureValue"
+    ],
+    "safeguardCategory": [
+      "likelyIssues",
+      "unknownFutureValue"
+    ],
+    "updateCategory": [
+      "driver",
+      "feature",
+      "quality",
+      "unknownFutureValue"
+    ],
+    "windowsReleaseHealthStatus": [
+      "confirmed",
+      "investigating",
+      "mitigated",
+      "mitigatedExternal",
+      "reported",
+      "resolved",
+      "resolvedExternal",
+      "unknownFutureValue"
+    ]
+  }
+}

--- a/schemas/type-mappings/beta-enum-types.json
+++ b/schemas/type-mappings/beta-enum-types.json
@@ -144,14 +144,6 @@
       "deny",
       "grant"
     ],
-    "accountStatus": [
-      "active",
-      "deleted",
-      "staged",
-      "suspended",
-      "unknown",
-      "unknownFutureValue"
-    ],
     "accountTargetContentType": [
       "addressBook",
       "includeAll",
@@ -308,26 +300,11 @@
       "unknownFutureValue",
       "userPrompt"
     ],
-    "alertFeedback": [
-      "benignPositive",
-      "falsePositive",
-      "truePositive",
-      "unknown",
-      "unknownFutureValue"
-    ],
     "alertSeverity": [
       "high",
       "informational",
       "low",
       "medium",
-      "unknown",
-      "unknownFutureValue"
-    ],
-    "alertStatus": [
-      "dismissed",
-      "inProgress",
-      "newAlert",
-      "resolved",
       "unknown",
       "unknownFutureValue"
     ],
@@ -873,15 +850,6 @@
       "automatic",
       "manual",
       "recommended"
-    ],
-    "applicationPermissionsRequired": [
-      "administrator",
-      "anonymous",
-      "guest",
-      "system",
-      "unknown",
-      "unknownFutureValue",
-      "user"
     ],
     "applicationType": [
       "desktop",
@@ -3080,12 +3048,6 @@
       "proposed",
       "unknownFutureValue"
     ],
-    "connectionDirection": [
-      "inbound",
-      "outbound",
-      "unknown",
-      "unknownFutureValue"
-    ],
     "connectionOperationStatus": [
       "completed",
       "failed",
@@ -3097,14 +3059,6 @@
       "limitExceeded",
       "obsolete",
       "ready",
-      "unknownFutureValue"
-    ],
-    "connectionStatus": [
-      "attempted",
-      "blocked",
-      "failed",
-      "succeeded",
-      "unknown",
       "unknownFutureValue"
     ],
     "connectionType": [
@@ -4358,14 +4312,6 @@
       "none",
       "userDefined"
     ],
-    "diamondModel": [
-      "adversary",
-      "capability",
-      "infrastructure",
-      "unknown",
-      "unknownFutureValue",
-      "victim"
-    ],
     "diffieHellmanGroup": [
       "ecp256",
       "ecp384",
@@ -4636,12 +4582,6 @@
       "certificate",
       "derivedCredential",
       "none"
-    ],
-    "emailRole": [
-      "recipient",
-      "sender",
-      "unknown",
-      "unknownFutureValue"
     ],
     "emailSyncDuration": [
       "oneDay",
@@ -5019,16 +4959,6 @@
       "fullyArchived",
       "notArchived",
       "reactivating",
-      "unknownFutureValue"
-    ],
-    "fileHashType": [
-      "authenticodeHash256",
-      "ctph",
-      "lsHash",
-      "md5",
-      "sha1",
-      "sha256",
-      "unknown",
       "unknownFutureValue"
     ],
     "fileStorageContainerBillingClassification": [
@@ -5763,15 +5693,6 @@
       "private",
       "unknown"
     ],
-    "logonType": [
-      "batch",
-      "interactive",
-      "network",
-      "remoteInteractive",
-      "service",
-      "unknown",
-      "unknownFutureValue"
-    ],
     "longRunningOperationStatus": [
       "failed",
       "notStarted",
@@ -6136,6 +6057,11 @@
       "wipeFailed",
       "wipeIssued",
       "wipePending"
+    ],
+    "matchConfidenceLevel": [
+      "exact",
+      "relaxed",
+      "unknownFutureValue"
     ],
     "matchOn": [
       "displayName",
@@ -8504,15 +8430,6 @@
       "undefined",
       "unknownFutureValue"
     ],
-    "processIntegrityLevel": [
-      "high",
-      "low",
-      "medium",
-      "system",
-      "unknown",
-      "unknownFutureValue",
-      "untrusted"
-    ],
     "promptLoginBehavior": [
       "disabled",
       "nativeSupport",
@@ -8984,39 +8901,6 @@
       "registered",
       "unknownFutureValue"
     ],
-    "registryHive": [
-      "currentConfig",
-      "currentUser",
-      "localMachineSam",
-      "localMachineSecurity",
-      "localMachineSoftware",
-      "localMachineSystem",
-      "unknown",
-      "unknownFutureValue",
-      "usersDefault"
-    ],
-    "registryOperation": [
-      "create",
-      "delete",
-      "modify",
-      "unknown",
-      "unknownFutureValue"
-    ],
-    "registryValueType": [
-      "binary",
-      "dword",
-      "dwordBigEndian",
-      "dwordLittleEndian",
-      "expandSz",
-      "link",
-      "multiSz",
-      "none",
-      "qword",
-      "qwordlittleEndian",
-      "sz",
-      "unknown",
-      "unknownFutureValue"
-    ],
     "rejectReason": [
       "busy",
       "forbidden",
@@ -9484,6 +9368,13 @@
       "bad",
       "ok"
     ],
+    "roleType": [
+      "active",
+      "application",
+      "delegated",
+      "eligible",
+      "unknownFutureValue"
+    ],
     "rootDomains": [
       "all",
       "allFederated",
@@ -9725,12 +9616,6 @@
     "securityQuestionType": [
       "custom",
       "predefined"
-    ],
-    "securityResourceType": [
-      "attacked",
-      "related",
-      "unknown",
-      "unknownFutureValue"
     ],
     "sendDtmfCompletionReason": [
       "completedSuccessfully",
@@ -10564,13 +10449,6 @@
       "block",
       "unblock"
     ],
-    "tiAction": [
-      "alert",
-      "allow",
-      "block",
-      "unknown",
-      "unknownFutureValue"
-    ],
     "timeCardState": [
       "clockedIn",
       "clockedOut",
@@ -10616,14 +10494,6 @@
       "center",
       "left",
       "unknownFutureValue"
-    ],
-    "tlpLevel": [
-      "amber",
-      "green",
-      "red",
-      "unknown",
-      "unknownFutureValue",
-      "white"
     ],
     "tlsClientRegistrationMetadata": [
       "tls_client_auth_san_dns",
@@ -10829,13 +10699,6 @@
       "suspended",
       "unknownFutureValue",
       "warning"
-    ],
-    "userAccountSecurityType": [
-      "administrator",
-      "power",
-      "standard",
-      "unknown",
-      "unknownFutureValue"
     ],
     "userAction": [
       "registerOrJoinDevices",

--- a/schemas/type-mappings/beta-enum-types.json
+++ b/schemas/type-mappings/beta-enum-types.json
@@ -144,6 +144,14 @@
       "deny",
       "grant"
     ],
+    "accountStatus": [
+      "active",
+      "deleted",
+      "staged",
+      "suspended",
+      "unknown",
+      "unknownFutureValue"
+    ],
     "accountTargetContentType": [
       "addressBook",
       "includeAll",
@@ -300,11 +308,26 @@
       "unknownFutureValue",
       "userPrompt"
     ],
+    "alertFeedback": [
+      "benignPositive",
+      "falsePositive",
+      "truePositive",
+      "unknown",
+      "unknownFutureValue"
+    ],
     "alertSeverity": [
       "high",
       "informational",
       "low",
       "medium",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alertStatus": [
+      "dismissed",
+      "inProgress",
+      "newAlert",
+      "resolved",
       "unknown",
       "unknownFutureValue"
     ],
@@ -850,6 +873,15 @@
       "automatic",
       "manual",
       "recommended"
+    ],
+    "applicationPermissionsRequired": [
+      "administrator",
+      "anonymous",
+      "guest",
+      "system",
+      "unknown",
+      "unknownFutureValue",
+      "user"
     ],
     "applicationType": [
       "desktop",
@@ -3048,6 +3080,12 @@
       "proposed",
       "unknownFutureValue"
     ],
+    "connectionDirection": [
+      "inbound",
+      "outbound",
+      "unknown",
+      "unknownFutureValue"
+    ],
     "connectionOperationStatus": [
       "completed",
       "failed",
@@ -3059,6 +3097,14 @@
       "limitExceeded",
       "obsolete",
       "ready",
+      "unknownFutureValue"
+    ],
+    "connectionStatus": [
+      "attempted",
+      "blocked",
+      "failed",
+      "succeeded",
+      "unknown",
       "unknownFutureValue"
     ],
     "connectionType": [
@@ -4312,6 +4358,14 @@
       "none",
       "userDefined"
     ],
+    "diamondModel": [
+      "adversary",
+      "capability",
+      "infrastructure",
+      "unknown",
+      "unknownFutureValue",
+      "victim"
+    ],
     "diffieHellmanGroup": [
       "ecp256",
       "ecp384",
@@ -4582,6 +4636,12 @@
       "certificate",
       "derivedCredential",
       "none"
+    ],
+    "emailRole": [
+      "recipient",
+      "sender",
+      "unknown",
+      "unknownFutureValue"
     ],
     "emailSyncDuration": [
       "oneDay",
@@ -4959,6 +5019,16 @@
       "fullyArchived",
       "notArchived",
       "reactivating",
+      "unknownFutureValue"
+    ],
+    "fileHashType": [
+      "authenticodeHash256",
+      "ctph",
+      "lsHash",
+      "md5",
+      "sha1",
+      "sha256",
+      "unknown",
       "unknownFutureValue"
     ],
     "fileStorageContainerBillingClassification": [
@@ -5692,6 +5762,15 @@
       "locationStore",
       "private",
       "unknown"
+    ],
+    "logonType": [
+      "batch",
+      "interactive",
+      "network",
+      "remoteInteractive",
+      "service",
+      "unknown",
+      "unknownFutureValue"
     ],
     "longRunningOperationStatus": [
       "failed",
@@ -8430,6 +8509,15 @@
       "undefined",
       "unknownFutureValue"
     ],
+    "processIntegrityLevel": [
+      "high",
+      "low",
+      "medium",
+      "system",
+      "unknown",
+      "unknownFutureValue",
+      "untrusted"
+    ],
     "promptLoginBehavior": [
       "disabled",
       "nativeSupport",
@@ -8899,6 +8987,39 @@
       "enabled",
       "mfaRegistered",
       "registered",
+      "unknownFutureValue"
+    ],
+    "registryHive": [
+      "currentConfig",
+      "currentUser",
+      "localMachineSam",
+      "localMachineSecurity",
+      "localMachineSoftware",
+      "localMachineSystem",
+      "unknown",
+      "unknownFutureValue",
+      "usersDefault"
+    ],
+    "registryOperation": [
+      "create",
+      "delete",
+      "modify",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "registryValueType": [
+      "binary",
+      "dword",
+      "dwordBigEndian",
+      "dwordLittleEndian",
+      "expandSz",
+      "link",
+      "multiSz",
+      "none",
+      "qword",
+      "qwordlittleEndian",
+      "sz",
+      "unknown",
       "unknownFutureValue"
     ],
     "rejectReason": [
@@ -9616,6 +9737,12 @@
     "securityQuestionType": [
       "custom",
       "predefined"
+    ],
+    "securityResourceType": [
+      "attacked",
+      "related",
+      "unknown",
+      "unknownFutureValue"
     ],
     "sendDtmfCompletionReason": [
       "completedSuccessfully",
@@ -10449,6 +10576,13 @@
       "block",
       "unblock"
     ],
+    "tiAction": [
+      "alert",
+      "allow",
+      "block",
+      "unknown",
+      "unknownFutureValue"
+    ],
     "timeCardState": [
       "clockedIn",
       "clockedOut",
@@ -10494,6 +10628,14 @@
       "center",
       "left",
       "unknownFutureValue"
+    ],
+    "tlpLevel": [
+      "amber",
+      "green",
+      "red",
+      "unknown",
+      "unknownFutureValue",
+      "white"
     ],
     "tlsClientRegistrationMetadata": [
       "tls_client_auth_san_dns",
@@ -10699,6 +10841,13 @@
       "suspended",
       "unknownFutureValue",
       "warning"
+    ],
+    "userAccountSecurityType": [
+      "administrator",
+      "power",
+      "standard",
+      "unknown",
+      "unknownFutureValue"
     ],
     "userAction": [
       "registerOrJoinDevices",

--- a/schemas/type-mappings/v1.0-complex-types.json
+++ b/schemas/type-mappings/v1.0-complex-types.json
@@ -444,34 +444,6 @@
         "coverImageItemId"
       ]
     },
-    "alertDetection": {
-      "navigationProperties": [],
-      "properties": [
-        "detectionType",
-        "method",
-        "name"
-      ]
-    },
-    "alertHistoryState": {
-      "navigationProperties": [],
-      "properties": [
-        "appId",
-        "assignedTo",
-        "comments",
-        "feedback",
-        "status",
-        "updatedDateTime",
-        "user"
-      ]
-    },
-    "alertTrigger": {
-      "navigationProperties": [],
-      "properties": [
-        "name",
-        "type",
-        "value"
-      ]
-    },
     "allAllowedScopes": {
       "navigationProperties": [],
       "properties": []
@@ -1324,6 +1296,17 @@
         "isVideoOnDemandEnabled"
       ]
     },
+    "browseQueryResponseItem": {
+      "navigationProperties": [],
+      "properties": [
+        "itemKey",
+        "itemsCount",
+        "name",
+        "sizeInBytes",
+        "type",
+        "webUrl"
+      ]
+    },
     "browserSharedCookieHistory": {
       "navigationProperties": [],
       "properties": [
@@ -1718,6 +1701,21 @@
         "displayAs"
       ]
     },
+    "claimBinding": {
+      "navigationProperties": [],
+      "properties": [
+        "matchConfidenceLevel",
+        "sourceAttribute",
+        "verifiedIdClaim"
+      ]
+    },
+    "claimValidation": {
+      "navigationProperties": [],
+      "properties": [
+        "customExtensionId",
+        "isEnabled"
+      ]
+    },
     "classifcationErrorBase": {
       "navigationProperties": [],
       "properties": [
@@ -1752,14 +1750,6 @@
       "navigationProperties": [],
       "properties": [
         "cloudAppSecurityType"
-      ]
-    },
-    "cloudAppSecurityState": {
-      "navigationProperties": [],
-      "properties": [
-        "destinationServiceIp",
-        "destinationServiceName",
-        "riskScore"
       ]
     },
     "cloudClipboardItemPayload": {
@@ -3377,6 +3367,13 @@
         "labels"
       ]
     },
+    "faceCheckConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "sourcePhotoClaimName"
+      ]
+    },
     "fallbackToMicrosoftProviderOnError": {
       "navigationProperties": [],
       "properties": []
@@ -3414,22 +3411,6 @@
         "mac",
         "macKey",
         "profileIdentifier"
-      ]
-    },
-    "fileHash": {
-      "navigationProperties": [],
-      "properties": [
-        "hashType",
-        "hashValue"
-      ]
-    },
-    "fileSecurityState": {
-      "navigationProperties": [],
-      "properties": [
-        "fileHash",
-        "name",
-        "path",
-        "riskScore"
       ]
     },
     "fileStorageContainerCustomPropertyDictionary": {
@@ -3615,20 +3596,6 @@
         "quickXorHash",
         "sha1Hash",
         "sha256Hash"
-      ]
-    },
-    "hostSecurityState": {
-      "navigationProperties": [],
-      "properties": [
-        "fqdn",
-        "isAzureAdJoined",
-        "isAzureAdRegistered",
-        "isHybridAzureDomainJoined",
-        "netBiosName",
-        "os",
-        "privateIpAddress",
-        "publicIpAddress",
-        "riskScore"
       ]
     },
     "httpRequestEndpoint": {
@@ -3837,13 +3804,6 @@
         "showLogo",
         "showNameNextToLogo",
         "themeColor"
-      ]
-    },
-    "investigationSecurityState": {
-      "navigationProperties": [],
-      "properties": [
-        "name",
-        "status"
       ]
     },
     "invitationParticipantInfo": {
@@ -4328,16 +4288,6 @@
         "description"
       ]
     },
-    "malwareState": {
-      "navigationProperties": [],
-      "properties": [
-        "category",
-        "family",
-        "name",
-        "severity",
-        "wasRunning"
-      ]
-    },
     "managedAppDiagnosticStatus": {
       "navigationProperties": [],
       "properties": [
@@ -4611,20 +4561,6 @@
         "withinSizeRange"
       ]
     },
-    "messageSecurityState": {
-      "navigationProperties": [],
-      "properties": [
-        "connectingIP",
-        "deliveryAction",
-        "deliveryLocation",
-        "directionality",
-        "internetMessageId",
-        "messageFingerprint",
-        "messageReceivedDateTime",
-        "messageSubject",
-        "networkMessageId"
-      ]
-    },
     "messageUnpinnedEventMessageDetail": {
       "navigationProperties": [],
       "properties": [
@@ -4742,31 +4678,6 @@
         "desiredState",
         "details",
         "status"
-      ]
-    },
-    "networkConnection": {
-      "navigationProperties": [],
-      "properties": [
-        "applicationName",
-        "destinationAddress",
-        "destinationDomain",
-        "destinationLocation",
-        "destinationPort",
-        "destinationUrl",
-        "direction",
-        "domainRegisteredDateTime",
-        "localDnsName",
-        "natDestinationAddress",
-        "natDestinationPort",
-        "natSourceAddress",
-        "natSourcePort",
-        "protocol",
-        "riskScore",
-        "sourceAddress",
-        "sourceLocation",
-        "sourcePort",
-        "status",
-        "urlParameters"
       ]
     },
     "noDeviceRegistrationMembership": {
@@ -5180,6 +5091,18 @@
       ]
     },
     "onUserCreateStartHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onVerifiedIdClaimValidationCustomExtensionHandler": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "configuration"
+      ]
+    },
+    "onVerifiedIdClaimValidationHandler": {
       "navigationProperties": [],
       "properties": []
     },
@@ -5835,23 +5758,6 @@
         "statementUrl"
       ]
     },
-    "process": {
-      "navigationProperties": [],
-      "properties": [
-        "accountName",
-        "commandLine",
-        "createdDateTime",
-        "fileHash",
-        "integrityLevel",
-        "isElevated",
-        "name",
-        "parentProcessCreatedDateTime",
-        "parentProcessId",
-        "parentProcessName",
-        "path",
-        "processId"
-      ]
-    },
     "processContentBatchRequest": {
       "navigationProperties": [],
       "properties": [
@@ -6187,21 +6093,6 @@
       "navigationProperties": [],
       "properties": [
         "authenticationMethodsRegistrationCampaign"
-      ]
-    },
-    "registryKeyState": {
-      "navigationProperties": [],
-      "properties": [
-        "hive",
-        "key",
-        "oldKey",
-        "oldValueData",
-        "oldValueName",
-        "operation",
-        "processId",
-        "valueData",
-        "valueName",
-        "valueType"
       ]
     },
     "rejectJoinResponse": {
@@ -6759,13 +6650,6 @@
     "secureSignInSessionControl": {
       "navigationProperties": [],
       "properties": []
-    },
-    "securityResource": {
-      "navigationProperties": [],
-      "properties": [
-        "resource",
-        "resourceType"
-      ]
     },
     "securityVendorInformation": {
       "navigationProperties": [],
@@ -8048,17 +7932,6 @@
         "uploadUrl"
       ]
     },
-    "uriClickSecurityState": {
-      "navigationProperties": [],
-      "properties": [
-        "clickAction",
-        "clickDateTime",
-        "id",
-        "sourceId",
-        "uriDomain",
-        "verdict"
-      ]
-    },
     "usageDetails": {
       "navigationProperties": [],
       "properties": [
@@ -8209,25 +8082,6 @@
       "navigationProperties": [],
       "properties": []
     },
-    "userSecurityState": {
-      "navigationProperties": [],
-      "properties": [
-        "aadUserId",
-        "accountName",
-        "domainName",
-        "emailRole",
-        "isVpn",
-        "logonDateTime",
-        "logonId",
-        "logonIp",
-        "logonLocation",
-        "logonType",
-        "onPremisesSecurityIdentifier",
-        "riskScore",
-        "userAccountType",
-        "userPrincipalName"
-      ]
-    },
     "userSignIn": {
       "navigationProperties": [],
       "properties": [
@@ -8306,6 +8160,23 @@
         "isInitial",
         "name",
         "type"
+      ]
+    },
+    "verifiedIdProfileConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "acceptedIssuer",
+        "claimBindings",
+        "claimBindingSource",
+        "claimValidation",
+        "type"
+      ]
+    },
+    "verifiedIdUsageConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabledForTestOnly",
+        "purpose"
       ]
     },
     "verifiedPublisher": {
@@ -8400,14 +8271,6 @@
       "properties": [
         "supportsDeviceLicensing",
         "supportsUserLicensing"
-      ]
-    },
-    "vulnerabilityState": {
-      "navigationProperties": [],
-      "properties": [
-        "cve",
-        "severity",
-        "wasRunning"
       ]
     },
     "watermarkProtectionValues": {

--- a/schemas/type-mappings/v1.0-complex-types.json
+++ b/schemas/type-mappings/v1.0-complex-types.json
@@ -444,6 +444,34 @@
         "coverImageItemId"
       ]
     },
+    "alertDetection": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionType",
+        "method",
+        "name"
+      ]
+    },
+    "alertHistoryState": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "assignedTo",
+        "comments",
+        "feedback",
+        "status",
+        "updatedDateTime",
+        "user"
+      ]
+    },
+    "alertTrigger": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "type",
+        "value"
+      ]
+    },
     "allAllowedScopes": {
       "navigationProperties": [],
       "properties": []
@@ -1750,6 +1778,14 @@
       "navigationProperties": [],
       "properties": [
         "cloudAppSecurityType"
+      ]
+    },
+    "cloudAppSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "destinationServiceIp",
+        "destinationServiceName",
+        "riskScore"
       ]
     },
     "cloudClipboardItemPayload": {
@@ -3208,6 +3244,14 @@
         "name"
       ]
     },
+    "emailDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "body",
+        "senderEmailAddress",
+        "subject"
+      ]
+    },
     "emailIdentity": {
       "navigationProperties": [],
       "properties": [
@@ -3413,6 +3457,22 @@
         "profileIdentifier"
       ]
     },
+    "fileHash": {
+      "navigationProperties": [],
+      "properties": [
+        "hashType",
+        "hashValue"
+      ]
+    },
+    "fileSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "fileHash",
+        "name",
+        "path",
+        "riskScore"
+      ]
+    },
     "fileStorageContainerCustomPropertyDictionary": {
       "navigationProperties": [],
       "properties": []
@@ -3596,6 +3656,20 @@
         "quickXorHash",
         "sha1Hash",
         "sha256Hash"
+      ]
+    },
+    "hostSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "fqdn",
+        "isAzureAdJoined",
+        "isAzureAdRegistered",
+        "isHybridAzureDomainJoined",
+        "netBiosName",
+        "os",
+        "privateIpAddress",
+        "publicIpAddress",
+        "riskScore"
       ]
     },
     "httpRequestEndpoint": {
@@ -3804,6 +3878,13 @@
         "showLogo",
         "showNameNextToLogo",
         "themeColor"
+      ]
+    },
+    "investigationSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "status"
       ]
     },
     "invitationParticipantInfo": {
@@ -4288,6 +4369,16 @@
         "description"
       ]
     },
+    "malwareState": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "family",
+        "name",
+        "severity",
+        "wasRunning"
+      ]
+    },
     "managedAppDiagnosticStatus": {
       "navigationProperties": [],
       "properties": [
@@ -4561,6 +4652,20 @@
         "withinSizeRange"
       ]
     },
+    "messageSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "connectingIP",
+        "deliveryAction",
+        "deliveryLocation",
+        "directionality",
+        "internetMessageId",
+        "messageFingerprint",
+        "messageReceivedDateTime",
+        "messageSubject",
+        "networkMessageId"
+      ]
+    },
     "messageUnpinnedEventMessageDetail": {
       "navigationProperties": [],
       "properties": [
@@ -4678,6 +4783,31 @@
         "desiredState",
         "details",
         "status"
+      ]
+    },
+    "networkConnection": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationName",
+        "destinationAddress",
+        "destinationDomain",
+        "destinationLocation",
+        "destinationPort",
+        "destinationUrl",
+        "direction",
+        "domainRegisteredDateTime",
+        "localDnsName",
+        "natDestinationAddress",
+        "natDestinationPort",
+        "natSourceAddress",
+        "natSourcePort",
+        "protocol",
+        "riskScore",
+        "sourceAddress",
+        "sourceLocation",
+        "sourcePort",
+        "status",
+        "urlParameters"
       ]
     },
     "noDeviceRegistrationMembership": {
@@ -5758,6 +5888,23 @@
         "statementUrl"
       ]
     },
+    "process": {
+      "navigationProperties": [],
+      "properties": [
+        "accountName",
+        "commandLine",
+        "createdDateTime",
+        "fileHash",
+        "integrityLevel",
+        "isElevated",
+        "name",
+        "parentProcessCreatedDateTime",
+        "parentProcessId",
+        "parentProcessName",
+        "path",
+        "processId"
+      ]
+    },
     "processContentBatchRequest": {
       "navigationProperties": [],
       "properties": [
@@ -6093,6 +6240,21 @@
       "navigationProperties": [],
       "properties": [
         "authenticationMethodsRegistrationCampaign"
+      ]
+    },
+    "registryKeyState": {
+      "navigationProperties": [],
+      "properties": [
+        "hive",
+        "key",
+        "oldKey",
+        "oldValueData",
+        "oldValueName",
+        "operation",
+        "processId",
+        "valueData",
+        "valueName",
+        "valueType"
       ]
     },
     "rejectJoinResponse": {
@@ -6650,6 +6812,13 @@
     "secureSignInSessionControl": {
       "navigationProperties": [],
       "properties": []
+    },
+    "securityResource": {
+      "navigationProperties": [],
+      "properties": [
+        "resource",
+        "resourceType"
+      ]
     },
     "securityVendorInformation": {
       "navigationProperties": [],
@@ -7371,6 +7540,13 @@
         "managerLevel"
       ]
     },
+    "targetOwners": {
+      "navigationProperties": [],
+      "properties": [
+        "notifyMembers",
+        "securityGroups"
+      ]
+    },
     "targetResource": {
       "navigationProperties": [],
       "properties": [
@@ -7932,6 +8108,17 @@
         "uploadUrl"
       ]
     },
+    "uriClickSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "clickAction",
+        "clickDateTime",
+        "id",
+        "sourceId",
+        "uriDomain",
+        "verdict"
+      ]
+    },
     "usageDetails": {
       "navigationProperties": [],
       "properties": [
@@ -8081,6 +8268,25 @@
     "userScope": {
       "navigationProperties": [],
       "properties": []
+    },
+    "userSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "aadUserId",
+        "accountName",
+        "domainName",
+        "emailRole",
+        "isVpn",
+        "logonDateTime",
+        "logonId",
+        "logonIp",
+        "logonLocation",
+        "logonType",
+        "onPremisesSecurityIdentifier",
+        "riskScore",
+        "userAccountType",
+        "userPrincipalName"
+      ]
     },
     "userSignIn": {
       "navigationProperties": [],
@@ -8273,6 +8479,14 @@
         "supportsUserLicensing"
       ]
     },
+    "vulnerabilityState": {
+      "navigationProperties": [],
+      "properties": [
+        "cve",
+        "severity",
+        "wasRunning"
+      ]
+    },
     "watermarkProtectionValues": {
       "navigationProperties": [],
       "properties": [
@@ -8313,6 +8527,88 @@
       "navigationProperties": [],
       "properties": [
         "dnsConfiguration"
+      ]
+    },
+    "webauthnAuthenticationExtensionsClientInputs": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "webauthnAuthenticationExtensionsClientOutputs": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "webauthnAuthenticatorAttestationResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "attestationObject",
+        "clientDataJSON"
+      ]
+    },
+    "webauthnAuthenticatorSelectionCriteria": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticatorAttachment",
+        "requireResidentKey",
+        "userVerification"
+      ]
+    },
+    "webauthnCredentialCreationOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "challengeTimeoutDateTime",
+        "publicKey"
+      ]
+    },
+    "webauthnPublicKeyCredential": {
+      "navigationProperties": [],
+      "properties": [
+        "clientExtensionResults",
+        "id",
+        "response"
+      ]
+    },
+    "webauthnPublicKeyCredentialCreationOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "attestation",
+        "authenticatorSelection",
+        "challenge",
+        "excludeCredentials",
+        "extensions",
+        "pubKeyCredParams",
+        "rp",
+        "timeout",
+        "user"
+      ]
+    },
+    "webauthnPublicKeyCredentialDescriptor": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "transports",
+        "type"
+      ]
+    },
+    "webauthnPublicKeyCredentialParameters": {
+      "navigationProperties": [],
+      "properties": [
+        "alg",
+        "type"
+      ]
+    },
+    "webauthnPublicKeyCredentialRpEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "name"
+      ]
+    },
+    "webauthnPublicKeyCredentialUserEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "id",
+        "name"
       ]
     },
     "webPartData": {

--- a/schemas/type-mappings/v1.0-complex-types.json
+++ b/schemas/type-mappings/v1.0-complex-types.json
@@ -1,0 +1,10537 @@
+{
+  "microsoft.graph": {
+    "aadUserConversationMemberResult": {
+      "navigationProperties": [],
+      "properties": [
+        "userId"
+      ]
+    },
+    "aadUserNotificationRecipient": {
+      "navigationProperties": [],
+      "properties": [
+        "userId"
+      ]
+    },
+    "acceptJoinResponse": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessPackageAnswer": {
+      "navigationProperties": [
+        "answeredQuestion"
+      ],
+      "properties": [
+        "displayValue"
+      ]
+    },
+    "accessPackageAnswerChoice": {
+      "navigationProperties": [],
+      "properties": [
+        "actualValue",
+        "localizations",
+        "text"
+      ]
+    },
+    "accessPackageAnswerString": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "accessPackageApprovalStage": {
+      "navigationProperties": [],
+      "properties": [
+        "durationBeforeAutomaticDenial",
+        "durationBeforeEscalation",
+        "escalationApprovers",
+        "fallbackEscalationApprovers",
+        "fallbackPrimaryApprovers",
+        "isApproverJustificationRequired",
+        "isEscalationEnabled",
+        "primaryApprovers"
+      ]
+    },
+    "accessPackageAssignmentApprovalSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isApprovalRequiredForAdd",
+        "isApprovalRequiredForUpdate",
+        "isRequestorJustificationRequired",
+        "stages"
+      ]
+    },
+    "accessPackageAssignmentRequestCallbackData": {
+      "navigationProperties": [],
+      "properties": [
+        "customExtensionStageInstanceDetail",
+        "customExtensionStageInstanceId",
+        "stage",
+        "state"
+      ]
+    },
+    "accessPackageAssignmentRequestorSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowCustomAssignmentSchedule",
+        "enableOnBehalfRequestorsToAddAccess",
+        "enableOnBehalfRequestorsToRemoveAccess",
+        "enableOnBehalfRequestorsToUpdateAccess",
+        "enableTargetsToSelfAddAccess",
+        "enableTargetsToSelfRemoveAccess",
+        "enableTargetsToSelfUpdateAccess",
+        "onBehalfRequestors"
+      ]
+    },
+    "accessPackageAssignmentRequestRequirements": {
+      "navigationProperties": [
+        "questions"
+      ],
+      "properties": [
+        "allowCustomAssignmentSchedule",
+        "isApprovalRequiredForAdd",
+        "isApprovalRequiredForUpdate",
+        "isRequestorJustificationRequired",
+        "policyDescription",
+        "policyDisplayName",
+        "policyId",
+        "schedule"
+      ]
+    },
+    "accessPackageAssignmentReviewSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "expirationBehavior",
+        "fallbackReviewers",
+        "isEnabled",
+        "isRecommendationEnabled",
+        "isReviewerJustificationRequired",
+        "isSelfReview",
+        "primaryReviewers",
+        "schedule"
+      ]
+    },
+    "accessPackageAutomaticRequestSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "gracePeriodBeforeAccessRemoval",
+        "removeAccessWhenTargetLeavesAllowedTargets",
+        "requestAccessForAllowedTargets"
+      ]
+    },
+    "accessPackageDynamicApprovalStage": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessPackageLocalizedText": {
+      "navigationProperties": [],
+      "properties": [
+        "languageCode",
+        "text"
+      ]
+    },
+    "accessPackageNotificationSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isAssignmentNotificationDisabled"
+      ]
+    },
+    "accessPackageRequestApprovalStageCallbackConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessPackageResourceAttribute": {
+      "navigationProperties": [],
+      "properties": [
+        "destination",
+        "isEditable",
+        "isPersistedOnAssignmentRemoval",
+        "name",
+        "source"
+      ]
+    },
+    "accessPackageResourceAttributeDestination": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessPackageResourceAttributeQuestion": {
+      "navigationProperties": [
+        "question"
+      ],
+      "properties": []
+    },
+    "accessPackageResourceAttributeSource": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessPackageUserDirectoryAttributeStore": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessReviewApplyAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessReviewHistoryScheduleSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "recurrence",
+        "reportRange"
+      ]
+    },
+    "accessReviewInactiveUsersQueryScope": {
+      "navigationProperties": [],
+      "properties": [
+        "inactiveDuration"
+      ]
+    },
+    "accessReviewInstanceDecisionItemAccessPackageAssignmentPolicyResource": {
+      "navigationProperties": [],
+      "properties": [
+        "accessPackageDisplayName",
+        "accessPackageId"
+      ]
+    },
+    "accessReviewInstanceDecisionItemAzureRoleResource": {
+      "navigationProperties": [],
+      "properties": [
+        "scope"
+      ]
+    },
+    "accessReviewInstanceDecisionItemResource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "id",
+        "type"
+      ]
+    },
+    "accessReviewInstanceDecisionItemServicePrincipalResource": {
+      "navigationProperties": [],
+      "properties": [
+        "appId"
+      ]
+    },
+    "accessReviewNotificationRecipientItem": {
+      "navigationProperties": [],
+      "properties": [
+        "notificationRecipientScope",
+        "notificationTemplateType"
+      ]
+    },
+    "accessReviewNotificationRecipientQueryScope": {
+      "navigationProperties": [],
+      "properties": [
+        "query",
+        "queryRoot",
+        "queryType"
+      ]
+    },
+    "accessReviewNotificationRecipientScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessReviewQueryScope": {
+      "navigationProperties": [],
+      "properties": [
+        "query",
+        "queryRoot",
+        "queryType"
+      ]
+    },
+    "accessReviewRecommendationInsightSetting": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessReviewReviewerScope": {
+      "navigationProperties": [],
+      "properties": [
+        "query",
+        "queryRoot",
+        "queryType"
+      ]
+    },
+    "accessReviewScheduleSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "applyActions",
+        "autoApplyDecisionsEnabled",
+        "decisionHistoriesForReviewersEnabled",
+        "defaultDecision",
+        "defaultDecisionEnabled",
+        "instanceDurationInDays",
+        "justificationRequiredOnApproval",
+        "mailNotificationsEnabled",
+        "recommendationInsightSettings",
+        "recommendationLookBackDuration",
+        "recommendationsEnabled",
+        "recurrence",
+        "reminderNotificationsEnabled"
+      ]
+    },
+    "accessReviewScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "accessReviewStageSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "decisionsThatWillMoveToNextStage",
+        "dependsOn",
+        "durationInDays",
+        "fallbackReviewers",
+        "recommendationInsightSettings",
+        "recommendationsEnabled",
+        "reviewers",
+        "stageId"
+      ]
+    },
+    "accountTargetContent": {
+      "navigationProperties": [],
+      "properties": [
+        "type"
+      ]
+    },
+    "actionItem": {
+      "navigationProperties": [],
+      "properties": [
+        "ownerDisplayName",
+        "text",
+        "title"
+      ]
+    },
+    "actionResultPart": {
+      "navigationProperties": [],
+      "properties": [
+        "error"
+      ]
+    },
+    "activityMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "activity"
+      ]
+    },
+    "addIn": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "properties",
+        "type"
+      ]
+    },
+    "addressBookAccountTargetContent": {
+      "navigationProperties": [],
+      "properties": [
+        "accountTargetEmails"
+      ]
+    },
+    "aggregationOption": {
+      "navigationProperties": [],
+      "properties": [
+        "bucketDefinition",
+        "field",
+        "size"
+      ]
+    },
+    "agreementFileData": {
+      "navigationProperties": [],
+      "properties": [
+        "data"
+      ]
+    },
+    "aiAgentInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "blueprintId"
+      ]
+    },
+    "aiInteractionAttachment": {
+      "navigationProperties": [],
+      "properties": [
+        "attachmentId",
+        "content",
+        "contentType",
+        "contentUrl",
+        "name"
+      ]
+    },
+    "aiInteractionContext": {
+      "navigationProperties": [],
+      "properties": [
+        "contextReference",
+        "contextType",
+        "displayName"
+      ]
+    },
+    "aiInteractionEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier",
+        "name",
+        "version"
+      ]
+    },
+    "aiInteractionLink": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "linkType",
+        "linkUrl"
+      ]
+    },
+    "aiInteractionMention": {
+      "navigationProperties": [],
+      "properties": [
+        "mentioned",
+        "mentionId",
+        "mentionText"
+      ]
+    },
+    "aiInteractionMentionedIdentitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "conversation",
+        "tag"
+      ]
+    },
+    "aiInteractionPlugin": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "airPrintSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "incompatiblePrinters"
+      ]
+    },
+    "akamaiAttackGroupActionModel": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "group"
+      ]
+    },
+    "akamaiCustomRuleModel": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "name",
+        "ruleId"
+      ]
+    },
+    "akamaiRapidRulesModel": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultAction",
+        "isEnabled"
+      ]
+    },
+    "akamaiVerifiedDetailsModel": {
+      "navigationProperties": [],
+      "properties": [
+        "activeAttackGroups",
+        "activeCustomRules",
+        "rapidRules"
+      ]
+    },
+    "album": {
+      "navigationProperties": [],
+      "properties": [
+        "coverImageItemId"
+      ]
+    },
+    "alertDetection": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionType",
+        "method",
+        "name"
+      ]
+    },
+    "alertHistoryState": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "assignedTo",
+        "comments",
+        "feedback",
+        "status",
+        "updatedDateTime",
+        "user"
+      ]
+    },
+    "alertTrigger": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "type",
+        "value"
+      ]
+    },
+    "allAllowedScopes": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "allDeviceRegistrationMembership": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "allDevicesAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "allLicensedUsersAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "alterationResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "originalQueryString",
+        "queryAlteration",
+        "queryAlterationType"
+      ]
+    },
+    "alteredQueryToken": {
+      "navigationProperties": [],
+      "properties": [
+        "length",
+        "offset",
+        "suggestion"
+      ]
+    },
+    "alternativeSecurityId": {
+      "navigationProperties": [],
+      "properties": [
+        "identityProvider",
+        "key",
+        "type"
+      ]
+    },
+    "androidMinimumOperatingSystem": {
+      "navigationProperties": [],
+      "properties": [
+        "v10_0",
+        "v11_0",
+        "v4_0",
+        "v4_0_3",
+        "v4_1",
+        "v4_2",
+        "v4_3",
+        "v4_4",
+        "v5_0",
+        "v5_1",
+        "v6_0",
+        "v7_0",
+        "v7_1",
+        "v8_0",
+        "v8_1",
+        "v9_0"
+      ]
+    },
+    "androidMobileAppIdentifier": {
+      "navigationProperties": [],
+      "properties": [
+        "packageId"
+      ]
+    },
+    "apiApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "acceptMappedClaims",
+        "knownClientApplications",
+        "oauth2PermissionScopes",
+        "preAuthorizedApplications",
+        "requestedAccessTokenVersion"
+      ]
+    },
+    "apiAuthenticationConfigurationBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "appConfigurationSettingItem": {
+      "navigationProperties": [],
+      "properties": [
+        "appConfigKey",
+        "appConfigKeyType",
+        "appConfigKeyValue"
+      ]
+    },
+    "appConsentRequestScope": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "appHostedMediaConfig": {
+      "navigationProperties": [],
+      "properties": [
+        "blob"
+      ]
+    },
+    "appIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "displayName",
+        "servicePrincipalId",
+        "servicePrincipalName"
+      ]
+    },
+    "applicationContext": {
+      "navigationProperties": [],
+      "properties": [
+        "includeApplications"
+      ]
+    },
+    "applicationEnforcedRestrictionsSessionControl": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "applicationServicePrincipal": {
+      "navigationProperties": [
+        "application",
+        "servicePrincipal"
+      ],
+      "properties": []
+    },
+    "appliedConditionalAccessPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "enforcedGrantControls",
+        "enforcedSessionControls",
+        "id",
+        "result"
+      ]
+    },
+    "appListItem": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "appStoreUrl",
+        "name",
+        "publisher"
+      ]
+    },
+    "appLogCollectionDownloadDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "appLogDecryptionAlgorithm",
+        "decryptionKey",
+        "downloadUrl"
+      ]
+    },
+    "appManagementApplicationConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "appManagementConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "keyCredentials",
+        "passwordCredentials"
+      ]
+    },
+    "appManagementServicePrincipalConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "appRole": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedMemberTypes",
+        "description",
+        "displayName",
+        "id",
+        "isEnabled",
+        "origin",
+        "value"
+      ]
+    },
+    "approvalSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalMode",
+        "approvalStages",
+        "isApprovalRequired",
+        "isApprovalRequiredForExtension",
+        "isRequestorJustificationRequired"
+      ]
+    },
+    "appsInstallationOptionsForMac": {
+      "navigationProperties": [],
+      "properties": [
+        "isMicrosoft365AppsEnabled",
+        "isSkypeForBusinessEnabled"
+      ]
+    },
+    "appsInstallationOptionsForWindows": {
+      "navigationProperties": [],
+      "properties": [
+        "isMicrosoft365AppsEnabled",
+        "isProjectEnabled",
+        "isSkypeForBusinessEnabled",
+        "isVisioEnabled"
+      ]
+    },
+    "archivedPrintJob": {
+      "navigationProperties": [],
+      "properties": [
+        "acquiredByPrinter",
+        "acquiredDateTime",
+        "completionDateTime",
+        "copiesPrinted",
+        "createdBy",
+        "createdDateTime",
+        "id",
+        "printerId",
+        "printerName",
+        "processingState"
+      ]
+    },
+    "artifactQuery": {
+      "navigationProperties": [],
+      "properties": [
+        "artifactType",
+        "queryExpression"
+      ]
+    },
+    "assignedLabel": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "labelId"
+      ]
+    },
+    "assignedLicense": {
+      "navigationProperties": [],
+      "properties": [
+        "disabledPlans",
+        "skuId"
+      ]
+    },
+    "assignedPlaceMode": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedUserEmailAddress",
+        "assignedUserId"
+      ]
+    },
+    "assignedPlan": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedDateTime",
+        "capabilityStatus",
+        "service",
+        "servicePlanId"
+      ]
+    },
+    "assignedTrainingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedUserCount",
+        "completedUserCount",
+        "displayName"
+      ]
+    },
+    "assignmentOrder": {
+      "navigationProperties": [],
+      "properties": [
+        "order"
+      ]
+    },
+    "assignmentRequestApprovalStageCallbackData": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalStage"
+      ]
+    },
+    "attachmentInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "attachmentType",
+        "contentType",
+        "name",
+        "size"
+      ]
+    },
+    "attachmentItem": {
+      "navigationProperties": [],
+      "properties": [
+        "attachmentType",
+        "contentId",
+        "contentType",
+        "isInline",
+        "name",
+        "size"
+      ]
+    },
+    "attackSimulationRepeatOffender": {
+      "navigationProperties": [],
+      "properties": [
+        "attackSimulationUser",
+        "repeatOffenceCount"
+      ]
+    },
+    "attackSimulationSimulationUserCoverage": {
+      "navigationProperties": [],
+      "properties": [
+        "attackSimulationUser",
+        "clickCount",
+        "compromisedCount",
+        "latestSimulationDateTime",
+        "simulationCount"
+      ]
+    },
+    "attackSimulationTrainingUserCoverage": {
+      "navigationProperties": [],
+      "properties": [
+        "attackSimulationUser",
+        "userTrainings"
+      ]
+    },
+    "attackSimulationUser": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "email",
+        "userId"
+      ]
+    },
+    "attendanceInterval": {
+      "navigationProperties": [],
+      "properties": [
+        "durationInSeconds",
+        "joinDateTime",
+        "leaveDateTime"
+      ]
+    },
+    "attendee": {
+      "navigationProperties": [],
+      "properties": [
+        "proposedNewTime",
+        "status"
+      ]
+    },
+    "attendeeAvailability": {
+      "navigationProperties": [],
+      "properties": [
+        "attendee",
+        "availability"
+      ]
+    },
+    "attendeeBase": {
+      "navigationProperties": [],
+      "properties": [
+        "type"
+      ]
+    },
+    "attendeeNotificationInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "phoneNumber",
+        "timeZone"
+      ]
+    },
+    "attributeDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "anchor",
+        "apiExpressions",
+        "caseExact",
+        "defaultValue",
+        "flowNullValues",
+        "metadata",
+        "multivalued",
+        "mutability",
+        "name",
+        "referencedObjects",
+        "required",
+        "type"
+      ]
+    },
+    "attributeDefinitionMetadataEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "attributeMapping": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue",
+        "exportMissingReferences",
+        "flowBehavior",
+        "flowType",
+        "matchingPriority",
+        "source",
+        "targetAttributeName"
+      ]
+    },
+    "attributeMappingParameterSchema": {
+      "navigationProperties": [],
+      "properties": [
+        "allowMultipleOccurrences",
+        "name",
+        "required",
+        "type"
+      ]
+    },
+    "attributeMappingSource": {
+      "navigationProperties": [],
+      "properties": [
+        "expression",
+        "name",
+        "parameters",
+        "type"
+      ]
+    },
+    "attributeRuleMembers": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "membershipRule"
+      ]
+    },
+    "audio": {
+      "navigationProperties": [],
+      "properties": [
+        "album",
+        "albumArtist",
+        "artist",
+        "bitrate",
+        "composers",
+        "copyright",
+        "disc",
+        "discCount",
+        "duration",
+        "genre",
+        "hasDrm",
+        "isVariableBitrate",
+        "title",
+        "track",
+        "trackCount",
+        "year"
+      ]
+    },
+    "audioConferencing": {
+      "navigationProperties": [],
+      "properties": [
+        "conferenceId",
+        "dialinUrl",
+        "tollFreeNumber",
+        "tollFreeNumbers",
+        "tollNumber",
+        "tollNumbers"
+      ]
+    },
+    "auditActivityInitiator": {
+      "navigationProperties": [],
+      "properties": [
+        "app",
+        "user"
+      ]
+    },
+    "auditActor": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationDisplayName",
+        "applicationId",
+        "auditActorType",
+        "ipAddress",
+        "servicePrincipalName",
+        "userId",
+        "userPermissions",
+        "userPrincipalName"
+      ]
+    },
+    "auditProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "newValue",
+        "oldValue"
+      ]
+    },
+    "auditResource": {
+      "navigationProperties": [],
+      "properties": [
+        "auditResourceType",
+        "displayName",
+        "modifiedProperties",
+        "resourceId"
+      ]
+    },
+    "authContext": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationContextValue"
+      ]
+    },
+    "authenticationAttributeCollectionInputConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "attribute",
+        "defaultValue",
+        "editable",
+        "hidden",
+        "inputType",
+        "label",
+        "options",
+        "required",
+        "validationRegEx",
+        "writeToDirectory"
+      ]
+    },
+    "authenticationAttributeCollectionOptionConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "label",
+        "value"
+      ]
+    },
+    "authenticationAttributeCollectionPage": {
+      "navigationProperties": [],
+      "properties": [
+        "views"
+      ]
+    },
+    "authenticationAttributeCollectionPageViewConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "inputs",
+        "title"
+      ]
+    },
+    "authenticationBehaviors": {
+      "navigationProperties": [],
+      "properties": [
+        "blockAzureADGraphAccess",
+        "removeUnverifiedEmailClaim",
+        "requireClientServicePrincipal"
+      ]
+    },
+    "authenticationConditions": {
+      "navigationProperties": [],
+      "properties": [
+        "applications"
+      ]
+    },
+    "authenticationConditionsApplications": {
+      "navigationProperties": [
+        "includeApplications"
+      ],
+      "properties": []
+    },
+    "authenticationConfigurationValidation": {
+      "navigationProperties": [],
+      "properties": [
+        "errors",
+        "warnings"
+      ]
+    },
+    "authenticationFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "transferMethod"
+      ]
+    },
+    "authenticationMethodFeatureConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeTarget",
+        "includeTarget",
+        "state"
+      ]
+    },
+    "authenticationMethodsRegistrationCampaign": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeTargets",
+        "includeTargets",
+        "snoozeDurationInDays",
+        "state"
+      ]
+    },
+    "authenticationMethodsRegistrationCampaignIncludeTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "targetedAuthenticationMethod",
+        "targetType"
+      ]
+    },
+    "authenticationStrengthUsage": {
+      "navigationProperties": [
+        "mfa",
+        "none"
+      ],
+      "properties": []
+    },
+    "authorizationInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateUserIds"
+      ]
+    },
+    "automaticRepliesMailTips": {
+      "navigationProperties": [],
+      "properties": [
+        "message",
+        "messageLanguage",
+        "scheduledEndTime",
+        "scheduledStartTime"
+      ]
+    },
+    "automaticRepliesSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "externalAudience",
+        "externalReplyMessage",
+        "internalReplyMessage",
+        "scheduledEndDateTime",
+        "scheduledStartDateTime",
+        "status"
+      ]
+    },
+    "availabilityItem": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "serviceId",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "averageComparativeScore": {
+      "navigationProperties": [],
+      "properties": [
+        "averageScore",
+        "basis"
+      ]
+    },
+    "azureActiveDirectoryTenant": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "tenantId"
+      ]
+    },
+    "azureADJoinPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedToJoin",
+        "isAdminConfigurable",
+        "localAdmins"
+      ]
+    },
+    "azureAdPopTokenAuthentication": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "azureADRegistrationPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedToRegister",
+        "isAdminConfigurable"
+      ]
+    },
+    "azureAdTokenAuthentication": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceId"
+      ]
+    },
+    "azureCommunicationServicesUserIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "azureCommunicationServicesResourceId"
+      ]
+    },
+    "baseEndUserNotification": {
+      "navigationProperties": [
+        "endUserNotification"
+      ],
+      "properties": [
+        "defaultLanguage"
+      ]
+    },
+    "baselineParameter": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "parameterType"
+      ]
+    },
+    "baselineResource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "properties",
+        "resourceType"
+      ]
+    },
+    "basicAuthentication": {
+      "navigationProperties": [],
+      "properties": [
+        "password",
+        "username"
+      ]
+    },
+    "binaryContent": {
+      "navigationProperties": [],
+      "properties": [
+        "data"
+      ]
+    },
+    "bitLockerRemovableDrivePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "blockCrossOrganizationWriteAccess",
+        "encryptionMethod",
+        "requireEncryptionForWriteAccess"
+      ]
+    },
+    "bookingCustomerInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "customerId",
+        "customQuestionAnswers",
+        "emailAddress",
+        "location",
+        "name",
+        "notes",
+        "phone",
+        "timeZone"
+      ]
+    },
+    "bookingCustomerInformationBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "bookingPageSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "accessControl",
+        "bookingPageColorCode",
+        "businessTimeZone",
+        "customerConsentMessage",
+        "enforceOneTimePassword",
+        "isBusinessLogoDisplayEnabled",
+        "isCustomerConsentEnabled",
+        "isSearchEngineIndexabilityDisabled",
+        "isTimeSlotTimeZoneSetToBusinessTimeZone",
+        "privacyPolicyWebUrl",
+        "termsAndConditionsWebUrl"
+      ]
+    },
+    "bookingQuestionAnswer": {
+      "navigationProperties": [],
+      "properties": [
+        "answer",
+        "answerInputType",
+        "answerOptions",
+        "isRequired",
+        "question",
+        "questionId",
+        "selectedOptions"
+      ]
+    },
+    "bookingQuestionAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "isRequired",
+        "questionId"
+      ]
+    },
+    "bookingReminder": {
+      "navigationProperties": [],
+      "properties": [
+        "message",
+        "offset",
+        "recipients"
+      ]
+    },
+    "bookingsAvailability": {
+      "navigationProperties": [],
+      "properties": [
+        "availabilityType",
+        "businessHours"
+      ]
+    },
+    "bookingsAvailabilityWindow": {
+      "navigationProperties": [],
+      "properties": [
+        "endDate",
+        "startDate"
+      ]
+    },
+    "bookingSchedulingPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "allowStaffSelection",
+        "customAvailabilities",
+        "generalAvailability",
+        "isMeetingInviteToCustomersEnabled",
+        "maximumAdvance",
+        "minimumLeadTime",
+        "sendConfirmationsToOwner",
+        "timeSlotInterval"
+      ]
+    },
+    "bookingWorkHours": {
+      "navigationProperties": [],
+      "properties": [
+        "day",
+        "timeSlots"
+      ]
+    },
+    "bookingWorkTimeSlot": {
+      "navigationProperties": [],
+      "properties": [
+        "endTime",
+        "startTime"
+      ]
+    },
+    "booleanColumn": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "broadcastMeetingCaptionSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isCaptionEnabled",
+        "spokenLanguage",
+        "translationLanguages"
+      ]
+    },
+    "broadcastMeetingSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedAudience",
+        "captions",
+        "isAttendeeReportEnabled",
+        "isQuestionAndAnswerEnabled",
+        "isRecordingEnabled",
+        "isVideoOnDemandEnabled"
+      ]
+    },
+    "browserSharedCookieHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "comment",
+        "displayName",
+        "hostOnly",
+        "hostOrDomain",
+        "lastModifiedBy",
+        "path",
+        "publishedDateTime",
+        "sourceEnvironment"
+      ]
+    },
+    "browserSiteHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "allowRedirect",
+        "comment",
+        "compatibilityMode",
+        "lastModifiedBy",
+        "mergeType",
+        "publishedDateTime",
+        "targetEnvironment"
+      ]
+    },
+    "bucketAggregationDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "isDescending",
+        "minimumCount",
+        "prefixFilter",
+        "ranges",
+        "sortBy"
+      ]
+    },
+    "bucketAggregationRange": {
+      "navigationProperties": [],
+      "properties": [
+        "from",
+        "to"
+      ]
+    },
+    "bundle": {
+      "navigationProperties": [],
+      "properties": [
+        "album",
+        "childCount"
+      ]
+    },
+    "calculatedColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "format",
+        "formula",
+        "outputType"
+      ]
+    },
+    "calendarSharingMessageAction": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "actionType",
+        "importance"
+      ]
+    },
+    "callAiInsightViewPoint": {
+      "navigationProperties": [],
+      "properties": [
+        "mentionEvents"
+      ]
+    },
+    "callEndedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "callDuration",
+        "callEventType",
+        "callId",
+        "callParticipants",
+        "initiator"
+      ]
+    },
+    "callMediaState": {
+      "navigationProperties": [],
+      "properties": [
+        "audio"
+      ]
+    },
+    "callOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "hideBotAfterEscalation",
+        "isContentSharingNotificationEnabled",
+        "isDeltaRosterEnabled",
+        "isInteractiveRosterEnabled"
+      ]
+    },
+    "callParticipantInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "participant"
+      ]
+    },
+    "callRecordingEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "callId",
+        "callRecordingDisplayName",
+        "callRecordingDuration",
+        "callRecordingStatus",
+        "callRecordingUrl",
+        "initiator",
+        "meetingOrganizer"
+      ]
+    },
+    "callRoute": {
+      "navigationProperties": [],
+      "properties": [
+        "final",
+        "original",
+        "routingType"
+      ]
+    },
+    "callStartedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "callEventType",
+        "callId",
+        "initiator"
+      ]
+    },
+    "callTranscriptEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "callId",
+        "callTranscriptICalUid",
+        "meetingOrganizer"
+      ]
+    },
+    "callTranscriptionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedDateTime",
+        "state"
+      ]
+    },
+    "certificateAuthority": {
+      "navigationProperties": [],
+      "properties": [
+        "certificate",
+        "certificateRevocationListUrl",
+        "deltaCertificateRevocationListUrl",
+        "isRootAuthority",
+        "issuer",
+        "issuerSki"
+      ]
+    },
+    "certification": {
+      "navigationProperties": [],
+      "properties": [
+        "certificationDetailsUrl",
+        "certificationExpirationDateTime",
+        "isCertifiedByMicrosoft",
+        "isPublisherAttested",
+        "lastCertificationDateTime"
+      ]
+    },
+    "certificationControl": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "url"
+      ]
+    },
+    "challengingWord": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "word"
+      ]
+    },
+    "changeNotification": {
+      "navigationProperties": [],
+      "properties": [
+        "changeType",
+        "clientState",
+        "encryptedContent",
+        "id",
+        "lifecycleEvent",
+        "resource",
+        "resourceData",
+        "subscriptionExpirationDateTime",
+        "subscriptionId",
+        "tenantId"
+      ]
+    },
+    "changeNotificationCollection": {
+      "navigationProperties": [],
+      "properties": [
+        "validationTokens",
+        "value"
+      ]
+    },
+    "changeNotificationEncryptedContent": {
+      "navigationProperties": [],
+      "properties": [
+        "data",
+        "dataKey",
+        "dataSignature",
+        "encryptionCertificateId",
+        "encryptionCertificateThumbprint"
+      ]
+    },
+    "channelAddedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "channelDisplayName",
+        "channelId",
+        "initiator"
+      ]
+    },
+    "channelDeletedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "channelDisplayName",
+        "channelId",
+        "initiator"
+      ]
+    },
+    "channelDescriptionUpdatedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "channelDescription",
+        "channelId",
+        "initiator"
+      ]
+    },
+    "channelIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "channelId",
+        "teamId"
+      ]
+    },
+    "channelMembersNotificationRecipient": {
+      "navigationProperties": [],
+      "properties": [
+        "channelId",
+        "teamId"
+      ]
+    },
+    "channelRenamedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "channelDisplayName",
+        "channelId",
+        "initiator"
+      ]
+    },
+    "channelSetAsFavoriteByDefaultEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "channelId",
+        "initiator"
+      ]
+    },
+    "channelSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "guestsCount",
+        "hasMembersFromOtherTenants",
+        "membersCount",
+        "ownersCount"
+      ]
+    },
+    "channelUnsetAsFavoriteByDefaultEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "channelId",
+        "initiator"
+      ]
+    },
+    "chatInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "messageId",
+        "replyChainMessageId",
+        "threadId"
+      ]
+    },
+    "chatMembersNotificationRecipient": {
+      "navigationProperties": [],
+      "properties": [
+        "chatId"
+      ]
+    },
+    "chatMessageAttachment": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "contentType",
+        "contentUrl",
+        "id",
+        "name",
+        "teamsAppId",
+        "thumbnailUrl"
+      ]
+    },
+    "chatMessageFromIdentitySet": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "chatMessageHistoryItem": {
+      "navigationProperties": [],
+      "properties": [
+        "actions",
+        "modifiedDateTime",
+        "reaction"
+      ]
+    },
+    "chatMessageMention": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "mentioned",
+        "mentionText"
+      ]
+    },
+    "chatMessageMentionedIdentitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "conversation"
+      ]
+    },
+    "chatMessagePolicyViolation": {
+      "navigationProperties": [],
+      "properties": [
+        "dlpAction",
+        "justificationText",
+        "policyTip",
+        "userAction",
+        "verdictDetails"
+      ]
+    },
+    "chatMessagePolicyViolationPolicyTip": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceUrl",
+        "generalText",
+        "matchedConditionDescriptions"
+      ]
+    },
+    "chatMessageReaction": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "reactionContentUrl",
+        "reactionType",
+        "user"
+      ]
+    },
+    "chatMessageReactionIdentitySet": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "chatRenamedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "chatDisplayName",
+        "chatId",
+        "initiator"
+      ]
+    },
+    "chatRestrictions": {
+      "navigationProperties": [],
+      "properties": [
+        "allowTextOnly"
+      ]
+    },
+    "chatViewpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "isHidden",
+        "lastMessageReadDateTime"
+      ]
+    },
+    "choiceColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "allowTextEntry",
+        "choices",
+        "displayAs"
+      ]
+    },
+    "classifcationErrorBase": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "innerError",
+        "message",
+        "target"
+      ]
+    },
+    "classificationError": {
+      "navigationProperties": [],
+      "properties": [
+        "details"
+      ]
+    },
+    "classificationInnerError": {
+      "navigationProperties": [],
+      "properties": [
+        "activityId",
+        "clientRequestId",
+        "code",
+        "errorDateTime"
+      ]
+    },
+    "clientCertificateAuthentication": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateList"
+      ]
+    },
+    "cloudAppSecuritySessionControl": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudAppSecurityType"
+      ]
+    },
+    "cloudAppSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "destinationServiceIp",
+        "destinationServiceName",
+        "riskScore"
+      ]
+    },
+    "cloudClipboardItemPayload": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "formatName"
+      ]
+    },
+    "cloudFlareRuleModel": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "name",
+        "ruleId"
+      ]
+    },
+    "cloudFlareRulesetModel": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "phaseName",
+        "rulesetId"
+      ]
+    },
+    "cloudFlareVerifiedDetailsModel": {
+      "navigationProperties": [],
+      "properties": [
+        "enabledCustomRules",
+        "enabledRecommendedRulesets",
+        "zoneId"
+      ]
+    },
+    "cloudPcAuditActor": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationDisplayName",
+        "applicationId",
+        "ipAddress",
+        "remoteTenantId",
+        "remoteUserId",
+        "servicePrincipalName",
+        "userId",
+        "userPermissions",
+        "userPrincipalName",
+        "userRoleScopeTags"
+      ]
+    },
+    "cloudPcAuditProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "newValue",
+        "oldValue"
+      ]
+    },
+    "cloudPcAuditResource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "modifiedProperties",
+        "resourceId"
+      ]
+    },
+    "cloudPcDomainJoinConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "domainJoinType",
+        "onPremisesConnectionId",
+        "regionGroup",
+        "regionName"
+      ]
+    },
+    "cloudPcLaunchDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudPcId",
+        "cloudPcLaunchUrl",
+        "windows365SwitchCompatibilityFailureReasonType",
+        "windows365SwitchCompatible"
+      ]
+    },
+    "cloudPcManagementAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcManagementGroupAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "groupId",
+        "servicePlanId"
+      ]
+    },
+    "cloudPcOnPremisesConnectionHealthCheck": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalDetail",
+        "correlationId",
+        "displayName",
+        "endDateTime",
+        "errorType",
+        "recommendedAction",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "cloudPcOnPremisesConnectionStatusDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "healthChecks",
+        "startDateTime"
+      ]
+    },
+    "cloudPcProvisioningPolicyAutopatch": {
+      "navigationProperties": [],
+      "properties": [
+        "autopatchGroupId"
+      ]
+    },
+    "cloudPcRestorePointSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "frequencyType",
+        "userRestoreEnabled"
+      ]
+    },
+    "cloudPcSourceDeviceImage": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "resourceId",
+        "subscriptionDisplayName",
+        "subscriptionId"
+      ]
+    },
+    "cloudPcUserRoleScopeTagInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "roleScopeTagId"
+      ]
+    },
+    "cloudPcWindowsSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "locale"
+      ]
+    },
+    "coachmarkLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "length",
+        "offset",
+        "type"
+      ]
+    },
+    "collapseProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "fields",
+        "limit"
+      ]
+    },
+    "columnValidation": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultLanguage",
+        "descriptions",
+        "formula"
+      ]
+    },
+    "commentAction": {
+      "navigationProperties": [],
+      "properties": [
+        "isReply",
+        "parentAuthor",
+        "participants"
+      ]
+    },
+    "commsNotification": {
+      "navigationProperties": [],
+      "properties": [
+        "changeType",
+        "resourceUrl"
+      ]
+    },
+    "commsNotifications": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "communicationsApplicationIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationType",
+        "hidden"
+      ]
+    },
+    "communicationsApplicationInstanceIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "hidden",
+        "tenantId"
+      ]
+    },
+    "communicationsEncryptedIdentity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "communicationsGuestIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "email"
+      ]
+    },
+    "communicationsIdentitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationInstance",
+        "assertedIdentity",
+        "azureCommunicationServicesUser",
+        "encrypted",
+        "endpointType",
+        "guest",
+        "onPremises",
+        "phone"
+      ]
+    },
+    "communicationsPhoneIdentity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "communicationsUserIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "tenantId"
+      ]
+    },
+    "ComplexExtensionValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "certificationControls",
+        "certificationName"
+      ]
+    },
+    "complianceManagementPartnerAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "computeRightsAndInheritanceResult": {
+      "navigationProperties": [
+        "contentRights",
+        "inheritedLabel",
+        "sensitivityLabels"
+      ],
+      "properties": []
+    },
+    "conditionalAccessAllExternalTenants": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "conditionalAccessApplications": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationFilter",
+        "excludeApplications",
+        "includeApplications",
+        "includeAuthenticationContextClassReferences",
+        "includeUserActions"
+      ]
+    },
+    "conditionalAccessAuthenticationFlows": {
+      "navigationProperties": [],
+      "properties": [
+        "transferMethods"
+      ]
+    },
+    "conditionalAccessClientApplications": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeServicePrincipals",
+        "includeServicePrincipals",
+        "servicePrincipalFilter"
+      ]
+    },
+    "conditionalAccessConditionSet": {
+      "navigationProperties": [],
+      "properties": [
+        "applications",
+        "authenticationFlows",
+        "clientApplications",
+        "clientAppTypes",
+        "devices",
+        "insiderRiskLevels",
+        "locations",
+        "platforms",
+        "servicePrincipalRiskLevels",
+        "signInRiskLevels",
+        "userRiskLevels",
+        "users"
+      ]
+    },
+    "conditionalAccessDevices": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceFilter"
+      ]
+    },
+    "conditionalAccessEnumeratedExternalTenants": {
+      "navigationProperties": [],
+      "properties": [
+        "members"
+      ]
+    },
+    "conditionalAccessExternalTenants": {
+      "navigationProperties": [],
+      "properties": [
+        "membershipKind"
+      ]
+    },
+    "conditionalAccessFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "mode",
+        "rule"
+      ]
+    },
+    "conditionalAccessGrantControls": {
+      "navigationProperties": [
+        "authenticationStrength"
+      ],
+      "properties": [
+        "builtInControls",
+        "customAuthenticationFactors",
+        "operator",
+        "termsOfUse"
+      ]
+    },
+    "conditionalAccessGuestsOrExternalUsers": {
+      "navigationProperties": [],
+      "properties": [
+        "externalTenants",
+        "guestOrExternalUserTypes"
+      ]
+    },
+    "conditionalAccessLocations": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeLocations",
+        "includeLocations"
+      ]
+    },
+    "conditionalAccessPlatforms": {
+      "navigationProperties": [],
+      "properties": [
+        "excludePlatforms",
+        "includePlatforms"
+      ]
+    },
+    "conditionalAccessPolicyDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "conditions",
+        "grantControls",
+        "sessionControls"
+      ]
+    },
+    "conditionalAccessSessionControl": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "conditionalAccessSessionControls": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationEnforcedRestrictions",
+        "cloudAppSecurity",
+        "disableResilienceDefaults",
+        "persistentBrowser",
+        "secureSignInSession",
+        "signInFrequency"
+      ]
+    },
+    "conditionalAccessUsers": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeGroups",
+        "excludeGuestsOrExternalUsers",
+        "excludeRoles",
+        "excludeUsers",
+        "includeGroups",
+        "includeGuestsOrExternalUsers",
+        "includeRoles",
+        "includeUsers"
+      ]
+    },
+    "configurationManagerClientEnabledFeatures": {
+      "navigationProperties": [],
+      "properties": [
+        "compliancePolicy",
+        "deviceConfiguration",
+        "inventory",
+        "modernApps",
+        "resourceAccess",
+        "windowsUpdateForBusiness"
+      ]
+    },
+    "configurationManagerCollectionAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "collectionId"
+      ]
+    },
+    "connectedOrganizationMembers": {
+      "navigationProperties": [],
+      "properties": [
+        "connectedOrganizationId",
+        "description"
+      ]
+    },
+    "connectionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "url"
+      ]
+    },
+    "connectionItem": {
+      "navigationProperties": [],
+      "properties": [
+        "connectionId"
+      ]
+    },
+    "containerFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "includedContainers"
+      ]
+    },
+    "contentApprovalStatusColumn": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "contentBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "contentCustomization": {
+      "navigationProperties": [],
+      "properties": [
+        "attributeCollection",
+        "attributeCollectionRelativeUrl",
+        "registrationCampaign",
+        "registrationCampaignRelativeUrl"
+      ]
+    },
+    "contentTypeInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "name"
+      ]
+    },
+    "contentTypeOrder": {
+      "navigationProperties": [],
+      "properties": [
+        "default",
+        "position"
+      ]
+    },
+    "controlScore": {
+      "navigationProperties": [],
+      "properties": [
+        "controlCategory",
+        "controlName",
+        "description",
+        "score"
+      ]
+    },
+    "conversationMemberRoleUpdatedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "conversationMemberRoles",
+        "conversationMemberUser",
+        "initiator"
+      ]
+    },
+    "convertIdResult": {
+      "navigationProperties": [],
+      "properties": [
+        "errorDetails",
+        "sourceId",
+        "targetId"
+      ]
+    },
+    "CopyNotebookModel": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdByIdentity",
+        "createdTime",
+        "id",
+        "isDefault",
+        "isShared",
+        "lastModifiedBy",
+        "lastModifiedByIdentity",
+        "lastModifiedTime",
+        "links",
+        "name",
+        "sectionGroupsUrl",
+        "sectionsUrl",
+        "self",
+        "userRole"
+      ]
+    },
+    "createAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "crossCloudAzureActiveDirectoryTenant": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudInstance",
+        "displayName",
+        "tenantId"
+      ]
+    },
+    "crossTenantAccessPolicyAppServiceConnectSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "applications"
+      ]
+    },
+    "crossTenantAccessPolicyB2BSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "applications",
+        "usersAndGroups"
+      ]
+    },
+    "crossTenantAccessPolicyInboundTrust": {
+      "navigationProperties": [],
+      "properties": [
+        "isCompliantDeviceAccepted",
+        "isHybridAzureADJoinedDeviceAccepted",
+        "isMfaAccepted"
+      ]
+    },
+    "crossTenantAccessPolicyM365CollaborationInboundSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "users"
+      ]
+    },
+    "crossTenantAccessPolicyM365CollaborationOutboundSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "usersAndGroups"
+      ]
+    },
+    "crossTenantAccessPolicyTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "target",
+        "targetType"
+      ]
+    },
+    "crossTenantAccessPolicyTargetConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accessType",
+        "targets"
+      ]
+    },
+    "crossTenantAccessPolicyTenantRestrictions": {
+      "navigationProperties": [],
+      "properties": [
+        "devices"
+      ]
+    },
+    "crossTenantUserSyncInbound": {
+      "navigationProperties": [],
+      "properties": [
+        "isSyncAllowed"
+      ]
+    },
+    "currencyColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "locale"
+      ]
+    },
+    "customAppManagementConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customExtensionAuthenticationConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customExtensionBehaviorOnError": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customExtensionCallbackConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "timeoutDuration"
+      ]
+    },
+    "customExtensionCalloutInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "customExtensionId",
+        "detail",
+        "externalCorrelationId",
+        "id",
+        "status"
+      ]
+    },
+    "customExtensionCalloutRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "data",
+        "source",
+        "type"
+      ]
+    },
+    "customExtensionCalloutResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "data",
+        "source",
+        "type"
+      ]
+    },
+    "customExtensionClientConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumRetries",
+        "timeoutInMilliseconds"
+      ]
+    },
+    "customExtensionData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customExtensionEndpointConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customExtensionOverwriteConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "behaviorOnError",
+        "clientConfiguration"
+      ]
+    },
+    "customMetadataDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customSecurityAttributeValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "customTimeZone": {
+      "navigationProperties": [],
+      "properties": [
+        "bias",
+        "daylightOffset",
+        "standardOffset"
+      ]
+    },
+    "customTrainingSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedTo",
+        "description",
+        "displayName",
+        "durationInMinutes",
+        "url"
+      ]
+    },
+    "dataSourceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "externalItem"
+      ]
+    },
+    "dataSubject": {
+      "navigationProperties": [],
+      "properties": [
+        "email",
+        "firstName",
+        "lastName",
+        "residency"
+      ]
+    },
+    "dateTimeColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "displayAs",
+        "format"
+      ]
+    },
+    "dateTimeTimeZone": {
+      "navigationProperties": [],
+      "properties": [
+        "dateTime",
+        "timeZone"
+      ]
+    },
+    "daylightTimeZoneOffset": {
+      "navigationProperties": [],
+      "properties": [
+        "daylightBias"
+      ]
+    },
+    "defaultColumnValue": {
+      "navigationProperties": [],
+      "properties": [
+        "formula",
+        "value"
+      ]
+    },
+    "defaultInvitationRedemptionIdentityProviderConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "defaultUserRolePermissions": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedToCreateApps",
+        "allowedToCreateSecurityGroups",
+        "allowedToCreateTenants",
+        "allowedToReadBitlockerKeysForOwnedDevice",
+        "allowedToReadOtherUsers",
+        "permissionGrantPoliciesAssigned"
+      ]
+    },
+    "defenderDetectedMalwareActions": {
+      "navigationProperties": [],
+      "properties": [
+        "highSeverity",
+        "lowSeverity",
+        "moderateSeverity",
+        "severeSeverity"
+      ]
+    },
+    "delegatedAdminAccessContainer": {
+      "navigationProperties": [],
+      "properties": [
+        "accessContainerId",
+        "accessContainerType"
+      ]
+    },
+    "delegatedAdminAccessDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "unifiedRoles"
+      ]
+    },
+    "delegatedAdminRelationshipCustomerParticipant": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "tenantId"
+      ]
+    },
+    "deleteAction": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "objectType"
+      ]
+    },
+    "deleted": {
+      "navigationProperties": [],
+      "properties": [
+        "state"
+      ]
+    },
+    "deleteUserFromSharedAppleDeviceActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "userPrincipalName"
+      ]
+    },
+    "detailsInfo": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "actionName",
+        "actionState",
+        "lastUpdatedDateTime",
+        "startDateTime"
+      ]
+    },
+    "deviceAndAppManagementAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceAndAppManagementData": {
+      "navigationProperties": [],
+      "properties": [
+        "content"
+      ]
+    },
+    "deviceCompliancePolicySettingState": {
+      "navigationProperties": [],
+      "properties": [
+        "currentValue",
+        "errorCode",
+        "errorDescription",
+        "instanceDisplayName",
+        "setting",
+        "settingName",
+        "sources",
+        "state",
+        "userEmail",
+        "userId",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceConfigurationSettingState": {
+      "navigationProperties": [],
+      "properties": [
+        "currentValue",
+        "errorCode",
+        "errorDescription",
+        "instanceDisplayName",
+        "setting",
+        "settingName",
+        "sources",
+        "state",
+        "userEmail",
+        "userId",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "browser",
+        "deviceId",
+        "displayName",
+        "isCompliant",
+        "isManaged",
+        "operatingSystem",
+        "trustType"
+      ]
+    },
+    "deviceEnrollmentPlatformRestriction": {
+      "navigationProperties": [],
+      "properties": [
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "personalDeviceEnrollmentBlocked",
+        "platformBlocked"
+      ]
+    },
+    "deviceExchangeAccessStateSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedDeviceCount",
+        "blockedDeviceCount",
+        "quarantinedDeviceCount",
+        "unavailableDeviceCount",
+        "unknownDeviceCount"
+      ]
+    },
+    "deviceGeoLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "altitude",
+        "heading",
+        "horizontalAccuracy",
+        "lastCollectedDateTime",
+        "latitude",
+        "longitude",
+        "speed",
+        "verticalAccuracy"
+      ]
+    },
+    "deviceHealthAttestationState": {
+      "navigationProperties": [],
+      "properties": [
+        "attestationIdentityKey",
+        "bitLockerStatus",
+        "bootAppSecurityVersion",
+        "bootDebugging",
+        "bootManagerSecurityVersion",
+        "bootManagerVersion",
+        "bootRevisionListInfo",
+        "codeIntegrity",
+        "codeIntegrityCheckVersion",
+        "codeIntegrityPolicy",
+        "contentNamespaceUrl",
+        "contentVersion",
+        "dataExcutionPolicy",
+        "deviceHealthAttestationStatus",
+        "earlyLaunchAntiMalwareDriverProtection",
+        "healthAttestationSupportedStatus",
+        "healthStatusMismatchInfo",
+        "issuedDateTime",
+        "lastUpdateDateTime",
+        "operatingSystemKernelDebugging",
+        "operatingSystemRevListInfo",
+        "pcr0",
+        "pcrHashAlgorithm",
+        "resetCount",
+        "restartCount",
+        "safeMode",
+        "secureBoot",
+        "secureBootConfigurationPolicyFingerPrint",
+        "testSigning",
+        "tpmVersion",
+        "virtualSecureMode",
+        "windowsPE"
+      ]
+    },
+    "deviceInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "displayName",
+        "enrollmentProfileName",
+        "extensionAttribute1",
+        "extensionAttribute10",
+        "extensionAttribute11",
+        "extensionAttribute12",
+        "extensionAttribute13",
+        "extensionAttribute14",
+        "extensionAttribute15",
+        "extensionAttribute2",
+        "extensionAttribute3",
+        "extensionAttribute4",
+        "extensionAttribute5",
+        "extensionAttribute6",
+        "extensionAttribute7",
+        "extensionAttribute8",
+        "extensionAttribute9",
+        "isCompliant",
+        "manufacturer",
+        "mdmAppId",
+        "model",
+        "operatingSystem",
+        "operatingSystemVersion",
+        "ownership",
+        "physicalIds",
+        "profileType",
+        "systemLabels",
+        "trustType"
+      ]
+    },
+    "deviceLocalCredential": {
+      "navigationProperties": [],
+      "properties": [
+        "accountName",
+        "accountSid",
+        "backupDateTime",
+        "passwordBase64"
+      ]
+    },
+    "deviceManagementPartnerAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "deviceManagementSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceComplianceCheckinThresholdDays",
+        "isScheduledActionEnabled",
+        "secureByDefault"
+      ]
+    },
+    "deviceMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceType",
+        "ipAddress",
+        "operatingSystemSpecifications"
+      ]
+    },
+    "deviceOperatingSystemSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "androidCorporateWorkProfileCount",
+        "androidCount",
+        "androidDedicatedCount",
+        "androidDeviceAdminCount",
+        "androidFullyManagedCount",
+        "androidWorkProfileCount",
+        "configMgrDeviceCount",
+        "iosCount",
+        "macOSCount",
+        "unknownCount",
+        "windowsCount",
+        "windowsMobileCount"
+      ]
+    },
+    "deviceProtectionOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "cleanDeviceCount",
+        "criticalFailuresDeviceCount",
+        "inactiveThreatAgentDeviceCount",
+        "pendingFullScanDeviceCount",
+        "pendingManualStepsDeviceCount",
+        "pendingOfflineScanDeviceCount",
+        "pendingQuickScanDeviceCount",
+        "pendingRestartDeviceCount",
+        "pendingSignatureUpdateDeviceCount",
+        "totalReportedDeviceCount",
+        "unknownStateThreatAgentDeviceCount"
+      ]
+    },
+    "deviceRegistrationMembership": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "devicesFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "mode",
+        "rule"
+      ]
+    },
+    "diagnostic": {
+      "navigationProperties": [],
+      "properties": [
+        "message",
+        "url"
+      ]
+    },
+    "dictionaries": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "Dictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "disableAndDeleteUserApplyAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "displayNameLocalization": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "languageTag"
+      ]
+    },
+    "dlpActionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "action"
+      ]
+    },
+    "documentSet": {
+      "navigationProperties": [
+        "sharedColumns",
+        "welcomePageColumns"
+      ],
+      "properties": [
+        "allowedContentTypes",
+        "defaultContents",
+        "propagateWelcomePageChanges",
+        "shouldPrefixNameToFile",
+        "welcomePageUrl"
+      ]
+    },
+    "documentSetContent": {
+      "navigationProperties": [],
+      "properties": [
+        "contentType",
+        "fileName",
+        "folderName"
+      ]
+    },
+    "documentSetVersionItem": {
+      "navigationProperties": [],
+      "properties": [
+        "itemId",
+        "title",
+        "versionId"
+      ]
+    },
+    "domainIdentitySource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "domainName"
+      ]
+    },
+    "domainState": {
+      "navigationProperties": [],
+      "properties": [
+        "lastActionDateTime",
+        "operation",
+        "status"
+      ]
+    },
+    "driftedProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "currentValue",
+        "desiredValue",
+        "propertyName"
+      ]
+    },
+    "driveItemSource": {
+      "navigationProperties": [],
+      "properties": [
+        "application",
+        "externalId"
+      ]
+    },
+    "driveItemUploadableProperties": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "driveItemSource",
+        "fileSize",
+        "fileSystemInfo",
+        "mediaSource",
+        "name"
+      ]
+    },
+    "driveRecipient": {
+      "navigationProperties": [],
+      "properties": [
+        "alias",
+        "email",
+        "objectId"
+      ]
+    },
+    "dropInPlaceMode": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "edgeSearchEngine": {
+      "navigationProperties": [],
+      "properties": [
+        "edgeSearchEngineType"
+      ]
+    },
+    "edgeSearchEngineBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "edgeSearchEngineCustom": {
+      "navigationProperties": [],
+      "properties": [
+        "edgeSearchEngineOpenSearchXmlUrl"
+      ]
+    },
+    "editAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "educationAiFeedbackAudienceEngagementSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "areEngagementStrategiesEnabled",
+        "isCallToActionEnabled",
+        "isEmotionalAndIntellectualAppealEnabled"
+      ]
+    },
+    "educationAiFeedbackContentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isMessageClarityEnabled",
+        "isQualityOfInformationEnabled",
+        "isSpeechOrganizationEnabled"
+      ]
+    },
+    "educationAiFeedbackCriteria": {
+      "navigationProperties": [],
+      "properties": [
+        "aiFeedbackSettings",
+        "speechType"
+      ]
+    },
+    "educationAiFeedbackDeliverySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "areRhetoricalTechniquesEnabled",
+        "isLanguageUseEnabled",
+        "isStyleEnabled"
+      ]
+    },
+    "educationAiFeedbackSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "audienceEngagementSettings",
+        "contentSettings",
+        "deliverySettings"
+      ]
+    },
+    "educationAssignmentClassRecipient": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "educationAssignmentGrade": {
+      "navigationProperties": [],
+      "properties": [
+        "gradedBy",
+        "gradedDateTime"
+      ]
+    },
+    "educationAssignmentGradeType": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "educationAssignmentGroupRecipient": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "educationAssignmentIndividualRecipient": {
+      "navigationProperties": [],
+      "properties": [
+        "recipients"
+      ]
+    },
+    "educationAssignmentPointsGrade": {
+      "navigationProperties": [],
+      "properties": [
+        "points"
+      ]
+    },
+    "educationAssignmentPointsGradeType": {
+      "navigationProperties": [],
+      "properties": [
+        "maxPoints"
+      ]
+    },
+    "educationAssignmentRecipient": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "educationChannelResource": {
+      "navigationProperties": [],
+      "properties": [
+        "url"
+      ]
+    },
+    "educationCourse": {
+      "navigationProperties": [],
+      "properties": [
+        "courseNumber",
+        "description",
+        "displayName",
+        "externalId",
+        "subject"
+      ]
+    },
+    "educationExcelResource": {
+      "navigationProperties": [],
+      "properties": [
+        "fileUrl"
+      ]
+    },
+    "educationExternalResource": {
+      "navigationProperties": [],
+      "properties": [
+        "webUrl"
+      ]
+    },
+    "educationFeedback": {
+      "navigationProperties": [],
+      "properties": [
+        "feedbackBy",
+        "feedbackDateTime",
+        "text"
+      ]
+    },
+    "educationFileResource": {
+      "navigationProperties": [],
+      "properties": [
+        "fileUrl"
+      ]
+    },
+    "educationGradingSchemeGrade": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultPercentage",
+        "displayName",
+        "minPercentage"
+      ]
+    },
+    "educationItemBody": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "contentType"
+      ]
+    },
+    "educationLinkedAssignmentResource": {
+      "navigationProperties": [],
+      "properties": [
+        "url"
+      ]
+    },
+    "educationLinkResource": {
+      "navigationProperties": [],
+      "properties": [
+        "link"
+      ]
+    },
+    "educationMediaResource": {
+      "navigationProperties": [],
+      "properties": [
+        "fileUrl"
+      ]
+    },
+    "educationOnPremisesInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "immutableId"
+      ]
+    },
+    "educationPowerPointResource": {
+      "navigationProperties": [],
+      "properties": [
+        "fileUrl"
+      ]
+    },
+    "educationResource": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "educationSpeakerCoachAudienceEngagementSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isBodyLanguageEnabled"
+      ]
+    },
+    "educationSpeakerCoachContentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isInclusivenessEnabled",
+        "isRepetitiveLanguageEnabled"
+      ]
+    },
+    "educationSpeakerCoachDeliverySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "areFillerWordsEnabled",
+        "isPaceEnabled",
+        "isPitchEnabled",
+        "isPronunciationEnabled"
+      ]
+    },
+    "educationSpeakerCoachSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "audienceEngagementSettings",
+        "contentSettings",
+        "deliverySettings"
+      ]
+    },
+    "educationSpeakerProgressResource": {
+      "navigationProperties": [],
+      "properties": [
+        "aiFeedbackCriteria",
+        "isAiFeedbackEnabled",
+        "isVideoRequired",
+        "maxRecordingAttempts",
+        "presentationTitle",
+        "recordingTimeLimitInMinutes",
+        "showRehearsalReportToStudentBeforeMediaUpload",
+        "speakerCoachSettings",
+        "spokenLanguageLocale"
+      ]
+    },
+    "educationStudent": {
+      "navigationProperties": [],
+      "properties": [
+        "birthDate",
+        "externalId",
+        "gender",
+        "grade",
+        "graduationYear",
+        "studentNumber"
+      ]
+    },
+    "educationSubmissionIndividualRecipient": {
+      "navigationProperties": [],
+      "properties": [
+        "userId"
+      ]
+    },
+    "educationSubmissionRecipient": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "educationTeacher": {
+      "navigationProperties": [],
+      "properties": [
+        "externalId",
+        "teacherNumber"
+      ]
+    },
+    "educationTeamsAppResource": {
+      "navigationProperties": [],
+      "properties": [
+        "appIconWebUrl",
+        "appId",
+        "teamsEmbeddedContentUrl",
+        "webUrl"
+      ]
+    },
+    "educationTerm": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "endDate",
+        "externalId",
+        "startDate"
+      ]
+    },
+    "educationWordResource": {
+      "navigationProperties": [],
+      "properties": [
+        "fileUrl"
+      ]
+    },
+    "emailAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "name"
+      ]
+    },
+    "emailIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "email"
+      ]
+    },
+    "emailPayloadDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "fromEmail",
+        "fromName",
+        "isExternalSender",
+        "subject"
+      ]
+    },
+    "emailSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "senderDomain",
+        "useCompanyBranding"
+      ]
+    },
+    "emergencyCallerInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "location",
+        "phoneNumber",
+        "tenantId",
+        "upn"
+      ]
+    },
+    "employeeOrgData": {
+      "navigationProperties": [],
+      "properties": [
+        "costCenter",
+        "division"
+      ]
+    },
+    "endUserNotificationSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "notificationPreference",
+        "positiveReinforcement",
+        "settingType"
+      ]
+    },
+    "engagementIdentitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "audience",
+        "group"
+      ]
+    },
+    "entitlementManagementSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "expiration",
+        "recurrence",
+        "startDateTime"
+      ]
+    },
+    "enumeratedDeviceRegistrationMembership": {
+      "navigationProperties": [],
+      "properties": [
+        "groups",
+        "users"
+      ]
+    },
+    "enumeratedScopes": {
+      "navigationProperties": [],
+      "properties": [
+        "scopes"
+      ]
+    },
+    "errorDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "errorMessage",
+        "resourceInstanceName",
+        "resourceType"
+      ]
+    },
+    "eventMessageDetail": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "excludeTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "targetType"
+      ]
+    },
+    "exclusionGroupAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "expirationPattern": {
+      "navigationProperties": [],
+      "properties": [
+        "duration",
+        "endDateTime",
+        "type"
+      ]
+    },
+    "exportItemResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "changeKey",
+        "data",
+        "error",
+        "itemId"
+      ]
+    },
+    "expressionInputObject": {
+      "navigationProperties": [],
+      "properties": [
+        "definition",
+        "properties"
+      ]
+    },
+    "extensionSchemaProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "type"
+      ]
+    },
+    "externalDomainFederation": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "domainName",
+        "issuerUri"
+      ]
+    },
+    "externalItemConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "connections"
+      ]
+    },
+    "externalLink": {
+      "navigationProperties": [],
+      "properties": [
+        "href"
+      ]
+    },
+    "externalSponsors": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "extractSensitivityLabelsResult": {
+      "navigationProperties": [],
+      "properties": [
+        "labels"
+      ]
+    },
+    "fallbackToMicrosoftProviderOnError": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "featureTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "targetType"
+      ]
+    },
+    "fido2KeyRestrictions": {
+      "navigationProperties": [],
+      "properties": [
+        "aaGuids",
+        "enforcementType",
+        "isEnforced"
+      ]
+    },
+    "file": {
+      "navigationProperties": [],
+      "properties": [
+        "hashes",
+        "mimeType",
+        "processingMetadata"
+      ]
+    },
+    "fileEncryptionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "encryptionKey",
+        "fileDigest",
+        "fileDigestAlgorithm",
+        "initializationVector",
+        "mac",
+        "macKey",
+        "profileIdentifier"
+      ]
+    },
+    "fileHash": {
+      "navigationProperties": [],
+      "properties": [
+        "hashType",
+        "hashValue"
+      ]
+    },
+    "fileSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "fileHash",
+        "name",
+        "path",
+        "riskScore"
+      ]
+    },
+    "fileStorageContainerCustomPropertyDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "fileStorageContainerCustomPropertyValue": {
+      "navigationProperties": [],
+      "properties": [
+        "isSearchable",
+        "value"
+      ]
+    },
+    "fileStorageContainerSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isItemVersioningEnabled",
+        "isOcrEnabled",
+        "itemMajorVersionLimit"
+      ]
+    },
+    "fileStorageContainerTypeRegistrationSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isDiscoverabilityEnabled",
+        "isItemVersioningEnabled",
+        "isSearchEnabled",
+        "isSharingRestricted",
+        "itemMajorVersionLimit",
+        "maxStoragePerContainerInBytes",
+        "sharingCapability",
+        "urlTemplate"
+      ]
+    },
+    "fileStorageContainerTypeSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "consumingTenantOverridables",
+        "isDiscoverabilityEnabled",
+        "isItemVersioningEnabled",
+        "isSearchEnabled",
+        "isSharingRestricted",
+        "itemMajorVersionLimit",
+        "maxStoragePerContainerInBytes",
+        "sharingCapability",
+        "urlTemplate"
+      ]
+    },
+    "fileStorageContainerViewpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "effectiveRole"
+      ]
+    },
+    "fileSystemInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastAccessedDateTime",
+        "lastModifiedDateTime"
+      ]
+    },
+    "filter": {
+      "navigationProperties": [],
+      "properties": [
+        "categoryFilterGroups",
+        "groups",
+        "inputFilterGroups"
+      ]
+    },
+    "filterClause": {
+      "navigationProperties": [],
+      "properties": [
+        "operatorName",
+        "sourceOperandName",
+        "targetOperand"
+      ]
+    },
+    "filterGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "clauses",
+        "name"
+      ]
+    },
+    "filterOperand": {
+      "navigationProperties": [],
+      "properties": [
+        "values"
+      ]
+    },
+    "folder": {
+      "navigationProperties": [],
+      "properties": [
+        "childCount",
+        "view"
+      ]
+    },
+    "folderView": {
+      "navigationProperties": [],
+      "properties": [
+        "sortBy",
+        "sortOrder",
+        "viewType"
+      ]
+    },
+    "followupFlag": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "dueDateTime",
+        "flagStatus",
+        "startDateTime"
+      ]
+    },
+    "fraudProtectionConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "fraudProtectionProviderConfiguration": {
+      "navigationProperties": [
+        "fraudProtectionProvider"
+      ],
+      "properties": []
+    },
+    "freeBusyError": {
+      "navigationProperties": [],
+      "properties": [
+        "message",
+        "responseCode"
+      ]
+    },
+    "genericError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message"
+      ]
+    },
+    "geoCoordinates": {
+      "navigationProperties": [],
+      "properties": [
+        "altitude",
+        "latitude",
+        "longitude"
+      ]
+    },
+    "geolocationColumn": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "groupAssignmentTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "groupId"
+      ]
+    },
+    "groupFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "includedGroups"
+      ]
+    },
+    "groupMembers": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "groupId"
+      ]
+    },
+    "groupPeerOutlierRecommendationInsightSettings": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "groupScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "hashes": {
+      "navigationProperties": [],
+      "properties": [
+        "crc32Hash",
+        "quickXorHash",
+        "sha1Hash",
+        "sha256Hash"
+      ]
+    },
+    "hostSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "fqdn",
+        "isAzureAdJoined",
+        "isAzureAdRegistered",
+        "isHybridAzureDomainJoined",
+        "netBiosName",
+        "os",
+        "privateIpAddress",
+        "publicIpAddress",
+        "riskScore"
+      ]
+    },
+    "httpRequestEndpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "targetUrl"
+      ]
+    },
+    "hyperlinkOrPictureColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "isPicture"
+      ]
+    },
+    "identity": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "id"
+      ]
+    },
+    "identitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "application",
+        "device",
+        "user"
+      ]
+    },
+    "identitySource": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "idleSessionSignOut": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "signOutAfterInSeconds",
+        "warnAfterInSeconds"
+      ]
+    },
+    "image": {
+      "navigationProperties": [],
+      "properties": [
+        "height",
+        "width"
+      ]
+    },
+    "imageInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "addImageQuery",
+        "alternateText",
+        "alternativeText",
+        "iconUrl"
+      ]
+    },
+    "implicitGrantSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "enableAccessTokenIssuance",
+        "enableIdTokenIssuance"
+      ]
+    },
+    "importBuildingMapSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "isDryRun"
+      ]
+    },
+    "importedWindowsAutopilotDeviceIdentityState": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceErrorCode",
+        "deviceErrorName",
+        "deviceImportStatus",
+        "deviceRegistrationId"
+      ]
+    },
+    "inboundOutboundPolicyConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "inboundAllowed",
+        "outboundAllowed"
+      ]
+    },
+    "includeAllAccountTargetContent": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "includeTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "targetType"
+      ]
+    },
+    "incomingCallOptions": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "incomingContext": {
+      "navigationProperties": [],
+      "properties": [
+        "observedParticipantId",
+        "onBehalfOf",
+        "sourceParticipantId",
+        "transferor"
+      ]
+    },
+    "incompleteData": {
+      "navigationProperties": [],
+      "properties": [
+        "missingDataBeforeDateTime",
+        "wasThrottled"
+      ]
+    },
+    "informationalUrl": {
+      "navigationProperties": [],
+      "properties": [
+        "logoUrl",
+        "marketingUrl",
+        "privacyStatementUrl",
+        "supportUrl",
+        "termsOfServiceUrl"
+      ]
+    },
+    "inheritableScopes": {
+      "navigationProperties": [],
+      "properties": [
+        "kind"
+      ]
+    },
+    "initiator": {
+      "navigationProperties": [],
+      "properties": [
+        "initiatorType"
+      ]
+    },
+    "insightIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "displayName",
+        "id"
+      ]
+    },
+    "insightValueDouble": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "insightValueInt": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "instanceResourceAccess": {
+      "navigationProperties": [],
+      "properties": [
+        "permissions",
+        "resourceAppId"
+      ]
+    },
+    "integerRange": {
+      "navigationProperties": [],
+      "properties": [
+        "end",
+        "start"
+      ]
+    },
+    "integratedApplicationMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "version"
+      ]
+    },
+    "internalSponsors": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "internetMessageHeader": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "value"
+      ]
+    },
+    "intuneBrand": {
+      "navigationProperties": [],
+      "properties": [
+        "contactITEmailAddress",
+        "contactITName",
+        "contactITNotes",
+        "contactITPhoneNumber",
+        "darkBackgroundLogo",
+        "displayName",
+        "lightBackgroundLogo",
+        "onlineSupportSiteName",
+        "onlineSupportSiteUrl",
+        "privacyUrl",
+        "showDisplayNameNextToLogo",
+        "showLogo",
+        "showNameNextToLogo",
+        "themeColor"
+      ]
+    },
+    "investigationSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "status"
+      ]
+    },
+    "invitationParticipantInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "hidden",
+        "identity",
+        "participantId",
+        "removeFromDefaultAudioRoutingGroup",
+        "replacesCallId"
+      ]
+    },
+    "invitationRedemptionIdentityProviderConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "fallbackIdentityProvider",
+        "primaryIdentityProviderPrecedenceOrder"
+      ]
+    },
+    "invitedUserMessageInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "ccRecipients",
+        "customizedMessageBody",
+        "messageLanguage"
+      ]
+    },
+    "inviteNewBotResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "inviteUri"
+      ]
+    },
+    "iosDeviceType": {
+      "navigationProperties": [],
+      "properties": [
+        "iPad",
+        "iPhoneAndIPod"
+      ]
+    },
+    "iosHomeScreenApp": {
+      "navigationProperties": [],
+      "properties": [
+        "bundleID"
+      ]
+    },
+    "iosHomeScreenFolder": {
+      "navigationProperties": [],
+      "properties": [
+        "pages"
+      ]
+    },
+    "iosHomeScreenFolderPage": {
+      "navigationProperties": [],
+      "properties": [
+        "apps",
+        "displayName"
+      ]
+    },
+    "iosHomeScreenItem": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "iosHomeScreenPage": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "icons"
+      ]
+    },
+    "iosLobAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isRemovable",
+        "uninstallOnDeviceRemoval",
+        "vpnConfigurationId"
+      ]
+    },
+    "iosMinimumOperatingSystem": {
+      "navigationProperties": [],
+      "properties": [
+        "v10_0",
+        "v11_0",
+        "v12_0",
+        "v13_0",
+        "v14_0",
+        "v15_0",
+        "v8_0",
+        "v9_0"
+      ]
+    },
+    "iosMobileAppIdentifier": {
+      "navigationProperties": [],
+      "properties": [
+        "bundleId"
+      ]
+    },
+    "iosNetworkUsageRule": {
+      "navigationProperties": [],
+      "properties": [
+        "cellularDataBlocked",
+        "cellularDataBlockWhenRoaming",
+        "managedApps"
+      ]
+    },
+    "iosNotificationSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "alertType",
+        "appName",
+        "badgesEnabled",
+        "bundleID",
+        "enabled",
+        "publisher",
+        "showInNotificationCenter",
+        "showOnLockScreen",
+        "soundsEnabled"
+      ]
+    },
+    "iosStoreAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isRemovable",
+        "uninstallOnDeviceRemoval",
+        "vpnConfigurationId"
+      ]
+    },
+    "iosVppAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "useDeviceLicensing",
+        "vpnConfigurationId"
+      ]
+    },
+    "ipRange": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "iPv4CidrRange": {
+      "navigationProperties": [],
+      "properties": [
+        "cidrAddress"
+      ]
+    },
+    "iPv4Range": {
+      "navigationProperties": [],
+      "properties": [
+        "lowerAddress",
+        "upperAddress"
+      ]
+    },
+    "iPv6CidrRange": {
+      "navigationProperties": [],
+      "properties": [
+        "cidrAddress"
+      ]
+    },
+    "iPv6Range": {
+      "navigationProperties": [],
+      "properties": [
+        "lowerAddress",
+        "upperAddress"
+      ]
+    },
+    "itemActionStat": {
+      "navigationProperties": [],
+      "properties": [
+        "actionCount",
+        "actorCount"
+      ]
+    },
+    "itemBody": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "contentType"
+      ]
+    },
+    "itemPreviewInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "getUrl",
+        "postParameters",
+        "postUrl"
+      ]
+    },
+    "itemReference": {
+      "navigationProperties": [],
+      "properties": [
+        "driveId",
+        "driveType",
+        "id",
+        "name",
+        "path",
+        "shareId",
+        "sharepointIds",
+        "siteId"
+      ]
+    },
+    "joinMeetingIdMeetingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "joinMeetingId",
+        "passcode"
+      ]
+    },
+    "joinMeetingIdSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isPasscodeRequired",
+        "joinMeetingId",
+        "passcode"
+      ]
+    },
+    "Json": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "keyCredential": {
+      "navigationProperties": [],
+      "properties": [
+        "customKeyIdentifier",
+        "displayName",
+        "endDateTime",
+        "key",
+        "keyId",
+        "startDateTime",
+        "type",
+        "usage"
+      ]
+    },
+    "keyCredentialConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "maxLifetime",
+        "restrictForAppsCreatedAfterDateTime",
+        "restrictionType",
+        "state"
+      ]
+    },
+    "keyValue": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "keyValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "value"
+      ]
+    },
+    "licenseAssignmentState": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedByGroup",
+        "disabledPlans",
+        "error",
+        "lastUpdatedDateTime",
+        "skuId",
+        "state"
+      ]
+    },
+    "licenseProcessingState": {
+      "navigationProperties": [],
+      "properties": [
+        "state"
+      ]
+    },
+    "licenseUnitsDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "enabled",
+        "lockedOut",
+        "suspended",
+        "warning"
+      ]
+    },
+    "listInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "contentTypesEnabled",
+        "hidden",
+        "template"
+      ]
+    },
+    "lobbyBypassSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isDialInBypassEnabled",
+        "scope"
+      ]
+    },
+    "localAdminPasswordSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "localAdminSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "enableGlobalAdmins",
+        "registeringUsers"
+      ]
+    },
+    "localeInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "locale"
+      ]
+    },
+    "locateDeviceActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceLocation"
+      ]
+    },
+    "location": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "coordinates",
+        "displayName",
+        "locationEmailAddress",
+        "locationType",
+        "locationUri",
+        "uniqueId",
+        "uniqueIdType"
+      ]
+    },
+    "locationConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "isRequired",
+        "locations",
+        "suggestLocation"
+      ]
+    },
+    "locationConstraintItem": {
+      "navigationProperties": [],
+      "properties": [
+        "resolveAvailability"
+      ]
+    },
+    "logicAppTriggerEndpointConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "logicAppWorkflowName",
+        "resourceGroupName",
+        "subscriptionId",
+        "url"
+      ]
+    },
+    "loginPageLayoutConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isFooterShown",
+        "isHeaderShown",
+        "layoutTemplateType"
+      ]
+    },
+    "loginPageTextVisibilitySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "hideAccountResetCredentials",
+        "hideCannotAccessYourAccount",
+        "hideForgotMyPassword",
+        "hidePrivacyAndCookies",
+        "hideResetItNow",
+        "hideTermsOfUse"
+      ]
+    },
+    "lookupColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "allowMultipleValues",
+        "allowUnlimitedLength",
+        "columnName",
+        "listId",
+        "primaryLookupColumnId"
+      ]
+    },
+    "macOSIncludedApp": {
+      "navigationProperties": [],
+      "properties": [
+        "bundleId",
+        "bundleVersion"
+      ]
+    },
+    "macOsLobAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "uninstallOnDeviceRemoval"
+      ]
+    },
+    "macOSLobChildApp": {
+      "navigationProperties": [],
+      "properties": [
+        "buildNumber",
+        "bundleId",
+        "versionNumber"
+      ]
+    },
+    "macOSMinimumOperatingSystem": {
+      "navigationProperties": [],
+      "properties": [
+        "v10_10",
+        "v10_11",
+        "v10_12",
+        "v10_13",
+        "v10_14",
+        "v10_15",
+        "v10_7",
+        "v10_8",
+        "v10_9",
+        "v11_0",
+        "v12_0",
+        "v13_0"
+      ]
+    },
+    "mailboxDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "emailAddress",
+        "externalDirectoryObjectId"
+      ]
+    },
+    "mailboxItemImportSession": {
+      "navigationProperties": [],
+      "properties": [
+        "expirationDateTime",
+        "importUrl"
+      ]
+    },
+    "mailboxSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "archiveFolder",
+        "automaticRepliesSetting",
+        "dateFormat",
+        "delegateMeetingMessageDeliveryOptions",
+        "language",
+        "timeFormat",
+        "timeZone",
+        "userPurpose",
+        "workingHours"
+      ]
+    },
+    "mailTips": {
+      "navigationProperties": [],
+      "properties": [
+        "automaticReplies",
+        "customMailTip",
+        "deliveryRestricted",
+        "emailAddress",
+        "error",
+        "externalMemberCount",
+        "isModerated",
+        "mailboxFull",
+        "maxMessageSize",
+        "recipientScope",
+        "recipientSuggestions",
+        "totalMemberCount"
+      ]
+    },
+    "mailTipsError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message"
+      ]
+    },
+    "malware": {
+      "navigationProperties": [],
+      "properties": [
+        "description"
+      ]
+    },
+    "malwareState": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "family",
+        "name",
+        "severity",
+        "wasRunning"
+      ]
+    },
+    "managedAppDiagnosticStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "mitigationInstruction",
+        "state",
+        "validationName"
+      ]
+    },
+    "managedAppPolicyDeploymentSummaryPerApp": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationAppliedUserCount",
+        "mobileAppIdentifier"
+      ]
+    },
+    "mediaConfig": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mediaContentRatingAustralia": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingCanada": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingFrance": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingGermany": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingIreland": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingJapan": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingNewZealand": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingUnitedKingdom": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaContentRatingUnitedStates": {
+      "navigationProperties": [],
+      "properties": [
+        "movieRating",
+        "tvRating"
+      ]
+    },
+    "mediaInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceId",
+        "uri"
+      ]
+    },
+    "mediaPrompt": {
+      "navigationProperties": [],
+      "properties": [
+        "mediaInfo"
+      ]
+    },
+    "mediaSource": {
+      "navigationProperties": [],
+      "properties": [
+        "contentCategory"
+      ]
+    },
+    "mediaStream": {
+      "navigationProperties": [],
+      "properties": [
+        "direction",
+        "label",
+        "mediaType",
+        "serverMuted",
+        "sourceId"
+      ]
+    },
+    "meetingInfo": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "meetingNote": {
+      "navigationProperties": [],
+      "properties": [
+        "subpoints",
+        "text",
+        "title"
+      ]
+    },
+    "meetingNoteSubpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "text",
+        "title"
+      ]
+    },
+    "meetingParticipantInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "identity",
+        "role",
+        "upn"
+      ]
+    },
+    "meetingParticipants": {
+      "navigationProperties": [],
+      "properties": [
+        "attendees",
+        "organizer"
+      ]
+    },
+    "meetingPolicyUpdatedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "meetingChatEnabled",
+        "meetingChatId"
+      ]
+    },
+    "meetingTimeSuggestion": {
+      "navigationProperties": [],
+      "properties": [
+        "attendeeAvailability",
+        "confidence",
+        "locations",
+        "meetingTimeSlot",
+        "order",
+        "organizerAvailability",
+        "suggestionReason"
+      ]
+    },
+    "meetingTimeSuggestionsResult": {
+      "navigationProperties": [],
+      "properties": [
+        "emptySuggestionsReason",
+        "meetingTimeSuggestions"
+      ]
+    },
+    "membersAddedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "members",
+        "visibleHistoryStartDateTime"
+      ]
+    },
+    "membersDeletedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "members"
+      ]
+    },
+    "membersJoinedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "members"
+      ]
+    },
+    "membersLeftEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "members"
+      ]
+    },
+    "mentionAction": {
+      "navigationProperties": [],
+      "properties": [
+        "mentionees"
+      ]
+    },
+    "mentionEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "eventDateTime",
+        "speaker",
+        "transcriptUtterance"
+      ]
+    },
+    "messagePinnedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "eventDateTime",
+        "initiator"
+      ]
+    },
+    "messageRuleActions": {
+      "navigationProperties": [],
+      "properties": [
+        "assignCategories",
+        "copyToFolder",
+        "delete",
+        "forwardAsAttachmentTo",
+        "forwardTo",
+        "markAsRead",
+        "markImportance",
+        "moveToFolder",
+        "permanentDelete",
+        "redirectTo",
+        "stopProcessingRules"
+      ]
+    },
+    "messageRulePredicates": {
+      "navigationProperties": [],
+      "properties": [
+        "bodyContains",
+        "bodyOrSubjectContains",
+        "categories",
+        "fromAddresses",
+        "hasAttachments",
+        "headerContains",
+        "importance",
+        "isApprovalRequest",
+        "isAutomaticForward",
+        "isAutomaticReply",
+        "isEncrypted",
+        "isMeetingRequest",
+        "isMeetingResponse",
+        "isNonDeliveryReport",
+        "isPermissionControlled",
+        "isReadReceipt",
+        "isSigned",
+        "isVoicemail",
+        "messageActionFlag",
+        "notSentToMe",
+        "recipientContains",
+        "senderContains",
+        "sensitivity",
+        "sentCcMe",
+        "sentOnlyToMe",
+        "sentToAddresses",
+        "sentToMe",
+        "sentToOrCcMe",
+        "subjectContains",
+        "withinSizeRange"
+      ]
+    },
+    "messageSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "connectingIP",
+        "deliveryAction",
+        "deliveryLocation",
+        "directionality",
+        "internetMessageId",
+        "messageFingerprint",
+        "messageReceivedDateTime",
+        "messageSubject",
+        "networkMessageId"
+      ]
+    },
+    "messageUnpinnedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "eventDateTime",
+        "initiator"
+      ]
+    },
+    "metaDataKeyStringPair": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "metaDataKeyValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "microsoftAuthenticatorFeatureSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "displayAppInformationRequiredState",
+        "displayLocationInformationRequiredState"
+      ]
+    },
+    "microsoftCustomTrainingSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "completionDateTime",
+        "trainingAssignmentMappings",
+        "trainingCompletionDuration"
+      ]
+    },
+    "microsoftManagedDesktop": {
+      "navigationProperties": [],
+      "properties": [
+        "managedType",
+        "profile"
+      ]
+    },
+    "microsoftManagedTrainingSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "completionDateTime",
+        "trainingCompletionDuration"
+      ]
+    },
+    "microsoftStoreForBusinessAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "useDeviceContext"
+      ]
+    },
+    "microsoftTrainingAssignmentMapping": {
+      "navigationProperties": [
+        "training"
+      ],
+      "properties": [
+        "assignedTo"
+      ]
+    },
+    "mimeContent": {
+      "navigationProperties": [],
+      "properties": [
+        "type",
+        "value"
+      ]
+    },
+    "mobileAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mobileAppIdentifier": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mobileAppInstallTimeSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "deadlineDateTime",
+        "startDateTime",
+        "useLocalTime"
+      ]
+    },
+    "modifiedProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "newValue",
+        "oldValue"
+      ]
+    },
+    "moveAction": {
+      "navigationProperties": [],
+      "properties": [
+        "from",
+        "to"
+      ]
+    },
+    "multiTenantOrganizationJoinRequestTransitionDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "desiredMemberState",
+        "details",
+        "status"
+      ]
+    },
+    "multiTenantOrganizationMemberTransitionDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "desiredRole",
+        "desiredState",
+        "details",
+        "status"
+      ]
+    },
+    "networkConnection": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationName",
+        "destinationAddress",
+        "destinationDomain",
+        "destinationLocation",
+        "destinationPort",
+        "destinationUrl",
+        "direction",
+        "domainRegisteredDateTime",
+        "localDnsName",
+        "natDestinationAddress",
+        "natDestinationPort",
+        "natSourceAddress",
+        "natSourcePort",
+        "protocol",
+        "riskScore",
+        "sourceAddress",
+        "sourceLocation",
+        "sourcePort",
+        "status",
+        "urlParameters"
+      ]
+    },
+    "noDeviceRegistrationMembership": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "noScopes": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "notebookLinks": {
+      "navigationProperties": [],
+      "properties": [
+        "oneNoteClientUrl",
+        "oneNoteWebUrl"
+      ]
+    },
+    "noTrainingNotificationSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "simulationNotification"
+      ]
+    },
+    "noTrainingSetting": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "numberColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "decimalPlaces",
+        "displayAs",
+        "maximum",
+        "minimum"
+      ]
+    },
+    "oAuthConsentAppDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "appScope",
+        "displayLogo",
+        "displayName"
+      ]
+    },
+    "objectDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "attributes",
+        "metadata",
+        "name",
+        "supportedApis"
+      ]
+    },
+    "objectDefinitionMetadataEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "objectIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "issuer",
+        "issuerAssignedId",
+        "signInType"
+      ]
+    },
+    "objectMapping": {
+      "navigationProperties": [],
+      "properties": [
+        "attributeMappings",
+        "enabled",
+        "flowTypes",
+        "metadata",
+        "name",
+        "scope",
+        "sourceObjectName",
+        "targetObjectName"
+      ]
+    },
+    "objectMappingMetadataEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "oidcAddressInboundClaims": {
+      "navigationProperties": [],
+      "properties": [
+        "country",
+        "locality",
+        "postal_code",
+        "region",
+        "street_address"
+      ]
+    },
+    "oidcClientAuthentication": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "oidcClientSecretAuthentication": {
+      "navigationProperties": [],
+      "properties": [
+        "clientSecret"
+      ]
+    },
+    "oidcInboundClaimMappingOverride": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "email",
+        "email_verified",
+        "family_name",
+        "given_name",
+        "name",
+        "phone_number",
+        "phone_number_verified",
+        "sub"
+      ]
+    },
+    "oidcPrivateJwtKeyClientAuthentication": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "omaSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "omaUri"
+      ]
+    },
+    "omaSettingBase64": {
+      "navigationProperties": [],
+      "properties": [
+        "fileName",
+        "value"
+      ]
+    },
+    "omaSettingBoolean": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "omaSettingDateTime": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "omaSettingFloatingPoint": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "omaSettingInteger": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "omaSettingString": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "omaSettingStringXml": {
+      "navigationProperties": [],
+      "properties": [
+        "fileName",
+        "value"
+      ]
+    },
+    "onAttributeCollectionExternalUsersSelfServiceSignUp": {
+      "navigationProperties": [
+        "attributes"
+      ],
+      "properties": [
+        "attributeCollectionPage"
+      ]
+    },
+    "onAttributeCollectionHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onAttributeCollectionStartCustomExtensionHandler": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "configuration"
+      ]
+    },
+    "onAttributeCollectionStartHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onAttributeCollectionSubmitCustomExtensionHandler": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "configuration"
+      ]
+    },
+    "onAttributeCollectionSubmitHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onAuthenticationMethodLoadStartExternalUsersSelfServiceSignUp": {
+      "navigationProperties": [
+        "identityProviders"
+      ],
+      "properties": []
+    },
+    "onAuthenticationMethodLoadStartHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onenoteOperationError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message"
+      ]
+    },
+    "onenotePagePreview": {
+      "navigationProperties": [],
+      "properties": [
+        "links",
+        "previewText"
+      ]
+    },
+    "onenotePagePreviewLinks": {
+      "navigationProperties": [],
+      "properties": [
+        "previewImageUrl"
+      ]
+    },
+    "onenotePatchContentCommand": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "content",
+        "position",
+        "target"
+      ]
+    },
+    "onFraudProtectionLoadStartExternalUsersAuthHandler": {
+      "navigationProperties": [],
+      "properties": [
+        "signUp"
+      ]
+    },
+    "onFraudProtectionLoadStartHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onInteractiveAuthFlowStartExternalUsersSelfServiceSignUp": {
+      "navigationProperties": [],
+      "properties": [
+        "isSignUpAllowed"
+      ]
+    },
+    "onInteractiveAuthFlowStartHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onlineMeetingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "conferenceId",
+        "joinUrl",
+        "phones",
+        "quickDial",
+        "tollFreeNumbers",
+        "tollNumber"
+      ]
+    },
+    "onlineMeetingRestricted": {
+      "navigationProperties": [],
+      "properties": [
+        "contentSharingDisabled",
+        "videoDisabled"
+      ]
+    },
+    "onlineMeetingSensitivityLabelAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "sensitivityLabelId"
+      ]
+    },
+    "onOtpSendCustomExtensionHandler": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "configuration"
+      ]
+    },
+    "onOtpSendHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onPasswordMigrationCustomExtensionHandler": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "configuration",
+        "migrationPropertyId"
+      ]
+    },
+    "onPasswordSubmitHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onPremisesAccidentalDeletionPrevention": {
+      "navigationProperties": [],
+      "properties": [
+        "alertThreshold",
+        "synchronizationPreventionType"
+      ]
+    },
+    "onPremisesDirectorySynchronizationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accidentalDeletionPrevention"
+      ]
+    },
+    "onPremisesDirectorySynchronizationFeature": {
+      "navigationProperties": [],
+      "properties": [
+        "blockCloudObjectTakeoverThroughHardMatchEnabled",
+        "blockSoftMatchEnabled",
+        "bypassDirSyncOverridesEnabled",
+        "cloudPasswordPolicyForPasswordSyncedUsersEnabled",
+        "concurrentCredentialUpdateEnabled",
+        "concurrentOrgIdProvisioningEnabled",
+        "deviceWritebackEnabled",
+        "directoryExtensionsEnabled",
+        "fopeConflictResolutionEnabled",
+        "groupWriteBackEnabled",
+        "passwordSyncEnabled",
+        "passwordWritebackEnabled",
+        "quarantineUponProxyAddressesConflictEnabled",
+        "quarantineUponUpnConflictEnabled",
+        "softMatchOnUpnEnabled",
+        "synchronizeUpnForManagedUsersEnabled",
+        "unifiedGroupWritebackEnabled",
+        "userForcePasswordChangeOnLogonEnabled",
+        "userWritebackEnabled"
+      ]
+    },
+    "onPremisesExtensionAttributes": {
+      "navigationProperties": [],
+      "properties": [
+        "extensionAttribute1",
+        "extensionAttribute10",
+        "extensionAttribute11",
+        "extensionAttribute12",
+        "extensionAttribute13",
+        "extensionAttribute14",
+        "extensionAttribute15",
+        "extensionAttribute2",
+        "extensionAttribute3",
+        "extensionAttribute4",
+        "extensionAttribute5",
+        "extensionAttribute6",
+        "extensionAttribute7",
+        "extensionAttribute8",
+        "extensionAttribute9"
+      ]
+    },
+    "onPremisesProvisioningError": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "occurredDateTime",
+        "propertyCausingError",
+        "value"
+      ]
+    },
+    "onTokenIssuanceStartCustomExtensionHandler": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "configuration"
+      ]
+    },
+    "onTokenIssuanceStartHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onTokenIssuanceStartReturnClaim": {
+      "navigationProperties": [],
+      "properties": [
+        "claimIdInApiResponse"
+      ]
+    },
+    "onUserCreateStartExternalUsersSelfServiceSignUp": {
+      "navigationProperties": [],
+      "properties": [
+        "userTypeToCreate"
+      ]
+    },
+    "onUserCreateStartHandler": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "openComplexDictionaryType": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "openIdConnectSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "clientId",
+        "discoveryUrl"
+      ]
+    },
+    "openShiftItem": {
+      "navigationProperties": [],
+      "properties": [
+        "openSlotCount"
+      ]
+    },
+    "operatingSystemSpecifications": {
+      "navigationProperties": [],
+      "properties": [
+        "operatingSystemPlatform",
+        "operatingSystemVersion"
+      ]
+    },
+    "operationError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message"
+      ]
+    },
+    "optionalClaim": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalProperties",
+        "essential",
+        "name",
+        "source"
+      ]
+    },
+    "optionalClaims": {
+      "navigationProperties": [],
+      "properties": [
+        "accessToken",
+        "idToken",
+        "saml2Token"
+      ]
+    },
+    "organizerMeetingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "organizer"
+      ]
+    },
+    "osVersionCount": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "lastUpdateDateTime",
+        "osVersion"
+      ]
+    },
+    "outgoingCallOptions": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "outlookGeoCoordinates": {
+      "navigationProperties": [],
+      "properties": [
+        "accuracy",
+        "altitude",
+        "altitudeAccuracy",
+        "latitude",
+        "longitude"
+      ]
+    },
+    "outOfBoxExperienceSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceUsageType",
+        "escapeLinkHidden",
+        "eulaHidden",
+        "keyboardSelectionPageSkipped",
+        "privacySettingsHidden",
+        "userType"
+      ]
+    },
+    "outOfOfficeSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isOutOfOffice",
+        "message"
+      ]
+    },
+    "package": {
+      "navigationProperties": [],
+      "properties": [
+        "type"
+      ]
+    },
+    "pageLinks": {
+      "navigationProperties": [],
+      "properties": [
+        "oneNoteClientUrl",
+        "oneNoteWebUrl"
+      ]
+    },
+    "parentalControlSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "countriesBlockedForMinors",
+        "legalAgeGroupRule"
+      ]
+    },
+    "parseExpressionResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "evaluationResult",
+        "evaluationSucceeded",
+        "parsedExpression",
+        "parsingSucceeded"
+      ]
+    },
+    "participantInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "countryCode",
+        "endpointType",
+        "identity",
+        "languageId",
+        "participantId",
+        "region"
+      ]
+    },
+    "participantJoiningResponse": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "passwordCredential": {
+      "navigationProperties": [],
+      "properties": [
+        "customKeyIdentifier",
+        "displayName",
+        "endDateTime",
+        "hint",
+        "keyId",
+        "secretText",
+        "startDateTime"
+      ]
+    },
+    "passwordCredentialConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "maxLifetime",
+        "restrictForAppsCreatedAfterDateTime",
+        "restrictionType",
+        "state"
+      ]
+    },
+    "passwordProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "forceChangePasswordNextSignIn",
+        "forceChangePasswordNextSignInWithMfa",
+        "password"
+      ]
+    },
+    "passwordResetResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "newPassword"
+      ]
+    },
+    "patternedRecurrence": {
+      "navigationProperties": [],
+      "properties": [
+        "pattern",
+        "range"
+      ]
+    },
+    "payloadCoachmark": {
+      "navigationProperties": [],
+      "properties": [
+        "coachmarkLocation",
+        "description",
+        "indicator",
+        "isValid",
+        "language",
+        "order"
+      ]
+    },
+    "payloadDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "coachmarks",
+        "content",
+        "phishingUrl"
+      ]
+    },
+    "pendingContentUpdate": {
+      "navigationProperties": [],
+      "properties": [
+        "queuedDateTime"
+      ]
+    },
+    "pendingOperations": {
+      "navigationProperties": [],
+      "properties": [
+        "pendingContentUpdate"
+      ]
+    },
+    "permissionScope": {
+      "navigationProperties": [],
+      "properties": [
+        "adminConsentDescription",
+        "adminConsentDisplayName",
+        "id",
+        "isEnabled",
+        "origin",
+        "type",
+        "userConsentDescription",
+        "userConsentDisplayName",
+        "value"
+      ]
+    },
+    "persistentBrowserSessionControl": {
+      "navigationProperties": [],
+      "properties": [
+        "mode"
+      ]
+    },
+    "personOrGroupColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "allowMultipleSelection",
+        "chooseFromType",
+        "displayAs"
+      ]
+    },
+    "personType": {
+      "navigationProperties": [],
+      "properties": [
+        "class",
+        "subclass"
+      ]
+    },
+    "phone": {
+      "navigationProperties": [],
+      "properties": [
+        "language",
+        "number",
+        "region",
+        "type"
+      ]
+    },
+    "photo": {
+      "navigationProperties": [],
+      "properties": [
+        "cameraMake",
+        "cameraModel",
+        "exposureDenominator",
+        "exposureNumerator",
+        "fNumber",
+        "focalLength",
+        "iso",
+        "orientation",
+        "takenDateTime"
+      ]
+    },
+    "physicalAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "city",
+        "countryOrRegion",
+        "postalCode",
+        "state",
+        "street"
+      ]
+    },
+    "physicalOfficeAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "city",
+        "countryOrRegion",
+        "officeLocation",
+        "postalCode",
+        "state",
+        "street"
+      ]
+    },
+    "pkcs12Certificate": {
+      "navigationProperties": [],
+      "properties": [
+        "password",
+        "pkcs12Value"
+      ]
+    },
+    "pkcs12CertificateInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "isActive",
+        "notAfter",
+        "notBefore",
+        "thumbprint"
+      ]
+    },
+    "placeMode": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerAppliedCategories": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedBy",
+        "assignedDateTime",
+        "orderHint"
+      ]
+    },
+    "plannerAssignments": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerCategoryDescriptions": {
+      "navigationProperties": [],
+      "properties": [
+        "category1",
+        "category10",
+        "category11",
+        "category12",
+        "category13",
+        "category14",
+        "category15",
+        "category16",
+        "category17",
+        "category18",
+        "category19",
+        "category2",
+        "category20",
+        "category21",
+        "category22",
+        "category23",
+        "category24",
+        "category25",
+        "category3",
+        "category4",
+        "category5",
+        "category6",
+        "category7",
+        "category8",
+        "category9"
+      ]
+    },
+    "plannerChecklistItem": {
+      "navigationProperties": [],
+      "properties": [
+        "isChecked",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "orderHint",
+        "title"
+      ]
+    },
+    "plannerChecklistItems": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerExternalReference": {
+      "navigationProperties": [],
+      "properties": [
+        "alias",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "previewPriority",
+        "type"
+      ]
+    },
+    "plannerExternalReferences": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerOrderHintsByAssignee": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "plannerPlanContainer": {
+      "navigationProperties": [],
+      "properties": [
+        "containerId",
+        "type",
+        "url"
+      ]
+    },
+    "plannerUserIds": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "policyBinding": {
+      "navigationProperties": [],
+      "properties": [
+        "exclusions",
+        "inclusions"
+      ]
+    },
+    "policyLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "policyLocationApplication": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "policyLocationDomain": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "policyLocationUrl": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "policyScopeBase": {
+      "navigationProperties": [],
+      "properties": [
+        "activities",
+        "executionMode",
+        "locations",
+        "policyActions"
+      ]
+    },
+    "policyTenantScope": {
+      "navigationProperties": [],
+      "properties": [
+        "policyScope"
+      ]
+    },
+    "policyUserScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "positiveReinforcementNotification": {
+      "navigationProperties": [],
+      "properties": [
+        "deliveryPreference"
+      ]
+    },
+    "preAuthorizedApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "delegatedPermissionIds"
+      ]
+    },
+    "presenceStatusMessage": {
+      "navigationProperties": [],
+      "properties": [
+        "expiryDateTime",
+        "message",
+        "publishedDateTime"
+      ]
+    },
+    "principalResourceMembershipsScope": {
+      "navigationProperties": [],
+      "properties": [
+        "principalScopes",
+        "resourceScopes"
+      ]
+    },
+    "printCertificateSigningRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "transportKey"
+      ]
+    },
+    "printDocumentUploadProperties": {
+      "navigationProperties": [],
+      "properties": [
+        "contentType",
+        "documentName",
+        "size"
+      ]
+    },
+    "printerCapabilities": {
+      "navigationProperties": [],
+      "properties": [
+        "bottomMargins",
+        "collation",
+        "colorModes",
+        "contentTypes",
+        "copiesPerJob",
+        "dpis",
+        "duplexModes",
+        "feedOrientations",
+        "finishings",
+        "inputBins",
+        "isColorPrintingSupported",
+        "isPageRangeSupported",
+        "leftMargins",
+        "mediaColors",
+        "mediaSizes",
+        "mediaTypes",
+        "multipageLayouts",
+        "orientations",
+        "outputBins",
+        "pagesPerSheet",
+        "qualities",
+        "rightMargins",
+        "scalings",
+        "supportsFitPdfToPage",
+        "topMargins"
+      ]
+    },
+    "printerDefaults": {
+      "navigationProperties": [],
+      "properties": [
+        "colorMode",
+        "contentType",
+        "copiesPerJob",
+        "dpi",
+        "duplexMode",
+        "finishings",
+        "fitPdfToPage",
+        "inputBin",
+        "mediaColor",
+        "mediaSize",
+        "mediaType",
+        "multipageLayout",
+        "orientation",
+        "outputBin",
+        "pagesPerSheet",
+        "quality",
+        "scaling"
+      ]
+    },
+    "printerDiscoverySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "airPrint"
+      ]
+    },
+    "printerLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "altitudeInMeters",
+        "building",
+        "city",
+        "countryOrRegion",
+        "floor",
+        "floorDescription",
+        "latitude",
+        "longitude",
+        "organization",
+        "postalCode",
+        "roomDescription",
+        "roomName",
+        "site",
+        "stateOrProvince",
+        "streetAddress",
+        "subdivision",
+        "subunit"
+      ]
+    },
+    "printerShareViewpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "lastUsedDateTime"
+      ]
+    },
+    "printerStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "details",
+        "state"
+      ]
+    },
+    "printJobConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "collate",
+        "colorMode",
+        "copies",
+        "dpi",
+        "duplexMode",
+        "feedOrientation",
+        "finishings",
+        "fitPdfToPage",
+        "inputBin",
+        "margin",
+        "mediaSize",
+        "mediaType",
+        "multipageLayout",
+        "orientation",
+        "outputBin",
+        "pageRanges",
+        "pagesPerSheet",
+        "quality",
+        "scaling"
+      ]
+    },
+    "printJobStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "details",
+        "isAcquiredByPrinter",
+        "state"
+      ]
+    },
+    "printMargin": {
+      "navigationProperties": [],
+      "properties": [
+        "bottom",
+        "left",
+        "right",
+        "top"
+      ]
+    },
+    "printOperationStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "state"
+      ]
+    },
+    "printSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "documentConversionEnabled",
+        "printerDiscoverySettings"
+      ]
+    },
+    "printTaskStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "state"
+      ]
+    },
+    "privacyProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "contactEmail",
+        "statementUrl"
+      ]
+    },
+    "process": {
+      "navigationProperties": [],
+      "properties": [
+        "accountName",
+        "commandLine",
+        "createdDateTime",
+        "fileHash",
+        "integrityLevel",
+        "isElevated",
+        "name",
+        "parentProcessCreatedDateTime",
+        "parentProcessId",
+        "parentProcessName",
+        "path",
+        "processId"
+      ]
+    },
+    "processContentBatchRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "contentToProcess",
+        "requestId",
+        "userId"
+      ]
+    },
+    "processContentMetadataBase": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "correlationId",
+        "createdDateTime",
+        "identifier",
+        "isTruncated",
+        "length",
+        "modifiedDateTime",
+        "name",
+        "sequenceNumber"
+      ]
+    },
+    "processContentRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "activityMetadata",
+        "contentEntries",
+        "deviceMetadata",
+        "integratedAppMetadata",
+        "protectedAppMetadata"
+      ]
+    },
+    "processContentResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "policyActions",
+        "processingErrors",
+        "protectionScopeState"
+      ]
+    },
+    "processContentResponses": {
+      "navigationProperties": [],
+      "properties": [
+        "requestId",
+        "results"
+      ]
+    },
+    "processConversationMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "accessedResources",
+        "accessedResources_v2",
+        "agents",
+        "parentMessageId",
+        "plugins"
+      ]
+    },
+    "processFileMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "customProperties",
+        "ownerId"
+      ]
+    },
+    "processingError": {
+      "navigationProperties": [],
+      "properties": [
+        "errorType"
+      ]
+    },
+    "profileCardAnnotation": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "localizations"
+      ]
+    },
+    "profileSourceLocalization": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "languageTag",
+        "webUrl"
+      ]
+    },
+    "prompt": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "protectedApplicationMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationLocation"
+      ]
+    },
+    "protectedContent": {
+      "navigationProperties": [],
+      "properties": [
+        "cid",
+        "format",
+        "labelId"
+      ]
+    },
+    "protectionPolicyArtifactCount": {
+      "navigationProperties": [],
+      "properties": [
+        "completed",
+        "failed",
+        "inProgress",
+        "total"
+      ]
+    },
+    "provisionChannelEmailResult": {
+      "navigationProperties": [],
+      "properties": [
+        "email"
+      ]
+    },
+    "provisionedIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "details",
+        "identityType"
+      ]
+    },
+    "provisionedPlan": {
+      "navigationProperties": [],
+      "properties": [
+        "capabilityStatus",
+        "provisioningStatus",
+        "service"
+      ]
+    },
+    "provisioningErrorInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalDetails",
+        "errorCategory",
+        "errorCode",
+        "reason",
+        "recommendedAction"
+      ]
+    },
+    "provisioningServicePrincipal": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "provisioningStatusInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "errorInformation",
+        "status"
+      ]
+    },
+    "provisioningStep": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "details",
+        "name",
+        "provisioningStepType",
+        "status"
+      ]
+    },
+    "provisioningSystem": {
+      "navigationProperties": [],
+      "properties": [
+        "details"
+      ]
+    },
+    "proxiedDomain": {
+      "navigationProperties": [],
+      "properties": [
+        "ipAddressOrFQDN",
+        "proxy"
+      ]
+    },
+    "publicationFacet": {
+      "navigationProperties": [],
+      "properties": [
+        "checkedOutBy",
+        "level",
+        "versionId"
+      ]
+    },
+    "publicClientApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "redirectUris"
+      ]
+    },
+    "publicError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "details",
+        "innerError",
+        "message",
+        "target"
+      ]
+    },
+    "publicErrorDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message",
+        "target"
+      ]
+    },
+    "publicErrorResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "error"
+      ]
+    },
+    "publicInnerError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "details",
+        "message",
+        "target"
+      ]
+    },
+    "qrCodeImageDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "binaryValue",
+        "errorCorrectionLevel",
+        "rawContent",
+        "version"
+      ]
+    },
+    "quota": {
+      "navigationProperties": [],
+      "properties": [
+        "deleted",
+        "remaining",
+        "state",
+        "storagePlanInformation",
+        "total",
+        "used"
+      ]
+    },
+    "reactionsFacet": {
+      "navigationProperties": [],
+      "properties": [
+        "commentCount",
+        "likeCount",
+        "shareCount"
+      ]
+    },
+    "recentNotebook": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastAccessedTime",
+        "links",
+        "sourceService"
+      ]
+    },
+    "recentNotebookLinks": {
+      "navigationProperties": [],
+      "properties": [
+        "oneNoteClientUrl",
+        "oneNoteWebUrl"
+      ]
+    },
+    "recipient": {
+      "navigationProperties": [],
+      "properties": [
+        "emailAddress"
+      ]
+    },
+    "recommendedAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actionWebUrl",
+        "potentialScoreImpact",
+        "title"
+      ]
+    },
+    "recordingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "recordingStatus"
+      ]
+    },
+    "recurrencePattern": {
+      "navigationProperties": [],
+      "properties": [
+        "dayOfMonth",
+        "daysOfWeek",
+        "firstDayOfWeek",
+        "index",
+        "interval",
+        "month",
+        "type"
+      ]
+    },
+    "recurrenceRange": {
+      "navigationProperties": [],
+      "properties": [
+        "endDate",
+        "numberOfOccurrences",
+        "recurrenceTimeZone",
+        "startDate",
+        "type"
+      ]
+    },
+    "recycleBinSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "retentionPeriodOverrideDays"
+      ]
+    },
+    "redirectUriSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "index",
+        "uri"
+      ]
+    },
+    "referencedObject": {
+      "navigationProperties": [],
+      "properties": [
+        "referencedObjectName",
+        "referencedProperty"
+      ]
+    },
+    "registrationEnforcement": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationMethodsRegistrationCampaign"
+      ]
+    },
+    "registryKeyState": {
+      "navigationProperties": [],
+      "properties": [
+        "hive",
+        "key",
+        "oldKey",
+        "oldValueData",
+        "oldValueName",
+        "operation",
+        "processId",
+        "valueData",
+        "valueName",
+        "valueType"
+      ]
+    },
+    "rejectJoinResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "reason"
+      ]
+    },
+    "relatedContact": {
+      "navigationProperties": [],
+      "properties": [
+        "accessConsent",
+        "displayName",
+        "emailAddress",
+        "mobilePhone",
+        "relationship"
+      ]
+    },
+    "reminder": {
+      "navigationProperties": [],
+      "properties": [
+        "changeKey",
+        "eventEndTime",
+        "eventId",
+        "eventLocation",
+        "eventStartTime",
+        "eventSubject",
+        "eventWebLink",
+        "reminderFireTime"
+      ]
+    },
+    "remoteItem": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "file",
+        "fileSystemInfo",
+        "folder",
+        "id",
+        "image",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "name",
+        "package",
+        "parentReference",
+        "shared",
+        "sharepointIds",
+        "size",
+        "specialFolder",
+        "video",
+        "webDavUrl",
+        "webUrl"
+      ]
+    },
+    "remoteLockActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "unlockPin"
+      ]
+    },
+    "removeAccessApplyAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "removedState": {
+      "navigationProperties": [],
+      "properties": [
+        "reason"
+      ]
+    },
+    "renameAction": {
+      "navigationProperties": [],
+      "properties": [
+        "newName",
+        "oldName"
+      ]
+    },
+    "report": {
+      "navigationProperties": [],
+      "properties": [
+        "content"
+      ]
+    },
+    "requestorManager": {
+      "navigationProperties": [],
+      "properties": [
+        "managerLevel"
+      ]
+    },
+    "requestSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "expiration",
+        "recurrence",
+        "startDateTime"
+      ]
+    },
+    "requestSignatureVerification": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedWeakAlgorithms",
+        "isSignedRequestRequired"
+      ]
+    },
+    "requiredResourceAccess": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceAccess",
+        "resourceAppId"
+      ]
+    },
+    "reservablePlaceMode": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "resetPasscodeActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "errorCode",
+        "passcode"
+      ]
+    },
+    "resourceAccess": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "type"
+      ]
+    },
+    "resourceAccessDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "accessType",
+        "identifier",
+        "isCrossPromptInjectionDetected",
+        "labelId",
+        "name",
+        "status",
+        "storageId",
+        "url"
+      ]
+    },
+    "resourceAction": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedResourceActions",
+        "notAllowedResourceActions"
+      ]
+    },
+    "resourceData": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "resourceLink": {
+      "navigationProperties": [],
+      "properties": [
+        "linkType",
+        "name",
+        "value"
+      ]
+    },
+    "resourcePermission": {
+      "navigationProperties": [],
+      "properties": [
+        "type",
+        "value"
+      ]
+    },
+    "resourceReference": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "type",
+        "webUrl"
+      ]
+    },
+    "resourceSpecificPermission": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "id",
+        "isEnabled",
+        "value"
+      ]
+    },
+    "resourceVisualization": {
+      "navigationProperties": [],
+      "properties": [
+        "containerDisplayName",
+        "containerType",
+        "containerWebUrl",
+        "mediaType",
+        "previewImageUrl",
+        "previewText",
+        "title",
+        "type"
+      ]
+    },
+    "responseStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "response",
+        "time"
+      ]
+    },
+    "restoreAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "restorePointSearchResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "noResultProtectionUnitIds",
+        "searchResponseId",
+        "searchResults"
+      ]
+    },
+    "restorePointSearchResult": {
+      "navigationProperties": [
+        "restorePoint"
+      ],
+      "properties": [
+        "artifactHitCount"
+      ]
+    },
+    "restoreSessionArtifactCount": {
+      "navigationProperties": [],
+      "properties": [
+        "completed",
+        "failed",
+        "inProgress",
+        "total"
+      ]
+    },
+    "restrictAccessAction": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "restrictAccessActionBase": {
+      "navigationProperties": [],
+      "properties": [
+        "restrictionAction"
+      ]
+    },
+    "resultInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message",
+        "subcode"
+      ]
+    },
+    "resultTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "body",
+        "displayName"
+      ]
+    },
+    "resultTemplateDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "resultTemplateOption": {
+      "navigationProperties": [],
+      "properties": [
+        "enableResultTemplate"
+      ]
+    },
+    "retentionLabelSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "behaviorDuringRetentionPeriod",
+        "isContentUpdateAllowed",
+        "isDeleteAllowed",
+        "isLabelUpdateAllowed",
+        "isMetadataUpdateAllowed",
+        "isRecordLocked"
+      ]
+    },
+    "retentionSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "interval",
+        "period"
+      ]
+    },
+    "retrievalExtract": {
+      "navigationProperties": [],
+      "properties": [
+        "relevanceScore",
+        "text"
+      ]
+    },
+    "retrievalHit": {
+      "navigationProperties": [],
+      "properties": [
+        "extracts",
+        "resourceMetadata",
+        "resourceType",
+        "sensitivityLabel",
+        "webUrl"
+      ]
+    },
+    "retrievalResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "retrievalHits"
+      ]
+    },
+    "rgbColor": {
+      "navigationProperties": [],
+      "properties": [
+        "b",
+        "g",
+        "r"
+      ]
+    },
+    "riskServicePrincipalActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "detail",
+        "riskEventTypes"
+      ]
+    },
+    "riskUserActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "detail",
+        "riskEventTypes"
+      ]
+    },
+    "rolePermission": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceActions"
+      ]
+    },
+    "root": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "rotateBitLockerKeysDeviceActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "errorCode"
+      ]
+    },
+    "rubricCriterion": {
+      "navigationProperties": [],
+      "properties": [
+        "description"
+      ]
+    },
+    "rubricLevel": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "grading",
+        "levelId"
+      ]
+    },
+    "rubricQuality": {
+      "navigationProperties": [],
+      "properties": [
+        "criteria",
+        "description",
+        "displayName",
+        "qualityId",
+        "weight"
+      ]
+    },
+    "rubricQualityFeedbackModel": {
+      "navigationProperties": [],
+      "properties": [
+        "feedback",
+        "qualityId"
+      ]
+    },
+    "rubricQualitySelectedColumnModel": {
+      "navigationProperties": [],
+      "properties": [
+        "columnId",
+        "qualityId"
+      ]
+    },
+    "samlSingleSignOnSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "relayState"
+      ]
+    },
+    "scheduleEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "startDateTime",
+        "theme"
+      ]
+    },
+    "scheduleInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "availabilityView",
+        "error",
+        "scheduleId",
+        "scheduleItems",
+        "workingHours"
+      ]
+    },
+    "scheduleItem": {
+      "navigationProperties": [],
+      "properties": [
+        "end",
+        "isPrivate",
+        "location",
+        "start",
+        "status",
+        "subject"
+      ]
+    },
+    "scopeBase": {
+      "navigationProperties": [],
+      "properties": [
+        "identity"
+      ]
+    },
+    "scoredEmailAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "itemId",
+        "relevanceScore",
+        "selectionLikelihood"
+      ]
+    },
+    "searchAggregation": {
+      "navigationProperties": [],
+      "properties": [
+        "buckets",
+        "field"
+      ]
+    },
+    "searchAlteration": {
+      "navigationProperties": [],
+      "properties": [
+        "alteredHighlightedQueryString",
+        "alteredQueryString",
+        "alteredQueryTokens"
+      ]
+    },
+    "searchAlterationOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "enableModification",
+        "enableSuggestion"
+      ]
+    },
+    "searchBucket": {
+      "navigationProperties": [],
+      "properties": [
+        "aggregationFilterToken",
+        "count",
+        "key"
+      ]
+    },
+    "searchHit": {
+      "navigationProperties": [
+        "resource"
+      ],
+      "properties": [
+        "contentSource",
+        "hitId",
+        "isCollapsed",
+        "rank",
+        "resultTemplateId",
+        "summary"
+      ]
+    },
+    "searchHitsContainer": {
+      "navigationProperties": [],
+      "properties": [
+        "aggregations",
+        "hits",
+        "moreResultsAvailable",
+        "total"
+      ]
+    },
+    "searchQuery": {
+      "navigationProperties": [],
+      "properties": [
+        "queryString",
+        "queryTemplate"
+      ]
+    },
+    "searchRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "aggregationFilters",
+        "aggregations",
+        "collapseProperties",
+        "contentSources",
+        "enableTopResults",
+        "entityTypes",
+        "fields",
+        "from",
+        "query",
+        "queryAlterationOptions",
+        "region",
+        "resultTemplateOptions",
+        "sharePointOneDriveOptions",
+        "size",
+        "sortProperties"
+      ]
+    },
+    "searchResourceMetadataDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "searchResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "hitsContainers",
+        "queryAlterationResponse",
+        "resultTemplates",
+        "searchTerms"
+      ]
+    },
+    "searchResult": {
+      "navigationProperties": [],
+      "properties": [
+        "onClickTelemetryUrl"
+      ]
+    },
+    "sectionLinks": {
+      "navigationProperties": [],
+      "properties": [
+        "oneNoteClientUrl",
+        "oneNoteWebUrl"
+      ]
+    },
+    "secureScoreControlStateUpdate": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedTo",
+        "comment",
+        "state",
+        "updatedBy",
+        "updatedDateTime"
+      ]
+    },
+    "secureSignInSessionControl": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "securityResource": {
+      "navigationProperties": [],
+      "properties": [
+        "resource",
+        "resourceType"
+      ]
+    },
+    "securityVendorInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "provider",
+        "providerVersion",
+        "subProvider",
+        "vendor"
+      ]
+    },
+    "selfServiceSignUpAuthenticationFlowConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "selfSignedCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "customKeyIdentifier",
+        "displayName",
+        "endDateTime",
+        "key",
+        "keyId",
+        "startDateTime",
+        "thumbprint",
+        "type",
+        "usage"
+      ]
+    },
+    "sensitivityLabelAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentMethod",
+        "sensitivityLabelId",
+        "tenantId"
+      ]
+    },
+    "sensitivityLabelInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "color",
+        "displayName",
+        "priority",
+        "sensitivityLabelId",
+        "tooltip"
+      ]
+    },
+    "serverProcessedContent": {
+      "navigationProperties": [],
+      "properties": [
+        "htmlStrings",
+        "imageSources",
+        "links",
+        "searchablePlainTexts"
+      ]
+    },
+    "serviceHealthIssuePost": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "postType"
+      ]
+    },
+    "serviceHostedMediaConfig": {
+      "navigationProperties": [],
+      "properties": [
+        "preFetchMedia"
+      ]
+    },
+    "servicePlanInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "appliesTo",
+        "provisioningStatus",
+        "servicePlanId",
+        "servicePlanName"
+      ]
+    },
+    "servicePrincipalIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "appId"
+      ]
+    },
+    "servicePrincipalLockConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allProperties",
+        "credentialsWithUsageSign",
+        "credentialsWithUsageVerify",
+        "isEnabled",
+        "tokenEncryptionKeyId"
+      ]
+    },
+    "servicePrincipalSignIn": {
+      "navigationProperties": [],
+      "properties": [
+        "servicePrincipalId"
+      ]
+    },
+    "serviceProvisioningError": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "isResolved",
+        "serviceInstance"
+      ]
+    },
+    "serviceProvisioningXmlError": {
+      "navigationProperties": [],
+      "properties": [
+        "errorDetail"
+      ]
+    },
+    "serviceStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "backupServiceConsumer",
+        "disableReason",
+        "gracePeriodDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "restoreAllowedTillDateTime",
+        "status"
+      ]
+    },
+    "serviceUpdateMessageViewpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "isArchived",
+        "isFavorited",
+        "isRead"
+      ]
+    },
+    "settingSource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "id",
+        "sourceType"
+      ]
+    },
+    "settingTemplateValue": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultValue",
+        "description",
+        "name",
+        "type"
+      ]
+    },
+    "settingValue": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "value"
+      ]
+    },
+    "shareAction": {
+      "navigationProperties": [],
+      "properties": [
+        "recipients"
+      ]
+    },
+    "shared": {
+      "navigationProperties": [],
+      "properties": [
+        "owner",
+        "scope",
+        "sharedBy",
+        "sharedDateTime"
+      ]
+    },
+    "sharedPCAccountManagerPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "accountDeletionPolicy",
+        "cacheAccountsAboveDiskFreePercentage",
+        "inactiveThresholdDays",
+        "removeAccountsBelowDiskFreePercentage"
+      ]
+    },
+    "sharePointGroupIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "principalId",
+        "title"
+      ]
+    },
+    "sharePointIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "loginName"
+      ]
+    },
+    "sharePointIdentitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "group",
+        "sharePointGroup",
+        "siteGroup",
+        "siteUser"
+      ]
+    },
+    "sharepointIds": {
+      "navigationProperties": [],
+      "properties": [
+        "listId",
+        "listItemId",
+        "listItemUniqueId",
+        "siteId",
+        "siteUrl",
+        "tenantId",
+        "webId"
+      ]
+    },
+    "sharePointMigrationContainerInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "dataContainerUri",
+        "encryptionKey",
+        "metadataContainerUri"
+      ]
+    },
+    "sharePointOneDriveOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "includeContent"
+      ]
+    },
+    "sharingDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "sharedBy",
+        "sharedDateTime",
+        "sharingReference",
+        "sharingSubject",
+        "sharingType"
+      ]
+    },
+    "sharingInvitation": {
+      "navigationProperties": [],
+      "properties": [
+        "email",
+        "invitedBy",
+        "redeemedBy",
+        "signInRequired"
+      ]
+    },
+    "sharingLink": {
+      "navigationProperties": [],
+      "properties": [
+        "application",
+        "preventsDownload",
+        "scope",
+        "type",
+        "webHtml",
+        "webUrl"
+      ]
+    },
+    "shiftActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "displayName",
+        "endDateTime",
+        "isPaid",
+        "startDateTime",
+        "theme"
+      ]
+    },
+    "shiftAvailability": {
+      "navigationProperties": [],
+      "properties": [
+        "recurrence",
+        "timeSlots",
+        "timeZone"
+      ]
+    },
+    "shiftItem": {
+      "navigationProperties": [],
+      "properties": [
+        "activities",
+        "displayName",
+        "notes"
+      ]
+    },
+    "signInActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "lastNonInteractiveSignInDateTime",
+        "lastNonInteractiveSignInRequestId",
+        "lastSignInDateTime",
+        "lastSignInRequestId",
+        "lastSuccessfulSignInDateTime",
+        "lastSuccessfulSignInRequestId"
+      ]
+    },
+    "signInConditions": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationFlow",
+        "clientAppType",
+        "country",
+        "deviceInfo",
+        "devicePlatform",
+        "insiderRiskLevel",
+        "ipAddress",
+        "servicePrincipalRiskLevel",
+        "signInRiskLevel",
+        "userRiskLevel"
+      ]
+    },
+    "signInContext": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "signInFrequencySessionControl": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationType",
+        "frequencyInterval",
+        "type",
+        "value"
+      ]
+    },
+    "signingCertificateUpdateStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateUpdateResult",
+        "lastRunDateTime"
+      ]
+    },
+    "signInIdentity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "signInLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "city",
+        "countryOrRegion",
+        "geoCoordinates",
+        "state"
+      ]
+    },
+    "signInStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalDetails",
+        "errorCode",
+        "failureReason"
+      ]
+    },
+    "simulationEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "count",
+        "eventName"
+      ]
+    },
+    "simulationEventsContent": {
+      "navigationProperties": [],
+      "properties": [
+        "compromisedRate",
+        "events"
+      ]
+    },
+    "simulationNotification": {
+      "navigationProperties": [],
+      "properties": [
+        "targettedUserType"
+      ]
+    },
+    "simulationReport": {
+      "navigationProperties": [],
+      "properties": [
+        "overview",
+        "simulationUsers"
+      ]
+    },
+    "simulationReportOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "recommendedActions",
+        "resolvedTargetsCount",
+        "simulationEventsContent",
+        "trainingEventsContent"
+      ]
+    },
+    "singleServicePrincipal": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "servicePrincipalId"
+      ]
+    },
+    "singleUser": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "userId"
+      ]
+    },
+    "siteArchivalDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "archiveStatus"
+      ]
+    },
+    "siteCollection": {
+      "navigationProperties": [],
+      "properties": [
+        "archivalDetails",
+        "dataLocationCode",
+        "hostname",
+        "root"
+      ]
+    },
+    "sizeRange": {
+      "navigationProperties": [],
+      "properties": [
+        "maximumSize",
+        "minimumSize"
+      ]
+    },
+    "socialIdentitySource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "socialIdentitySourceType"
+      ]
+    },
+    "sortProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "isDescending",
+        "name"
+      ]
+    },
+    "spaApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "redirectUris"
+      ]
+    },
+    "specialFolder": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "staffAvailabilityItem": {
+      "navigationProperties": [],
+      "properties": [
+        "availabilityItems",
+        "staffId"
+      ]
+    },
+    "standardTimeZoneOffset": {
+      "navigationProperties": [],
+      "properties": [
+        "dayOccurrence",
+        "dayOfWeek",
+        "month",
+        "time",
+        "year"
+      ]
+    },
+    "storagePlanInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "upgradeAvailable"
+      ]
+    },
+    "stringKeyAttributeMappingSourceValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "stringKeyLongValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "stringKeyObjectValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "key"
+      ]
+    },
+    "stringKeyStringValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "subjectRightsRequestAllMailboxLocation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "subjectRightsRequestAllSiteLocation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "subjectRightsRequestDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "excludedItemCount",
+        "insightCounts",
+        "itemCount",
+        "itemNeedReview",
+        "productItemCounts",
+        "signedOffItemCount",
+        "totalItemSize"
+      ]
+    },
+    "subjectRightsRequestEnumeratedMailboxLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "userPrincipalNames"
+      ]
+    },
+    "subjectRightsRequestEnumeratedSiteLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "urls"
+      ]
+    },
+    "subjectRightsRequestHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "changedBy",
+        "eventDateTime",
+        "stage",
+        "stageStatus",
+        "type"
+      ]
+    },
+    "subjectRightsRequestMailboxLocation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "subjectRightsRequestSiteLocation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "subjectRightsRequestStageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "stage",
+        "status"
+      ]
+    },
+    "subjectSet": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "synchronizationError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "message",
+        "tenantActionable"
+      ]
+    },
+    "synchronizationJobApplicationParameters": {
+      "navigationProperties": [],
+      "properties": [
+        "ruleId",
+        "subjects"
+      ]
+    },
+    "synchronizationJobRestartCriteria": {
+      "navigationProperties": [],
+      "properties": [
+        "resetScope"
+      ]
+    },
+    "synchronizationJobSubject": {
+      "navigationProperties": [],
+      "properties": [
+        "links",
+        "objectId",
+        "objectTypeName"
+      ]
+    },
+    "synchronizationLinkedObjects": {
+      "navigationProperties": [],
+      "properties": [
+        "manager",
+        "members",
+        "owners"
+      ]
+    },
+    "synchronizationMetadataEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "synchronizationProgress": {
+      "navigationProperties": [],
+      "properties": [
+        "completedUnits",
+        "progressObservationDateTime",
+        "totalUnits",
+        "units"
+      ]
+    },
+    "synchronizationQuarantine": {
+      "navigationProperties": [],
+      "properties": [
+        "currentBegan",
+        "error",
+        "nextAttempt",
+        "reason",
+        "seriesBegan",
+        "seriesCount"
+      ]
+    },
+    "synchronizationRule": {
+      "navigationProperties": [],
+      "properties": [
+        "containerFilter",
+        "editable",
+        "groupFilter",
+        "id",
+        "metadata",
+        "name",
+        "objectMappings",
+        "priority",
+        "sourceDirectoryName",
+        "targetDirectoryName"
+      ]
+    },
+    "synchronizationSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "expiration",
+        "interval",
+        "state"
+      ]
+    },
+    "synchronizationSecretKeyStringValuePair": {
+      "navigationProperties": [],
+      "properties": [
+        "key",
+        "value"
+      ]
+    },
+    "synchronizationStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "countSuccessiveCompleteFailures",
+        "escrowsPruned",
+        "lastExecution",
+        "lastSuccessfulExecution",
+        "lastSuccessfulExecutionWithExports",
+        "progress",
+        "quarantine",
+        "steadyStateFirstAchievedTime",
+        "steadyStateLastAchievedTime",
+        "synchronizedEntryCountByType",
+        "troubleshootingUrl"
+      ]
+    },
+    "synchronizationTaskExecution": {
+      "navigationProperties": [],
+      "properties": [
+        "activityIdentifier",
+        "countEntitled",
+        "countEntitledForProvisioning",
+        "countEscrowed",
+        "countEscrowedRaw",
+        "countExported",
+        "countExports",
+        "countImported",
+        "countImportedDeltas",
+        "countImportedReferenceDeltas",
+        "error",
+        "state",
+        "timeBegan",
+        "timeEnded"
+      ]
+    },
+    "systemFacet": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "tabUpdatedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "tabId"
+      ]
+    },
+    "targetAgentIdentitySponsorsOrOwners": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "targetApplicationOwners": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "targetManager": {
+      "navigationProperties": [],
+      "properties": [
+        "managerLevel"
+      ]
+    },
+    "targetResource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "groupType",
+        "id",
+        "modifiedProperties",
+        "type",
+        "userPrincipalName"
+      ]
+    },
+    "targetUserSponsors": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamArchivedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamId"
+      ]
+    },
+    "teamClassSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "notifyGuardiansAboutAssignments"
+      ]
+    },
+    "teamCreatedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamDescription",
+        "teamDisplayName",
+        "teamId"
+      ]
+    },
+    "teamDescriptionUpdatedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamDescription",
+        "teamId"
+      ]
+    },
+    "teamFunSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowCustomMemes",
+        "allowGiphy",
+        "allowStickersAndMemes",
+        "giphyContentRating"
+      ]
+    },
+    "teamGuestSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowCreateUpdateChannels",
+        "allowDeleteChannels"
+      ]
+    },
+    "teamJoiningDisabledEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamId"
+      ]
+    },
+    "teamJoiningEnabledEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamId"
+      ]
+    },
+    "teamMemberSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowAddRemoveApps",
+        "allowCreatePrivateChannels",
+        "allowCreateUpdateChannels",
+        "allowCreateUpdateRemoveConnectors",
+        "allowCreateUpdateRemoveTabs",
+        "allowDeleteChannels"
+      ]
+    },
+    "teamMembersNotificationRecipient": {
+      "navigationProperties": [],
+      "properties": [
+        "teamId"
+      ]
+    },
+    "teamMessagingSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowChannelMentions",
+        "allowOwnerDeleteMessages",
+        "allowTeamMentions",
+        "allowUserDeleteMessages",
+        "allowUserEditMessages"
+      ]
+    },
+    "teamRenamedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamDisplayName",
+        "teamId"
+      ]
+    },
+    "teamsAppAuthorization": {
+      "navigationProperties": [],
+      "properties": [
+        "clientAppId",
+        "requiredPermissionSet"
+      ]
+    },
+    "teamsAppInstalledEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamsAppDisplayName",
+        "teamsAppId"
+      ]
+    },
+    "teamsAppPermissionSet": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceSpecificPermissions"
+      ]
+    },
+    "teamsAppRemovedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamsAppDisplayName",
+        "teamsAppId"
+      ]
+    },
+    "teamsAppResourceSpecificPermission": {
+      "navigationProperties": [],
+      "properties": [
+        "permissionType",
+        "permissionValue"
+      ]
+    },
+    "teamsAppUpgradedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamsAppDisplayName",
+        "teamsAppId"
+      ]
+    },
+    "teamsLicensingDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "hasTeamsLicense"
+      ]
+    },
+    "teamsTabConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "contentUrl",
+        "entityId",
+        "removeUrl",
+        "websiteUrl"
+      ]
+    },
+    "teamSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "guestsCount",
+        "membersCount",
+        "ownersCount"
+      ]
+    },
+    "teamUnarchivedEventMessageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "initiator",
+        "teamId"
+      ]
+    },
+    "teamworkActivityTopic": {
+      "navigationProperties": [],
+      "properties": [
+        "source",
+        "value",
+        "webUrl"
+      ]
+    },
+    "teamworkApplicationIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationIdentityType"
+      ]
+    },
+    "teamworkConversationIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "conversationIdentityType"
+      ]
+    },
+    "teamworkNotificationRecipient": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamworkOnlineMeetingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "calendarEventId",
+        "joinWebUrl",
+        "organizer"
+      ]
+    },
+    "teamworkTagIdentity": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamworkUserIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "userIdentityType"
+      ]
+    },
+    "teleconferenceDeviceAudioQuality": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teleconferenceDeviceMediaQuality": {
+      "navigationProperties": [],
+      "properties": [
+        "averageInboundJitter",
+        "averageInboundPacketLossRateInPercentage",
+        "averageInboundRoundTripDelay",
+        "averageOutboundJitter",
+        "averageOutboundPacketLossRateInPercentage",
+        "averageOutboundRoundTripDelay",
+        "channelIndex",
+        "inboundPackets",
+        "localIPAddress",
+        "localPort",
+        "maximumInboundJitter",
+        "maximumInboundPacketLossRateInPercentage",
+        "maximumInboundRoundTripDelay",
+        "maximumOutboundJitter",
+        "maximumOutboundPacketLossRateInPercentage",
+        "maximumOutboundRoundTripDelay",
+        "mediaDuration",
+        "networkLinkSpeedInBytes",
+        "outboundPackets",
+        "remoteIPAddress",
+        "remotePort"
+      ]
+    },
+    "teleconferenceDeviceQuality": {
+      "navigationProperties": [],
+      "properties": [
+        "callChainId",
+        "cloudServiceDeploymentEnvironment",
+        "cloudServiceDeploymentId",
+        "cloudServiceInstanceName",
+        "cloudServiceName",
+        "deviceDescription",
+        "deviceName",
+        "mediaLegId",
+        "mediaQualityList",
+        "participantId"
+      ]
+    },
+    "teleconferenceDeviceScreenSharingQuality": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teleconferenceDeviceVideoQuality": {
+      "navigationProperties": [],
+      "properties": [
+        "averageInboundBitRate",
+        "averageInboundFrameRate",
+        "averageOutboundBitRate",
+        "averageOutboundFrameRate"
+      ]
+    },
+    "tenantInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "defaultDomainName",
+        "displayName",
+        "federationBrandName",
+        "tenantId"
+      ]
+    },
+    "tenantScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "termColumn": {
+      "navigationProperties": [
+        "parentTerm",
+        "termSet"
+      ],
+      "properties": [
+        "allowMultipleValues",
+        "showFullyQualifiedName"
+      ]
+    },
+    "termsExpiration": {
+      "navigationProperties": [],
+      "properties": [
+        "frequency",
+        "startDateTime"
+      ]
+    },
+    "textColumn": {
+      "navigationProperties": [],
+      "properties": [
+        "allowMultipleLines",
+        "appendChangesToExistingText",
+        "linesForEditing",
+        "maxLength",
+        "textType"
+      ]
+    },
+    "textContent": {
+      "navigationProperties": [],
+      "properties": [
+        "data"
+      ]
+    },
+    "thumbnail": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "height",
+        "sourceItemId",
+        "url",
+        "width"
+      ]
+    },
+    "thumbnailColumn": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ticketInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "ticketNumber",
+        "ticketSystem"
+      ]
+    },
+    "timeCardBreak": {
+      "navigationProperties": [],
+      "properties": [
+        "breakId",
+        "end",
+        "notes",
+        "start"
+      ]
+    },
+    "timeCardEntry": {
+      "navigationProperties": [],
+      "properties": [
+        "breaks",
+        "clockInEvent",
+        "clockOutEvent"
+      ]
+    },
+    "timeCardEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "dateTime",
+        "isAtApprovedLocation",
+        "notes"
+      ]
+    },
+    "timeClockSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "approvedLocation"
+      ]
+    },
+    "timeConstraint": {
+      "navigationProperties": [],
+      "properties": [
+        "activityDomain",
+        "timeSlots"
+      ]
+    },
+    "timeOffDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "isAllDay",
+        "subject"
+      ]
+    },
+    "timeOffItem": {
+      "navigationProperties": [],
+      "properties": [
+        "timeOffReasonId"
+      ]
+    },
+    "timePeriod": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "startDateTime"
+      ]
+    },
+    "timeRange": {
+      "navigationProperties": [],
+      "properties": [
+        "endTime",
+        "startTime"
+      ]
+    },
+    "timeSlot": {
+      "navigationProperties": [],
+      "properties": [
+        "end",
+        "start"
+      ]
+    },
+    "timeZoneBase": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "timeZoneInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "alias",
+        "displayName"
+      ]
+    },
+    "titleArea": {
+      "navigationProperties": [],
+      "properties": [
+        "alternativeText",
+        "enableGradientEffect",
+        "imageWebUrl",
+        "layout",
+        "serverProcessedContent",
+        "showAuthor",
+        "showPublishedDate",
+        "showTextBlockAboveTitle",
+        "textAboveTitle",
+        "textAlignment"
+      ]
+    },
+    "tokenMeetingInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "token"
+      ]
+    },
+    "toneInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "sequenceId",
+        "tone"
+      ]
+    },
+    "trainingEventsContent": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedTrainingsInfos",
+        "trainingsAssignedUserCount"
+      ]
+    },
+    "trainingNotificationSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "trainingAssignment",
+        "trainingReminder"
+      ]
+    },
+    "trainingReminderNotification": {
+      "navigationProperties": [],
+      "properties": [
+        "deliveryFrequency"
+      ]
+    },
+    "trainingSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "settingType"
+      ]
+    },
+    "unavailablePlaceMode": {
+      "navigationProperties": [],
+      "properties": [
+        "reason"
+      ]
+    },
+    "unifiedApprovalStage": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalStageTimeOutInDays",
+        "escalationApprovers",
+        "escalationTimeInMinutes",
+        "isApproverJustificationRequired",
+        "isEscalationEnabled",
+        "primaryApprovers"
+      ]
+    },
+    "unifiedRole": {
+      "navigationProperties": [],
+      "properties": [
+        "roleDefinitionId"
+      ]
+    },
+    "unifiedRoleManagementPolicyRuleTarget": {
+      "navigationProperties": [
+        "targetObjects"
+      ],
+      "properties": [
+        "caller",
+        "enforcedSettings",
+        "inheritableSettings",
+        "level",
+        "operations"
+      ]
+    },
+    "unifiedRolePermission": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedResourceActions",
+        "condition",
+        "excludedResourceActions"
+      ]
+    },
+    "updateAllowedCombinationsResult": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformation",
+        "conditionalAccessReferences",
+        "currentCombinations",
+        "previousCombinations"
+      ]
+    },
+    "updateWindowsDeviceAccountActionParameter": {
+      "navigationProperties": [],
+      "properties": [
+        "calendarSyncEnabled",
+        "deviceAccount",
+        "deviceAccountEmail",
+        "exchangeServer",
+        "passwordRotationEnabled",
+        "sessionInitiationProtocalAddress"
+      ]
+    },
+    "uploadSession": {
+      "navigationProperties": [],
+      "properties": [
+        "expirationDateTime",
+        "nextExpectedRanges",
+        "uploadUrl"
+      ]
+    },
+    "uriClickSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "clickAction",
+        "clickDateTime",
+        "id",
+        "sourceId",
+        "uriDomain",
+        "verdict"
+      ]
+    },
+    "usageDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "lastAccessedDateTime",
+        "lastModifiedDateTime"
+      ]
+    },
+    "userActionContext": {
+      "navigationProperties": [],
+      "properties": [
+        "userAction"
+      ]
+    },
+    "userAttributeValuesItem": {
+      "navigationProperties": [],
+      "properties": [
+        "isDefault",
+        "name",
+        "value"
+      ]
+    },
+    "userExperienceAnalyticsAutopilotDevicesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "devicesNotAutopilotRegistered",
+        "devicesWithoutAutopilotProfileAssigned",
+        "totalWindows10DevicesWithoutTenantAttached"
+      ]
+    },
+    "userExperienceAnalyticsCloudIdentityDevicesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceWithoutCloudIdentityCount"
+      ]
+    },
+    "userExperienceAnalyticsCloudManagementDevicesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "coManagedDeviceCount",
+        "intuneDeviceCount",
+        "tenantAttachDeviceCount"
+      ]
+    },
+    "userExperienceAnalyticsInsight": {
+      "navigationProperties": [],
+      "properties": [
+        "insightId",
+        "severity",
+        "userExperienceAnalyticsMetricId",
+        "values"
+      ]
+    },
+    "userExperienceAnalyticsInsightValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "userExperienceAnalyticsSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationManagerDataConnectorConfigured"
+      ]
+    },
+    "userExperienceAnalyticsWindows10DevicesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "unsupportedOSversionDeviceCount"
+      ]
+    },
+    "userExperienceAnalyticsWorkFromAnywhereDevicesSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "autopilotDevicesSummary",
+        "cloudIdentityDevicesSummary",
+        "cloudManagementDevicesSummary",
+        "coManagedDevices",
+        "devicesNotAutopilotRegistered",
+        "devicesWithoutAutopilotProfileAssigned",
+        "devicesWithoutCloudIdentity",
+        "intuneDevices",
+        "tenantAttachDevices",
+        "totalDevices",
+        "unsupportedOSversionDevices",
+        "windows10Devices",
+        "windows10DevicesSummary",
+        "windows10DevicesWithoutTenantAttach"
+      ]
+    },
+    "userFlowApiConnectorConfiguration": {
+      "navigationProperties": [
+        "postAttributeCollection",
+        "postFederationSignup"
+      ],
+      "properties": []
+    },
+    "userIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "ipAddress",
+        "userPrincipalName"
+      ]
+    },
+    "userLastSignInRecommendationInsightSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "recommendationLookBackDuration",
+        "signInScope"
+      ]
+    },
+    "userPrint": {
+      "navigationProperties": [
+        "recentPrinterShares"
+      ],
+      "properties": []
+    },
+    "userRegistrationFeatureCount": {
+      "navigationProperties": [],
+      "properties": [
+        "feature",
+        "userCount"
+      ]
+    },
+    "userRegistrationFeatureSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "totalUserCount",
+        "userRegistrationFeatureCounts",
+        "userRoles",
+        "userTypes"
+      ]
+    },
+    "userRegistrationMethodCount": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationMethod",
+        "userCount"
+      ]
+    },
+    "userRegistrationMethodSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "totalUserCount",
+        "userRegistrationMethodCounts",
+        "userRoles",
+        "userTypes"
+      ]
+    },
+    "userScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "userSecurityState": {
+      "navigationProperties": [],
+      "properties": [
+        "aadUserId",
+        "accountName",
+        "domainName",
+        "emailRole",
+        "isVpn",
+        "logonDateTime",
+        "logonId",
+        "logonIp",
+        "logonLocation",
+        "logonType",
+        "onPremisesSecurityIdentifier",
+        "riskScore",
+        "userAccountType",
+        "userPrincipalName"
+      ]
+    },
+    "userSignIn": {
+      "navigationProperties": [],
+      "properties": [
+        "externalTenantId",
+        "externalUserType",
+        "userId"
+      ]
+    },
+    "userSimulationDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedTrainingsCount",
+        "completedTrainingsCount",
+        "compromisedDateTime",
+        "inProgressTrainingsCount",
+        "isCompromised",
+        "reportedPhishDateTime",
+        "simulationEvents",
+        "simulationUser",
+        "trainingEvents"
+      ]
+    },
+    "userSimulationEventInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "browser",
+        "clickSource",
+        "eventDateTime",
+        "eventName",
+        "ipAddress",
+        "osPlatformDeviceDetails"
+      ]
+    },
+    "userTrainingContentEventInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "browser",
+        "contentDateTime",
+        "ipAddress",
+        "osPlatformDeviceDetails",
+        "potentialScoreImpact"
+      ]
+    },
+    "userTrainingEventInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "latestTrainingStatus",
+        "trainingAssignedProperties",
+        "trainingCompletedProperties",
+        "trainingUpdatedProperties"
+      ]
+    },
+    "userTrainingStatusInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedDateTime",
+        "completionDateTime",
+        "displayName",
+        "trainingStatus"
+      ]
+    },
+    "userWorkLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "placeId",
+        "source",
+        "workLocationType"
+      ]
+    },
+    "verifiedDomain": {
+      "navigationProperties": [],
+      "properties": [
+        "capabilities",
+        "isDefault",
+        "isInitial",
+        "name",
+        "type"
+      ]
+    },
+    "verifiedPublisher": {
+      "navigationProperties": [],
+      "properties": [
+        "addedDateTime",
+        "displayName",
+        "verifiedPublisherId"
+      ]
+    },
+    "versionAction": {
+      "navigationProperties": [],
+      "properties": [
+        "newVersion"
+      ]
+    },
+    "video": {
+      "navigationProperties": [],
+      "properties": [
+        "audioBitsPerSample",
+        "audioChannels",
+        "audioFormat",
+        "audioSamplesPerSecond",
+        "bitrate",
+        "duration",
+        "fourCC",
+        "frameRate",
+        "height",
+        "width"
+      ]
+    },
+    "virtualEventExternalInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationId",
+        "externalEventId"
+      ]
+    },
+    "virtualEventExternalRegistrationInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "referrer",
+        "registrationId"
+      ]
+    },
+    "virtualEventPresenterDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "bio",
+        "company",
+        "jobTitle",
+        "linkedInProfileWebUrl",
+        "personalSiteWebUrl",
+        "photo",
+        "twitterProfileWebUrl"
+      ]
+    },
+    "virtualEventPresenterInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "presenterDetails"
+      ]
+    },
+    "virtualEventRegistrationQuestionAnswer": {
+      "navigationProperties": [],
+      "properties": [
+        "booleanValue",
+        "displayName",
+        "multiChoiceValues",
+        "questionId",
+        "value"
+      ]
+    },
+    "virtualEventSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isAttendeeEmailNotificationEnabled"
+      ]
+    },
+    "visualInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "attribution",
+        "backgroundColor",
+        "content",
+        "description",
+        "displayText"
+      ]
+    },
+    "vppLicensingType": {
+      "navigationProperties": [],
+      "properties": [
+        "supportsDeviceLicensing",
+        "supportsUserLicensing"
+      ]
+    },
+    "vulnerabilityState": {
+      "navigationProperties": [],
+      "properties": [
+        "cve",
+        "severity",
+        "wasRunning"
+      ]
+    },
+    "watermarkProtectionValues": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabledForContentSharing",
+        "isEnabledForVideo"
+      ]
+    },
+    "webApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "homePageUrl",
+        "implicitGrantSettings",
+        "logoutUrl",
+        "redirectUris",
+        "redirectUriSettings"
+      ]
+    },
+    "webApplicationFirewallDnsConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isDomainVerified",
+        "isProxied",
+        "name",
+        "recordType",
+        "value"
+      ]
+    },
+    "webApplicationFirewallVerificationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "errors",
+        "status",
+        "verifiedOnDateTime",
+        "warnings"
+      ]
+    },
+    "webApplicationFirewallVerifiedDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "dnsConfiguration"
+      ]
+    },
+    "webPartData": {
+      "navigationProperties": [],
+      "properties": [
+        "dataVersion",
+        "description",
+        "properties",
+        "serverProcessedContent",
+        "title"
+      ]
+    },
+    "webPartPosition": {
+      "navigationProperties": [],
+      "properties": [
+        "columnId",
+        "horizontalSectionId",
+        "isInVerticalSection",
+        "webPartIndex"
+      ]
+    },
+    "website": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "displayName",
+        "type"
+      ]
+    },
+    "win32LobAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "autoUpdateSettings",
+        "deliveryOptimizationPriority",
+        "installTimeSettings",
+        "notifications",
+        "restartSettings"
+      ]
+    },
+    "win32LobAppAutoUpdateSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "autoUpdateSupersededAppsState"
+      ]
+    },
+    "win32LobAppFileSystemRule": {
+      "navigationProperties": [],
+      "properties": [
+        "check32BitOn64System",
+        "comparisonValue",
+        "fileOrFolderName",
+        "operationType",
+        "operator",
+        "path"
+      ]
+    },
+    "win32LobAppInstallExperience": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceRestartBehavior",
+        "runAsAccount"
+      ]
+    },
+    "win32LobAppMsiInformation": {
+      "navigationProperties": [],
+      "properties": [
+        "packageType",
+        "productCode",
+        "productName",
+        "productVersion",
+        "publisher",
+        "requiresReboot",
+        "upgradeCode"
+      ]
+    },
+    "win32LobAppPowerShellScriptRule": {
+      "navigationProperties": [],
+      "properties": [
+        "comparisonValue",
+        "displayName",
+        "enforceSignatureCheck",
+        "operationType",
+        "operator",
+        "runAs32Bit",
+        "runAsAccount",
+        "scriptContent"
+      ]
+    },
+    "win32LobAppProductCodeRule": {
+      "navigationProperties": [],
+      "properties": [
+        "productCode",
+        "productVersion",
+        "productVersionOperator"
+      ]
+    },
+    "win32LobAppRegistryRule": {
+      "navigationProperties": [],
+      "properties": [
+        "check32BitOn64System",
+        "comparisonValue",
+        "keyPath",
+        "operationType",
+        "operator",
+        "valueName"
+      ]
+    },
+    "win32LobAppRestartSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "countdownDisplayBeforeRestartInMinutes",
+        "gracePeriodInMinutes",
+        "restartNotificationSnoozeDurationInMinutes"
+      ]
+    },
+    "win32LobAppReturnCode": {
+      "navigationProperties": [],
+      "properties": [
+        "returnCode",
+        "type"
+      ]
+    },
+    "win32LobAppRule": {
+      "navigationProperties": [],
+      "properties": [
+        "ruleType"
+      ]
+    },
+    "windows10NetworkProxyServer": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "exceptions",
+        "useForLocalAddresses"
+      ]
+    },
+    "windowsAppXAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "useDeviceContext"
+      ]
+    },
+    "windowsDefenderScanActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "scanType"
+      ]
+    },
+    "windowsDeviceAccount": {
+      "navigationProperties": [],
+      "properties": [
+        "password"
+      ]
+    },
+    "windowsDeviceADAccount": {
+      "navigationProperties": [],
+      "properties": [
+        "domainName",
+        "userName"
+      ]
+    },
+    "windowsDeviceAzureADAccount": {
+      "navigationProperties": [],
+      "properties": [
+        "userPrincipalName"
+      ]
+    },
+    "windowsFirewallNetworkProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "authorizedApplicationRulesFromGroupPolicyMerged",
+        "connectionSecurityRulesFromGroupPolicyMerged",
+        "firewallEnabled",
+        "globalPortRulesFromGroupPolicyMerged",
+        "inboundConnectionsBlocked",
+        "inboundNotificationsBlocked",
+        "incomingTrafficBlocked",
+        "outboundConnectionsBlocked",
+        "policyRulesFromGroupPolicyMerged",
+        "securedPacketExemptionAllowed",
+        "stealthModeBlocked",
+        "unicastResponsesToMulticastBroadcastsBlocked"
+      ]
+    },
+    "windowsInformationProtectionApp": {
+      "navigationProperties": [],
+      "properties": [
+        "denied",
+        "description",
+        "displayName",
+        "productName",
+        "publisherName"
+      ]
+    },
+    "windowsInformationProtectionDataRecoveryCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "certificate",
+        "description",
+        "expirationDateTime",
+        "subjectName"
+      ]
+    },
+    "windowsInformationProtectionDesktopApp": {
+      "navigationProperties": [],
+      "properties": [
+        "binaryName",
+        "binaryVersionHigh",
+        "binaryVersionLow"
+      ]
+    },
+    "windowsInformationProtectionIPRangeCollection": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "ranges"
+      ]
+    },
+    "windowsInformationProtectionProxiedDomainCollection": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "proxiedDomains"
+      ]
+    },
+    "windowsInformationProtectionResourceCollection": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "resources"
+      ]
+    },
+    "windowsInformationProtectionStoreApp": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "windowsMalwareCategoryCount": {
+      "navigationProperties": [],
+      "properties": [
+        "activeMalwareDetectionCount",
+        "category",
+        "deviceCount",
+        "distinctActiveMalwareCount",
+        "lastUpdateDateTime"
+      ]
+    },
+    "windowsMalwareExecutionStateCount": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "executionState",
+        "lastUpdateDateTime"
+      ]
+    },
+    "windowsMalwareNameCount": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "lastUpdateDateTime",
+        "malwareIdentifier",
+        "name"
+      ]
+    },
+    "windowsMalwareOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "malwareCategorySummary",
+        "malwareDetectedDeviceCount",
+        "malwareExecutionStateSummary",
+        "malwareNameSummary",
+        "malwareSeveritySummary",
+        "malwareStateSummary",
+        "osVersionsSummary",
+        "totalDistinctMalwareCount",
+        "totalMalwareCount"
+      ]
+    },
+    "windowsMalwareSeverityCount": {
+      "navigationProperties": [],
+      "properties": [
+        "distinctMalwareCount",
+        "lastUpdateDateTime",
+        "malwareDetectionCount",
+        "severity"
+      ]
+    },
+    "windowsMalwareStateCount": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "distinctMalwareCount",
+        "lastUpdateDateTime",
+        "malwareDetectionCount",
+        "state"
+      ]
+    },
+    "windowsMinimumOperatingSystem": {
+      "navigationProperties": [],
+      "properties": [
+        "v10_0",
+        "v8_0",
+        "v8_1"
+      ]
+    },
+    "windowsUniversalAppXAppAssignmentSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "useDeviceContext"
+      ]
+    },
+    "windowsUpdateActiveHoursInstall": {
+      "navigationProperties": [],
+      "properties": [
+        "activeHoursEnd",
+        "activeHoursStart"
+      ]
+    },
+    "windowsUpdateInstallScheduleType": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "windowsUpdateScheduledInstall": {
+      "navigationProperties": [],
+      "properties": [
+        "scheduledInstallDay",
+        "scheduledInstallTime"
+      ]
+    },
+    "workbookFilterCriteria": {
+      "navigationProperties": [],
+      "properties": [
+        "color",
+        "criterion1",
+        "criterion2",
+        "dynamicCriteria",
+        "filterOn",
+        "icon",
+        "operator",
+        "values"
+      ]
+    },
+    "workbookFilterDatetime": {
+      "navigationProperties": [],
+      "properties": [
+        "date",
+        "specificity"
+      ]
+    },
+    "workbookIcon": {
+      "navigationProperties": [],
+      "properties": [
+        "index",
+        "set"
+      ]
+    },
+    "workbookOperationError": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "innerError",
+        "message"
+      ]
+    },
+    "workbookRangeReference": {
+      "navigationProperties": [],
+      "properties": [
+        "address"
+      ]
+    },
+    "workbookSessionInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "persistChanges"
+      ]
+    },
+    "workbookSortField": {
+      "navigationProperties": [],
+      "properties": [
+        "ascending",
+        "color",
+        "dataOption",
+        "icon",
+        "key",
+        "sortOn"
+      ]
+    },
+    "workbookWorksheetProtectionOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "allowAutoFilter",
+        "allowDeleteColumns",
+        "allowDeleteRows",
+        "allowFormatCells",
+        "allowFormatColumns",
+        "allowFormatRows",
+        "allowInsertColumns",
+        "allowInsertHyperlinks",
+        "allowInsertRows",
+        "allowPivotTables",
+        "allowSort"
+      ]
+    },
+    "workforceIntegrationEncryption": {
+      "navigationProperties": [],
+      "properties": [
+        "protocol",
+        "secret"
+      ]
+    },
+    "workingHours": {
+      "navigationProperties": [],
+      "properties": [
+        "daysOfWeek",
+        "endTime",
+        "startTime",
+        "timeZone"
+      ]
+    },
+    "x509CertificateAuthenticationModeConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "rules",
+        "x509CertificateAuthenticationDefaultMode",
+        "x509CertificateDefaultRequiredAffinityLevel"
+      ]
+    },
+    "x509CertificateAuthorityScope": {
+      "navigationProperties": [],
+      "properties": [
+        "includeTargets",
+        "publicKeyInfrastructureIdentifier",
+        "subjectKeyIdentifier"
+      ]
+    },
+    "x509CertificateCRLValidationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "exemptedCertificateAuthoritiesSubjectKeyIdentifiers",
+        "state"
+      ]
+    },
+    "x509CertificateIssuerHintsConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "state"
+      ]
+    },
+    "x509CertificateRule": {
+      "navigationProperties": [],
+      "properties": [
+        "identifier",
+        "issuerSubjectIdentifier",
+        "policyOidIdentifier",
+        "x509CertificateAuthenticationMode",
+        "x509CertificateRequiredAffinityLevel",
+        "x509CertificateRuleType"
+      ]
+    },
+    "x509CertificateUserBinding": {
+      "navigationProperties": [],
+      "properties": [
+        "priority",
+        "trustAffinityLevel",
+        "userProperty",
+        "x509CertificateField"
+      ]
+    }
+  },
+  "microsoft.graph.callRecords": {
+    "administrativeUnitInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "id"
+      ]
+    },
+    "clientUserAgent": {
+      "navigationProperties": [],
+      "properties": [
+        "azureADAppId",
+        "communicationServiceId",
+        "platform",
+        "productFamily"
+      ]
+    },
+    "deviceInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "captureDeviceDriver",
+        "captureDeviceName",
+        "captureNotFunctioningEventRatio",
+        "cpuInsufficentEventRatio",
+        "deviceClippingEventRatio",
+        "deviceGlitchEventRatio",
+        "howlingEventCount",
+        "initialSignalLevelRootMeanSquare",
+        "lowSpeechLevelEventRatio",
+        "lowSpeechToNoiseEventRatio",
+        "micGlitchRate",
+        "receivedNoiseLevel",
+        "receivedSignalLevel",
+        "renderDeviceDriver",
+        "renderDeviceName",
+        "renderMuteEventRatio",
+        "renderNotFunctioningEventRatio",
+        "renderZeroVolumeEventRatio",
+        "sentNoiseLevel",
+        "sentSignalLevel",
+        "speakerGlitchRate"
+      ]
+    },
+    "directRoutingLogRow": {
+      "navigationProperties": [],
+      "properties": [
+        "calleeNumber",
+        "callEndSubReason",
+        "callerNumber",
+        "callType",
+        "correlationId",
+        "duration",
+        "endDateTime",
+        "failureDateTime",
+        "finalSipCode",
+        "finalSipCodePhrase",
+        "id",
+        "inviteDateTime",
+        "mediaBypassEnabled",
+        "mediaPathLocation",
+        "signalingLocation",
+        "startDateTime",
+        "successfulCall",
+        "trunkFullyQualifiedDomainName",
+        "userDisplayName",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "endpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "userAgent"
+      ]
+    },
+    "failureInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "reason",
+        "stage"
+      ]
+    },
+    "feedbackTokenSet": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "media": {
+      "navigationProperties": [],
+      "properties": [
+        "calleeDevice",
+        "calleeNetwork",
+        "callerDevice",
+        "callerNetwork",
+        "label",
+        "streams"
+      ]
+    },
+    "mediaStream": {
+      "navigationProperties": [],
+      "properties": [
+        "audioCodec",
+        "averageAudioDegradation",
+        "averageAudioNetworkJitter",
+        "averageBandwidthEstimate",
+        "averageFreezeDuration",
+        "averageJitter",
+        "averagePacketLossRate",
+        "averageRatioOfConcealedSamples",
+        "averageReceivedFrameRate",
+        "averageRoundTripTime",
+        "averageVideoFrameLossPercentage",
+        "averageVideoFrameRate",
+        "averageVideoPacketLossRate",
+        "endDateTime",
+        "isAudioForwardErrorCorrectionUsed",
+        "lowFrameRateRatio",
+        "lowVideoProcessingCapabilityRatio",
+        "maxAudioNetworkJitter",
+        "maxJitter",
+        "maxPacketLossRate",
+        "maxRatioOfConcealedSamples",
+        "maxRoundTripTime",
+        "packetUtilization",
+        "postForwardErrorCorrectionPacketLossRate",
+        "rmsFreezeDuration",
+        "startDateTime",
+        "streamDirection",
+        "streamId",
+        "videoCodec",
+        "wasMediaBypassed"
+      ]
+    },
+    "networkInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "bandwidthLowEventRatio",
+        "basicServiceSetIdentifier",
+        "connectionType",
+        "delayEventRatio",
+        "dnsSuffix",
+        "ipAddress",
+        "linkSpeed",
+        "macAddress",
+        "networkTransportProtocol",
+        "port",
+        "receivedQualityEventRatio",
+        "reflexiveIPAddress",
+        "relayIPAddress",
+        "relayPort",
+        "sentQualityEventRatio",
+        "subnet",
+        "traceRouteHops",
+        "wifiBand",
+        "wifiBatteryCharge",
+        "wifiChannel",
+        "wifiMicrosoftDriver",
+        "wifiMicrosoftDriverVersion",
+        "wifiRadioType",
+        "wifiSignalStrength",
+        "wifiVendorDriver",
+        "wifiVendorDriverVersion"
+      ]
+    },
+    "participantEndpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "associatedIdentity",
+        "cpuCoresCount",
+        "cpuName",
+        "cpuProcessorSpeedInMhz",
+        "feedback",
+        "identity",
+        "name"
+      ]
+    },
+    "pstnCallLogRow": {
+      "navigationProperties": [],
+      "properties": [
+        "callDurationSource",
+        "calleeNumber",
+        "callerNumber",
+        "callId",
+        "callType",
+        "charge",
+        "conferenceId",
+        "connectionCharge",
+        "currency",
+        "destinationContext",
+        "destinationName",
+        "duration",
+        "endDateTime",
+        "id",
+        "inventoryType",
+        "licenseCapability",
+        "operator",
+        "startDateTime",
+        "tenantCountryCode",
+        "usageCountryCode",
+        "userDisplayName",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "serviceEndpoint": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "serviceUserAgent": {
+      "navigationProperties": [],
+      "properties": [
+        "role"
+      ]
+    },
+    "traceRouteHop": {
+      "navigationProperties": [],
+      "properties": [
+        "hopCount",
+        "ipAddress",
+        "roundTripTime"
+      ]
+    },
+    "userAgent": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationVersion",
+        "headerValue"
+      ]
+    },
+    "userFeedback": {
+      "navigationProperties": [],
+      "properties": [
+        "rating",
+        "text",
+        "tokens"
+      ]
+    },
+    "userIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "userPrincipalName"
+      ]
+    }
+  },
+  "microsoft.graph.externalConnectors": {
+    "acl": {
+      "navigationProperties": [],
+      "properties": [
+        "accessType",
+        "type",
+        "value"
+      ]
+    },
+    "activitySettings": {
+      "navigationProperties": [],
+      "properties": [
+        "urlToItemResolvers"
+      ]
+    },
+    "configuration": {
+      "navigationProperties": [],
+      "properties": [
+        "authorizedAppIds"
+      ]
+    },
+    "displayTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "id",
+        "layout",
+        "priority",
+        "rules"
+      ]
+    },
+    "externalItemContent": {
+      "navigationProperties": [],
+      "properties": [
+        "type",
+        "value"
+      ]
+    },
+    "itemIdResolver": {
+      "navigationProperties": [],
+      "properties": [
+        "itemId",
+        "urlMatchInfo"
+      ]
+    },
+    "principal": {
+      "navigationProperties": [],
+      "properties": [
+        "email",
+        "entraDisplayName",
+        "entraId",
+        "externalId",
+        "externalName",
+        "tenantId",
+        "upn"
+      ]
+    },
+    "properties": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "property": {
+      "navigationProperties": [],
+      "properties": [
+        "aliases",
+        "description",
+        "isQueryable",
+        "isRefinable",
+        "isRetrievable",
+        "isSearchable",
+        "labels",
+        "name",
+        "type"
+      ]
+    },
+    "propertyRule": {
+      "navigationProperties": [],
+      "properties": [
+        "operation",
+        "property",
+        "values",
+        "valuesJoinedBy"
+      ]
+    },
+    "searchSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "searchResultTemplates"
+      ]
+    },
+    "urlMatchInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "baseUrls",
+        "urlPattern"
+      ]
+    },
+    "urlToItemResolverBase": {
+      "navigationProperties": [],
+      "properties": [
+        "priority"
+      ]
+    }
+  },
+  "microsoft.graph.identityGovernance": {
+    "activateGroupScope": {
+      "navigationProperties": [
+        "group"
+      ],
+      "properties": []
+    },
+    "activateProcessingResultScope": {
+      "navigationProperties": [
+        "processingResults"
+      ],
+      "properties": [
+        "taskScope"
+      ]
+    },
+    "activateRunScope": {
+      "navigationProperties": [
+        "run"
+      ],
+      "properties": [
+        "taskScope",
+        "userScope"
+      ]
+    },
+    "activateUserScope": {
+      "navigationProperties": [
+        "users"
+      ],
+      "properties": []
+    },
+    "activationScope": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "attributeChangeTrigger": {
+      "navigationProperties": [],
+      "properties": [
+        "triggerAttributes"
+      ]
+    },
+    "customTaskExtensionCallbackConfiguration": {
+      "navigationProperties": [
+        "authorizedApps"
+      ],
+      "properties": []
+    },
+    "customTaskExtensionCallbackData": {
+      "navigationProperties": [],
+      "properties": [
+        "operationStatus"
+      ]
+    },
+    "customTaskExtensionCalloutData": {
+      "navigationProperties": [
+        "subject",
+        "task",
+        "taskProcessingresult",
+        "workflow"
+      ],
+      "properties": []
+    },
+    "groupBasedSubjectSet": {
+      "navigationProperties": [
+        "groups"
+      ],
+      "properties": []
+    },
+    "membershipChangeTrigger": {
+      "navigationProperties": [],
+      "properties": [
+        "changeType"
+      ]
+    },
+    "onDemandExecutionOnly": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "parameter": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "values",
+        "valueType"
+      ]
+    },
+    "ruleBasedSubjectSet": {
+      "navigationProperties": [],
+      "properties": [
+        "rule"
+      ]
+    },
+    "runSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedRuns",
+        "failedTasks",
+        "successfulRuns",
+        "totalRuns",
+        "totalTasks",
+        "totalUsers"
+      ]
+    },
+    "taskReportSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedTasks",
+        "successfulTasks",
+        "totalTasks",
+        "unprocessedTasks"
+      ]
+    },
+    "timeBasedAttributeTrigger": {
+      "navigationProperties": [],
+      "properties": [
+        "offsetInDays",
+        "timeBasedAttribute"
+      ]
+    },
+    "topTasksInsightsSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedTasks",
+        "failedUsers",
+        "successfulTasks",
+        "successfulUsers",
+        "taskDefinitionDisplayName",
+        "taskDefinitionId",
+        "totalTasks",
+        "totalUsers"
+      ]
+    },
+    "topWorkflowsInsightsSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedRuns",
+        "failedUsers",
+        "successfulRuns",
+        "successfulUsers",
+        "totalRuns",
+        "totalUsers",
+        "workflowCategory",
+        "workflowDisplayName",
+        "workflowId",
+        "workflowVersion"
+      ]
+    },
+    "triggerAndScopeBasedConditions": {
+      "navigationProperties": [],
+      "properties": [
+        "scope",
+        "trigger"
+      ]
+    },
+    "triggerAttribute": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "userInactivityTrigger": {
+      "navigationProperties": [],
+      "properties": [
+        "inactivityPeriodInDays"
+      ]
+    },
+    "usersProcessingSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedTasks",
+        "failedUsers",
+        "successfulUsers",
+        "totalTasks",
+        "totalUsers"
+      ]
+    },
+    "userSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedTasks",
+        "failedUsers",
+        "successfulUsers",
+        "totalTasks",
+        "totalUsers"
+      ]
+    },
+    "workflowExecutionConditions": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "workflowExecutionTrigger": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "workflowsInsightsByCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "failedJoinerRuns",
+        "failedLeaverRuns",
+        "failedMoverRuns",
+        "successfulJoinerRuns",
+        "successfulLeaverRuns",
+        "successfulMoverRuns",
+        "totalJoinerRuns",
+        "totalLeaverRuns",
+        "totalMoverRuns"
+      ]
+    },
+    "workflowsInsightsSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedRuns",
+        "failedTasks",
+        "failedUsers",
+        "successfulRuns",
+        "successfulTasks",
+        "successfulUsers",
+        "totalRuns",
+        "totalTasks",
+        "totalUsers"
+      ]
+    }
+  },
+  "microsoft.graph.partners.billing": {
+    "blob": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "partitionValue"
+      ]
+    }
+  },
+  "microsoft.graph.search": {
+    "answerKeyword": {
+      "navigationProperties": [],
+      "properties": [
+        "keywords",
+        "matchSimilarKeywords",
+        "reservedKeywords"
+      ]
+    },
+    "answerVariant": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "languageTag",
+        "platform",
+        "webUrl"
+      ]
+    },
+    "identity": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "id"
+      ]
+    },
+    "identitySet": {
+      "navigationProperties": [],
+      "properties": [
+        "application",
+        "device",
+        "user"
+      ]
+    }
+  },
+  "microsoft.graph.security": {
+    "account": {
+      "navigationProperties": [],
+      "properties": [
+        "actions",
+        "identifier",
+        "identityProvider"
+      ]
+    },
+    "activeDirectoryDomainEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDirectoryDomainName",
+        "trustedDomains"
+      ]
+    },
+    "aiAgentEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "agentId",
+        "agentName",
+        "hostingPlatformType",
+        "instructions"
+      ]
+    },
+    "alertComment": {
+      "navigationProperties": [],
+      "properties": [
+        "comment",
+        "createdByDisplayName",
+        "createdDateTime"
+      ]
+    },
+    "alertEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "detailedRoles",
+        "remediationStatus",
+        "remediationStatusDetails",
+        "roles",
+        "tags",
+        "verdict"
+      ]
+    },
+    "amazonResourceEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "amazonAccountId",
+        "amazonResourceId",
+        "resourceName",
+        "resourceType"
+      ]
+    },
+    "analyzedMessageEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "antiSpamDirection",
+        "attachmentsCount",
+        "deliveryAction",
+        "deliveryLocation",
+        "internetMessageId",
+        "language",
+        "networkMessageId",
+        "p1Sender",
+        "p2Sender",
+        "receivedDateTime",
+        "recipientEmailAddress",
+        "senderIp",
+        "subject",
+        "threatDetectionMethods",
+        "threats",
+        "urlCount",
+        "urls",
+        "urn"
+      ]
+    },
+    "autonomousSystem": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "number",
+        "organization",
+        "value"
+      ]
+    },
+    "azureResourceEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceId",
+        "resourceName",
+        "resourceType"
+      ]
+    },
+    "blobContainerEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "storageResource",
+        "url"
+      ]
+    },
+    "blobEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "blobContainer",
+        "etag",
+        "fileHashes",
+        "name",
+        "url"
+      ]
+    },
+    "cloudApplicationEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "displayName",
+        "instanceId",
+        "instanceName",
+        "saasAppId",
+        "stream"
+      ]
+    },
+    "cloudLogonRequestEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "requestId"
+      ]
+    },
+    "cloudLogonSessionEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "account",
+        "browser",
+        "deviceName",
+        "operatingSystem",
+        "previousLogonDateTime",
+        "protocol",
+        "sessionId",
+        "startUtcDateTime",
+        "userAgent"
+      ]
+    },
+    "containerEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "args",
+        "command",
+        "containerId",
+        "image",
+        "isPrivileged",
+        "name",
+        "pod"
+      ]
+    },
+    "containerImageEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "digestImage",
+        "imageId",
+        "registry"
+      ]
+    },
+    "containerRegistryEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "registry"
+      ]
+    },
+    "cvssSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "score",
+        "severity",
+        "vectorString"
+      ]
+    },
+    "deploymentAccessKeyType": {
+      "navigationProperties": [],
+      "properties": [
+        "deploymentAccessKey"
+      ]
+    },
+    "deviceEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "azureAdDeviceId",
+        "defenderAvStatus",
+        "deviceDnsName",
+        "dnsDomain",
+        "firstSeenDateTime",
+        "healthStatus",
+        "hostName",
+        "ipInterfaces",
+        "lastExternalIpAddress",
+        "lastIpAddress",
+        "loggedOnUsers",
+        "mdeDeviceId",
+        "ntDomain",
+        "onboardingStatus",
+        "osBuild",
+        "osPlatform",
+        "rbacGroupId",
+        "rbacGroupName",
+        "resourceAccessEvents",
+        "riskScore",
+        "version",
+        "vmMetadata"
+      ]
+    },
+    "dictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "dnsEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "dnsServerIp",
+        "domainName",
+        "hostIpAddress",
+        "ipAddresses"
+      ]
+    },
+    "dynamicColumnValue": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "emailSender": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "domainName",
+        "emailAddress"
+      ]
+    },
+    "eventPropagationResult": {
+      "navigationProperties": [],
+      "properties": [
+        "location",
+        "serviceName",
+        "status",
+        "statusInformation"
+      ]
+    },
+    "eventQuery": {
+      "navigationProperties": [],
+      "properties": [
+        "query",
+        "queryType"
+      ]
+    },
+    "exportFileMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "downloadUrl",
+        "fileName",
+        "size"
+      ]
+    },
+    "fileDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "fileName",
+        "filePath",
+        "filePublisher",
+        "fileSize",
+        "issuer",
+        "md5",
+        "sha1",
+        "sha256",
+        "sha256Ac",
+        "signer"
+      ]
+    },
+    "fileEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionStatus",
+        "fileDetails",
+        "mdeDeviceId"
+      ]
+    },
+    "fileHash": {
+      "navigationProperties": [],
+      "properties": [
+        "algorithm",
+        "value"
+      ]
+    },
+    "fileHashEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "algorithm",
+        "value"
+      ]
+    },
+    "filePlanAppliedCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "subcategory"
+      ]
+    },
+    "filePlanAuthority": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "filePlanCitation": {
+      "navigationProperties": [],
+      "properties": [
+        "citationJurisdiction",
+        "citationUrl"
+      ]
+    },
+    "filePlanDepartment": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "filePlanDescriptorBase": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "filePlanReference": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "filePlanSubcategory": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "formattedContent": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "format"
+      ]
+    },
+    "geoLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "city",
+        "countryName",
+        "latitude",
+        "longitude",
+        "state"
+      ]
+    },
+    "gitHubOrganizationEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "company",
+        "displayName",
+        "email",
+        "login",
+        "orgId",
+        "webUrl"
+      ]
+    },
+    "gitHubRepoEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "baseUrl",
+        "login",
+        "owner",
+        "ownerType",
+        "repoId"
+      ]
+    },
+    "gitHubUserEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "email",
+        "login",
+        "name",
+        "userId",
+        "webUrl"
+      ]
+    },
+    "googleCloudResourceEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "fullResourceName",
+        "location",
+        "locationType",
+        "projectId",
+        "projectNumber",
+        "resourceName",
+        "resourceType"
+      ]
+    },
+    "hostLogonSessionEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "account",
+        "endUtcDateTime",
+        "host",
+        "sessionId",
+        "startUtcDateTime"
+      ]
+    },
+    "hostPortBanner": {
+      "navigationProperties": [],
+      "properties": [
+        "banner",
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "scanProtocol",
+        "timesObserved"
+      ]
+    },
+    "hostPortComponent": {
+      "navigationProperties": [
+        "component"
+      ],
+      "properties": [
+        "firstSeenDateTime",
+        "isRecent",
+        "lastSeenDateTime"
+      ]
+    },
+    "hostReputationRule": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "name",
+        "relatedDetailsUrl",
+        "severity"
+      ]
+    },
+    "hostSslCertificatePort": {
+      "navigationProperties": [],
+      "properties": [
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "port"
+      ]
+    },
+    "huntingQueryResults": {
+      "navigationProperties": [],
+      "properties": [
+        "results",
+        "schema"
+      ]
+    },
+    "huntingRowResult": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "hyperlink": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "url"
+      ]
+    },
+    "intelligenceProfileCountryOrRegionOfOrigin": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "label"
+      ]
+    },
+    "invokeActionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "accountId",
+        "action",
+        "correlationId",
+        "identityProvider"
+      ]
+    },
+    "ioTDeviceEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "deviceName",
+        "devicePageLink",
+        "deviceSubType",
+        "deviceType",
+        "importance",
+        "ioTHub",
+        "ioTSecurityAgentId",
+        "ipAddress",
+        "isAuthorized",
+        "isProgramming",
+        "isScanner",
+        "macAddress",
+        "manufacturer",
+        "model",
+        "nics",
+        "operatingSystem",
+        "owners",
+        "protocols",
+        "purdueLayer",
+        "sensor",
+        "serialNumber",
+        "site",
+        "source",
+        "sourceRef",
+        "zone"
+      ]
+    },
+    "ipEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "countryLetterCode",
+        "ipAddress",
+        "location",
+        "stream"
+      ]
+    },
+    "kubernetesClusterEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudResource",
+        "distribution",
+        "name",
+        "platform",
+        "version"
+      ]
+    },
+    "kubernetesControllerEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "labels",
+        "name",
+        "namespace",
+        "type"
+      ]
+    },
+    "kubernetesNamespaceEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "cluster",
+        "labels",
+        "name"
+      ]
+    },
+    "kubernetesPodEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "containers",
+        "controller",
+        "ephemeralContainers",
+        "initContainers",
+        "labels",
+        "name",
+        "namespace",
+        "podIp",
+        "serviceAccount"
+      ]
+    },
+    "kubernetesSecretEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "namespace",
+        "secretType"
+      ]
+    },
+    "kubernetesServiceAccountEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "namespace"
+      ]
+    },
+    "kubernetesServiceEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "clusterIP",
+        "externalIPs",
+        "labels",
+        "name",
+        "namespace",
+        "selector",
+        "servicePorts",
+        "serviceType"
+      ]
+    },
+    "kubernetesServicePort": {
+      "navigationProperties": [],
+      "properties": [
+        "appProtocol",
+        "name",
+        "nodePort",
+        "port",
+        "protocol",
+        "targetPort"
+      ]
+    },
+    "loggedOnUser": {
+      "navigationProperties": [],
+      "properties": [
+        "accountName",
+        "domainName"
+      ]
+    },
+    "mailboxConfigurationEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationId",
+        "configurationType",
+        "displayName",
+        "externalDirectoryObjectId",
+        "mailboxPrimaryAddress",
+        "upn"
+      ]
+    },
+    "mailboxEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "primaryAddress",
+        "upn",
+        "userAccount"
+      ]
+    },
+    "mailClusterEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "clusterBy",
+        "clusterByValue",
+        "emailCount",
+        "networkMessageIds",
+        "query",
+        "urn"
+      ]
+    },
+    "malwareEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "files",
+        "name",
+        "processes"
+      ]
+    },
+    "networkConnectionEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "destinationAddress",
+        "destinationPort",
+        "protocol",
+        "sourceAddress",
+        "sourcePort"
+      ]
+    },
+    "nicEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "ipAddress",
+        "macAddress",
+        "vlans"
+      ]
+    },
+    "oauthApplicationEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "displayName",
+        "objectId",
+        "publisher"
+      ]
+    },
+    "ocrSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "maxImageSize",
+        "timeout"
+      ]
+    },
+    "processEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionStatus",
+        "imageFile",
+        "mdeDeviceId",
+        "parentProcessCreationDateTime",
+        "parentProcessId",
+        "parentProcessImageFile",
+        "processCommandLine",
+        "processCreationDateTime",
+        "processId",
+        "userAccount"
+      ]
+    },
+    "redundancyDetectionSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "maxWords",
+        "minWords",
+        "similarityThreshold"
+      ]
+    },
+    "registryKeyEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "registryHive",
+        "registryKey"
+      ]
+    },
+    "registryValueEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "mdeDeviceId",
+        "registryHive",
+        "registryKey",
+        "registryValue",
+        "registryValueName",
+        "registryValueType"
+      ]
+    },
+    "reportFileMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "downloadUrl",
+        "fileName",
+        "size"
+      ]
+    },
+    "resourceAccessEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "accessDateTime",
+        "accountId",
+        "ipAddress",
+        "resourceIdentifier"
+      ]
+    },
+    "retentionDuration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "retentionDurationForever": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "retentionDurationInDays": {
+      "navigationProperties": [],
+      "properties": [
+        "days"
+      ]
+    },
+    "retentionEventStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "status"
+      ]
+    },
+    "sasTokenEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedIpAddresses",
+        "allowedResourceTypes",
+        "allowedServices",
+        "expiryDateTime",
+        "permissions",
+        "protocol",
+        "signatureHash",
+        "signedWith",
+        "startDateTime",
+        "storageResource"
+      ]
+    },
+    "securityGroupEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDirectoryObjectGuid",
+        "displayName",
+        "distinguishedName",
+        "friendlyName",
+        "securityGroupId",
+        "sid"
+      ]
+    },
+    "sensorDeploymentPackage": {
+      "navigationProperties": [],
+      "properties": [
+        "downloadUrl",
+        "version"
+      ]
+    },
+    "sensorSettings": {
+      "navigationProperties": [
+        "networkAdapters"
+      ],
+      "properties": [
+        "description",
+        "domainControllerDnsNames",
+        "isDelayedDeploymentEnabled"
+      ]
+    },
+    "servicePrincipalEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "appOwnerTenantId",
+        "servicePrincipalName",
+        "servicePrincipalObjectId",
+        "servicePrincipalType",
+        "tenantId"
+      ]
+    },
+    "singlePropertySchema": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "type"
+      ]
+    },
+    "sslCertificateEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "alternateNames",
+        "commonName",
+        "email",
+        "givenName",
+        "organizationName",
+        "organizationUnitName",
+        "serialNumber",
+        "surname"
+      ]
+    },
+    "stream": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "stringValueDictionary": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "submissionMailEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "networkMessageId",
+        "recipient",
+        "reportType",
+        "sender",
+        "senderIp",
+        "subject",
+        "submissionDateTime",
+        "submissionId",
+        "submitter"
+      ]
+    },
+    "teamsMessageEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "campaignId",
+        "channelId",
+        "deliveryAction",
+        "deliveryLocation",
+        "files",
+        "groupId",
+        "isExternal",
+        "isOwned",
+        "lastModifiedDateTime",
+        "messageDirection",
+        "messageId",
+        "owningTenantId",
+        "parentMessageId",
+        "receivedDateTime",
+        "recipients",
+        "senderFromAddress",
+        "senderIP",
+        "sourceAppName",
+        "sourceId",
+        "subject",
+        "suspiciousRecipients",
+        "threadId",
+        "threadType",
+        "urls"
+      ]
+    },
+    "topicModelingSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "dynamicallyAdjustTopicCount",
+        "ignoreNumbers",
+        "isEnabled",
+        "topicCount"
+      ]
+    },
+    "urlEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "url"
+      ]
+    },
+    "userAccount": {
+      "navigationProperties": [],
+      "properties": [
+        "accountName",
+        "activeDirectoryObjectGuid",
+        "azureAdUserId",
+        "displayName",
+        "domainName",
+        "resourceAccessEvents",
+        "userPrincipalName",
+        "userSid"
+      ]
+    },
+    "userEvidence": {
+      "navigationProperties": [],
+      "properties": [
+        "stream",
+        "userAccount"
+      ]
+    },
+    "vmMetadata": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudProvider",
+        "resourceId",
+        "subscriptionId",
+        "vmId"
+      ]
+    },
+    "whoisContact": {
+      "navigationProperties": [],
+      "properties": [
+        "address",
+        "email",
+        "fax",
+        "name",
+        "organization",
+        "telephone"
+      ]
+    },
+    "whoisNameserver": {
+      "navigationProperties": [
+        "host"
+      ],
+      "properties": [
+        "firstSeenDateTime",
+        "lastSeenDateTime"
+      ]
+    }
+  },
+  "microsoft.graph.teamsAdministration": {
+    "assignedTelephoneNumber": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentCategory",
+        "telephoneNumber"
+      ]
+    },
+    "effectivePolicyAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "policyAssignment",
+        "policyType"
+      ]
+    },
+    "policyAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentType",
+        "displayName",
+        "groupId",
+        "policyId"
+      ]
+    },
+    "telephoneNumberLongRunningOperationDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "resourceLocation",
+        "status",
+        "statusDetail"
+      ]
+    }
+  },
+  "microsoft.graph.termStore": {
+    "localizedDescription": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "languageTag"
+      ]
+    },
+    "localizedLabel": {
+      "navigationProperties": [],
+      "properties": [
+        "isDefault",
+        "languageTag",
+        "name"
+      ]
+    },
+    "localizedName": {
+      "navigationProperties": [],
+      "properties": [
+        "languageTag",
+        "name"
+      ]
+    }
+  }
+}

--- a/schemas/type-mappings/v1.0-entity-types.json
+++ b/schemas/type-mappings/v1.0-entity-types.json
@@ -561,50 +561,6 @@
         "hostPrefix"
       ]
     },
-    "alert": {
-      "navigationProperties": [],
-      "properties": [
-        "activityGroupName",
-        "alertDetections",
-        "assignedTo",
-        "azureSubscriptionId",
-        "azureTenantId",
-        "category",
-        "closedDateTime",
-        "cloudAppStates",
-        "comments",
-        "confidence",
-        "createdDateTime",
-        "description",
-        "detectionIds",
-        "eventDateTime",
-        "feedback",
-        "fileStates",
-        "historyStates",
-        "hostStates",
-        "incidentIds",
-        "investigationSecurityStates",
-        "lastEventDateTime",
-        "lastModifiedDateTime",
-        "malwareStates",
-        "messageSecurityStates",
-        "networkConnections",
-        "processes",
-        "recommendedActions",
-        "registryKeyStates",
-        "securityResources",
-        "severity",
-        "sourceMaterials",
-        "status",
-        "tags",
-        "title",
-        "triggers",
-        "uriClickSecurityStates",
-        "userStates",
-        "vendorInformation",
-        "vulnerabilityStates"
-      ]
-    },
     "allowedValue": {
       "navigationProperties": [],
       "properties": [
@@ -1278,6 +1234,7 @@
     },
     "backupRestoreRoot": {
       "navigationProperties": [
+        "browseSessions",
         "driveInclusionRules",
         "driveProtectionUnits",
         "driveProtectionUnitsBulkAdditionJobs",
@@ -1286,6 +1243,7 @@
         "mailboxInclusionRules",
         "mailboxProtectionUnits",
         "mailboxProtectionUnitsBulkAdditionJobs",
+        "oneDriveForBusinessBrowseSessions",
         "oneDriveForBusinessProtectionPolicies",
         "oneDriveForBusinessRestoreSessions",
         "protectionPolicies",
@@ -1293,6 +1251,7 @@
         "restorePoints",
         "restoreSessions",
         "serviceApps",
+        "sharePointBrowseSessions",
         "sharePointProtectionPolicies",
         "sharePointRestoreSessions",
         "siteInclusionRules",
@@ -1548,6 +1507,18 @@
         "publishedBy",
         "publishedDateTime",
         "revision",
+        "status"
+      ]
+    },
+    "browseSessionBase": {
+      "navigationProperties": [],
+      "properties": [
+        "backupSizeInBytes",
+        "createdDateTime",
+        "error",
+        "expirationDateTime",
+        "restorePointDateTime",
+        "restorePointId",
         "status"
       ]
     },
@@ -4427,11 +4398,37 @@
         "insightCreatedDateTime"
       ]
     },
+    "granularDriveRestoreArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectId"
+      ]
+    },
     "granularMailboxRestoreArtifact": {
       "navigationProperties": [],
       "properties": [
         "artifactCount",
         "searchResponseId"
+      ]
+    },
+    "granularRestoreArtifactBase": {
+      "navigationProperties": [],
+      "properties": [
+        "browseSessionId",
+        "completionDateTime",
+        "restoredItemKey",
+        "restoredItemPath",
+        "restoredItemWebUrl",
+        "restorePointDateTime",
+        "startDateTime",
+        "status",
+        "webUrl"
+      ]
+    },
+    "granularSiteRestoreArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "siteId"
       ]
     },
     "group": {
@@ -4586,7 +4583,8 @@
         "customAuthenticationExtensions",
         "identityProviders",
         "riskPrevention",
-        "userFlowAttributes"
+        "userFlowAttributes",
+        "verifiedId"
       ],
       "properties": []
     },
@@ -4662,6 +4660,12 @@
         "userAttributeValues",
         "userInputType"
       ]
+    },
+    "identityVerifiedIdRoot": {
+      "navigationProperties": [
+        "profiles"
+      ],
+      "properties": []
     },
     "importedWindowsAutopilotDeviceIdentity": {
       "navigationProperties": [],
@@ -6259,6 +6263,12 @@
         "handler"
       ]
     },
+    "oneDriveForBusinessBrowseSession": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectId"
+      ]
+    },
     "oneDriveForBusinessProtectionPolicy": {
       "navigationProperties": [
         "driveInclusionRules",
@@ -6270,7 +6280,8 @@
     "oneDriveForBusinessRestoreSession": {
       "navigationProperties": [
         "driveRestoreArtifacts",
-        "driveRestoreArtifactsBulkAdditionRequests"
+        "driveRestoreArtifactsBulkAdditionRequests",
+        "granularDriveRestoreArtifacts"
       ],
       "properties": []
     },
@@ -6485,6 +6496,16 @@
       ]
     },
     "onUserCreateStartListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onVerifiedIdClaimValidationCustomExtension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onVerifiedIdClaimValidationListener": {
       "navigationProperties": [],
       "properties": [
         "handler"
@@ -8031,7 +8052,6 @@
     },
     "security": {
       "navigationProperties": [
-        "alerts",
         "alerts_v2",
         "attackSimulation",
         "cases",
@@ -8317,6 +8337,12 @@
       ],
       "properties": []
     },
+    "sharePointBrowseSession": {
+      "navigationProperties": [],
+      "properties": [
+        "siteId"
+      ]
+    },
     "sharePointGroup": {
       "navigationProperties": [
         "members"
@@ -8429,6 +8455,7 @@
     },
     "sharePointRestoreSession": {
       "navigationProperties": [
+        "granularSiteRestoreArtifacts",
         "siteRestoreArtifacts",
         "siteRestoreArtifactsBulkAdditionRequests"
       ],
@@ -10252,6 +10279,20 @@
       "properties": [
         "locale",
         "region"
+      ]
+    },
+    "verifiedIdProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "faceCheckConfiguration",
+        "lastModifiedDateTime",
+        "name",
+        "priority",
+        "state",
+        "verifiedIdProfileConfiguration",
+        "verifiedIdUsageConfigurations",
+        "verifierDid"
       ]
     },
     "verticalSection": {

--- a/schemas/type-mappings/v1.0-entity-types.json
+++ b/schemas/type-mappings/v1.0-entity-types.json
@@ -1,0 +1,13202 @@
+{
+  "microsoft.graph": {
+    "aadUserConversationMember": {
+      "navigationProperties": [
+        "user"
+      ],
+      "properties": [
+        "email",
+        "tenantId",
+        "userId"
+      ]
+    },
+    "accessPackage": {
+      "navigationProperties": [
+        "accessPackagesIncompatibleWith",
+        "assignmentPolicies",
+        "catalog",
+        "incompatibleAccessPackages",
+        "incompatibleGroups",
+        "resourceRoleScopes"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "isHidden",
+        "modifiedDateTime"
+      ]
+    },
+    "accessPackageAssignment": {
+      "navigationProperties": [
+        "accessPackage",
+        "assignmentPolicy",
+        "target"
+      ],
+      "properties": [
+        "customExtensionCalloutInstances",
+        "expiredDateTime",
+        "schedule",
+        "state",
+        "status"
+      ]
+    },
+    "accessPackageAssignmentPolicy": {
+      "navigationProperties": [
+        "accessPackage",
+        "catalog",
+        "customExtensionStageSettings",
+        "questions"
+      ],
+      "properties": [
+        "allowedTargetScope",
+        "automaticRequestSettings",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "expiration",
+        "modifiedDateTime",
+        "notificationSettings",
+        "requestApprovalSettings",
+        "requestorSettings",
+        "reviewSettings",
+        "specificAllowedTargets"
+      ]
+    },
+    "accessPackageAssignmentRequest": {
+      "navigationProperties": [
+        "accessPackage",
+        "assignment",
+        "requestor"
+      ],
+      "properties": [
+        "answers",
+        "completedDateTime",
+        "createdDateTime",
+        "customExtensionCalloutInstances",
+        "justification",
+        "requestType",
+        "schedule",
+        "state",
+        "status"
+      ]
+    },
+    "accessPackageAssignmentRequestWorkflowExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "callbackConfiguration",
+        "createdBy",
+        "createdDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "accessPackageAssignmentWorkflowExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "callbackConfiguration",
+        "createdBy",
+        "createdDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "accessPackageCatalog": {
+      "navigationProperties": [
+        "accessPackages",
+        "customWorkflowExtensions",
+        "resourceRoles",
+        "resources",
+        "resourceScopes"
+      ],
+      "properties": [
+        "catalogType",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "isExternallyVisible",
+        "modifiedDateTime",
+        "state"
+      ]
+    },
+    "accessPackageMultipleChoiceQuestion": {
+      "navigationProperties": [],
+      "properties": [
+        "choices",
+        "isMultipleSelectionAllowed"
+      ]
+    },
+    "accessPackageQuestion": {
+      "navigationProperties": [],
+      "properties": [
+        "isAnswerEditable",
+        "isRequired",
+        "localizations",
+        "sequence",
+        "text"
+      ]
+    },
+    "accessPackageResource": {
+      "navigationProperties": [
+        "environment",
+        "roles",
+        "scopes"
+      ],
+      "properties": [
+        "attributes",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "modifiedDateTime",
+        "originId",
+        "originSystem"
+      ]
+    },
+    "accessPackageResourceEnvironment": {
+      "navigationProperties": [
+        "resources"
+      ],
+      "properties": [
+        "connectionInfo",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "isDefaultEnvironment",
+        "modifiedDateTime",
+        "originId",
+        "originSystem"
+      ]
+    },
+    "accessPackageResourceRequest": {
+      "navigationProperties": [
+        "catalog",
+        "resource"
+      ],
+      "properties": [
+        "createdDateTime",
+        "requestType",
+        "state"
+      ]
+    },
+    "accessPackageResourceRole": {
+      "navigationProperties": [
+        "resource"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "originId",
+        "originSystem"
+      ]
+    },
+    "accessPackageResourceRoleScope": {
+      "navigationProperties": [
+        "role",
+        "scope"
+      ],
+      "properties": [
+        "createdDateTime"
+      ]
+    },
+    "accessPackageResourceScope": {
+      "navigationProperties": [
+        "resource"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "isRootScope",
+        "originId",
+        "originSystem"
+      ]
+    },
+    "accessPackageSubject": {
+      "navigationProperties": [
+        "connectedOrganization"
+      ],
+      "properties": [
+        "displayName",
+        "email",
+        "objectId",
+        "onPremisesSecurityIdentifier",
+        "principalName",
+        "subjectType"
+      ]
+    },
+    "accessPackageTextInputQuestion": {
+      "navigationProperties": [],
+      "properties": [
+        "isSingleLineQuestion",
+        "regexPattern"
+      ]
+    },
+    "accessReviewHistoryDefinition": {
+      "navigationProperties": [
+        "instances"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "decisions",
+        "displayName",
+        "reviewHistoryPeriodEndDateTime",
+        "reviewHistoryPeriodStartDateTime",
+        "scheduleSettings",
+        "scopes",
+        "status"
+      ]
+    },
+    "accessReviewHistoryInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "downloadUri",
+        "expirationDateTime",
+        "fulfilledDateTime",
+        "reviewHistoryPeriodEndDateTime",
+        "reviewHistoryPeriodStartDateTime",
+        "runDateTime",
+        "status"
+      ]
+    },
+    "accessReviewInstance": {
+      "navigationProperties": [
+        "contactedReviewers",
+        "decisions",
+        "stages"
+      ],
+      "properties": [
+        "endDateTime",
+        "fallbackReviewers",
+        "reviewers",
+        "scope",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "accessReviewInstanceDecisionItem": {
+      "navigationProperties": [
+        "insights"
+      ],
+      "properties": [
+        "accessReviewId",
+        "appliedBy",
+        "appliedDateTime",
+        "applyResult",
+        "decision",
+        "justification",
+        "principal",
+        "principalLink",
+        "recommendation",
+        "resource",
+        "resourceLink",
+        "reviewedBy",
+        "reviewedDateTime"
+      ]
+    },
+    "accessReviewReviewer": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "userPrincipalName"
+      ]
+    },
+    "accessReviewScheduleDefinition": {
+      "navigationProperties": [
+        "instances"
+      ],
+      "properties": [
+        "additionalNotificationRecipients",
+        "createdBy",
+        "createdDateTime",
+        "descriptionForAdmins",
+        "descriptionForReviewers",
+        "displayName",
+        "fallbackReviewers",
+        "instanceEnumerationScope",
+        "lastModifiedDateTime",
+        "reviewers",
+        "scope",
+        "settings",
+        "stageSettings",
+        "status"
+      ]
+    },
+    "accessReviewSet": {
+      "navigationProperties": [
+        "definitions",
+        "historyDefinitions"
+      ],
+      "properties": []
+    },
+    "accessReviewStage": {
+      "navigationProperties": [
+        "decisions"
+      ],
+      "properties": [
+        "endDateTime",
+        "fallbackReviewers",
+        "reviewers",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "activitiesContainer": {
+      "navigationProperties": [
+        "contentActivities"
+      ],
+      "properties": []
+    },
+    "activityBasedTimeoutPolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "activityHistoryItem": {
+      "navigationProperties": [
+        "activity"
+      ],
+      "properties": [
+        "activeDurationSeconds",
+        "createdDateTime",
+        "expirationDateTime",
+        "lastActiveDateTime",
+        "lastModifiedDateTime",
+        "startedDateTime",
+        "status",
+        "userTimezone"
+      ]
+    },
+    "addLargeGalleryViewOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "adhocCall": {
+      "navigationProperties": [
+        "recordings",
+        "transcripts"
+      ],
+      "properties": []
+    },
+    "admin": {
+      "navigationProperties": [
+        "configurationManagement",
+        "edge",
+        "exchange",
+        "microsoft365Apps",
+        "people",
+        "reportSettings",
+        "serviceAnnouncement",
+        "sharepoint",
+        "teams"
+      ],
+      "properties": []
+    },
+    "adminConsentRequestPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "notifyReviewers",
+        "remindersEnabled",
+        "requestDurationInDays",
+        "reviewers",
+        "version"
+      ]
+    },
+    "administrativeUnit": {
+      "navigationProperties": [
+        "extensions",
+        "members",
+        "scopedRoleMembers"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "isMemberManagementRestricted",
+        "membershipRule",
+        "membershipRuleProcessingState",
+        "membershipType",
+        "visibility"
+      ]
+    },
+    "adminMicrosoft365Apps": {
+      "navigationProperties": [
+        "installationOptions"
+      ],
+      "properties": []
+    },
+    "adminReportSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "displayConcealedNames"
+      ]
+    },
+    "agentIdentity": {
+      "navigationProperties": [
+        "sponsors"
+      ],
+      "properties": [
+        "agentIdentityBlueprintId",
+        "createdDateTime"
+      ]
+    },
+    "agentIdentityBlueprint": {
+      "navigationProperties": [
+        "inheritablePermissions",
+        "sponsors"
+      ],
+      "properties": []
+    },
+    "agentIdentityBlueprintPrincipal": {
+      "navigationProperties": [
+        "sponsors"
+      ],
+      "properties": []
+    },
+    "agentUser": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "agreement": {
+      "navigationProperties": [
+        "acceptances",
+        "file",
+        "files"
+      ],
+      "properties": [
+        "displayName",
+        "isPerDeviceAcceptanceRequired",
+        "isViewingBeforeAcceptanceRequired",
+        "termsExpiration",
+        "userReacceptRequiredFrequency"
+      ]
+    },
+    "agreementAcceptance": {
+      "navigationProperties": [],
+      "properties": [
+        "agreementFileId",
+        "agreementId",
+        "deviceDisplayName",
+        "deviceId",
+        "deviceOSType",
+        "deviceOSVersion",
+        "expirationDateTime",
+        "recordedDateTime",
+        "state",
+        "userDisplayName",
+        "userEmail",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "agreementFile": {
+      "navigationProperties": [
+        "localizations"
+      ],
+      "properties": []
+    },
+    "agreementFileLocalization": {
+      "navigationProperties": [
+        "versions"
+      ],
+      "properties": []
+    },
+    "agreementFileProperties": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "fileData",
+        "fileName",
+        "isDefault",
+        "isMajorVersion",
+        "language"
+      ]
+    },
+    "agreementFileVersion": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aiInteraction": {
+      "navigationProperties": [],
+      "properties": [
+        "appClass",
+        "attachments",
+        "body",
+        "contexts",
+        "conversationType",
+        "createdDateTime",
+        "etag",
+        "from",
+        "interactionType",
+        "links",
+        "locale",
+        "mentions",
+        "requestId",
+        "sessionId"
+      ]
+    },
+    "aiInteractionHistory": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "aiOnlineMeeting": {
+      "navigationProperties": [
+        "aiInsights"
+      ],
+      "properties": []
+    },
+    "aiUser": {
+      "navigationProperties": [
+        "interactionHistory",
+        "onlineMeetings"
+      ],
+      "properties": []
+    },
+    "akamaiWebApplicationFirewallProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "accessToken",
+        "clientSecret",
+        "clientToken",
+        "hostPrefix"
+      ]
+    },
+    "alert": {
+      "navigationProperties": [],
+      "properties": [
+        "activityGroupName",
+        "alertDetections",
+        "assignedTo",
+        "azureSubscriptionId",
+        "azureTenantId",
+        "category",
+        "closedDateTime",
+        "cloudAppStates",
+        "comments",
+        "confidence",
+        "createdDateTime",
+        "description",
+        "detectionIds",
+        "eventDateTime",
+        "feedback",
+        "fileStates",
+        "historyStates",
+        "hostStates",
+        "incidentIds",
+        "investigationSecurityStates",
+        "lastEventDateTime",
+        "lastModifiedDateTime",
+        "malwareStates",
+        "messageSecurityStates",
+        "networkConnections",
+        "processes",
+        "recommendedActions",
+        "registryKeyStates",
+        "securityResources",
+        "severity",
+        "sourceMaterials",
+        "status",
+        "tags",
+        "title",
+        "triggers",
+        "uriClickSecurityStates",
+        "userStates",
+        "vendorInformation",
+        "vulnerabilityStates"
+      ]
+    },
+    "allowedValue": {
+      "navigationProperties": [],
+      "properties": [
+        "isActive"
+      ]
+    },
+    "androidCompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceThreatProtectionEnabled",
+        "deviceThreatProtectionRequiredSecurityLevel",
+        "minAndroidSecurityPatchLevel",
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordExpirationDays",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "securityBlockJailbrokenDevices",
+        "securityDisableUsbDebugging",
+        "securityPreventInstallAppsFromUnknownSources",
+        "securityRequireCompanyPortalAppIntegrity",
+        "securityRequireGooglePlayServices",
+        "securityRequireSafetyNetAttestationBasicIntegrity",
+        "securityRequireSafetyNetAttestationCertifiedDevice",
+        "securityRequireUpToDateSecurityProviders",
+        "securityRequireVerifyApps",
+        "storageRequireEncryption"
+      ]
+    },
+    "androidCustomConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "omaSettings"
+      ]
+    },
+    "androidGeneralDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "appsBlockClipboardSharing",
+        "appsBlockCopyPaste",
+        "appsBlockYouTube",
+        "appsHideList",
+        "appsInstallAllowList",
+        "appsLaunchBlockList",
+        "bluetoothBlocked",
+        "cameraBlocked",
+        "cellularBlockDataRoaming",
+        "cellularBlockMessaging",
+        "cellularBlockVoiceRoaming",
+        "cellularBlockWiFiTethering",
+        "compliantAppListType",
+        "compliantAppsList",
+        "deviceSharingAllowed",
+        "diagnosticDataBlockSubmission",
+        "factoryResetBlocked",
+        "googleAccountBlockAutoSync",
+        "googlePlayStoreBlocked",
+        "kioskModeApps",
+        "kioskModeBlockSleepButton",
+        "kioskModeBlockVolumeButtons",
+        "locationServicesBlocked",
+        "nfcBlocked",
+        "passwordBlockFingerprintUnlock",
+        "passwordBlockTrustAgents",
+        "passwordExpirationDays",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "powerOffBlocked",
+        "screenCaptureBlocked",
+        "securityRequireVerifyApps",
+        "storageBlockGoogleBackup",
+        "storageBlockRemovableStorage",
+        "storageRequireDeviceEncryption",
+        "storageRequireRemovableStorageEncryption",
+        "voiceAssistantBlocked",
+        "voiceDialingBlocked",
+        "webBrowserBlockAutofill",
+        "webBrowserBlocked",
+        "webBrowserBlockJavaScript",
+        "webBrowserBlockPopups",
+        "webBrowserCookieSettings",
+        "wiFiBlocked"
+      ]
+    },
+    "androidLobApp": {
+      "navigationProperties": [],
+      "properties": [
+        "minimumSupportedOperatingSystem",
+        "packageId",
+        "versionCode",
+        "versionName"
+      ]
+    },
+    "androidManagedAppProtection": {
+      "navigationProperties": [
+        "apps",
+        "deploymentSummary"
+      ],
+      "properties": [
+        "customBrowserDisplayName",
+        "customBrowserPackageId",
+        "deployedAppCount",
+        "disableAppEncryptionIfDeviceEncryptionIsEnabled",
+        "encryptAppData",
+        "minimumRequiredPatchVersion",
+        "minimumWarningPatchVersion",
+        "screenCaptureBlocked"
+      ]
+    },
+    "androidManagedAppRegistration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "androidStoreApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appStoreUrl",
+        "minimumSupportedOperatingSystem",
+        "packageId"
+      ]
+    },
+    "androidWorkProfileCompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceThreatProtectionEnabled",
+        "deviceThreatProtectionRequiredSecurityLevel",
+        "minAndroidSecurityPatchLevel",
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordExpirationDays",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "securityBlockJailbrokenDevices",
+        "securityDisableUsbDebugging",
+        "securityPreventInstallAppsFromUnknownSources",
+        "securityRequireCompanyPortalAppIntegrity",
+        "securityRequireGooglePlayServices",
+        "securityRequireSafetyNetAttestationBasicIntegrity",
+        "securityRequireSafetyNetAttestationCertifiedDevice",
+        "securityRequireUpToDateSecurityProviders",
+        "securityRequireVerifyApps",
+        "storageRequireEncryption"
+      ]
+    },
+    "androidWorkProfileCustomConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "omaSettings"
+      ]
+    },
+    "androidWorkProfileGeneralDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "passwordBlockFingerprintUnlock",
+        "passwordBlockTrustAgents",
+        "passwordExpirationDays",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequiredType",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "securityRequireVerifyApps",
+        "workProfileBlockAddingAccounts",
+        "workProfileBlockCamera",
+        "workProfileBlockCrossProfileCallerId",
+        "workProfileBlockCrossProfileContactsSearch",
+        "workProfileBlockCrossProfileCopyPaste",
+        "workProfileBlockNotificationsWhileDeviceLocked",
+        "workProfileBlockScreenCapture",
+        "workProfileBluetoothEnableContactSharing",
+        "workProfileDataSharingType",
+        "workProfileDefaultAppPermissionPolicy",
+        "workProfilePasswordBlockFingerprintUnlock",
+        "workProfilePasswordBlockTrustAgents",
+        "workProfilePasswordExpirationDays",
+        "workProfilePasswordMinimumLength",
+        "workProfilePasswordMinLetterCharacters",
+        "workProfilePasswordMinLowerCaseCharacters",
+        "workProfilePasswordMinNonLetterCharacters",
+        "workProfilePasswordMinNumericCharacters",
+        "workProfilePasswordMinSymbolCharacters",
+        "workProfilePasswordMinUpperCaseCharacters",
+        "workProfilePasswordMinutesOfInactivityBeforeScreenTimeout",
+        "workProfilePasswordPreviousPasswordBlockCount",
+        "workProfilePasswordRequiredType",
+        "workProfilePasswordSignInFailureCountBeforeFactoryReset",
+        "workProfileRequirePassword"
+      ]
+    },
+    "anonymousGuestConversationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "anonymousGuestId"
+      ]
+    },
+    "appCatalogs": {
+      "navigationProperties": [
+        "teamsApps"
+      ],
+      "properties": []
+    },
+    "appConsentApprovalRoute": {
+      "navigationProperties": [
+        "appConsentRequests"
+      ],
+      "properties": []
+    },
+    "appConsentRequest": {
+      "navigationProperties": [
+        "userConsentRequests"
+      ],
+      "properties": [
+        "appDisplayName",
+        "appId",
+        "pendingScopes"
+      ]
+    },
+    "appleDeviceFeaturesConfigurationBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "appleManagedIdentityProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateData",
+        "developerId",
+        "keyId",
+        "serviceId"
+      ]
+    },
+    "applePushNotificationCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "appleIdentifier",
+        "certificate",
+        "certificateSerialNumber",
+        "certificateUploadFailureReason",
+        "certificateUploadStatus",
+        "expirationDateTime",
+        "lastModifiedDateTime",
+        "topicIdentifier"
+      ]
+    },
+    "application": {
+      "navigationProperties": [
+        "appManagementPolicies",
+        "createdOnBehalfOf",
+        "extensionProperties",
+        "federatedIdentityCredentials",
+        "homeRealmDiscoveryPolicies",
+        "owners",
+        "synchronization",
+        "tokenIssuancePolicies",
+        "tokenLifetimePolicies"
+      ],
+      "properties": [
+        "addIns",
+        "api",
+        "appId",
+        "applicationTemplateId",
+        "appRoles",
+        "authenticationBehaviors",
+        "certification",
+        "createdByAppId",
+        "createdDateTime",
+        "defaultRedirectUri",
+        "description",
+        "disabledByMicrosoftStatus",
+        "displayName",
+        "groupMembershipClaims",
+        "identifierUris",
+        "info",
+        "isDeviceOnlyAuthSupported",
+        "isDisabled",
+        "isFallbackPublicClient",
+        "keyCredentials",
+        "logo",
+        "managerApplications",
+        "nativeAuthenticationApisEnabled",
+        "notes",
+        "oauth2RequirePostResponse",
+        "optionalClaims",
+        "parentalControlSettings",
+        "passwordCredentials",
+        "publicClient",
+        "publisherDomain",
+        "requestSignatureVerification",
+        "requiredResourceAccess",
+        "samlMetadataUrl",
+        "serviceManagementReference",
+        "servicePrincipalLockConfiguration",
+        "signInAudience",
+        "spa",
+        "tags",
+        "tokenEncryptionKeyId",
+        "uniqueName",
+        "verifiedPublisher",
+        "web"
+      ]
+    },
+    "applicationTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "categories",
+        "description",
+        "displayName",
+        "homePageUrl",
+        "logoUrl",
+        "publisher",
+        "supportedProvisioningTypes",
+        "supportedSingleSignOnModes"
+      ]
+    },
+    "appLogCollectionRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "customLogFolders",
+        "errorMessage",
+        "status"
+      ]
+    },
+    "appManagementPolicy": {
+      "navigationProperties": [
+        "appliesTo"
+      ],
+      "properties": [
+        "isEnabled",
+        "restrictions"
+      ]
+    },
+    "appRoleAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "appRoleId",
+        "createdDateTime",
+        "principalDisplayName",
+        "principalId",
+        "principalType",
+        "resourceDisplayName",
+        "resourceId"
+      ]
+    },
+    "approval": {
+      "navigationProperties": [
+        "stages"
+      ],
+      "properties": []
+    },
+    "approvalStage": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedToMe",
+        "displayName",
+        "justification",
+        "reviewedBy",
+        "reviewedDateTime",
+        "reviewResult",
+        "status"
+      ]
+    },
+    "approvedClientApp": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "appScope": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "type"
+      ]
+    },
+    "arkoseFraudProtectionProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "clientSubDomain",
+        "privateKey",
+        "publicKey",
+        "verifySubDomain"
+      ]
+    },
+    "associatedTeamInfo": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "attachment": {
+      "navigationProperties": [],
+      "properties": [
+        "contentType",
+        "isInline",
+        "lastModifiedDateTime",
+        "name",
+        "size"
+      ]
+    },
+    "attachmentBase": {
+      "navigationProperties": [],
+      "properties": [
+        "contentType",
+        "lastModifiedDateTime",
+        "name",
+        "size"
+      ]
+    },
+    "attachmentSession": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "expirationDateTime",
+        "nextExpectedRanges"
+      ]
+    },
+    "attackSimulationOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "percentageCompleted",
+        "tenantId",
+        "type"
+      ]
+    },
+    "attackSimulationRoot": {
+      "navigationProperties": [
+        "endUserNotifications",
+        "landingPages",
+        "loginPages",
+        "operations",
+        "payloads",
+        "simulationAutomations",
+        "simulations",
+        "trainings"
+      ],
+      "properties": []
+    },
+    "attendanceRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "attendanceIntervals",
+        "emailAddress",
+        "externalRegistrationInformation",
+        "identity",
+        "registrationId",
+        "role",
+        "totalAttendanceInSeconds"
+      ]
+    },
+    "attributeMappingFunctionSchema": {
+      "navigationProperties": [],
+      "properties": [
+        "parameters"
+      ]
+    },
+    "attributeSet": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "maxAttributesPerSet"
+      ]
+    },
+    "audioRoutingGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "receivers",
+        "routingMode",
+        "sources"
+      ]
+    },
+    "auditEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "activityDateTime",
+        "activityOperationType",
+        "activityResult",
+        "activityType",
+        "actor",
+        "category",
+        "componentName",
+        "correlationId",
+        "displayName",
+        "resources"
+      ]
+    },
+    "auditLogRoot": {
+      "navigationProperties": [
+        "directoryAudits",
+        "provisioning",
+        "signIns"
+      ],
+      "properties": []
+    },
+    "authentication": {
+      "navigationProperties": [
+        "emailMethods",
+        "externalAuthenticationMethods",
+        "fido2Methods",
+        "methods",
+        "microsoftAuthenticatorMethods",
+        "operations",
+        "passwordMethods",
+        "phoneMethods",
+        "platformCredentialMethods",
+        "softwareOathMethods",
+        "temporaryAccessPassMethods",
+        "windowsHelloForBusinessMethods"
+      ],
+      "properties": []
+    },
+    "authenticationCombinationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "appliesToCombinations"
+      ]
+    },
+    "authenticationConditionApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "appId"
+      ]
+    },
+    "authenticationContextClassReference": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "isAvailable"
+      ]
+    },
+    "authenticationEventListener": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationEventsFlowId",
+        "conditions",
+        "displayName"
+      ]
+    },
+    "authenticationEventsFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "conditions",
+        "description",
+        "displayName"
+      ]
+    },
+    "authenticationFlowsPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "selfServiceSignUp"
+      ]
+    },
+    "authenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime"
+      ]
+    },
+    "authenticationMethodConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "excludeTargets",
+        "state"
+      ]
+    },
+    "authenticationMethodModeDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationMethod",
+        "displayName"
+      ]
+    },
+    "authenticationMethodsPolicy": {
+      "navigationProperties": [
+        "authenticationMethodConfigurations"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "policyMigrationState",
+        "policyVersion",
+        "reconfirmationInDays",
+        "registrationEnforcement"
+      ]
+    },
+    "authenticationMethodsRoot": {
+      "navigationProperties": [
+        "userRegistrationDetails"
+      ],
+      "properties": []
+    },
+    "authenticationMethodTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "isRegistrationRequired",
+        "targetType"
+      ]
+    },
+    "authenticationStrengthPolicy": {
+      "navigationProperties": [
+        "combinationConfigurations"
+      ],
+      "properties": [
+        "allowedCombinations",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "modifiedDateTime",
+        "policyType",
+        "requirementsSatisfied"
+      ]
+    },
+    "authenticationStrengthRoot": {
+      "navigationProperties": [
+        "authenticationMethodModes",
+        "policies"
+      ],
+      "properties": [
+        "combinations"
+      ]
+    },
+    "authoredNote": {
+      "navigationProperties": [],
+      "properties": [
+        "author",
+        "content",
+        "createdDateTime"
+      ]
+    },
+    "authorizationPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedToSignUpEmailBasedSubscriptions",
+        "allowedToUseSSPR",
+        "allowEmailVerifiedUsersToJoinOrganization",
+        "allowInvitesFrom",
+        "allowUserConsentForRiskyApps",
+        "blockMsolPowerShell",
+        "defaultUserRolePermissions",
+        "guestUserRoleId"
+      ]
+    },
+    "azureCommunicationServicesUserConversationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "azureCommunicationServicesId"
+      ]
+    },
+    "b2xIdentityUserFlow": {
+      "navigationProperties": [
+        "identityProviders",
+        "languages",
+        "userAttributeAssignments",
+        "userFlowIdentityProviders"
+      ],
+      "properties": [
+        "apiConnectorConfiguration"
+      ]
+    },
+    "backupRestoreRoot": {
+      "navigationProperties": [
+        "driveInclusionRules",
+        "driveProtectionUnits",
+        "driveProtectionUnitsBulkAdditionJobs",
+        "exchangeProtectionPolicies",
+        "exchangeRestoreSessions",
+        "mailboxInclusionRules",
+        "mailboxProtectionUnits",
+        "mailboxProtectionUnitsBulkAdditionJobs",
+        "oneDriveForBusinessProtectionPolicies",
+        "oneDriveForBusinessRestoreSessions",
+        "protectionPolicies",
+        "protectionUnits",
+        "restorePoints",
+        "restoreSessions",
+        "serviceApps",
+        "sharePointProtectionPolicies",
+        "sharePointRestoreSessions",
+        "siteInclusionRules",
+        "siteProtectionUnits",
+        "siteProtectionUnitsBulkAdditionJobs"
+      ],
+      "properties": [
+        "serviceStatus"
+      ]
+    },
+    "baseItem": {
+      "navigationProperties": [
+        "createdByUser",
+        "lastModifiedByUser"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "eTag",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "name",
+        "parentReference",
+        "webUrl"
+      ]
+    },
+    "baseItemVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "publication"
+      ]
+    },
+    "baseMapFeature": {
+      "navigationProperties": [],
+      "properties": [
+        "properties"
+      ]
+    },
+    "baseSitePage": {
+      "navigationProperties": [],
+      "properties": [
+        "pageLayout",
+        "publishingState",
+        "title"
+      ]
+    },
+    "bitlocker": {
+      "navigationProperties": [
+        "recoveryKeys"
+      ],
+      "properties": []
+    },
+    "bitlockerRecoveryKey": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "deviceId",
+        "key",
+        "volumeType"
+      ]
+    },
+    "bookingAppointment": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformation",
+        "anonymousJoinWebUrl",
+        "appointmentLabel",
+        "createdDateTime",
+        "customerEmailAddress",
+        "customerName",
+        "customerNotes",
+        "customerPhone",
+        "customers",
+        "customerTimeZone",
+        "duration",
+        "endDateTime",
+        "filledAttendeesCount",
+        "isCustomerAllowedToManageBooking",
+        "isLocationOnline",
+        "joinWebUrl",
+        "lastUpdatedDateTime",
+        "maximumAttendeesCount",
+        "optOutOfCustomerEmail",
+        "postBuffer",
+        "preBuffer",
+        "price",
+        "priceType",
+        "reminders",
+        "selfServiceAppointmentId",
+        "serviceId",
+        "serviceLocation",
+        "serviceName",
+        "serviceNotes",
+        "smsNotificationsEnabled",
+        "staffMemberIds",
+        "startDateTime"
+      ]
+    },
+    "bookingBusiness": {
+      "navigationProperties": [
+        "appointments",
+        "calendarView",
+        "customers",
+        "customQuestions",
+        "services",
+        "staffMembers"
+      ],
+      "properties": [
+        "address",
+        "bookingPageSettings",
+        "businessHours",
+        "businessType",
+        "createdDateTime",
+        "defaultCurrencyIso",
+        "displayName",
+        "email",
+        "isPublished",
+        "languageTag",
+        "lastUpdatedDateTime",
+        "phone",
+        "publicUrl",
+        "schedulingPolicy",
+        "webSiteUrl"
+      ]
+    },
+    "bookingCurrency": {
+      "navigationProperties": [],
+      "properties": [
+        "symbol"
+      ]
+    },
+    "bookingCustomer": {
+      "navigationProperties": [],
+      "properties": [
+        "addresses",
+        "createdDateTime",
+        "displayName",
+        "emailAddress",
+        "lastUpdatedDateTime",
+        "phones"
+      ]
+    },
+    "bookingCustomerBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "bookingCustomQuestion": {
+      "navigationProperties": [],
+      "properties": [
+        "answerInputType",
+        "answerOptions",
+        "createdDateTime",
+        "displayName",
+        "lastUpdatedDateTime"
+      ]
+    },
+    "bookingService": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformation",
+        "createdDateTime",
+        "customQuestions",
+        "defaultDuration",
+        "defaultLocation",
+        "defaultPrice",
+        "defaultPriceType",
+        "defaultReminders",
+        "description",
+        "displayName",
+        "isAnonymousJoinEnabled",
+        "isCustomerAllowedToManageBooking",
+        "isHiddenFromCustomers",
+        "isLocationOnline",
+        "languageTag",
+        "lastUpdatedDateTime",
+        "maximumAttendeesCount",
+        "notes",
+        "postBuffer",
+        "preBuffer",
+        "schedulingPolicy",
+        "smsNotificationsEnabled",
+        "staffMemberIds",
+        "webUrl"
+      ]
+    },
+    "bookingStaffMember": {
+      "navigationProperties": [],
+      "properties": [
+        "availabilityIsAffectedByPersonalCalendar",
+        "createdDateTime",
+        "displayName",
+        "emailAddress",
+        "isEmailNotificationEnabled",
+        "lastUpdatedDateTime",
+        "membershipStatus",
+        "role",
+        "timeZone",
+        "useBusinessHours",
+        "workingHours"
+      ]
+    },
+    "bookingStaffMemberBase": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "browserSharedCookie": {
+      "navigationProperties": [],
+      "properties": [
+        "comment",
+        "createdDateTime",
+        "deletedDateTime",
+        "displayName",
+        "history",
+        "hostOnly",
+        "hostOrDomain",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "path",
+        "sourceEnvironment",
+        "status"
+      ]
+    },
+    "browserSite": {
+      "navigationProperties": [],
+      "properties": [
+        "allowRedirect",
+        "comment",
+        "compatibilityMode",
+        "createdDateTime",
+        "deletedDateTime",
+        "history",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "mergeType",
+        "status",
+        "targetEnvironment",
+        "webUrl"
+      ]
+    },
+    "browserSiteList": {
+      "navigationProperties": [
+        "sharedCookies",
+        "sites"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "publishedBy",
+        "publishedDateTime",
+        "revision",
+        "status"
+      ]
+    },
+    "building": {
+      "navigationProperties": [
+        "map"
+      ],
+      "properties": [
+        "resourceLinks",
+        "wifiState"
+      ]
+    },
+    "buildingMap": {
+      "navigationProperties": [
+        "footprints",
+        "levels"
+      ],
+      "properties": [
+        "placeId"
+      ]
+    },
+    "builtInIdentityProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "identityProviderType"
+      ]
+    },
+    "bulkUpload": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "calendar": {
+      "navigationProperties": [
+        "calendarPermissions",
+        "calendarView",
+        "events",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "allowedOnlineMeetingProviders",
+        "canEdit",
+        "canShare",
+        "canViewPrivateItems",
+        "changeKey",
+        "color",
+        "defaultOnlineMeetingProvider",
+        "hexColor",
+        "isDefaultCalendar",
+        "isRemovable",
+        "isTallyingResponses",
+        "name",
+        "owner"
+      ]
+    },
+    "calendarGroup": {
+      "navigationProperties": [
+        "calendars"
+      ],
+      "properties": [
+        "changeKey",
+        "classId",
+        "name"
+      ]
+    },
+    "calendarPermission": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedRoles",
+        "emailAddress",
+        "isInsideOrganization",
+        "isRemovable",
+        "role"
+      ]
+    },
+    "calendarSharingMessage": {
+      "navigationProperties": [],
+      "properties": [
+        "canAccept",
+        "sharingMessageAction",
+        "sharingMessageActions",
+        "suggestedCalendarName"
+      ]
+    },
+    "call": {
+      "navigationProperties": [
+        "audioRoutingGroups",
+        "contentSharingSessions",
+        "operations",
+        "participants"
+      ],
+      "properties": [
+        "callbackUri",
+        "callChainId",
+        "callOptions",
+        "callRoutes",
+        "chatInfo",
+        "direction",
+        "incomingContext",
+        "mediaConfig",
+        "mediaState",
+        "meetingInfo",
+        "myParticipantId",
+        "requestedModalities",
+        "resultInfo",
+        "source",
+        "state",
+        "subject",
+        "targets",
+        "tenantId",
+        "toneInfo",
+        "transcription"
+      ]
+    },
+    "callAiInsight": {
+      "navigationProperties": [],
+      "properties": [
+        "actionItems",
+        "callId",
+        "contentCorrelationId",
+        "createdDateTime",
+        "endDateTime",
+        "meetingNotes",
+        "viewpoint"
+      ]
+    },
+    "callEvent": {
+      "navigationProperties": [
+        "participants"
+      ],
+      "properties": [
+        "callEventType",
+        "eventDateTime"
+      ]
+    },
+    "callRecording": {
+      "navigationProperties": [],
+      "properties": [
+        "callId",
+        "content",
+        "contentCorrelationId",
+        "createdDateTime",
+        "endDateTime",
+        "meetingId",
+        "meetingOrganizer",
+        "recordingContentUrl"
+      ]
+    },
+    "callTranscript": {
+      "navigationProperties": [],
+      "properties": [
+        "callId",
+        "content",
+        "contentCorrelationId",
+        "createdDateTime",
+        "endDateTime",
+        "meetingId",
+        "meetingOrganizer",
+        "metadataContent",
+        "transcriptContentUrl"
+      ]
+    },
+    "cancelMediaProcessingOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "canvasLayout": {
+      "navigationProperties": [
+        "horizontalSections",
+        "verticalSection"
+      ],
+      "properties": []
+    },
+    "caPoliciesDeletableRoot": {
+      "navigationProperties": [
+        "namedLocations",
+        "policies"
+      ],
+      "properties": []
+    },
+    "certificateAuthorityDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "certificate",
+        "certificateAuthorityType",
+        "certificateRevocationListUrl",
+        "createdDateTime",
+        "deltaCertificateRevocationListUrl",
+        "displayName",
+        "expirationDateTime",
+        "isIssuerHintEnabled",
+        "issuer",
+        "issuerSubjectKeyIdentifier",
+        "thumbprint"
+      ]
+    },
+    "certificateBasedAuthConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "certificateAuthorities"
+      ]
+    },
+    "certificateBasedAuthPki": {
+      "navigationProperties": [
+        "certificateAuthorities"
+      ],
+      "properties": [
+        "displayName",
+        "lastModifiedDateTime",
+        "status",
+        "statusDetails"
+      ]
+    },
+    "changeTrackedEntity": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "channel": {
+      "navigationProperties": [
+        "allMembers",
+        "enabledApps",
+        "filesFolder",
+        "members",
+        "messages",
+        "sharedWithTeams",
+        "tabs"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "email",
+        "isArchived",
+        "isFavoriteByDefault",
+        "layoutType",
+        "membershipType",
+        "migrationMode",
+        "originalCreatedDateTime",
+        "summary",
+        "tenantId",
+        "webUrl"
+      ]
+    },
+    "chat": {
+      "navigationProperties": [
+        "installedApps",
+        "lastMessagePreview",
+        "members",
+        "messages",
+        "permissionGrants",
+        "pinnedMessages",
+        "tabs"
+      ],
+      "properties": [
+        "chatType",
+        "createdDateTime",
+        "isHiddenForAllMembers",
+        "lastUpdatedDateTime",
+        "migrationMode",
+        "onlineMeetingInfo",
+        "originalCreatedDateTime",
+        "tenantId",
+        "topic",
+        "viewpoint",
+        "webUrl"
+      ]
+    },
+    "chatMessage": {
+      "navigationProperties": [
+        "hostedContents",
+        "replies"
+      ],
+      "properties": [
+        "attachments",
+        "body",
+        "channelIdentity",
+        "chatId",
+        "createdDateTime",
+        "deletedDateTime",
+        "etag",
+        "eventDetail",
+        "from",
+        "importance",
+        "lastEditedDateTime",
+        "lastModifiedDateTime",
+        "locale",
+        "mentions",
+        "messageHistory",
+        "messageType",
+        "policyViolation",
+        "reactions",
+        "replyToId",
+        "subject",
+        "summary",
+        "webUrl"
+      ]
+    },
+    "chatMessageHostedContent": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "chatMessageInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "body",
+        "createdDateTime",
+        "eventDetail",
+        "from",
+        "isDeleted",
+        "messageType"
+      ]
+    },
+    "checkInClaim": {
+      "navigationProperties": [],
+      "properties": [
+        "calendarEventId",
+        "checkInMethod",
+        "createdDateTime"
+      ]
+    },
+    "checklistItem": {
+      "navigationProperties": [],
+      "properties": [
+        "checkedDateTime",
+        "createdDateTime",
+        "displayName",
+        "isChecked"
+      ]
+    },
+    "claimsMappingPolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudClipboardItem": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "expirationDateTime",
+        "lastModifiedDateTime",
+        "payloads"
+      ]
+    },
+    "cloudClipboardRoot": {
+      "navigationProperties": [
+        "items"
+      ],
+      "properties": []
+    },
+    "cloudCommunications": {
+      "navigationProperties": [
+        "adhocCalls",
+        "callRecords",
+        "calls",
+        "onlineMeetingConversations",
+        "onlineMeetings",
+        "presences"
+      ],
+      "properties": []
+    },
+    "cloudFlareWebApplicationFirewallProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "apiToken",
+        "zoneId"
+      ]
+    },
+    "cloudPC": {
+      "navigationProperties": [],
+      "properties": [
+        "aadDeviceId",
+        "displayName",
+        "gracePeriodEndDateTime",
+        "imageDisplayName",
+        "lastModifiedDateTime",
+        "managedDeviceId",
+        "managedDeviceName",
+        "onPremisesConnectionName",
+        "provisioningPolicyId",
+        "provisioningPolicyName",
+        "provisioningType",
+        "servicePlanId",
+        "servicePlanName",
+        "userPrincipalName"
+      ]
+    },
+    "cloudPcAuditEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "activityDateTime",
+        "activityOperationType",
+        "activityResult",
+        "activityType",
+        "actor",
+        "category",
+        "componentName",
+        "correlationId",
+        "displayName",
+        "resources"
+      ]
+    },
+    "cloudPcDeviceImage": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "errorCode",
+        "expirationDate",
+        "lastModifiedDateTime",
+        "operatingSystem",
+        "osBuildNumber",
+        "osStatus",
+        "osVersionNumber",
+        "sizeInGB",
+        "sourceImageResourceId",
+        "status",
+        "version"
+      ]
+    },
+    "cloudPcGalleryImage": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "endDate",
+        "expirationDate",
+        "offerName",
+        "osVersionNumber",
+        "publisherName",
+        "sizeInGB",
+        "skuName",
+        "startDate",
+        "status"
+      ]
+    },
+    "cloudPcOnPremisesConnection": {
+      "navigationProperties": [],
+      "properties": [
+        "adDomainName",
+        "adDomainPassword",
+        "adDomainUsername",
+        "alternateResourceUrl",
+        "connectionType",
+        "displayName",
+        "healthCheckPaused",
+        "healthCheckStatus",
+        "healthCheckStatusDetail",
+        "inUse",
+        "inUseByCloudPc",
+        "organizationalUnit",
+        "resourceGroupId",
+        "scopeIds",
+        "subnetId",
+        "subscriptionId",
+        "subscriptionName",
+        "virtualNetworkId",
+        "virtualNetworkLocation"
+      ]
+    },
+    "cloudPcProvisioningPolicy": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "alternateResourceUrl",
+        "autopatch",
+        "cloudPcGroupDisplayName",
+        "cloudPcNamingTemplate",
+        "description",
+        "displayName",
+        "domainJoinConfigurations",
+        "enableSingleSignOn",
+        "gracePeriodInHours",
+        "imageDisplayName",
+        "imageId",
+        "imageType",
+        "localAdminEnabled",
+        "microsoftManagedDesktop",
+        "provisioningType",
+        "windowsSetting"
+      ]
+    },
+    "cloudPcProvisioningPolicyAssignment": {
+      "navigationProperties": [
+        "assignedUsers"
+      ],
+      "properties": [
+        "target"
+      ]
+    },
+    "cloudPcReport": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "cloudPcUserSetting": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "lastModifiedDateTime",
+        "localAdminEnabled",
+        "resetEnabled",
+        "restorePointSetting"
+      ]
+    },
+    "cloudPcUserSettingAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "target"
+      ]
+    },
+    "columnDefinition": {
+      "navigationProperties": [
+        "sourceColumn"
+      ],
+      "properties": [
+        "boolean",
+        "calculated",
+        "choice",
+        "columnGroup",
+        "contentApprovalStatus",
+        "currency",
+        "dateTime",
+        "defaultValue",
+        "description",
+        "displayName",
+        "enforceUniqueValues",
+        "geolocation",
+        "hidden",
+        "hyperlinkOrPicture",
+        "indexed",
+        "isDeletable",
+        "isReorderable",
+        "isSealed",
+        "lookup",
+        "name",
+        "number",
+        "personOrGroup",
+        "propagateChanges",
+        "readOnly",
+        "required",
+        "sourceContentType",
+        "term",
+        "text",
+        "thumbnail",
+        "type",
+        "validation"
+      ]
+    },
+    "columnLink": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "commsOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "clientContext",
+        "resultInfo",
+        "status"
+      ]
+    },
+    "community": {
+      "navigationProperties": [
+        "group",
+        "owners"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "groupId",
+        "privacy"
+      ]
+    },
+    "companySubscription": {
+      "navigationProperties": [],
+      "properties": [
+        "commerceSubscriptionId",
+        "createdDateTime",
+        "isTrial",
+        "nextLifecycleDateTime",
+        "ownerId",
+        "ownerTenantId",
+        "ownerType",
+        "serviceStatus",
+        "skuId",
+        "skuPartNumber",
+        "status",
+        "totalLicenses"
+      ]
+    },
+    "compliance": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "complianceManagementPartner": {
+      "navigationProperties": [],
+      "properties": [
+        "androidEnrollmentAssignments",
+        "androidOnboarded",
+        "displayName",
+        "iosEnrollmentAssignments",
+        "iosOnboarded",
+        "lastHeartbeatDateTime",
+        "macOsEnrollmentAssignments",
+        "macOsOnboarded",
+        "partnerState"
+      ]
+    },
+    "conditionalAccessPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "conditions",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "grantControls",
+        "id",
+        "modifiedDateTime",
+        "sessionControls",
+        "state",
+        "templateId"
+      ]
+    },
+    "conditionalAccessRoot": {
+      "navigationProperties": [
+        "authenticationContextClassReferences",
+        "authenticationStrength",
+        "deletedItems",
+        "namedLocations",
+        "policies",
+        "templates"
+      ],
+      "properties": []
+    },
+    "conditionalAccessTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "details",
+        "name",
+        "scenarios"
+      ]
+    },
+    "configurationBaseline": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "parameters",
+        "resources"
+      ]
+    },
+    "configurationDrift": {
+      "navigationProperties": [],
+      "properties": [
+        "baselineResourceDisplayName",
+        "driftedProperties",
+        "firstReportedDateTime",
+        "monitorId",
+        "resourceInstanceIdentifier",
+        "resourceType",
+        "status",
+        "tenantId"
+      ]
+    },
+    "configurationManagement": {
+      "navigationProperties": [
+        "configurationDrifts",
+        "configurationMonitoringResults",
+        "configurationMonitors",
+        "configurationSnapshotJobs",
+        "configurationSnapshots"
+      ],
+      "properties": []
+    },
+    "configurationMonitor": {
+      "navigationProperties": [
+        "baseline"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "inactivationReason",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "mode",
+        "monitorRunFrequencyInHours",
+        "parameters",
+        "status",
+        "tenantId"
+      ]
+    },
+    "configurationMonitoringResult": {
+      "navigationProperties": [],
+      "properties": [
+        "driftsCount",
+        "errorDetails",
+        "monitorId",
+        "runCompletionDateTime",
+        "runInitiationDateTime",
+        "runStatus",
+        "tenantId"
+      ]
+    },
+    "configurationSnapshotJob": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "errorDetails",
+        "resourceLocation",
+        "resources",
+        "status",
+        "tenantId"
+      ]
+    },
+    "connectedOrganization": {
+      "navigationProperties": [
+        "externalSponsors",
+        "internalSponsors"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "identitySources",
+        "modifiedDateTime",
+        "state"
+      ]
+    },
+    "contact": {
+      "navigationProperties": [
+        "extensions",
+        "multiValueExtendedProperties",
+        "photo",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "assistantName",
+        "birthday",
+        "businessAddress",
+        "businessHomePage",
+        "businessPhones",
+        "children",
+        "companyName",
+        "department",
+        "displayName",
+        "emailAddresses",
+        "fileAs",
+        "generation",
+        "givenName",
+        "homeAddress",
+        "homePhones",
+        "imAddresses",
+        "initials",
+        "jobTitle",
+        "manager",
+        "middleName",
+        "mobilePhone",
+        "nickName",
+        "officeLocation",
+        "otherAddress",
+        "parentFolderId",
+        "personalNotes",
+        "primaryEmailAddress",
+        "profession",
+        "secondaryEmailAddress",
+        "spouseName",
+        "surname",
+        "tertiaryEmailAddress",
+        "title",
+        "yomiCompanyName",
+        "yomiGivenName",
+        "yomiSurname"
+      ]
+    },
+    "contactFolder": {
+      "navigationProperties": [
+        "childFolders",
+        "contacts",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "displayName",
+        "parentFolderId"
+      ]
+    },
+    "contentActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "contentMetadata",
+        "scopeIdentifier",
+        "userId"
+      ]
+    },
+    "contentSharingSession": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "contentType": {
+      "navigationProperties": [
+        "base",
+        "baseTypes",
+        "columnLinks",
+        "columnPositions",
+        "columns"
+      ],
+      "properties": [
+        "associatedHubsUrls",
+        "description",
+        "documentSet",
+        "documentTemplate",
+        "group",
+        "hidden",
+        "inheritedFrom",
+        "isBuiltIn",
+        "name",
+        "order",
+        "parentId",
+        "propagateChanges",
+        "readOnly",
+        "sealed"
+      ]
+    },
+    "contract": {
+      "navigationProperties": [],
+      "properties": [
+        "contractType",
+        "customerId",
+        "defaultDomainName",
+        "displayName"
+      ]
+    },
+    "conversation": {
+      "navigationProperties": [
+        "threads"
+      ],
+      "properties": [
+        "hasAttachments",
+        "lastDeliveredDateTime",
+        "preview",
+        "topic",
+        "uniqueSenders"
+      ]
+    },
+    "conversationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "roles",
+        "visibleHistoryStartDateTime"
+      ]
+    },
+    "conversationThread": {
+      "navigationProperties": [
+        "posts"
+      ],
+      "properties": [
+        "ccRecipients",
+        "hasAttachments",
+        "isLocked",
+        "lastDeliveredDateTime",
+        "preview",
+        "topic",
+        "toRecipients",
+        "uniqueSenders"
+      ]
+    },
+    "copilotAdmin": {
+      "navigationProperties": [
+        "settings"
+      ],
+      "properties": []
+    },
+    "copilotAdminLimitedMode": {
+      "navigationProperties": [],
+      "properties": [
+        "groupId",
+        "isEnabledForGroup"
+      ]
+    },
+    "copilotAdminSetting": {
+      "navigationProperties": [
+        "limitedMode"
+      ],
+      "properties": []
+    },
+    "copilotReportRoot": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "copilotRoot": {
+      "navigationProperties": [
+        "admin",
+        "interactionHistory",
+        "reports",
+        "users"
+      ],
+      "properties": []
+    },
+    "countryNamedLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "countriesAndRegions",
+        "countryLookupMethod",
+        "includeUnknownCountriesAndRegions"
+      ]
+    },
+    "crossTenantAccessPolicy": {
+      "navigationProperties": [
+        "default",
+        "partners",
+        "templates"
+      ],
+      "properties": [
+        "allowedCloudEndpoints"
+      ]
+    },
+    "crossTenantAccessPolicyConfigurationDefault": {
+      "navigationProperties": [],
+      "properties": [
+        "appServiceConnectInbound",
+        "automaticUserConsentSettings",
+        "b2bCollaborationInbound",
+        "b2bCollaborationOutbound",
+        "b2bDirectConnectInbound",
+        "b2bDirectConnectOutbound",
+        "inboundTrust",
+        "invitationRedemptionIdentityProviderConfiguration",
+        "isServiceDefault",
+        "m365CollaborationInbound",
+        "m365CollaborationOutbound",
+        "tenantRestrictions"
+      ]
+    },
+    "crossTenantAccessPolicyConfigurationPartner": {
+      "navigationProperties": [
+        "identitySynchronization"
+      ],
+      "properties": [
+        "appServiceConnectInbound",
+        "automaticUserConsentSettings",
+        "b2bCollaborationInbound",
+        "b2bCollaborationOutbound",
+        "b2bDirectConnectInbound",
+        "b2bDirectConnectOutbound",
+        "inboundTrust",
+        "isInMultiTenantOrganization",
+        "isServiceProvider",
+        "m365CollaborationInbound",
+        "m365CollaborationOutbound",
+        "tenantId",
+        "tenantRestrictions"
+      ]
+    },
+    "crossTenantIdentitySyncPolicyPartner": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "tenantId",
+        "userSyncInbound"
+      ]
+    },
+    "customAuthenticationExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "behaviorOnError"
+      ]
+    },
+    "customCalloutExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationConfiguration",
+        "clientConfiguration",
+        "description",
+        "displayName",
+        "endpointConfiguration"
+      ]
+    },
+    "customExtensionStageSetting": {
+      "navigationProperties": [
+        "customExtension"
+      ],
+      "properties": [
+        "stage"
+      ]
+    },
+    "customSecurityAttributeDefinition": {
+      "navigationProperties": [
+        "allowedValues"
+      ],
+      "properties": [
+        "attributeSet",
+        "description",
+        "isCollection",
+        "isSearchable",
+        "name",
+        "status",
+        "type",
+        "usePreDefinedValuesOnly"
+      ]
+    },
+    "dataPolicyOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "progress",
+        "status",
+        "storageLocation",
+        "submittedDateTime",
+        "userId"
+      ]
+    },
+    "dataSecurityAndGovernance": {
+      "navigationProperties": [
+        "sensitivityLabels"
+      ],
+      "properties": []
+    },
+    "dayNote": {
+      "navigationProperties": [],
+      "properties": [
+        "dayNoteDate",
+        "draftDayNote",
+        "sharedDayNote"
+      ]
+    },
+    "defaultManagedAppProtection": {
+      "navigationProperties": [
+        "apps",
+        "deploymentSummary"
+      ],
+      "properties": [
+        "appDataEncryptionType",
+        "customSettings",
+        "deployedAppCount",
+        "disableAppEncryptionIfDeviceEncryptionIsEnabled",
+        "encryptAppData",
+        "faceIdBlocked",
+        "minimumRequiredPatchVersion",
+        "minimumRequiredSdkVersion",
+        "minimumWarningPatchVersion",
+        "screenCaptureBlocked"
+      ]
+    },
+    "delegatedAdminAccessAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "accessContainer",
+        "accessDetails",
+        "createdDateTime",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "delegatedAdminCustomer": {
+      "navigationProperties": [
+        "serviceManagementDetails"
+      ],
+      "properties": [
+        "displayName",
+        "tenantId"
+      ]
+    },
+    "delegatedAdminRelationship": {
+      "navigationProperties": [
+        "accessAssignments",
+        "operations",
+        "requests"
+      ],
+      "properties": [
+        "accessDetails",
+        "activatedDateTime",
+        "autoExtendDuration",
+        "createdDateTime",
+        "customer",
+        "displayName",
+        "duration",
+        "endDateTime",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "delegatedAdminRelationshipOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "data",
+        "lastModifiedDateTime",
+        "operationType",
+        "status"
+      ]
+    },
+    "delegatedAdminRelationshipRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "createdDateTime",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "delegatedAdminServiceManagementDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "serviceManagementUrl",
+        "serviceName"
+      ]
+    },
+    "delegatedPermissionClassification": {
+      "navigationProperties": [],
+      "properties": [
+        "classification",
+        "permissionId",
+        "permissionName"
+      ]
+    },
+    "deletedChat": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deletedItemContainer": {
+      "navigationProperties": [
+        "workflows"
+      ],
+      "properties": []
+    },
+    "deletedTeam": {
+      "navigationProperties": [
+        "channels"
+      ],
+      "properties": []
+    },
+    "deltaParticipants": {
+      "navigationProperties": [
+        "participants"
+      ],
+      "properties": [
+        "sequenceNumber"
+      ]
+    },
+    "desk": {
+      "navigationProperties": [],
+      "properties": [
+        "displayDeviceName",
+        "heightAdjustableState",
+        "mailboxDetails",
+        "mode"
+      ]
+    },
+    "detectedApp": {
+      "navigationProperties": [
+        "managedDevices"
+      ],
+      "properties": [
+        "deviceCount",
+        "displayName",
+        "platform",
+        "publisher",
+        "sizeInByte",
+        "version"
+      ]
+    },
+    "device": {
+      "navigationProperties": [
+        "extensions",
+        "memberOf",
+        "registeredOwners",
+        "registeredUsers",
+        "transitiveMemberOf"
+      ],
+      "properties": [
+        "accountEnabled",
+        "alternativeSecurityIds",
+        "approximateLastSignInDateTime",
+        "complianceExpirationDateTime",
+        "deviceCategory",
+        "deviceId",
+        "deviceMetadata",
+        "deviceOwnership",
+        "deviceVersion",
+        "displayName",
+        "enrollmentProfileName",
+        "enrollmentType",
+        "isCompliant",
+        "isManaged",
+        "isManagementRestricted",
+        "isRooted",
+        "managementType",
+        "manufacturer",
+        "mdmAppId",
+        "model",
+        "onPremisesLastSyncDateTime",
+        "onPremisesSecurityIdentifier",
+        "onPremisesSyncEnabled",
+        "operatingSystem",
+        "operatingSystemVersion",
+        "physicalIds",
+        "profileType",
+        "registrationDateTime",
+        "systemLabels",
+        "trustType"
+      ]
+    },
+    "deviceAndAppManagementRoleAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "members"
+      ]
+    },
+    "deviceAndAppManagementRoleDefinition": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceAppManagement": {
+      "navigationProperties": [
+        "androidManagedAppProtections",
+        "defaultManagedAppProtections",
+        "iosManagedAppProtections",
+        "managedAppPolicies",
+        "managedAppRegistrations",
+        "managedAppStatuses",
+        "managedEBooks",
+        "mdmWindowsInformationProtectionPolicies",
+        "mobileAppCategories",
+        "mobileAppConfigurations",
+        "mobileAppRelationships",
+        "mobileApps",
+        "targetedManagedAppConfigurations",
+        "vppTokens",
+        "windowsInformationProtectionPolicies"
+      ],
+      "properties": [
+        "isEnabledForMicrosoftStoreForBusiness",
+        "microsoftStoreForBusinessLanguage",
+        "microsoftStoreForBusinessLastCompletedApplicationSyncTime",
+        "microsoftStoreForBusinessLastSuccessfulSyncDateTime"
+      ]
+    },
+    "deviceCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName"
+      ]
+    },
+    "deviceComplianceActionItem": {
+      "navigationProperties": [],
+      "properties": [
+        "actionType",
+        "gracePeriodHours",
+        "notificationMessageCCList",
+        "notificationTemplateId"
+      ]
+    },
+    "deviceComplianceDeviceOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationVersion",
+        "errorCount",
+        "failedCount",
+        "lastUpdateDateTime",
+        "notApplicableCount",
+        "pendingCount",
+        "successCount"
+      ]
+    },
+    "deviceComplianceDeviceStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceGracePeriodExpirationDateTime",
+        "deviceDisplayName",
+        "deviceModel",
+        "lastReportedDateTime",
+        "status",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceCompliancePolicy": {
+      "navigationProperties": [
+        "assignments",
+        "deviceSettingStateSummaries",
+        "deviceStatuses",
+        "deviceStatusOverview",
+        "scheduledActionsForRule",
+        "userStatuses",
+        "userStatusOverview"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "version"
+      ]
+    },
+    "deviceCompliancePolicyAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "deviceCompliancePolicyDeviceStateSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantDeviceCount",
+        "configManagerCount",
+        "conflictDeviceCount",
+        "errorDeviceCount",
+        "inGracePeriodCount",
+        "nonCompliantDeviceCount",
+        "notApplicableDeviceCount",
+        "remediatedDeviceCount",
+        "unknownDeviceCount"
+      ]
+    },
+    "deviceCompliancePolicySettingStateSummary": {
+      "navigationProperties": [
+        "deviceComplianceSettingStates"
+      ],
+      "properties": [
+        "compliantDeviceCount",
+        "conflictDeviceCount",
+        "errorDeviceCount",
+        "nonCompliantDeviceCount",
+        "notApplicableDeviceCount",
+        "platformType",
+        "remediatedDeviceCount",
+        "setting",
+        "settingName",
+        "unknownDeviceCount"
+      ]
+    },
+    "deviceCompliancePolicyState": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "platformType",
+        "settingCount",
+        "settingStates",
+        "state",
+        "version"
+      ]
+    },
+    "deviceComplianceScheduledActionForRule": {
+      "navigationProperties": [
+        "scheduledActionConfigurations"
+      ],
+      "properties": [
+        "ruleName"
+      ]
+    },
+    "deviceComplianceSettingState": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceGracePeriodExpirationDateTime",
+        "deviceId",
+        "deviceModel",
+        "deviceName",
+        "setting",
+        "settingName",
+        "state",
+        "userEmail",
+        "userId",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceComplianceUserOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationVersion",
+        "errorCount",
+        "failedCount",
+        "lastUpdateDateTime",
+        "notApplicableCount",
+        "pendingCount",
+        "successCount"
+      ]
+    },
+    "deviceComplianceUserStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "devicesCount",
+        "lastReportedDateTime",
+        "status",
+        "userDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceConfiguration": {
+      "navigationProperties": [
+        "assignments",
+        "deviceSettingStateSummaries",
+        "deviceStatuses",
+        "deviceStatusOverview",
+        "userStatuses",
+        "userStatusOverview"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "version"
+      ]
+    },
+    "deviceConfigurationAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "deviceConfigurationDeviceOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationVersion",
+        "errorCount",
+        "failedCount",
+        "lastUpdateDateTime",
+        "notApplicableCount",
+        "pendingCount",
+        "successCount"
+      ]
+    },
+    "deviceConfigurationDeviceStateSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantDeviceCount",
+        "conflictDeviceCount",
+        "errorDeviceCount",
+        "nonCompliantDeviceCount",
+        "notApplicableDeviceCount",
+        "remediatedDeviceCount",
+        "unknownDeviceCount"
+      ]
+    },
+    "deviceConfigurationDeviceStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceGracePeriodExpirationDateTime",
+        "deviceDisplayName",
+        "deviceModel",
+        "lastReportedDateTime",
+        "status",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceConfigurationState": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "platformType",
+        "settingCount",
+        "settingStates",
+        "state",
+        "version"
+      ]
+    },
+    "deviceConfigurationUserOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationVersion",
+        "errorCount",
+        "failedCount",
+        "lastUpdateDateTime",
+        "notApplicableCount",
+        "pendingCount",
+        "successCount"
+      ]
+    },
+    "deviceConfigurationUserStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "devicesCount",
+        "lastReportedDateTime",
+        "status",
+        "userDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "deviceEnrollmentConfiguration": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "priority",
+        "version"
+      ]
+    },
+    "deviceEnrollmentLimitConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "limit"
+      ]
+    },
+    "deviceEnrollmentPlatformRestrictionsConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "androidRestriction",
+        "iosRestriction",
+        "macOSRestriction",
+        "windowsMobileRestriction",
+        "windowsRestriction"
+      ]
+    },
+    "deviceEnrollmentWindowsHelloForBusinessConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "enhancedBiometricsState",
+        "pinExpirationInDays",
+        "pinLowercaseCharactersUsage",
+        "pinMaximumLength",
+        "pinMinimumLength",
+        "pinPreviousBlockCount",
+        "pinSpecialCharactersUsage",
+        "pinUppercaseCharactersUsage",
+        "remotePassportEnabled",
+        "securityDeviceRequired",
+        "state",
+        "unlockWithBiometricsEnabled"
+      ]
+    },
+    "deviceInstallState": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "deviceName",
+        "errorCode",
+        "installState",
+        "lastSyncDateTime",
+        "osDescription",
+        "osVersion",
+        "userName"
+      ]
+    },
+    "deviceLocalCredentialInfo": {
+      "navigationProperties": [],
+      "properties": [
+        "credentials",
+        "deviceName",
+        "lastBackupDateTime",
+        "refreshDateTime"
+      ]
+    },
+    "deviceLogCollectionResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "enrolledByUser",
+        "expirationDateTimeUTC",
+        "initiatedByUserPrincipalName",
+        "managedDeviceId",
+        "receivedDateTimeUTC",
+        "requestedDateTimeUTC",
+        "sizeInKB",
+        "status"
+      ]
+    },
+    "deviceManagement": {
+      "navigationProperties": [
+        "applePushNotificationCertificate",
+        "auditEvents",
+        "complianceManagementPartners",
+        "conditionalAccessSettings",
+        "detectedApps",
+        "deviceCategories",
+        "deviceCompliancePolicies",
+        "deviceCompliancePolicyDeviceStateSummary",
+        "deviceCompliancePolicySettingStateSummaries",
+        "deviceConfigurationDeviceStateSummaries",
+        "deviceConfigurations",
+        "deviceEnrollmentConfigurations",
+        "deviceManagementPartners",
+        "exchangeConnectors",
+        "importedWindowsAutopilotDeviceIdentities",
+        "iosUpdateStatuses",
+        "managedDeviceOverview",
+        "managedDevices",
+        "mobileAppTroubleshootingEvents",
+        "mobileThreatDefenseConnectors",
+        "notificationMessageTemplates",
+        "remoteAssistancePartners",
+        "reports",
+        "resourceOperations",
+        "roleAssignments",
+        "roleDefinitions",
+        "softwareUpdateStatusSummary",
+        "termsAndConditions",
+        "troubleshootingEvents",
+        "userExperienceAnalyticsAppHealthApplicationPerformance",
+        "userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersionDetails",
+        "userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersionDeviceId",
+        "userExperienceAnalyticsAppHealthApplicationPerformanceByOSVersion",
+        "userExperienceAnalyticsAppHealthDeviceModelPerformance",
+        "userExperienceAnalyticsAppHealthDevicePerformance",
+        "userExperienceAnalyticsAppHealthDevicePerformanceDetails",
+        "userExperienceAnalyticsAppHealthOSVersionPerformance",
+        "userExperienceAnalyticsAppHealthOverview",
+        "userExperienceAnalyticsBaselines",
+        "userExperienceAnalyticsCategories",
+        "userExperienceAnalyticsDevicePerformance",
+        "userExperienceAnalyticsDeviceScores",
+        "userExperienceAnalyticsDeviceStartupHistory",
+        "userExperienceAnalyticsDeviceStartupProcesses",
+        "userExperienceAnalyticsDeviceStartupProcessPerformance",
+        "userExperienceAnalyticsMetricHistory",
+        "userExperienceAnalyticsModelScores",
+        "userExperienceAnalyticsOverview",
+        "userExperienceAnalyticsScoreHistory",
+        "userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric",
+        "userExperienceAnalyticsWorkFromAnywhereMetrics",
+        "userExperienceAnalyticsWorkFromAnywhereModelPerformance",
+        "virtualEndpoint",
+        "windowsAutopilotDeviceIdentities",
+        "windowsInformationProtectionAppLearningSummaries",
+        "windowsInformationProtectionNetworkLearningSummaries",
+        "windowsMalwareInformation"
+      ],
+      "properties": [
+        "deviceProtectionOverview",
+        "intuneAccountId",
+        "intuneBrand",
+        "settings",
+        "subscriptionState",
+        "userExperienceAnalyticsSettings",
+        "windowsMalwareOverview"
+      ]
+    },
+    "deviceManagementCachedReportConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "deviceManagementExchangeConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "connectorServerName",
+        "exchangeAlias",
+        "exchangeConnectorType",
+        "exchangeOrganization",
+        "lastSyncDateTime",
+        "primarySmtpAddress",
+        "serverName",
+        "status",
+        "version"
+      ]
+    },
+    "deviceManagementExportJob": {
+      "navigationProperties": [],
+      "properties": [
+        "expirationDateTime",
+        "filter",
+        "format",
+        "localizationType",
+        "reportName",
+        "requestDateTime",
+        "select",
+        "snapshotId",
+        "status",
+        "url"
+      ]
+    },
+    "deviceManagementPartner": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "groupsRequiringPartnerEnrollment",
+        "isConfigured",
+        "lastHeartbeatDateTime",
+        "partnerAppType",
+        "partnerState",
+        "singleTenantAppId",
+        "whenPartnerDevicesWillBeMarkedAsNonCompliantDateTime",
+        "whenPartnerDevicesWillBeRemovedDateTime"
+      ]
+    },
+    "deviceManagementReports": {
+      "navigationProperties": [
+        "exportJobs"
+      ],
+      "properties": []
+    },
+    "deviceManagementTroubleshootingEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "correlationId",
+        "eventDateTime"
+      ]
+    },
+    "deviceRegistrationPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "azureADJoin",
+        "azureADRegistration",
+        "description",
+        "displayName",
+        "localAdminPassword",
+        "multiFactorAuthConfiguration",
+        "userDeviceQuota"
+      ]
+    },
+    "directory": {
+      "navigationProperties": [
+        "administrativeUnits",
+        "attributeSets",
+        "customSecurityAttributeDefinitions",
+        "deletedItems",
+        "deviceLocalCredentials",
+        "federationConfigurations",
+        "onPremisesSynchronization",
+        "publicKeyInfrastructure",
+        "subscriptions"
+      ],
+      "properties": []
+    },
+    "directoryAudit": {
+      "navigationProperties": [],
+      "properties": [
+        "activityDateTime",
+        "activityDisplayName",
+        "additionalDetails",
+        "category",
+        "correlationId",
+        "initiatedBy",
+        "loggedByService",
+        "operationType",
+        "result",
+        "resultReason",
+        "targetResources"
+      ]
+    },
+    "directoryDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "discoverabilities",
+        "discoveryDateTime",
+        "name",
+        "objects",
+        "readOnly",
+        "version"
+      ]
+    },
+    "directoryObject": {
+      "navigationProperties": [],
+      "properties": [
+        "deletedDateTime"
+      ]
+    },
+    "directoryObjectPartnerReference": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "externalPartnerTenantId",
+        "objectType"
+      ]
+    },
+    "directoryRole": {
+      "navigationProperties": [
+        "members",
+        "scopedMembers"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "roleTemplateId"
+      ]
+    },
+    "directoryRoleTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName"
+      ]
+    },
+    "documentSetVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "comment",
+        "createdBy",
+        "createdDateTime",
+        "items",
+        "shouldCaptureMinorVersion"
+      ]
+    },
+    "domain": {
+      "navigationProperties": [
+        "domainNameReferences",
+        "federationConfiguration",
+        "rootDomain",
+        "serviceConfigurationRecords",
+        "verificationDnsRecords"
+      ],
+      "properties": [
+        "authenticationType",
+        "availabilityStatus",
+        "isAdminManaged",
+        "isDefault",
+        "isInitial",
+        "isRoot",
+        "isVerified",
+        "manufacturer",
+        "model",
+        "passwordNotificationWindowInDays",
+        "passwordValidityPeriodInDays",
+        "state",
+        "supportedServices"
+      ]
+    },
+    "domainDnsCnameRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "canonicalName"
+      ]
+    },
+    "domainDnsMxRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "mailExchange",
+        "preference"
+      ]
+    },
+    "domainDnsRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "isOptional",
+        "label",
+        "recordType",
+        "supportedService",
+        "ttl"
+      ]
+    },
+    "domainDnsSrvRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "nameTarget",
+        "port",
+        "priority",
+        "protocol",
+        "service",
+        "weight"
+      ]
+    },
+    "domainDnsTxtRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "text"
+      ]
+    },
+    "domainDnsUnavailableRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "description"
+      ]
+    },
+    "drive": {
+      "navigationProperties": [
+        "bundles",
+        "following",
+        "items",
+        "list",
+        "root",
+        "special"
+      ],
+      "properties": [
+        "driveType",
+        "owner",
+        "quota",
+        "sharePointIds",
+        "system"
+      ]
+    },
+    "driveItem": {
+      "navigationProperties": [
+        "analytics",
+        "children",
+        "listItem",
+        "permissions",
+        "retentionLabel",
+        "subscriptions",
+        "thumbnails",
+        "versions",
+        "workbook"
+      ],
+      "properties": [
+        "audio",
+        "bundle",
+        "content",
+        "cTag",
+        "deleted",
+        "file",
+        "fileSystemInfo",
+        "folder",
+        "image",
+        "location",
+        "malware",
+        "package",
+        "pendingOperations",
+        "photo",
+        "publication",
+        "remoteItem",
+        "root",
+        "searchResult",
+        "shared",
+        "sharepointIds",
+        "size",
+        "specialFolder",
+        "video",
+        "webDavUrl"
+      ]
+    },
+    "driveItemVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "size"
+      ]
+    },
+    "driveProtectionRule": {
+      "navigationProperties": [],
+      "properties": [
+        "driveExpression"
+      ]
+    },
+    "driveProtectionUnit": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectId",
+        "displayName",
+        "email"
+      ]
+    },
+    "driveProtectionUnitsBulkAdditionJob": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectIds",
+        "drives"
+      ]
+    },
+    "driveRestoreArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "restoredSiteId",
+        "restoredSiteName",
+        "restoredSiteWebUrl"
+      ]
+    },
+    "driveRestoreArtifactsBulkAdditionRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectIds",
+        "drives"
+      ]
+    },
+    "eBookInstallSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedDeviceCount",
+        "failedUserCount",
+        "installedDeviceCount",
+        "installedUserCount",
+        "notInstalledDeviceCount",
+        "notInstalledUserCount"
+      ]
+    },
+    "edge": {
+      "navigationProperties": [
+        "internetExplorerMode"
+      ],
+      "properties": []
+    },
+    "editionUpgradeConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "license",
+        "licenseType",
+        "productKey",
+        "targetEdition"
+      ]
+    },
+    "educationAssignment": {
+      "navigationProperties": [
+        "categories",
+        "gradingCategory",
+        "gradingScheme",
+        "resources",
+        "rubric",
+        "submissions"
+      ],
+      "properties": [
+        "addedStudentAction",
+        "addToCalendarAction",
+        "allowLateSubmissions",
+        "allowStudentsToAddResourcesToSubmission",
+        "assignDateTime",
+        "assignedDateTime",
+        "assignTo",
+        "classId",
+        "closeDateTime",
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "dueDateTime",
+        "feedbackResourcesFolderUrl",
+        "grading",
+        "instructions",
+        "languageTag",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "moduleUrl",
+        "notificationChannelUrl",
+        "resourcesFolderUrl",
+        "status",
+        "webUrl"
+      ]
+    },
+    "educationAssignmentDefaults": {
+      "navigationProperties": [],
+      "properties": [
+        "addedStudentAction",
+        "addToCalendarAction",
+        "dueTime",
+        "notificationChannelUrl"
+      ]
+    },
+    "educationAssignmentResource": {
+      "navigationProperties": [
+        "dependentResources"
+      ],
+      "properties": [
+        "distributeForStudentWork",
+        "resource"
+      ]
+    },
+    "educationAssignmentSettings": {
+      "navigationProperties": [
+        "defaultGradingScheme",
+        "gradingCategories",
+        "gradingSchemes"
+      ],
+      "properties": [
+        "submissionAnimationDisabled"
+      ]
+    },
+    "educationCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "educationClass": {
+      "navigationProperties": [
+        "assignmentCategories",
+        "assignmentDefaults",
+        "assignments",
+        "assignmentSettings",
+        "group",
+        "members",
+        "modules",
+        "schools",
+        "teachers"
+      ],
+      "properties": [
+        "classCode",
+        "course",
+        "createdBy",
+        "description",
+        "displayName",
+        "externalId",
+        "externalName",
+        "externalSource",
+        "externalSourceDetail",
+        "grade",
+        "mailNickname",
+        "term"
+      ]
+    },
+    "educationFeedbackOutcome": {
+      "navigationProperties": [],
+      "properties": [
+        "feedback",
+        "publishedFeedback"
+      ]
+    },
+    "educationFeedbackResourceOutcome": {
+      "navigationProperties": [],
+      "properties": [
+        "feedbackResource",
+        "resourceStatus"
+      ]
+    },
+    "educationGradingCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "percentageWeight"
+      ]
+    },
+    "educationGradingScheme": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "grades",
+        "hidePointsDuringGrading"
+      ]
+    },
+    "educationModule": {
+      "navigationProperties": [
+        "resources"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "isPinned",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "resourcesFolderUrl",
+        "status"
+      ]
+    },
+    "educationModuleResource": {
+      "navigationProperties": [],
+      "properties": [
+        "resource"
+      ]
+    },
+    "educationOrganization": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "externalSource",
+        "externalSourceDetail"
+      ]
+    },
+    "educationOutcome": {
+      "navigationProperties": [],
+      "properties": [
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "educationPointsOutcome": {
+      "navigationProperties": [],
+      "properties": [
+        "points",
+        "publishedPoints"
+      ]
+    },
+    "educationRoot": {
+      "navigationProperties": [
+        "classes",
+        "me",
+        "reports",
+        "schools",
+        "users"
+      ],
+      "properties": []
+    },
+    "educationRubric": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "grading",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "levels",
+        "qualities"
+      ]
+    },
+    "educationRubricOutcome": {
+      "navigationProperties": [],
+      "properties": [
+        "publishedRubricQualityFeedback",
+        "publishedRubricQualitySelectedLevels",
+        "rubricQualityFeedback",
+        "rubricQualitySelectedLevels"
+      ]
+    },
+    "educationSchool": {
+      "navigationProperties": [
+        "administrativeUnit",
+        "classes",
+        "users"
+      ],
+      "properties": [
+        "address",
+        "createdBy",
+        "externalId",
+        "externalPrincipalId",
+        "fax",
+        "highestGrade",
+        "lowestGrade",
+        "phone",
+        "principalEmail",
+        "principalName",
+        "schoolNumber"
+      ]
+    },
+    "educationSubmission": {
+      "navigationProperties": [
+        "outcomes",
+        "resources",
+        "submittedResources"
+      ],
+      "properties": [
+        "assignmentId",
+        "excusedBy",
+        "excusedDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "reassignedBy",
+        "reassignedDateTime",
+        "recipient",
+        "resourcesFolderUrl",
+        "returnedBy",
+        "returnedDateTime",
+        "status",
+        "submittedBy",
+        "submittedDateTime",
+        "unsubmittedBy",
+        "unsubmittedDateTime",
+        "webUrl"
+      ]
+    },
+    "educationSubmissionResource": {
+      "navigationProperties": [
+        "dependentResources"
+      ],
+      "properties": [
+        "assignmentResourceUrl",
+        "resource"
+      ]
+    },
+    "educationUser": {
+      "navigationProperties": [
+        "assignments",
+        "classes",
+        "rubrics",
+        "schools",
+        "taughtClasses",
+        "user"
+      ],
+      "properties": [
+        "accountEnabled",
+        "assignedLicenses",
+        "assignedPlans",
+        "businessPhones",
+        "createdBy",
+        "department",
+        "displayName",
+        "externalSource",
+        "externalSourceDetail",
+        "givenName",
+        "mail",
+        "mailingAddress",
+        "mailNickname",
+        "middleName",
+        "mobilePhone",
+        "officeLocation",
+        "onPremisesInfo",
+        "passwordPolicies",
+        "passwordProfile",
+        "preferredLanguage",
+        "primaryRole",
+        "provisionedPlans",
+        "refreshTokensValidFromDateTime",
+        "relatedContacts",
+        "residenceAddress",
+        "showInAddressList",
+        "student",
+        "surname",
+        "teacher",
+        "usageLocation",
+        "userPrincipalName",
+        "userType"
+      ]
+    },
+    "emailAuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "emailAddress"
+      ]
+    },
+    "emailAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": [
+        "allowExternalIdToUseEmailOtp"
+      ]
+    },
+    "emailFileAssessmentRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "contentData",
+        "destinationRoutingReason",
+        "recipientEmail"
+      ]
+    },
+    "emergencyCallEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "callerInfo",
+        "emergencyNumberDialed",
+        "policyName"
+      ]
+    },
+    "employeeExperience": {
+      "navigationProperties": [
+        "communities",
+        "engagementAsyncOperations",
+        "learningCourseActivities",
+        "learningProviders",
+        "roles"
+      ],
+      "properties": []
+    },
+    "employeeExperienceUser": {
+      "navigationProperties": [
+        "assignedRoles",
+        "learningCourseActivities"
+      ],
+      "properties": []
+    },
+    "endpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "capability",
+        "providerId",
+        "providerName",
+        "providerResourceId",
+        "uri"
+      ]
+    },
+    "endUserNotification": {
+      "navigationProperties": [
+        "details"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "notificationType",
+        "source",
+        "status",
+        "supportedLocales"
+      ]
+    },
+    "endUserNotificationDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "emailContent",
+        "isDefaultLangauge",
+        "language",
+        "locale",
+        "sentFrom",
+        "subject"
+      ]
+    },
+    "engagementAsyncOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "operationType",
+        "resourceId"
+      ]
+    },
+    "engagementConversation": {
+      "navigationProperties": [
+        "messages",
+        "starter"
+      ],
+      "properties": [
+        "creationMode",
+        "starterId"
+      ]
+    },
+    "engagementConversationDiscussionMessage": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "engagementConversationMessage": {
+      "navigationProperties": [
+        "conversation",
+        "reactions",
+        "replies",
+        "replyTo"
+      ],
+      "properties": [
+        "body",
+        "createdDateTime",
+        "creationMode",
+        "from",
+        "lastModifiedDateTime",
+        "replyToId"
+      ]
+    },
+    "engagementConversationMessageReaction": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "reactionBy",
+        "reactionType"
+      ]
+    },
+    "engagementConversationQuestionMessage": {
+      "navigationProperties": [],
+      "properties": [
+        "title"
+      ]
+    },
+    "engagementConversationSystemMessage": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "engagementRole": {
+      "navigationProperties": [
+        "members"
+      ],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "engagementRoleMember": {
+      "navigationProperties": [
+        "user"
+      ],
+      "properties": [
+        "createdDateTime",
+        "userId"
+      ]
+    },
+    "enrollmentConfigurationAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "enrollmentTroubleshootingEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "enrollmentType",
+        "failureCategory",
+        "failureReason",
+        "managedDeviceIdentifier",
+        "operatingSystem",
+        "osVersion",
+        "userId"
+      ]
+    },
+    "enterpriseCodeSigningCertificate": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "expirationDateTime",
+        "issuer",
+        "issuerName",
+        "status",
+        "subject",
+        "subjectName",
+        "uploadDateTime"
+      ]
+    },
+    "entitlementManagement": {
+      "navigationProperties": [
+        "accessPackageAssignmentApprovals",
+        "accessPackages",
+        "assignmentPolicies",
+        "assignmentRequests",
+        "assignments",
+        "catalogs",
+        "connectedOrganizations",
+        "resourceEnvironments",
+        "resourceRequests",
+        "resourceRoleScopes",
+        "resources",
+        "settings"
+      ],
+      "properties": []
+    },
+    "entitlementManagementSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "durationUntilExternalUserDeletedAfterBlocked",
+        "externalUserLifecycleAction"
+      ]
+    },
+    "entity": {
+      "navigationProperties": [],
+      "properties": [
+        "id"
+      ]
+    },
+    "event": {
+      "navigationProperties": [
+        "attachments",
+        "calendar",
+        "exceptionOccurrences",
+        "extensions",
+        "instances",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "allowNewTimeProposals",
+        "attendees",
+        "body",
+        "bodyPreview",
+        "cancelledOccurrences",
+        "end",
+        "hasAttachments",
+        "hideAttendees",
+        "iCalUId",
+        "importance",
+        "isAllDay",
+        "isCancelled",
+        "isDraft",
+        "isOnlineMeeting",
+        "isOrganizer",
+        "isReminderOn",
+        "location",
+        "locations",
+        "onlineMeeting",
+        "onlineMeetingProvider",
+        "onlineMeetingUrl",
+        "organizer",
+        "originalEndTimeZone",
+        "originalStart",
+        "originalStartTimeZone",
+        "recurrence",
+        "reminderMinutesBeforeStart",
+        "responseRequested",
+        "responseStatus",
+        "sensitivity",
+        "seriesMasterId",
+        "showAs",
+        "start",
+        "subject",
+        "transactionId",
+        "type",
+        "webLink"
+      ]
+    },
+    "eventMessage": {
+      "navigationProperties": [
+        "event"
+      ],
+      "properties": [
+        "endDateTime",
+        "isAllDay",
+        "isDelegated",
+        "isOutOfDate",
+        "location",
+        "meetingMessageType",
+        "recurrence",
+        "startDateTime",
+        "type"
+      ]
+    },
+    "eventMessageRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "allowNewTimeProposals",
+        "meetingRequestType",
+        "previousEndDateTime",
+        "previousLocation",
+        "previousStartDateTime",
+        "responseRequested"
+      ]
+    },
+    "eventMessageResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "proposedNewTime",
+        "responseType"
+      ]
+    },
+    "exchangeAdmin": {
+      "navigationProperties": [
+        "mailboxes",
+        "tracing"
+      ],
+      "properties": []
+    },
+    "exchangeMessageTrace": {
+      "navigationProperties": [],
+      "properties": [
+        "fromIP",
+        "messageId",
+        "receivedDateTime",
+        "recipientAddress",
+        "senderAddress",
+        "size",
+        "status",
+        "subject",
+        "toIP"
+      ]
+    },
+    "exchangeMessageTraceDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "data",
+        "dateTime",
+        "description",
+        "event",
+        "messageId"
+      ]
+    },
+    "exchangeProtectionPolicy": {
+      "navigationProperties": [
+        "mailboxInclusionRules",
+        "mailboxProtectionUnits",
+        "mailboxProtectionUnitsBulkAdditionJobs"
+      ],
+      "properties": []
+    },
+    "exchangeRestoreSession": {
+      "navigationProperties": [
+        "granularMailboxRestoreArtifacts",
+        "mailboxRestoreArtifacts",
+        "mailboxRestoreArtifactsBulkAdditionRequests"
+      ],
+      "properties": []
+    },
+    "exchangeSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "primaryMailboxId"
+      ]
+    },
+    "extension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "extensionProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "appDisplayName",
+        "dataType",
+        "isMultiValued",
+        "isSyncedFromOnPremises",
+        "name",
+        "targetObjects"
+      ]
+    },
+    "externalAuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationId",
+        "displayName"
+      ]
+    },
+    "externalAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": [
+        "appId",
+        "displayName",
+        "openIdConnectSetting"
+      ]
+    },
+    "externalDomainName": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "externalUsersSelfServiceSignUpEventsFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "onAttributeCollection",
+        "onAttributeCollectionStart",
+        "onAttributeCollectionSubmit",
+        "onAuthenticationMethodLoadStart",
+        "onInteractiveAuthFlowStart",
+        "onUserCreateStart"
+      ]
+    },
+    "featureRolloutPolicy": {
+      "navigationProperties": [
+        "appliesTo"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "feature",
+        "isAppliedToOrganization",
+        "isEnabled"
+      ]
+    },
+    "federatedIdentityCredential": {
+      "navigationProperties": [],
+      "properties": [
+        "audiences",
+        "description",
+        "issuer",
+        "name",
+        "subject"
+      ]
+    },
+    "fido2AuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "aaGuid",
+        "attestationCertificates",
+        "attestationLevel",
+        "displayName",
+        "model",
+        "passkeyType"
+      ]
+    },
+    "fido2AuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets",
+        "passkeyProfiles"
+      ],
+      "properties": [
+        "defaultPasskeyProfile",
+        "isAttestationEnforced",
+        "isSelfServiceRegistrationAllowed",
+        "keyRestrictions"
+      ]
+    },
+    "fido2CombinationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedAAGUIDs"
+      ]
+    },
+    "fieldValueSet": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "fileAssessmentRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "contentData",
+        "fileName"
+      ]
+    },
+    "fileAttachment": {
+      "navigationProperties": [],
+      "properties": [
+        "contentBytes",
+        "contentId",
+        "contentLocation"
+      ]
+    },
+    "fileStorage": {
+      "navigationProperties": [
+        "containers",
+        "containerTypeRegistrations",
+        "containerTypes",
+        "deletedContainers"
+      ],
+      "properties": []
+    },
+    "fileStorageContainer": {
+      "navigationProperties": [
+        "columns",
+        "drive",
+        "migrationJobs",
+        "permissions",
+        "recycleBin",
+        "sharePointGroups"
+      ],
+      "properties": [
+        "assignedSensitivityLabel",
+        "containerTypeId",
+        "createdDateTime",
+        "customProperties",
+        "description",
+        "displayName",
+        "lockState",
+        "settings",
+        "status",
+        "viewpoint"
+      ]
+    },
+    "fileStorageContainerType": {
+      "navigationProperties": [],
+      "properties": [
+        "billingClassification",
+        "billingStatus",
+        "createdDateTime",
+        "etag",
+        "expirationDateTime",
+        "name",
+        "owningAppId",
+        "settings"
+      ]
+    },
+    "fileStorageContainerTypeAppPermissionGrant": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "applicationPermissions",
+        "delegatedPermissions"
+      ]
+    },
+    "fileStorageContainerTypeRegistration": {
+      "navigationProperties": [
+        "applicationPermissionGrants"
+      ],
+      "properties": [
+        "billingClassification",
+        "billingStatus",
+        "etag",
+        "expirationDateTime",
+        "name",
+        "owningAppId",
+        "registeredDateTime",
+        "settings"
+      ]
+    },
+    "filterOperatorSchema": {
+      "navigationProperties": [],
+      "properties": [
+        "arity",
+        "multivaluedComparisonType",
+        "supportedAttributeTypes"
+      ]
+    },
+    "fixtureMap": {
+      "navigationProperties": [],
+      "properties": [
+        "placeId"
+      ]
+    },
+    "floor": {
+      "navigationProperties": [],
+      "properties": [
+        "sortOrder"
+      ]
+    },
+    "footprintMap": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "fraudProtectionProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "governanceInsight": {
+      "navigationProperties": [],
+      "properties": [
+        "insightCreatedDateTime"
+      ]
+    },
+    "granularMailboxRestoreArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "artifactCount",
+        "searchResponseId"
+      ]
+    },
+    "group": {
+      "navigationProperties": [
+        "acceptedSenders",
+        "appRoleAssignments",
+        "calendar",
+        "calendarView",
+        "conversations",
+        "createdOnBehalfOf",
+        "drive",
+        "drives",
+        "events",
+        "extensions",
+        "groupLifecyclePolicies",
+        "memberOf",
+        "members",
+        "membersWithLicenseErrors",
+        "onenote",
+        "onPremisesSyncBehavior",
+        "owners",
+        "permissionGrants",
+        "photo",
+        "photos",
+        "planner",
+        "rejectedSenders",
+        "settings",
+        "sites",
+        "team",
+        "threads",
+        "transitiveMemberOf",
+        "transitiveMembers"
+      ],
+      "properties": [
+        "allowExternalSenders",
+        "assignedLabels",
+        "assignedLicenses",
+        "autoSubscribeNewMembers",
+        "classification",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "expirationDateTime",
+        "groupTypes",
+        "hasMembersWithLicenseErrors",
+        "hideFromAddressLists",
+        "hideFromOutlookClients",
+        "isArchived",
+        "isAssignableToRole",
+        "isManagementRestricted",
+        "isSubscribedByMail",
+        "licenseProcessingState",
+        "mail",
+        "mailEnabled",
+        "mailNickname",
+        "membershipRule",
+        "membershipRuleProcessingState",
+        "onPremisesDomainName",
+        "onPremisesLastSyncDateTime",
+        "onPremisesNetBiosName",
+        "onPremisesProvisioningErrors",
+        "onPremisesSamAccountName",
+        "onPremisesSecurityIdentifier",
+        "onPremisesSyncEnabled",
+        "preferredDataLocation",
+        "preferredLanguage",
+        "proxyAddresses",
+        "renewedDateTime",
+        "resourceBehaviorOptions",
+        "resourceProvisioningOptions",
+        "securityEnabled",
+        "securityIdentifier",
+        "serviceProvisioningErrors",
+        "theme",
+        "uniqueName",
+        "unseenCount",
+        "visibility",
+        "welcomeMessageEnabled"
+      ]
+    },
+    "groupLifecyclePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "alternateNotificationEmails",
+        "groupLifetimeInDays",
+        "managedGroupTypes"
+      ]
+    },
+    "groupSetting": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "templateId",
+        "values"
+      ]
+    },
+    "groupSettingTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "values"
+      ]
+    },
+    "homeRealmDiscoveryPolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "horizontalSection": {
+      "navigationProperties": [
+        "columns"
+      ],
+      "properties": [
+        "emphasis",
+        "layout"
+      ]
+    },
+    "horizontalSectionColumn": {
+      "navigationProperties": [
+        "webparts"
+      ],
+      "properties": [
+        "width"
+      ]
+    },
+    "humanSecurityFraudProtectionProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "appId",
+        "serverToken"
+      ]
+    },
+    "identityApiConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationConfiguration",
+        "displayName",
+        "targetUrl"
+      ]
+    },
+    "identityBuiltInUserFlowAttribute": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "identityContainer": {
+      "navigationProperties": [
+        "apiConnectors",
+        "authenticationEventListeners",
+        "authenticationEventsFlows",
+        "b2xUserFlows",
+        "conditionalAccess",
+        "customAuthenticationExtensions",
+        "identityProviders",
+        "riskPrevention",
+        "userFlowAttributes"
+      ],
+      "properties": []
+    },
+    "identityCustomUserFlowAttribute": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "identityGovernance": {
+      "navigationProperties": [
+        "accessReviews",
+        "appConsent",
+        "entitlementManagement",
+        "lifecycleWorkflows",
+        "privilegedAccess",
+        "termsOfUse"
+      ],
+      "properties": []
+    },
+    "identityProtectionRoot": {
+      "navigationProperties": [
+        "riskDetections",
+        "riskyServicePrincipals",
+        "riskyUsers",
+        "servicePrincipalRiskDetections"
+      ],
+      "properties": []
+    },
+    "identityProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "clientId",
+        "clientSecret",
+        "name",
+        "type"
+      ]
+    },
+    "identityProviderBase": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "identitySecurityDefaultsEnforcementPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "identityUserFlow": {
+      "navigationProperties": [],
+      "properties": [
+        "userFlowType",
+        "userFlowTypeVersion"
+      ]
+    },
+    "identityUserFlowAttribute": {
+      "navigationProperties": [],
+      "properties": [
+        "dataType",
+        "description",
+        "displayName",
+        "userFlowAttributeType"
+      ]
+    },
+    "identityUserFlowAttributeAssignment": {
+      "navigationProperties": [
+        "userAttribute"
+      ],
+      "properties": [
+        "displayName",
+        "isOptional",
+        "requiresVerification",
+        "userAttributeValues",
+        "userInputType"
+      ]
+    },
+    "importedWindowsAutopilotDeviceIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedUserPrincipalName",
+        "groupTag",
+        "hardwareIdentifier",
+        "importId",
+        "productKey",
+        "serialNumber",
+        "state"
+      ]
+    },
+    "importedWindowsAutopilotDeviceIdentityUpload": {
+      "navigationProperties": [
+        "deviceIdentities"
+      ],
+      "properties": [
+        "createdDateTimeUtc",
+        "status"
+      ]
+    },
+    "inferenceClassification": {
+      "navigationProperties": [
+        "overrides"
+      ],
+      "properties": []
+    },
+    "inferenceClassificationOverride": {
+      "navigationProperties": [],
+      "properties": [
+        "classifyAs",
+        "senderEmailAddress"
+      ]
+    },
+    "informationProtection": {
+      "navigationProperties": [
+        "bitlocker",
+        "threatAssessmentRequests"
+      ],
+      "properties": []
+    },
+    "inheritablePermission": {
+      "navigationProperties": [],
+      "properties": [
+        "inheritableScopes",
+        "resourceAppId"
+      ]
+    },
+    "insightsSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "disabledForGroup",
+        "isEnabledInOrganization"
+      ]
+    },
+    "internalDomainFederation": {
+      "navigationProperties": [],
+      "properties": [
+        "activeSignInUri",
+        "federatedIdpMfaBehavior",
+        "isSignedAuthenticationRequestRequired",
+        "nextSigningCertificate",
+        "passwordResetUri",
+        "promptLoginBehavior",
+        "signingCertificateUpdateStatus",
+        "signOutUri"
+      ]
+    },
+    "internetExplorerMode": {
+      "navigationProperties": [
+        "siteLists"
+      ],
+      "properties": []
+    },
+    "invitation": {
+      "navigationProperties": [
+        "invitedUser",
+        "invitedUserSponsors"
+      ],
+      "properties": [
+        "invitedUserDisplayName",
+        "invitedUserEmailAddress",
+        "invitedUserMessageInfo",
+        "invitedUserType",
+        "inviteRedeemUrl",
+        "inviteRedirectUrl",
+        "resetRedemption",
+        "sendInvitationMessage",
+        "status"
+      ]
+    },
+    "inviteParticipantsOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "participants"
+      ]
+    },
+    "iosCertificateProfile": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "iosCompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceThreatProtectionEnabled",
+        "deviceThreatProtectionRequiredSecurityLevel",
+        "managedEmailProfileRequired",
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passcodeBlockSimple",
+        "passcodeExpirationDays",
+        "passcodeMinimumCharacterSetCount",
+        "passcodeMinimumLength",
+        "passcodeMinutesOfInactivityBeforeLock",
+        "passcodePreviousPasscodeBlockCount",
+        "passcodeRequired",
+        "passcodeRequiredType",
+        "securityBlockJailbrokenDevices"
+      ]
+    },
+    "iosCustomConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "payload",
+        "payloadFileName",
+        "payloadName"
+      ]
+    },
+    "iosDeviceFeaturesConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "assetTagTemplate",
+        "homeScreenDockIcons",
+        "homeScreenPages",
+        "lockScreenFootnote",
+        "notificationSettings"
+      ]
+    },
+    "iosGeneralDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accountBlockModification",
+        "activationLockAllowWhenSupervised",
+        "airDropBlocked",
+        "airDropForceUnmanagedDropTarget",
+        "airPlayForcePairingPasswordForOutgoingRequests",
+        "appleNewsBlocked",
+        "appleWatchBlockPairing",
+        "appleWatchForceWristDetection",
+        "appsSingleAppModeList",
+        "appStoreBlockAutomaticDownloads",
+        "appStoreBlocked",
+        "appStoreBlockInAppPurchases",
+        "appStoreBlockUIAppInstallation",
+        "appStoreRequirePassword",
+        "appsVisibilityList",
+        "appsVisibilityListType",
+        "bluetoothBlockModification",
+        "cameraBlocked",
+        "cellularBlockDataRoaming",
+        "cellularBlockGlobalBackgroundFetchWhileRoaming",
+        "cellularBlockPerAppDataModification",
+        "cellularBlockPersonalHotspot",
+        "cellularBlockVoiceRoaming",
+        "certificatesBlockUntrustedTlsCertificates",
+        "classroomAppBlockRemoteScreenObservation",
+        "classroomAppForceUnpromptedScreenObservation",
+        "compliantAppListType",
+        "compliantAppsList",
+        "configurationProfileBlockChanges",
+        "definitionLookupBlocked",
+        "deviceBlockEnableRestrictions",
+        "deviceBlockEraseContentAndSettings",
+        "deviceBlockNameModification",
+        "diagnosticDataBlockSubmission",
+        "diagnosticDataBlockSubmissionModification",
+        "documentsBlockManagedDocumentsInUnmanagedApps",
+        "documentsBlockUnmanagedDocumentsInManagedApps",
+        "emailInDomainSuffixes",
+        "enterpriseAppBlockTrust",
+        "enterpriseAppBlockTrustModification",
+        "faceTimeBlocked",
+        "findMyFriendsBlocked",
+        "gameCenterBlocked",
+        "gamingBlockGameCenterFriends",
+        "gamingBlockMultiplayer",
+        "hostPairingBlocked",
+        "iBooksStoreBlocked",
+        "iBooksStoreBlockErotica",
+        "iCloudBlockActivityContinuation",
+        "iCloudBlockBackup",
+        "iCloudBlockDocumentSync",
+        "iCloudBlockManagedAppsSync",
+        "iCloudBlockPhotoLibrary",
+        "iCloudBlockPhotoStreamSync",
+        "iCloudBlockSharedPhotoStream",
+        "iCloudRequireEncryptedBackup",
+        "iTunesBlockExplicitContent",
+        "iTunesBlockMusicService",
+        "iTunesBlockRadio",
+        "keyboardBlockAutoCorrect",
+        "keyboardBlockDictation",
+        "keyboardBlockPredictive",
+        "keyboardBlockShortcuts",
+        "keyboardBlockSpellCheck",
+        "kioskModeAllowAssistiveSpeak",
+        "kioskModeAllowAssistiveTouchSettings",
+        "kioskModeAllowAutoLock",
+        "kioskModeAllowColorInversionSettings",
+        "kioskModeAllowRingerSwitch",
+        "kioskModeAllowScreenRotation",
+        "kioskModeAllowSleepButton",
+        "kioskModeAllowTouchscreen",
+        "kioskModeAllowVoiceOverSettings",
+        "kioskModeAllowVolumeButtons",
+        "kioskModeAllowZoomSettings",
+        "kioskModeAppStoreUrl",
+        "kioskModeBuiltInAppId",
+        "kioskModeManagedAppId",
+        "kioskModeRequireAssistiveTouch",
+        "kioskModeRequireColorInversion",
+        "kioskModeRequireMonoAudio",
+        "kioskModeRequireVoiceOver",
+        "kioskModeRequireZoom",
+        "lockScreenBlockControlCenter",
+        "lockScreenBlockNotificationView",
+        "lockScreenBlockPassbook",
+        "lockScreenBlockTodayView",
+        "mediaContentRatingApps",
+        "mediaContentRatingAustralia",
+        "mediaContentRatingCanada",
+        "mediaContentRatingFrance",
+        "mediaContentRatingGermany",
+        "mediaContentRatingIreland",
+        "mediaContentRatingJapan",
+        "mediaContentRatingNewZealand",
+        "mediaContentRatingUnitedKingdom",
+        "mediaContentRatingUnitedStates",
+        "messagesBlocked",
+        "networkUsageRules",
+        "notificationsBlockSettingsModification",
+        "passcodeBlockFingerprintModification",
+        "passcodeBlockFingerprintUnlock",
+        "passcodeBlockModification",
+        "passcodeBlockSimple",
+        "passcodeExpirationDays",
+        "passcodeMinimumCharacterSetCount",
+        "passcodeMinimumLength",
+        "passcodeMinutesOfInactivityBeforeLock",
+        "passcodeMinutesOfInactivityBeforeScreenTimeout",
+        "passcodePreviousPasscodeBlockCount",
+        "passcodeRequired",
+        "passcodeRequiredType",
+        "passcodeSignInFailureCountBeforeWipe",
+        "podcastsBlocked",
+        "safariBlockAutofill",
+        "safariBlocked",
+        "safariBlockJavaScript",
+        "safariBlockPopups",
+        "safariCookieSettings",
+        "safariManagedDomains",
+        "safariPasswordAutoFillDomains",
+        "safariRequireFraudWarning",
+        "screenCaptureBlocked",
+        "siriBlocked",
+        "siriBlockedWhenLocked",
+        "siriBlockUserGeneratedContent",
+        "siriRequireProfanityFilter",
+        "spotlightBlockInternetResults",
+        "voiceDialingBlocked",
+        "wallpaperBlockModification",
+        "wiFiConnectOnlyToConfiguredNetworks"
+      ]
+    },
+    "iosiPadOSWebClip": {
+      "navigationProperties": [],
+      "properties": [
+        "appUrl",
+        "useManagedBrowser"
+      ]
+    },
+    "iosLobApp": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableDeviceType",
+        "buildNumber",
+        "bundleId",
+        "expirationDateTime",
+        "minimumSupportedOperatingSystem",
+        "versionNumber"
+      ]
+    },
+    "iosLobAppProvisioningConfigurationAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "iosManagedAppProtection": {
+      "navigationProperties": [
+        "apps",
+        "deploymentSummary"
+      ],
+      "properties": [
+        "appDataEncryptionType",
+        "customBrowserProtocol",
+        "deployedAppCount",
+        "faceIdBlocked",
+        "minimumRequiredSdkVersion"
+      ]
+    },
+    "iosManagedAppRegistration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "iosMobileAppConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "encodedSettingXml",
+        "settings"
+      ]
+    },
+    "iosStoreApp": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableDeviceType",
+        "appStoreUrl",
+        "bundleId",
+        "minimumSupportedOperatingSystem"
+      ]
+    },
+    "iosUpdateConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "activeHoursEnd",
+        "activeHoursStart",
+        "scheduledInstallDays",
+        "utcTimeOffsetInMinutes"
+      ]
+    },
+    "iosUpdateDeviceStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceGracePeriodExpirationDateTime",
+        "deviceDisplayName",
+        "deviceId",
+        "deviceModel",
+        "installStatus",
+        "lastReportedDateTime",
+        "osVersion",
+        "status",
+        "userId",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "iosVppApp": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableDeviceType",
+        "appStoreUrl",
+        "bundleId",
+        "licensingType",
+        "releaseDateTime",
+        "totalLicenseCount",
+        "usedLicenseCount",
+        "vppTokenAccountType",
+        "vppTokenAppleId",
+        "vppTokenOrganizationName"
+      ]
+    },
+    "iosVppEBook": {
+      "navigationProperties": [],
+      "properties": [
+        "appleId",
+        "genres",
+        "language",
+        "seller",
+        "totalLicenseCount",
+        "usedLicenseCount",
+        "vppOrganizationName",
+        "vppTokenId"
+      ]
+    },
+    "iosVppEBookAssignment": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ipNamedLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "ipRanges",
+        "isTrusted"
+      ]
+    },
+    "itemActivity": {
+      "navigationProperties": [
+        "driveItem"
+      ],
+      "properties": [
+        "access",
+        "activityDateTime",
+        "actor"
+      ]
+    },
+    "itemActivityStat": {
+      "navigationProperties": [
+        "activities"
+      ],
+      "properties": [
+        "access",
+        "create",
+        "delete",
+        "edit",
+        "endDateTime",
+        "incompleteData",
+        "isTrending",
+        "move",
+        "startDateTime"
+      ]
+    },
+    "itemAnalytics": {
+      "navigationProperties": [
+        "allTime",
+        "itemActivityStats",
+        "lastSevenDays"
+      ],
+      "properties": []
+    },
+    "itemAttachment": {
+      "navigationProperties": [
+        "item"
+      ],
+      "properties": []
+    },
+    "itemInsights": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "itemRetentionLabel": {
+      "navigationProperties": [],
+      "properties": [
+        "isLabelAppliedExplicitly",
+        "labelAppliedBy",
+        "labelAppliedDateTime",
+        "name",
+        "retentionSettings"
+      ]
+    },
+    "labelContentRight": {
+      "navigationProperties": [
+        "label"
+      ],
+      "properties": [
+        "cid",
+        "format",
+        "rights"
+      ]
+    },
+    "landingPage": {
+      "navigationProperties": [
+        "details"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "locale",
+        "source",
+        "status",
+        "supportedLocales"
+      ]
+    },
+    "landingPageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "isDefaultLangauge",
+        "language"
+      ]
+    },
+    "learningAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedDateTime",
+        "assignerUserId",
+        "assignmentType",
+        "dueDateTime",
+        "notes"
+      ]
+    },
+    "learningContent": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalTags",
+        "contentWebUrl",
+        "contributors",
+        "createdDateTime",
+        "description",
+        "duration",
+        "externalId",
+        "format",
+        "isActive",
+        "isPremium",
+        "isSearchable",
+        "languageTag",
+        "lastModifiedDateTime",
+        "level",
+        "numberOfPages",
+        "skillTags",
+        "sourceName",
+        "thumbnailWebUrl",
+        "title"
+      ]
+    },
+    "learningCourseActivity": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "completionPercentage",
+        "externalcourseActivityId",
+        "learnerUserId",
+        "learningContentId",
+        "learningProviderId",
+        "status"
+      ]
+    },
+    "learningProvider": {
+      "navigationProperties": [
+        "learningContents",
+        "learningCourseActivities"
+      ],
+      "properties": [
+        "displayName",
+        "isCourseActivitySyncEnabled",
+        "loginWebUrl",
+        "longLogoWebUrlForDarkTheme",
+        "longLogoWebUrlForLightTheme",
+        "squareLogoWebUrlForDarkTheme",
+        "squareLogoWebUrlForLightTheme"
+      ]
+    },
+    "learningSelfInitiatedCourse": {
+      "navigationProperties": [],
+      "properties": [
+        "startedDateTime"
+      ]
+    },
+    "levelMap": {
+      "navigationProperties": [
+        "fixtures",
+        "sections",
+        "units"
+      ],
+      "properties": [
+        "placeId"
+      ]
+    },
+    "licenseDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "servicePlans",
+        "skuId",
+        "skuPartNumber"
+      ]
+    },
+    "linkedResource": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationName",
+        "displayName",
+        "externalId",
+        "webUrl"
+      ]
+    },
+    "list": {
+      "navigationProperties": [
+        "columns",
+        "contentTypes",
+        "drive",
+        "items",
+        "operations",
+        "subscriptions"
+      ],
+      "properties": [
+        "displayName",
+        "list",
+        "sharepointIds",
+        "system"
+      ]
+    },
+    "listItem": {
+      "navigationProperties": [
+        "analytics",
+        "documentSetVersions",
+        "driveItem",
+        "fields",
+        "versions"
+      ],
+      "properties": [
+        "contentType",
+        "deleted",
+        "sharepointIds"
+      ]
+    },
+    "listItemVersion": {
+      "navigationProperties": [
+        "fields"
+      ],
+      "properties": []
+    },
+    "localizedNotificationMessage": {
+      "navigationProperties": [],
+      "properties": [
+        "isDefault",
+        "lastModifiedDateTime",
+        "locale",
+        "messageTemplate",
+        "subject"
+      ]
+    },
+    "loginPage": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "language",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "source",
+        "status"
+      ]
+    },
+    "longRunningOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastActionDateTime",
+        "resourceLocation",
+        "status",
+        "statusDetail"
+      ]
+    },
+    "m365AppsInstallationOptions": {
+      "navigationProperties": [],
+      "properties": [
+        "appsForMac",
+        "appsForWindows",
+        "updateChannel"
+      ]
+    },
+    "macOSCompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceThreatProtectionEnabled",
+        "deviceThreatProtectionRequiredSecurityLevel",
+        "firewallBlockAllIncoming",
+        "firewallEnabled",
+        "firewallEnableStealthMode",
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "storageRequireEncryption",
+        "systemIntegrityProtectionEnabled"
+      ]
+    },
+    "macOSCustomConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "payload",
+        "payloadFileName",
+        "payloadName"
+      ]
+    },
+    "macOSDeviceFeaturesConfiguration": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "macOSDmgApp": {
+      "navigationProperties": [],
+      "properties": [
+        "ignoreVersionDetection",
+        "includedApps",
+        "minimumSupportedOperatingSystem",
+        "primaryBundleId",
+        "primaryBundleVersion"
+      ]
+    },
+    "macOSGeneralDeviceConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantAppListType",
+        "compliantAppsList",
+        "emailInDomainSuffixes",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType"
+      ]
+    },
+    "macOSLobApp": {
+      "navigationProperties": [],
+      "properties": [
+        "buildNumber",
+        "bundleId",
+        "childApps",
+        "ignoreVersionDetection",
+        "installAsManaged",
+        "md5Hash",
+        "md5HashChunkSize",
+        "minimumSupportedOperatingSystem",
+        "versionNumber"
+      ]
+    },
+    "macOSMicrosoftDefenderApp": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "macOSMicrosoftEdgeApp": {
+      "navigationProperties": [],
+      "properties": [
+        "channel"
+      ]
+    },
+    "macOSOfficeSuiteApp": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mailAssessmentRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "destinationRoutingReason",
+        "messageUri",
+        "recipientEmail"
+      ]
+    },
+    "mailbox": {
+      "navigationProperties": [
+        "folders"
+      ],
+      "properties": []
+    },
+    "mailboxFolder": {
+      "navigationProperties": [
+        "childFolders",
+        "items",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "childFolderCount",
+        "displayName",
+        "parentFolderId",
+        "totalItemCount",
+        "type"
+      ]
+    },
+    "mailboxItem": {
+      "navigationProperties": [
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "size",
+        "type"
+      ]
+    },
+    "mailboxProtectionRule": {
+      "navigationProperties": [],
+      "properties": [
+        "mailboxExpression"
+      ]
+    },
+    "mailboxProtectionUnit": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectId",
+        "displayName",
+        "email"
+      ]
+    },
+    "mailboxProtectionUnitsBulkAdditionJob": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectIds",
+        "mailboxes"
+      ]
+    },
+    "mailboxRestoreArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "restoredFolderId",
+        "restoredFolderName",
+        "restoredItemCount"
+      ]
+    },
+    "mailboxRestoreArtifactsBulkAdditionRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "directoryObjectIds",
+        "mailboxes"
+      ]
+    },
+    "mailFolder": {
+      "navigationProperties": [
+        "childFolders",
+        "messageRules",
+        "messages",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "childFolderCount",
+        "displayName",
+        "isHidden",
+        "parentFolderId",
+        "totalItemCount",
+        "unreadItemCount"
+      ]
+    },
+    "mailSearchFolder": {
+      "navigationProperties": [],
+      "properties": [
+        "filterQuery",
+        "includeNestedFolders",
+        "isSupported",
+        "sourceFolderIds"
+      ]
+    },
+    "malwareStateForWindowsDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "detectionCount",
+        "deviceName",
+        "executionState",
+        "initialDetectionDateTime",
+        "lastStateChangeDateTime",
+        "threatState"
+      ]
+    },
+    "managedAndroidLobApp": {
+      "navigationProperties": [],
+      "properties": [
+        "minimumSupportedOperatingSystem",
+        "packageId",
+        "versionCode",
+        "versionName"
+      ]
+    },
+    "managedAndroidStoreApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appStoreUrl",
+        "minimumSupportedOperatingSystem",
+        "packageId"
+      ]
+    },
+    "managedApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appAvailability",
+        "version"
+      ]
+    },
+    "managedAppConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "customSettings"
+      ]
+    },
+    "managedAppOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastModifiedDateTime",
+        "state",
+        "version"
+      ]
+    },
+    "managedAppPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "version"
+      ]
+    },
+    "managedAppPolicyDeploymentSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationDeployedUserCount",
+        "configurationDeploymentSummaryPerApp",
+        "displayName",
+        "lastRefreshTime",
+        "version"
+      ]
+    },
+    "managedAppProtection": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedDataStorageLocations",
+        "allowedInboundDataTransferSources",
+        "allowedOutboundClipboardSharingLevel",
+        "allowedOutboundDataTransferDestinations",
+        "contactSyncBlocked",
+        "dataBackupBlocked",
+        "deviceComplianceRequired",
+        "disableAppPinIfDevicePinIsSet",
+        "fingerprintBlocked",
+        "managedBrowser",
+        "managedBrowserToOpenLinksRequired",
+        "maximumPinRetries",
+        "minimumPinLength",
+        "minimumRequiredAppVersion",
+        "minimumRequiredOsVersion",
+        "minimumWarningAppVersion",
+        "minimumWarningOsVersion",
+        "organizationalCredentialsRequired",
+        "periodBeforePinReset",
+        "periodOfflineBeforeAccessCheck",
+        "periodOfflineBeforeWipeIsEnforced",
+        "periodOnlineBeforeAccessCheck",
+        "pinCharacterSet",
+        "pinRequired",
+        "printBlocked",
+        "saveAsBlocked",
+        "simplePinBlocked"
+      ]
+    },
+    "managedAppRegistration": {
+      "navigationProperties": [
+        "appliedPolicies",
+        "intendedPolicies",
+        "operations"
+      ],
+      "properties": [
+        "appIdentifier",
+        "applicationVersion",
+        "createdDateTime",
+        "deviceName",
+        "deviceTag",
+        "deviceType",
+        "flaggedReasons",
+        "lastSyncDateTime",
+        "managementSdkVersion",
+        "platformVersion",
+        "userId",
+        "version"
+      ]
+    },
+    "managedAppStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "version"
+      ]
+    },
+    "managedAppStatusRaw": {
+      "navigationProperties": [],
+      "properties": [
+        "content"
+      ]
+    },
+    "managedDevice": {
+      "navigationProperties": [
+        "deviceCategory",
+        "deviceCompliancePolicyStates",
+        "deviceConfigurationStates",
+        "logCollectionRequests",
+        "users",
+        "windowsProtectionState"
+      ],
+      "properties": [
+        "activationLockBypassCode",
+        "androidSecurityPatchLevel",
+        "azureADDeviceId",
+        "azureADRegistered",
+        "complianceGracePeriodExpirationDateTime",
+        "complianceState",
+        "configurationManagerClientEnabledFeatures",
+        "deviceActionResults",
+        "deviceCategoryDisplayName",
+        "deviceEnrollmentType",
+        "deviceHealthAttestationState",
+        "deviceName",
+        "deviceRegistrationState",
+        "easActivated",
+        "easActivationDateTime",
+        "easDeviceId",
+        "emailAddress",
+        "enrolledDateTime",
+        "enrollmentProfileName",
+        "ethernetMacAddress",
+        "exchangeAccessState",
+        "exchangeAccessStateReason",
+        "exchangeLastSuccessfulSyncDateTime",
+        "freeStorageSpaceInBytes",
+        "iccid",
+        "imei",
+        "isEncrypted",
+        "isSupervised",
+        "jailBroken",
+        "lastSyncDateTime",
+        "managedDeviceName",
+        "managedDeviceOwnerType",
+        "managementAgent",
+        "managementCertificateExpirationDate",
+        "managementState",
+        "manufacturer",
+        "meid",
+        "model",
+        "notes",
+        "operatingSystem",
+        "osVersion",
+        "partnerReportedThreatState",
+        "phoneNumber",
+        "physicalMemoryInBytes",
+        "remoteAssistanceSessionErrorDetails",
+        "remoteAssistanceSessionUrl",
+        "requireUserEnrollmentApproval",
+        "serialNumber",
+        "subscriberCarrier",
+        "totalStorageSpaceInBytes",
+        "udid",
+        "userDisplayName",
+        "userId",
+        "userPrincipalName",
+        "wiFiMacAddress"
+      ]
+    },
+    "managedDeviceMobileAppConfiguration": {
+      "navigationProperties": [
+        "assignments",
+        "deviceStatuses",
+        "deviceStatusSummary",
+        "userStatuses",
+        "userStatusSummary"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "targetedMobileApps",
+        "version"
+      ]
+    },
+    "managedDeviceMobileAppConfigurationAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "managedDeviceMobileAppConfigurationDeviceStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "complianceGracePeriodExpirationDateTime",
+        "deviceDisplayName",
+        "deviceModel",
+        "lastReportedDateTime",
+        "status",
+        "userName",
+        "userPrincipalName"
+      ]
+    },
+    "managedDeviceMobileAppConfigurationDeviceSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationVersion",
+        "errorCount",
+        "failedCount",
+        "lastUpdateDateTime",
+        "notApplicableCount",
+        "pendingCount",
+        "successCount"
+      ]
+    },
+    "managedDeviceMobileAppConfigurationUserStatus": {
+      "navigationProperties": [],
+      "properties": [
+        "devicesCount",
+        "lastReportedDateTime",
+        "status",
+        "userDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "managedDeviceMobileAppConfigurationUserSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "configurationVersion",
+        "errorCount",
+        "failedCount",
+        "lastUpdateDateTime",
+        "notApplicableCount",
+        "pendingCount",
+        "successCount"
+      ]
+    },
+    "managedDeviceOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceExchangeAccessStateSummary",
+        "deviceOperatingSystemSummary",
+        "dualEnrolledDeviceCount",
+        "enrolledDeviceCount",
+        "mdmEnrolledCount"
+      ]
+    },
+    "managedEBook": {
+      "navigationProperties": [
+        "assignments",
+        "deviceStates",
+        "installSummary",
+        "userStateSummary"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "informationUrl",
+        "largeCover",
+        "lastModifiedDateTime",
+        "privacyInformationUrl",
+        "publishedDateTime",
+        "publisher"
+      ]
+    },
+    "managedEBookAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "installIntent",
+        "target"
+      ]
+    },
+    "managedIOSLobApp": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableDeviceType",
+        "buildNumber",
+        "bundleId",
+        "expirationDateTime",
+        "minimumSupportedOperatingSystem",
+        "versionNumber"
+      ]
+    },
+    "managedIOSStoreApp": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableDeviceType",
+        "appStoreUrl",
+        "bundleId",
+        "minimumSupportedOperatingSystem"
+      ]
+    },
+    "managedMobileApp": {
+      "navigationProperties": [],
+      "properties": [
+        "mobileAppIdentifier",
+        "version"
+      ]
+    },
+    "managedMobileLobApp": {
+      "navigationProperties": [
+        "contentVersions"
+      ],
+      "properties": [
+        "committedContentVersion",
+        "fileName",
+        "size"
+      ]
+    },
+    "mdmWindowsInformationProtectionPolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "meetingAttendanceReport": {
+      "navigationProperties": [
+        "attendanceRecords"
+      ],
+      "properties": [
+        "externalEventInformation",
+        "meetingEndDateTime",
+        "meetingStartDateTime",
+        "totalParticipantCount"
+      ]
+    },
+    "membershipOutlierInsight": {
+      "navigationProperties": [
+        "container",
+        "lastModifiedBy",
+        "member"
+      ],
+      "properties": [
+        "containerId",
+        "memberId",
+        "outlierContainerType",
+        "outlierMemberType"
+      ]
+    },
+    "message": {
+      "navigationProperties": [
+        "attachments",
+        "extensions",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "bccRecipients",
+        "body",
+        "bodyPreview",
+        "ccRecipients",
+        "conversationId",
+        "conversationIndex",
+        "flag",
+        "from",
+        "hasAttachments",
+        "importance",
+        "inferenceClassification",
+        "internetMessageHeaders",
+        "internetMessageId",
+        "isDeliveryReceiptRequested",
+        "isDraft",
+        "isRead",
+        "isReadReceiptRequested",
+        "parentFolderId",
+        "receivedDateTime",
+        "replyTo",
+        "sender",
+        "sentDateTime",
+        "subject",
+        "toRecipients",
+        "uniqueBody",
+        "webLink"
+      ]
+    },
+    "messageRule": {
+      "navigationProperties": [],
+      "properties": [
+        "actions",
+        "conditions",
+        "displayName",
+        "exceptions",
+        "hasError",
+        "isEnabled",
+        "isReadOnly",
+        "sequence"
+      ]
+    },
+    "messageTracingRoot": {
+      "navigationProperties": [
+        "messageTraces"
+      ],
+      "properties": []
+    },
+    "microsoftAccountUserConversationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "userId"
+      ]
+    },
+    "microsoftAuthenticatorAuthenticationMethod": {
+      "navigationProperties": [
+        "device"
+      ],
+      "properties": [
+        "deviceTag",
+        "displayName",
+        "phoneAppVersion"
+      ]
+    },
+    "microsoftAuthenticatorAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": [
+        "featureSettings",
+        "isSoftwareOathEnabled"
+      ]
+    },
+    "microsoftAuthenticatorAuthenticationMethodTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "authenticationMode"
+      ]
+    },
+    "microsoftStoreForBusinessApp": {
+      "navigationProperties": [],
+      "properties": [
+        "licenseType",
+        "packageIdentityName",
+        "productKey",
+        "totalLicenseCount",
+        "usedLicenseCount"
+      ]
+    },
+    "mobileApp": {
+      "navigationProperties": [
+        "assignments",
+        "categories"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "developer",
+        "displayName",
+        "informationUrl",
+        "isFeatured",
+        "largeIcon",
+        "lastModifiedDateTime",
+        "notes",
+        "owner",
+        "privacyInformationUrl",
+        "publisher",
+        "publishingState"
+      ]
+    },
+    "mobileAppAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "intent",
+        "settings",
+        "target"
+      ]
+    },
+    "mobileAppCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastModifiedDateTime"
+      ]
+    },
+    "mobileAppContent": {
+      "navigationProperties": [
+        "containedApps",
+        "files"
+      ],
+      "properties": []
+    },
+    "mobileAppContentFile": {
+      "navigationProperties": [],
+      "properties": [
+        "azureStorageUri",
+        "azureStorageUriExpirationDateTime",
+        "createdDateTime",
+        "isCommitted",
+        "isDependency",
+        "manifest",
+        "name",
+        "size",
+        "sizeEncrypted",
+        "uploadState"
+      ]
+    },
+    "mobileAppRelationship": {
+      "navigationProperties": [],
+      "properties": [
+        "sourceDisplayName",
+        "sourceDisplayVersion",
+        "sourceId",
+        "sourcePublisherDisplayName",
+        "targetDisplayName",
+        "targetDisplayVersion",
+        "targetId",
+        "targetPublisherDisplayName"
+      ]
+    },
+    "mobileAppTroubleshootingEvent": {
+      "navigationProperties": [
+        "appLogCollectionRequests"
+      ],
+      "properties": []
+    },
+    "mobileContainedApp": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "mobileLobApp": {
+      "navigationProperties": [
+        "contentVersions"
+      ],
+      "properties": [
+        "committedContentVersion",
+        "fileName",
+        "size"
+      ]
+    },
+    "mobileThreatDefenseConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "allowPartnerToCollectIOSApplicationMetadata",
+        "allowPartnerToCollectIOSPersonalApplicationMetadata",
+        "androidDeviceBlockedOnMissingPartnerData",
+        "androidEnabled",
+        "androidMobileApplicationManagementEnabled",
+        "iosDeviceBlockedOnMissingPartnerData",
+        "iosEnabled",
+        "iosMobileApplicationManagementEnabled",
+        "lastHeartbeatDateTime",
+        "microsoftDefenderForEndpointAttachEnabled",
+        "partnerState",
+        "partnerUnresponsivenessThresholdInDays",
+        "partnerUnsupportedOsVersionBlocked",
+        "windowsDeviceBlockedOnMissingPartnerData",
+        "windowsEnabled"
+      ]
+    },
+    "multiTenantOrganization": {
+      "navigationProperties": [
+        "joinRequest",
+        "tenants"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "state"
+      ]
+    },
+    "multiTenantOrganizationIdentitySyncPolicyTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "templateApplicationLevel",
+        "userSyncInbound"
+      ]
+    },
+    "multiTenantOrganizationJoinRequestRecord": {
+      "navigationProperties": [],
+      "properties": [
+        "addedByTenantId",
+        "memberState",
+        "role",
+        "transitionDetails"
+      ]
+    },
+    "multiTenantOrganizationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "addedByTenantId",
+        "addedDateTime",
+        "displayName",
+        "joinedDateTime",
+        "role",
+        "state",
+        "tenantId",
+        "transitionDetails"
+      ]
+    },
+    "multiTenantOrganizationPartnerConfigurationTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "automaticUserConsentSettings",
+        "b2bCollaborationInbound",
+        "b2bCollaborationOutbound",
+        "b2bDirectConnectInbound",
+        "b2bDirectConnectOutbound",
+        "inboundTrust",
+        "templateApplicationLevel"
+      ]
+    },
+    "multiValueLegacyExtendedProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "muteParticipantOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "namedLocation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "id",
+        "modifiedDateTime"
+      ]
+    },
+    "notebook": {
+      "navigationProperties": [
+        "sectionGroups",
+        "sections"
+      ],
+      "properties": [
+        "isDefault",
+        "isShared",
+        "links",
+        "sectionGroupsUrl",
+        "sectionsUrl",
+        "userRole"
+      ]
+    },
+    "notificationMessageTemplate": {
+      "navigationProperties": [
+        "localizedNotificationMessages"
+      ],
+      "properties": [
+        "brandingOptions",
+        "defaultLocale",
+        "displayName",
+        "lastModifiedDateTime",
+        "roleScopeTagIds"
+      ]
+    },
+    "oAuth2PermissionGrant": {
+      "navigationProperties": [],
+      "properties": [
+        "clientId",
+        "consentType",
+        "principalId",
+        "resourceId",
+        "scope"
+      ]
+    },
+    "offerShiftRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "recipientActionDateTime",
+        "recipientActionMessage",
+        "recipientUserId",
+        "senderShiftId"
+      ]
+    },
+    "officeGraphInsights": {
+      "navigationProperties": [
+        "shared",
+        "trending",
+        "used"
+      ],
+      "properties": []
+    },
+    "oidcIdentityProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "clientAuthentication",
+        "clientId",
+        "inboundClaimMapping",
+        "issuer",
+        "responseType",
+        "scope",
+        "wellKnownEndpoint"
+      ]
+    },
+    "onAttributeCollectionListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onAttributeCollectionStartCustomExtension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onAttributeCollectionStartListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onAttributeCollectionSubmitCustomExtension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onAttributeCollectionSubmitListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onAuthenticationMethodLoadStartListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "oneDriveForBusinessProtectionPolicy": {
+      "navigationProperties": [
+        "driveInclusionRules",
+        "driveProtectionUnits",
+        "driveProtectionUnitsBulkAdditionJobs"
+      ],
+      "properties": []
+    },
+    "oneDriveForBusinessRestoreSession": {
+      "navigationProperties": [
+        "driveRestoreArtifacts",
+        "driveRestoreArtifactsBulkAdditionRequests"
+      ],
+      "properties": []
+    },
+    "onEmailOtpSendListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onenote": {
+      "navigationProperties": [
+        "notebooks",
+        "operations",
+        "pages",
+        "resources",
+        "sectionGroups",
+        "sections"
+      ],
+      "properties": []
+    },
+    "onenoteEntityBaseModel": {
+      "navigationProperties": [],
+      "properties": [
+        "self"
+      ]
+    },
+    "onenoteEntityHierarchyModel": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "onenoteEntitySchemaObjectModel": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime"
+      ]
+    },
+    "onenoteOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "percentComplete",
+        "resourceId",
+        "resourceLocation"
+      ]
+    },
+    "onenotePage": {
+      "navigationProperties": [
+        "parentNotebook",
+        "parentSection"
+      ],
+      "properties": [
+        "content",
+        "contentUrl",
+        "createdByAppId",
+        "lastModifiedDateTime",
+        "level",
+        "links",
+        "order",
+        "title",
+        "userTags"
+      ]
+    },
+    "onenoteResource": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "contentUrl"
+      ]
+    },
+    "onenoteSection": {
+      "navigationProperties": [
+        "pages",
+        "parentNotebook",
+        "parentSectionGroup"
+      ],
+      "properties": [
+        "isDefault",
+        "links",
+        "pagesUrl"
+      ]
+    },
+    "onFraudProtectionLoadStartListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onInteractiveAuthFlowStartListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onlineMeeting": {
+      "navigationProperties": [
+        "recordings",
+        "transcripts"
+      ],
+      "properties": [
+        "attendeeReport",
+        "broadcastSettings",
+        "creationDateTime",
+        "endDateTime",
+        "externalId",
+        "isBroadcast",
+        "meetingTemplateId",
+        "participants",
+        "startDateTime"
+      ]
+    },
+    "onlineMeetingBase": {
+      "navigationProperties": [
+        "attendanceReports"
+      ],
+      "properties": [
+        "allowAttendeeToEnableCamera",
+        "allowAttendeeToEnableMic",
+        "allowBreakoutRooms",
+        "allowCopyingAndSharingMeetingContent",
+        "allowedLobbyAdmitters",
+        "allowedPresenters",
+        "allowLiveShare",
+        "allowMeetingChat",
+        "allowParticipantsToChangeName",
+        "allowPowerPointSharing",
+        "allowRecording",
+        "allowTeamworkReactions",
+        "allowTranscription",
+        "allowWhiteboard",
+        "audioConferencing",
+        "chatInfo",
+        "chatRestrictions",
+        "expiryDateTime",
+        "isEndToEndEncryptionEnabled",
+        "isEntryExitAnnounced",
+        "joinInformation",
+        "joinMeetingIdSettings",
+        "joinWebUrl",
+        "lobbyBypassSettings",
+        "meetingOptionsWebUrl",
+        "meetingSpokenLanguageTag",
+        "recordAutomatically",
+        "sensitivityLabelAssignment",
+        "shareMeetingChatHistoryDefault",
+        "subject",
+        "videoTeleconferenceId",
+        "watermarkProtection"
+      ]
+    },
+    "onlineMeetingEngagementConversation": {
+      "navigationProperties": [
+        "onlineMeeting"
+      ],
+      "properties": [
+        "moderationState",
+        "onlineMeetingId",
+        "organizer",
+        "upvoteCount"
+      ]
+    },
+    "onOtpSendCustomExtension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onPasswordSubmitCustomExtension": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "onPasswordSubmitListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onPremisesConditionalAccessSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "enabled",
+        "excludedGroups",
+        "includedGroups",
+        "overrideDefaultRule"
+      ]
+    },
+    "onPremisesDirectorySynchronization": {
+      "navigationProperties": [],
+      "properties": [
+        "configuration",
+        "features"
+      ]
+    },
+    "onPremisesSyncBehavior": {
+      "navigationProperties": [],
+      "properties": [
+        "isCloudManaged"
+      ]
+    },
+    "onTokenIssuanceStartCustomExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "claimsForTokenConfiguration"
+      ]
+    },
+    "onTokenIssuanceStartListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "onUserCreateStartListener": {
+      "navigationProperties": [],
+      "properties": [
+        "handler"
+      ]
+    },
+    "openShift": {
+      "navigationProperties": [],
+      "properties": [
+        "draftOpenShift",
+        "isStagedForDeletion",
+        "schedulingGroupId",
+        "sharedOpenShift"
+      ]
+    },
+    "openShiftChangeRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "openShiftId"
+      ]
+    },
+    "openTypeExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "extensionName"
+      ]
+    },
+    "operation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastActionDateTime",
+        "status"
+      ]
+    },
+    "organization": {
+      "navigationProperties": [
+        "branding",
+        "certificateBasedAuthConfiguration",
+        "extensions"
+      ],
+      "properties": [
+        "assignedPlans",
+        "businessPhones",
+        "city",
+        "country",
+        "countryLetterCode",
+        "createdDateTime",
+        "defaultUsageLocation",
+        "displayName",
+        "marketingNotificationEmails",
+        "mobileDeviceManagementAuthority",
+        "onPremisesLastSyncDateTime",
+        "onPremisesSyncEnabled",
+        "partnerTenantType",
+        "postalCode",
+        "preferredLanguage",
+        "privacyProfile",
+        "provisionedPlans",
+        "securityComplianceNotificationMails",
+        "securityComplianceNotificationPhones",
+        "state",
+        "street",
+        "technicalNotificationMails",
+        "tenantType",
+        "verifiedDomains"
+      ]
+    },
+    "organizationalBranding": {
+      "navigationProperties": [
+        "localizations"
+      ],
+      "properties": []
+    },
+    "organizationalBrandingLocalization": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "organizationalBrandingProperties": {
+      "navigationProperties": [],
+      "properties": [
+        "backgroundColor",
+        "backgroundImage",
+        "backgroundImageRelativeUrl",
+        "bannerLogo",
+        "bannerLogoRelativeUrl",
+        "cdnList",
+        "contentCustomization",
+        "customAccountResetCredentialsUrl",
+        "customCannotAccessYourAccountText",
+        "customCannotAccessYourAccountUrl",
+        "customCSS",
+        "customCSSRelativeUrl",
+        "customForgotMyPasswordText",
+        "customPrivacyAndCookiesText",
+        "customPrivacyAndCookiesUrl",
+        "customResetItNowText",
+        "customTermsOfUseText",
+        "customTermsOfUseUrl",
+        "favicon",
+        "faviconRelativeUrl",
+        "headerBackgroundColor",
+        "headerLogo",
+        "headerLogoRelativeUrl",
+        "loginPageLayoutConfiguration",
+        "loginPageTextVisibilitySettings",
+        "signInPageText",
+        "squareLogo",
+        "squareLogoDark",
+        "squareLogoDarkRelativeUrl",
+        "squareLogoRelativeUrl",
+        "usernameHintText"
+      ]
+    },
+    "orgContact": {
+      "navigationProperties": [
+        "directReports",
+        "manager",
+        "memberOf",
+        "onPremisesSyncBehavior",
+        "transitiveMemberOf"
+      ],
+      "properties": [
+        "addresses",
+        "companyName",
+        "department",
+        "displayName",
+        "givenName",
+        "jobTitle",
+        "mail",
+        "mailNickname",
+        "onPremisesLastSyncDateTime",
+        "onPremisesProvisioningErrors",
+        "onPremisesSyncEnabled",
+        "phones",
+        "proxyAddresses",
+        "serviceProvisioningErrors",
+        "surname"
+      ]
+    },
+    "outlookCategory": {
+      "navigationProperties": [],
+      "properties": [
+        "color",
+        "displayName"
+      ]
+    },
+    "outlookItem": {
+      "navigationProperties": [],
+      "properties": [
+        "categories",
+        "changeKey",
+        "createdDateTime",
+        "lastModifiedDateTime"
+      ]
+    },
+    "outlookUser": {
+      "navigationProperties": [
+        "masterCategories"
+      ],
+      "properties": []
+    },
+    "participant": {
+      "navigationProperties": [],
+      "properties": [
+        "info",
+        "isInLobby",
+        "isMuted",
+        "mediaStreams",
+        "metadata",
+        "recordingInfo",
+        "removedState",
+        "restrictedExperience",
+        "rosterSequenceNumber"
+      ]
+    },
+    "participantJoiningNotification": {
+      "navigationProperties": [
+        "call"
+      ],
+      "properties": []
+    },
+    "participantLeftNotification": {
+      "navigationProperties": [
+        "call"
+      ],
+      "properties": [
+        "participantId"
+      ]
+    },
+    "partners": {
+      "navigationProperties": [
+        "billing"
+      ],
+      "properties": []
+    },
+    "passkeyAuthenticationMethodTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedPasskeyProfiles"
+      ]
+    },
+    "passkeyProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "attestationEnforcement",
+        "keyRestrictions",
+        "name",
+        "passkeyTypes"
+      ]
+    },
+    "passwordAuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "password"
+      ]
+    },
+    "payload": {
+      "navigationProperties": [],
+      "properties": [
+        "brand",
+        "complexity",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "detail",
+        "displayName",
+        "industry",
+        "isAutomated",
+        "isControversial",
+        "isCurrentEvent",
+        "language",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "payloadTags",
+        "platform",
+        "predictedCompromiseRate",
+        "simulationAttackType",
+        "source",
+        "status",
+        "technique",
+        "theme"
+      ]
+    },
+    "peopleAdminSettings": {
+      "navigationProperties": [
+        "itemInsights",
+        "profileCardProperties",
+        "profilePropertySettings",
+        "profileSources",
+        "pronouns"
+      ],
+      "properties": []
+    },
+    "permission": {
+      "navigationProperties": [],
+      "properties": [
+        "expirationDateTime",
+        "grantedTo",
+        "grantedToIdentities",
+        "grantedToIdentitiesV2",
+        "grantedToV2",
+        "hasPassword",
+        "inheritedFrom",
+        "invitation",
+        "link",
+        "roles",
+        "shareId"
+      ]
+    },
+    "permissionGrantConditionSet": {
+      "navigationProperties": [],
+      "properties": [
+        "clientApplicationIds",
+        "clientApplicationPublisherIds",
+        "clientApplicationsFromVerifiedPublisherOnly",
+        "clientApplicationTenantIds",
+        "permissionClassification",
+        "permissions",
+        "permissionType",
+        "resourceApplication"
+      ]
+    },
+    "permissionGrantPolicy": {
+      "navigationProperties": [
+        "excludes",
+        "includes"
+      ],
+      "properties": []
+    },
+    "person": {
+      "navigationProperties": [],
+      "properties": [
+        "birthday",
+        "companyName",
+        "department",
+        "displayName",
+        "givenName",
+        "imAddress",
+        "isFavorite",
+        "jobTitle",
+        "officeLocation",
+        "personNotes",
+        "personType",
+        "phones",
+        "postalAddresses",
+        "profession",
+        "scoredEmailAddresses",
+        "surname",
+        "userPrincipalName",
+        "websites",
+        "yomiCompany"
+      ]
+    },
+    "phoneAuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "phoneNumber",
+        "phoneType",
+        "smsSignInState"
+      ]
+    },
+    "phoneUserConversationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "phoneNumber"
+      ]
+    },
+    "pinnedChatMessageInfo": {
+      "navigationProperties": [
+        "message"
+      ],
+      "properties": []
+    },
+    "place": {
+      "navigationProperties": [
+        "checkIns"
+      ],
+      "properties": [
+        "address",
+        "displayName",
+        "geoCoordinates",
+        "isWheelChairAccessible",
+        "label",
+        "parentId",
+        "phone",
+        "tags"
+      ]
+    },
+    "planner": {
+      "navigationProperties": [
+        "buckets",
+        "plans",
+        "tasks"
+      ],
+      "properties": []
+    },
+    "plannerAssignedToTaskBoardTaskFormat": {
+      "navigationProperties": [],
+      "properties": [
+        "orderHintsByAssignee",
+        "unassignedOrderHint"
+      ]
+    },
+    "plannerBucket": {
+      "navigationProperties": [
+        "tasks"
+      ],
+      "properties": [
+        "name",
+        "orderHint",
+        "planId"
+      ]
+    },
+    "plannerBucketTaskBoardTaskFormat": {
+      "navigationProperties": [],
+      "properties": [
+        "orderHint"
+      ]
+    },
+    "plannerGroup": {
+      "navigationProperties": [
+        "plans"
+      ],
+      "properties": []
+    },
+    "plannerPlan": {
+      "navigationProperties": [
+        "buckets",
+        "details",
+        "tasks"
+      ],
+      "properties": [
+        "container",
+        "createdBy",
+        "createdDateTime",
+        "owner",
+        "title"
+      ]
+    },
+    "plannerPlanDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "categoryDescriptions",
+        "sharedWith"
+      ]
+    },
+    "plannerProgressTaskBoardTaskFormat": {
+      "navigationProperties": [],
+      "properties": [
+        "orderHint"
+      ]
+    },
+    "plannerTask": {
+      "navigationProperties": [
+        "assignedToTaskBoardFormat",
+        "bucketTaskBoardFormat",
+        "details",
+        "progressTaskBoardFormat"
+      ],
+      "properties": [
+        "activeChecklistItemCount",
+        "appliedCategories",
+        "assigneePriority",
+        "assignments",
+        "bucketId",
+        "checklistItemCount",
+        "completedBy",
+        "completedDateTime",
+        "conversationThreadId",
+        "createdBy",
+        "createdDateTime",
+        "dueDateTime",
+        "hasDescription",
+        "orderHint",
+        "percentComplete",
+        "planId",
+        "previewType",
+        "priority",
+        "referenceCount",
+        "startDateTime",
+        "title"
+      ]
+    },
+    "plannerTaskDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "checklist",
+        "description",
+        "previewType",
+        "references"
+      ]
+    },
+    "plannerUser": {
+      "navigationProperties": [
+        "plans",
+        "tasks"
+      ],
+      "properties": []
+    },
+    "platformCredentialAuthenticationMethod": {
+      "navigationProperties": [
+        "device"
+      ],
+      "properties": [
+        "displayName",
+        "keyStrength",
+        "platform"
+      ]
+    },
+    "playPromptOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "policyBase": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName"
+      ]
+    },
+    "policyDeletableItem": {
+      "navigationProperties": [],
+      "properties": [
+        "deletedDateTime"
+      ]
+    },
+    "policyRoot": {
+      "navigationProperties": [
+        "activityBasedTimeoutPolicies",
+        "adminConsentRequestPolicy",
+        "appManagementPolicies",
+        "authenticationFlowsPolicy",
+        "authenticationMethodsPolicy",
+        "authenticationStrengthPolicies",
+        "authorizationPolicy",
+        "claimsMappingPolicies",
+        "conditionalAccessPolicies",
+        "crossTenantAccessPolicy",
+        "defaultAppManagementPolicy",
+        "deviceRegistrationPolicy",
+        "featureRolloutPolicies",
+        "homeRealmDiscoveryPolicies",
+        "identitySecurityDefaultsEnforcementPolicy",
+        "permissionGrantPolicies",
+        "roleManagementPolicies",
+        "roleManagementPolicyAssignments",
+        "tokenIssuancePolicies",
+        "tokenLifetimePolicies"
+      ],
+      "properties": []
+    },
+    "policyTemplate": {
+      "navigationProperties": [
+        "multiTenantOrganizationIdentitySynchronization",
+        "multiTenantOrganizationPartnerConfiguration"
+      ],
+      "properties": []
+    },
+    "post": {
+      "navigationProperties": [
+        "attachments",
+        "extensions",
+        "inReplyTo",
+        "multiValueExtendedProperties",
+        "singleValueExtendedProperties"
+      ],
+      "properties": [
+        "body",
+        "conversationId",
+        "conversationThreadId",
+        "from",
+        "hasAttachments",
+        "newParticipants",
+        "receivedDateTime",
+        "sender"
+      ]
+    },
+    "presence": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "availability",
+        "outOfOfficeSettings",
+        "sequenceNumber",
+        "statusMessage",
+        "workLocation"
+      ]
+    },
+    "print": {
+      "navigationProperties": [
+        "connectors",
+        "operations",
+        "printers",
+        "services",
+        "shares",
+        "taskDefinitions"
+      ],
+      "properties": [
+        "settings"
+      ]
+    },
+    "printConnector": {
+      "navigationProperties": [],
+      "properties": [
+        "appVersion",
+        "displayName",
+        "fullyQualifiedDomainName",
+        "location",
+        "operatingSystem",
+        "registeredDateTime"
+      ]
+    },
+    "printDocument": {
+      "navigationProperties": [],
+      "properties": [
+        "contentType",
+        "displayName",
+        "downloadedDateTime",
+        "size",
+        "uploadedDateTime"
+      ]
+    },
+    "printer": {
+      "navigationProperties": [
+        "connectors",
+        "shares",
+        "taskTriggers"
+      ],
+      "properties": [
+        "hasPhysicalDevice",
+        "isShared",
+        "lastSeenDateTime",
+        "registeredDateTime"
+      ]
+    },
+    "printerBase": {
+      "navigationProperties": [
+        "jobs"
+      ],
+      "properties": [
+        "capabilities",
+        "defaults",
+        "displayName",
+        "isAcceptingJobs",
+        "location",
+        "manufacturer",
+        "model",
+        "status"
+      ]
+    },
+    "printerCreateOperation": {
+      "navigationProperties": [
+        "printer"
+      ],
+      "properties": [
+        "certificate"
+      ]
+    },
+    "printerShare": {
+      "navigationProperties": [
+        "allowedGroups",
+        "allowedUsers",
+        "printer"
+      ],
+      "properties": [
+        "allowAllUsers",
+        "createdDateTime",
+        "viewPoint"
+      ]
+    },
+    "printJob": {
+      "navigationProperties": [
+        "documents",
+        "tasks"
+      ],
+      "properties": [
+        "acknowledgedDateTime",
+        "configuration",
+        "createdBy",
+        "createdDateTime",
+        "errorCode",
+        "isFetchable",
+        "redirectedFrom",
+        "redirectedTo",
+        "status"
+      ]
+    },
+    "printOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "status"
+      ]
+    },
+    "printService": {
+      "navigationProperties": [
+        "endpoints"
+      ],
+      "properties": []
+    },
+    "printServiceEndpoint": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "uri"
+      ]
+    },
+    "printTask": {
+      "navigationProperties": [
+        "definition",
+        "trigger"
+      ],
+      "properties": [
+        "parentUrl",
+        "status"
+      ]
+    },
+    "printTaskDefinition": {
+      "navigationProperties": [
+        "tasks"
+      ],
+      "properties": [
+        "createdBy",
+        "displayName"
+      ]
+    },
+    "printTaskTrigger": {
+      "navigationProperties": [
+        "definition"
+      ],
+      "properties": [
+        "event"
+      ]
+    },
+    "printUsage": {
+      "navigationProperties": [],
+      "properties": [
+        "blackAndWhitePageCount",
+        "colorPageCount",
+        "completedBlackAndWhiteJobCount",
+        "completedColorJobCount",
+        "completedJobCount",
+        "doubleSidedSheetCount",
+        "incompleteJobCount",
+        "mediaSheetCount",
+        "pageCount",
+        "singleSidedSheetCount",
+        "usageDate"
+      ]
+    },
+    "printUsageByPrinter": {
+      "navigationProperties": [],
+      "properties": [
+        "printerId",
+        "printerName"
+      ]
+    },
+    "printUsageByUser": {
+      "navigationProperties": [],
+      "properties": [
+        "userPrincipalName"
+      ]
+    },
+    "privacy": {
+      "navigationProperties": [
+        "subjectRightsRequests"
+      ],
+      "properties": []
+    },
+    "privilegedAccessGroup": {
+      "navigationProperties": [
+        "assignmentApprovals",
+        "assignmentScheduleInstances",
+        "assignmentScheduleRequests",
+        "assignmentSchedules",
+        "eligibilityScheduleInstances",
+        "eligibilityScheduleRequests",
+        "eligibilitySchedules"
+      ],
+      "properties": []
+    },
+    "privilegedAccessGroupAssignmentSchedule": {
+      "navigationProperties": [
+        "activatedUsing",
+        "group",
+        "principal"
+      ],
+      "properties": [
+        "accessId",
+        "assignmentType",
+        "groupId",
+        "memberType",
+        "principalId"
+      ]
+    },
+    "privilegedAccessGroupAssignmentScheduleInstance": {
+      "navigationProperties": [
+        "activatedUsing",
+        "group",
+        "principal"
+      ],
+      "properties": [
+        "accessId",
+        "assignmentScheduleId",
+        "assignmentType",
+        "groupId",
+        "memberType",
+        "principalId"
+      ]
+    },
+    "privilegedAccessGroupAssignmentScheduleRequest": {
+      "navigationProperties": [
+        "activatedUsing",
+        "group",
+        "principal",
+        "targetSchedule"
+      ],
+      "properties": [
+        "accessId",
+        "groupId",
+        "principalId",
+        "targetScheduleId"
+      ]
+    },
+    "privilegedAccessGroupEligibilitySchedule": {
+      "navigationProperties": [
+        "group",
+        "principal"
+      ],
+      "properties": [
+        "accessId",
+        "groupId",
+        "memberType",
+        "principalId"
+      ]
+    },
+    "privilegedAccessGroupEligibilityScheduleInstance": {
+      "navigationProperties": [
+        "group",
+        "principal"
+      ],
+      "properties": [
+        "accessId",
+        "eligibilityScheduleId",
+        "groupId",
+        "memberType",
+        "principalId"
+      ]
+    },
+    "privilegedAccessGroupEligibilityScheduleRequest": {
+      "navigationProperties": [
+        "group",
+        "principal",
+        "targetSchedule"
+      ],
+      "properties": [
+        "accessId",
+        "groupId",
+        "principalId",
+        "targetScheduleId"
+      ]
+    },
+    "privilegedAccessRoot": {
+      "navigationProperties": [
+        "group"
+      ],
+      "properties": []
+    },
+    "privilegedAccessSchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "createdUsing",
+        "modifiedDateTime",
+        "scheduleInfo",
+        "status"
+      ]
+    },
+    "privilegedAccessScheduleInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "startDateTime"
+      ]
+    },
+    "privilegedAccessScheduleRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "isValidationOnly",
+        "justification",
+        "scheduleInfo",
+        "ticketInfo"
+      ]
+    },
+    "profileCardProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "annotations",
+        "directoryPropertyName"
+      ]
+    },
+    "profilePhoto": {
+      "navigationProperties": [],
+      "properties": [
+        "height",
+        "width"
+      ]
+    },
+    "profilePropertySetting": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "name",
+        "prioritizedSourceUrls"
+      ]
+    },
+    "profileSource": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "kind",
+        "localizations",
+        "sourceId",
+        "webUrl"
+      ]
+    },
+    "pronounsSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabledInOrganization"
+      ]
+    },
+    "protectionPolicyBase": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "isEnabled",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "protectionPolicyArtifactCount",
+        "retentionSettings",
+        "status"
+      ]
+    },
+    "protectionRuleBase": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "error",
+        "isAutoApplyEnabled",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "protectionUnitBase": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "error",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "offboardRequestedDateTime",
+        "policyId",
+        "protectionSources",
+        "status"
+      ]
+    },
+    "protectionUnitsBulkJobBase": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "error",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "provisioningObjectSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "activityDateTime",
+        "changeId",
+        "cycleId",
+        "durationInMilliseconds",
+        "initiatedBy",
+        "jobId",
+        "modifiedProperties",
+        "provisioningAction",
+        "provisioningStatusInfo",
+        "provisioningSteps",
+        "servicePrincipal",
+        "sourceIdentity",
+        "sourceSystem",
+        "targetIdentity",
+        "targetSystem",
+        "tenantId"
+      ]
+    },
+    "publicKeyInfrastructureRoot": {
+      "navigationProperties": [
+        "certificateBasedAuthConfigurations"
+      ],
+      "properties": []
+    },
+    "qrCode": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "expireDateTime",
+        "image",
+        "lastUsedDateTime",
+        "startDateTime"
+      ]
+    },
+    "qrCodePinAuthenticationMethod": {
+      "navigationProperties": [
+        "pin",
+        "standardQRCode",
+        "temporaryQRCode"
+      ],
+      "properties": []
+    },
+    "qrCodePinAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": [
+        "pinLength",
+        "standardQRCodeLifetimeInDays"
+      ]
+    },
+    "qrPin": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "createdDateTime",
+        "forceChangePinNextSignIn",
+        "updatedDateTime"
+      ]
+    },
+    "rbacApplication": {
+      "navigationProperties": [
+        "resourceNamespaces",
+        "roleAssignments",
+        "roleAssignmentScheduleInstances",
+        "roleAssignmentScheduleRequests",
+        "roleAssignmentSchedules",
+        "roleDefinitions",
+        "roleEligibilityScheduleInstances",
+        "roleEligibilityScheduleRequests",
+        "roleEligibilitySchedules"
+      ],
+      "properties": []
+    },
+    "readingAssignmentSubmission": {
+      "navigationProperties": [],
+      "properties": [
+        "accuracyScore",
+        "action",
+        "assignmentId",
+        "challengingWords",
+        "classId",
+        "insertions",
+        "mispronunciations",
+        "missedExclamationMarks",
+        "missedPeriods",
+        "missedQuestionMarks",
+        "missedShorts",
+        "monotoneScore",
+        "omissions",
+        "repetitions",
+        "selfCorrections",
+        "studentId",
+        "submissionDateTime",
+        "submissionId",
+        "unexpectedPauses",
+        "wordCount",
+        "wordsPerMinute"
+      ]
+    },
+    "readingCoachPassage": {
+      "navigationProperties": [],
+      "properties": [
+        "isReadingCompleted",
+        "languageTag",
+        "practicedAtDateTime",
+        "practiceWords",
+        "storyType",
+        "studentId",
+        "timeSpentReadingInSeconds",
+        "wordsAccuracyPercentage",
+        "wordsPerMinute"
+      ]
+    },
+    "recordOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "recordingAccessToken",
+        "recordingLocation"
+      ]
+    },
+    "recycleBin": {
+      "navigationProperties": [
+        "items"
+      ],
+      "properties": [
+        "settings"
+      ]
+    },
+    "recycleBinItem": {
+      "navigationProperties": [],
+      "properties": [
+        "deletedDateTime",
+        "deletedFromLocation",
+        "size"
+      ]
+    },
+    "referenceAttachment": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "reflectCheckInResponse": {
+      "navigationProperties": [],
+      "properties": [
+        "checkInId",
+        "checkInTitle",
+        "classId",
+        "createdDateTime",
+        "creatorId",
+        "isClosed",
+        "responderId",
+        "responseEmotion",
+        "responseFeedback",
+        "submitDateTime"
+      ]
+    },
+    "relyingPartyDetailedSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "failedSignInCount",
+        "migrationStatus",
+        "migrationValidationDetails",
+        "relyingPartyId",
+        "relyingPartyName",
+        "replyUrls",
+        "serviceId",
+        "signInSuccessRate",
+        "successfulSignInCount",
+        "totalSignInCount",
+        "uniqueUserCount"
+      ]
+    },
+    "remoteAssistancePartner": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "lastConnectionDateTime",
+        "onboardingStatus",
+        "onboardingUrl"
+      ]
+    },
+    "remoteDesktopSecurityConfiguration": {
+      "navigationProperties": [
+        "approvedClientApps",
+        "targetDeviceGroups"
+      ],
+      "properties": [
+        "isRemoteDesktopProtocolEnabled"
+      ]
+    },
+    "reportRoot": {
+      "navigationProperties": [
+        "authenticationMethods",
+        "dailyPrintUsageByPrinter",
+        "dailyPrintUsageByUser",
+        "monthlyPrintUsageByPrinter",
+        "monthlyPrintUsageByUser",
+        "partners",
+        "security"
+      ],
+      "properties": []
+    },
+    "reportsRoot": {
+      "navigationProperties": [
+        "readingAssignmentSubmissions",
+        "readingCoachPassages",
+        "reflectCheckInResponses",
+        "speakerAssignmentSubmissions"
+      ],
+      "properties": []
+    },
+    "request": {
+      "navigationProperties": [],
+      "properties": [
+        "approvalId",
+        "completedDateTime",
+        "createdBy",
+        "createdDateTime",
+        "customData",
+        "status"
+      ]
+    },
+    "resellerDelegatedAdminRelationship": {
+      "navigationProperties": [],
+      "properties": [
+        "indirectProviderTenantId",
+        "isPartnerConsentPending"
+      ]
+    },
+    "resourceOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "actionName",
+        "description",
+        "resourceName"
+      ]
+    },
+    "resourceSpecificPermissionGrant": {
+      "navigationProperties": [],
+      "properties": [
+        "clientAppId",
+        "clientId",
+        "permission",
+        "permissionType",
+        "resourceAppId"
+      ]
+    },
+    "restoreArtifactBase": {
+      "navigationProperties": [
+        "restorePoint"
+      ],
+      "properties": [
+        "completionDateTime",
+        "destinationType",
+        "error",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "restoreArtifactsBulkRequestBase": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "destinationType",
+        "displayName",
+        "error",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "protectionTimePeriod",
+        "protectionUnitIds",
+        "restorePointPreference",
+        "status",
+        "tags"
+      ]
+    },
+    "restorePoint": {
+      "navigationProperties": [
+        "protectionUnit"
+      ],
+      "properties": [
+        "expirationDateTime",
+        "protectionDateTime",
+        "tags"
+      ]
+    },
+    "restoreSessionBase": {
+      "navigationProperties": [],
+      "properties": [
+        "completedDateTime",
+        "createdBy",
+        "createdDateTime",
+        "error",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "restoreJobType",
+        "restoreSessionArtifactCount",
+        "status"
+      ]
+    },
+    "richLongRunningOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "percentageComplete",
+        "resourceId",
+        "type"
+      ]
+    },
+    "riskDetection": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "activityDateTime",
+        "additionalInfo",
+        "correlationId",
+        "detectedDateTime",
+        "detectionTimingType",
+        "ipAddress",
+        "lastUpdatedDateTime",
+        "location",
+        "requestId",
+        "riskDetail",
+        "riskEventType",
+        "riskLevel",
+        "riskState",
+        "source",
+        "tokenIssuerType",
+        "userDisplayName",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "riskPreventionContainer": {
+      "navigationProperties": [
+        "fraudProtectionProviders",
+        "webApplicationFirewallProviders",
+        "webApplicationFirewallVerifications"
+      ],
+      "properties": []
+    },
+    "riskyServicePrincipal": {
+      "navigationProperties": [
+        "history"
+      ],
+      "properties": [
+        "appId",
+        "displayName",
+        "isEnabled",
+        "isProcessing",
+        "riskDetail",
+        "riskLastUpdatedDateTime",
+        "riskLevel",
+        "riskState",
+        "servicePrincipalType"
+      ]
+    },
+    "riskyServicePrincipalHistoryItem": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "initiatedBy"
+      ]
+    },
+    "riskyUser": {
+      "navigationProperties": [
+        "history"
+      ],
+      "properties": [
+        "isDeleted",
+        "isProcessing",
+        "riskDetail",
+        "riskLastUpdatedDateTime",
+        "riskLevel",
+        "riskState",
+        "userDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "riskyUserHistoryItem": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "initiatedBy",
+        "userId"
+      ]
+    },
+    "roleAssignment": {
+      "navigationProperties": [
+        "roleDefinition"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "resourceScopes"
+      ]
+    },
+    "roleDefinition": {
+      "navigationProperties": [
+        "roleAssignments"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "isBuiltIn",
+        "rolePermissions"
+      ]
+    },
+    "roleManagement": {
+      "navigationProperties": [
+        "directory",
+        "entitlementManagement"
+      ],
+      "properties": []
+    },
+    "room": {
+      "navigationProperties": [],
+      "properties": [
+        "audioDeviceName",
+        "bookingType",
+        "building",
+        "capacity",
+        "displayDeviceName",
+        "emailAddress",
+        "floorLabel",
+        "floorNumber",
+        "nickname",
+        "placeId",
+        "teamsEnabledState",
+        "videoDeviceName"
+      ]
+    },
+    "roomList": {
+      "navigationProperties": [
+        "rooms",
+        "workspaces"
+      ],
+      "properties": [
+        "emailAddress"
+      ]
+    },
+    "samlOrWsFedExternalDomainFederation": {
+      "navigationProperties": [
+        "domains"
+      ],
+      "properties": []
+    },
+    "samlOrWsFedProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "issuerUri",
+        "metadataExchangeUri",
+        "passiveSignInUri",
+        "preferredAuthenticationProtocol",
+        "signingCertificate"
+      ]
+    },
+    "schedule": {
+      "navigationProperties": [
+        "dayNotes",
+        "offerShiftRequests",
+        "openShiftChangeRequests",
+        "openShifts",
+        "schedulingGroups",
+        "shifts",
+        "swapShiftsChangeRequests",
+        "timeCards",
+        "timeOffReasons",
+        "timeOffRequests",
+        "timesOff"
+      ],
+      "properties": [
+        "enabled",
+        "isActivitiesIncludedWhenCopyingShiftsEnabled",
+        "offerShiftRequestsEnabled",
+        "openShiftsEnabled",
+        "provisionStatus",
+        "provisionStatusCode",
+        "startDayOfWeek",
+        "swapShiftsRequestsEnabled",
+        "timeClockEnabled",
+        "timeClockSettings",
+        "timeOffRequestsEnabled",
+        "timeZone",
+        "workforceIntegrationIds"
+      ]
+    },
+    "scheduleChangeRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "assignedTo",
+        "managerActionDateTime",
+        "managerActionMessage",
+        "managerUserId",
+        "senderDateTime",
+        "senderMessage",
+        "senderUserId",
+        "state"
+      ]
+    },
+    "schedulingGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "displayName",
+        "isActive",
+        "userIds"
+      ]
+    },
+    "schemaExtension": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "owner",
+        "properties",
+        "status",
+        "targetTypes"
+      ]
+    },
+    "scopedRoleMembership": {
+      "navigationProperties": [],
+      "properties": [
+        "administrativeUnitId",
+        "roleId",
+        "roleMemberInfo"
+      ]
+    },
+    "searchEntity": {
+      "navigationProperties": [
+        "acronyms",
+        "bookmarks",
+        "qnas"
+      ],
+      "properties": []
+    },
+    "section": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sectionGroup": {
+      "navigationProperties": [
+        "parentNotebook",
+        "parentSectionGroup",
+        "sectionGroups",
+        "sections"
+      ],
+      "properties": [
+        "sectionGroupsUrl",
+        "sectionsUrl"
+      ]
+    },
+    "sectionMap": {
+      "navigationProperties": [],
+      "properties": [
+        "placeId"
+      ]
+    },
+    "secureScore": {
+      "navigationProperties": [],
+      "properties": [
+        "activeUserCount",
+        "averageComparativeScores",
+        "azureTenantId",
+        "controlScores",
+        "createdDateTime",
+        "currentScore",
+        "enabledServices",
+        "licensedUserCount",
+        "maxScore",
+        "vendorInformation"
+      ]
+    },
+    "secureScoreControlProfile": {
+      "navigationProperties": [],
+      "properties": [
+        "actionType",
+        "actionUrl",
+        "azureTenantId",
+        "complianceInformation",
+        "controlCategory",
+        "controlStateUpdates",
+        "deprecated",
+        "implementationCost",
+        "lastModifiedDateTime",
+        "maxScore",
+        "rank",
+        "remediation",
+        "remediationImpact",
+        "service",
+        "threats",
+        "tier",
+        "title",
+        "userImpact",
+        "vendorInformation"
+      ]
+    },
+    "security": {
+      "navigationProperties": [
+        "alerts",
+        "alerts_v2",
+        "attackSimulation",
+        "cases",
+        "dataSecurityAndGovernance",
+        "identities",
+        "incidents",
+        "labels",
+        "secureScoreControlProfiles",
+        "secureScores",
+        "subjectRightsRequests",
+        "threatIntelligence",
+        "triggers",
+        "triggerTypes"
+      ],
+      "properties": []
+    },
+    "securityReportsRoot": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sendDtmfTonesOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "completionReason"
+      ]
+    },
+    "sensitivityLabel": {
+      "navigationProperties": [
+        "rights",
+        "sublabels"
+      ],
+      "properties": [
+        "actionSource",
+        "autoTooltip",
+        "description",
+        "displayName",
+        "hasProtection",
+        "isDefault",
+        "isEndpointProtectionEnabled",
+        "isScopedToUser",
+        "locale",
+        "name",
+        "priority",
+        "toolTip"
+      ]
+    },
+    "serviceAnnouncement": {
+      "navigationProperties": [
+        "healthOverviews",
+        "issues",
+        "messages"
+      ],
+      "properties": []
+    },
+    "serviceAnnouncementAttachment": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "contentType",
+        "lastModifiedDateTime",
+        "name",
+        "size"
+      ]
+    },
+    "serviceAnnouncementBase": {
+      "navigationProperties": [],
+      "properties": [
+        "details",
+        "endDateTime",
+        "lastModifiedDateTime",
+        "startDateTime",
+        "title"
+      ]
+    },
+    "serviceApp": {
+      "navigationProperties": [],
+      "properties": [
+        "application",
+        "effectiveDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "registrationDateTime",
+        "status"
+      ]
+    },
+    "serviceHealth": {
+      "navigationProperties": [
+        "issues"
+      ],
+      "properties": [
+        "service",
+        "status"
+      ]
+    },
+    "serviceHealthIssue": {
+      "navigationProperties": [],
+      "properties": [
+        "classification",
+        "feature",
+        "featureGroup",
+        "impactDescription",
+        "isResolved",
+        "origin",
+        "posts",
+        "service",
+        "status"
+      ]
+    },
+    "servicePrincipal": {
+      "navigationProperties": [
+        "appManagementPolicies",
+        "appRoleAssignedTo",
+        "appRoleAssignments",
+        "claimsMappingPolicies",
+        "createdObjects",
+        "delegatedPermissionClassifications",
+        "endpoints",
+        "federatedIdentityCredentials",
+        "homeRealmDiscoveryPolicies",
+        "memberOf",
+        "oauth2PermissionGrants",
+        "ownedObjects",
+        "owners",
+        "remoteDesktopSecurityConfiguration",
+        "synchronization",
+        "tokenIssuancePolicies",
+        "tokenLifetimePolicies",
+        "transitiveMemberOf"
+      ],
+      "properties": [
+        "accountEnabled",
+        "addIns",
+        "alternativeNames",
+        "appDescription",
+        "appDisplayName",
+        "appId",
+        "applicationTemplateId",
+        "appOwnerOrganizationId",
+        "appRoleAssignmentRequired",
+        "appRoles",
+        "createdByAppId",
+        "customSecurityAttributes",
+        "description",
+        "disabledByMicrosoftStatus",
+        "displayName",
+        "homepage",
+        "info",
+        "isDisabled",
+        "keyCredentials",
+        "loginUrl",
+        "logoutUrl",
+        "notes",
+        "notificationEmailAddresses",
+        "oauth2PermissionScopes",
+        "passwordCredentials",
+        "preferredSingleSignOnMode",
+        "preferredTokenSigningKeyThumbprint",
+        "replyUrls",
+        "resourceSpecificApplicationPermissions",
+        "samlSingleSignOnSettings",
+        "servicePrincipalNames",
+        "servicePrincipalType",
+        "signInAudience",
+        "tags",
+        "tokenEncryptionKeyId",
+        "verifiedPublisher"
+      ]
+    },
+    "servicePrincipalRiskDetection": {
+      "navigationProperties": [],
+      "properties": [
+        "activity",
+        "activityDateTime",
+        "additionalInfo",
+        "appId",
+        "correlationId",
+        "detectedDateTime",
+        "detectionTimingType",
+        "ipAddress",
+        "keyIds",
+        "lastUpdatedDateTime",
+        "location",
+        "requestId",
+        "riskDetail",
+        "riskEventType",
+        "riskLevel",
+        "riskState",
+        "servicePrincipalDisplayName",
+        "servicePrincipalId",
+        "source",
+        "tokenIssuerType"
+      ]
+    },
+    "serviceStorageQuotaBreakdown": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "serviceUpdateMessage": {
+      "navigationProperties": [
+        "attachments"
+      ],
+      "properties": [
+        "actionRequiredByDateTime",
+        "attachmentsArchive",
+        "body",
+        "category",
+        "hasAttachments",
+        "isMajorChange",
+        "services",
+        "severity",
+        "tags",
+        "viewPoint"
+      ]
+    },
+    "settingStateDeviceSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantDeviceCount",
+        "conflictDeviceCount",
+        "errorDeviceCount",
+        "instancePath",
+        "nonCompliantDeviceCount",
+        "notApplicableDeviceCount",
+        "remediatedDeviceCount",
+        "settingName",
+        "unknownDeviceCount"
+      ]
+    },
+    "sharedDriveItem": {
+      "navigationProperties": [
+        "driveItem",
+        "items",
+        "list",
+        "listItem",
+        "permission",
+        "root",
+        "site"
+      ],
+      "properties": [
+        "owner"
+      ]
+    },
+    "sharedInsight": {
+      "navigationProperties": [
+        "lastSharedMethod",
+        "resource"
+      ],
+      "properties": [
+        "lastShared",
+        "resourceReference",
+        "resourceVisualization",
+        "sharingHistory"
+      ]
+    },
+    "sharedPCConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accountManagerPolicy",
+        "allowedAccounts",
+        "allowLocalStorage",
+        "disableAccountManager",
+        "disableEduPolicies",
+        "disablePowerPolicies",
+        "disableSignInOnResume",
+        "enabled",
+        "idleTimeBeforeSleepInSeconds",
+        "kioskAppDisplayName",
+        "kioskAppUserModelId",
+        "maintenanceStartTime"
+      ]
+    },
+    "sharedWithChannelTeamInfo": {
+      "navigationProperties": [
+        "allowedMembers"
+      ],
+      "properties": [
+        "isHostTeam"
+      ]
+    },
+    "sharepoint": {
+      "navigationProperties": [
+        "settings"
+      ],
+      "properties": []
+    },
+    "sharePointGroup": {
+      "navigationProperties": [
+        "members"
+      ],
+      "properties": [
+        "description",
+        "principalId",
+        "title"
+      ]
+    },
+    "sharePointGroupMember": {
+      "navigationProperties": [],
+      "properties": [
+        "identity"
+      ]
+    },
+    "sharePointMigrationEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "correlationId",
+        "eventDateTime",
+        "jobId"
+      ]
+    },
+    "sharePointMigrationFinishManifestFileUploadEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "manifestFileName"
+      ]
+    },
+    "sharePointMigrationJob": {
+      "navigationProperties": [
+        "progressEvents"
+      ],
+      "properties": [
+        "containerInfo"
+      ]
+    },
+    "sharePointMigrationJobCancelledEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "isCancelledByUser",
+        "totalRetryCount"
+      ]
+    },
+    "sharePointMigrationJobDeletedEvent": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointMigrationJobErrorEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "errorLevel",
+        "objectId",
+        "objectType",
+        "objectUrl",
+        "totalRetryCount"
+      ]
+    },
+    "sharePointMigrationJobPostponedEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "jobsInQueue",
+        "nextPickupDateTime",
+        "reason",
+        "totalRetryCount"
+      ]
+    },
+    "sharePointMigrationJobProgressEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "bytesProcessed",
+        "bytesProcessedOnlyCurrentVersion",
+        "cpuDurationMs",
+        "filesProcessed",
+        "filesProcessedOnlyCurrentVersion",
+        "isCompleted",
+        "lastProcessedObjectId",
+        "objectsProcessed",
+        "sqlDurationMs",
+        "sqlQueryCount",
+        "totalDurationMs",
+        "totalErrors",
+        "totalExpectedBytes",
+        "totalExpectedObjects",
+        "totalRetryCount",
+        "totalWarnings",
+        "waitTimeOnSqlThrottlingMs"
+      ]
+    },
+    "sharePointMigrationJobQueuedEvent": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "sharePointMigrationJobStartEvent": {
+      "navigationProperties": [],
+      "properties": [
+        "isRestarted",
+        "totalRetryCount"
+      ]
+    },
+    "sharePointProtectionPolicy": {
+      "navigationProperties": [
+        "siteInclusionRules",
+        "siteProtectionUnits",
+        "siteProtectionUnitsBulkAdditionJobs"
+      ],
+      "properties": []
+    },
+    "sharePointRestoreSession": {
+      "navigationProperties": [
+        "siteRestoreArtifacts",
+        "siteRestoreArtifactsBulkAdditionRequests"
+      ],
+      "properties": []
+    },
+    "sharepointSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedDomainGuidsForSyncApp",
+        "availableManagedPathsForSiteCreation",
+        "deletedUserPersonalSiteRetentionPeriodInDays",
+        "excludedFileExtensionsForSyncApp",
+        "idleSessionSignOut",
+        "imageTaggingOption",
+        "isCommentingOnSitePagesEnabled",
+        "isFileActivityNotificationEnabled",
+        "isLegacyAuthProtocolsEnabled",
+        "isLoopEnabled",
+        "isMacSyncAppEnabled",
+        "isRequireAcceptingUserToMatchInvitedUserEnabled",
+        "isResharingByExternalUsersEnabled",
+        "isSharePointMobileNotificationEnabled",
+        "isSharePointNewsfeedEnabled",
+        "isSiteCreationEnabled",
+        "isSiteCreationUIEnabled",
+        "isSitePagesCreationEnabled",
+        "isSitesStorageLimitAutomatic",
+        "isSyncButtonHiddenOnPersonalSite",
+        "isUnmanagedSyncAppForTenantRestricted",
+        "personalSiteDefaultStorageLimitInMB",
+        "sharingAllowedDomainList",
+        "sharingBlockedDomainList",
+        "sharingCapability",
+        "sharingDomainRestrictionMode",
+        "siteCreationDefaultManagedPath",
+        "siteCreationDefaultStorageLimitInMB",
+        "tenantDefaultTimezone"
+      ]
+    },
+    "shift": {
+      "navigationProperties": [],
+      "properties": [
+        "draftShift",
+        "isStagedForDeletion",
+        "schedulingGroupId",
+        "sharedShift",
+        "userId"
+      ]
+    },
+    "shiftPreferences": {
+      "navigationProperties": [],
+      "properties": [
+        "availability"
+      ]
+    },
+    "signIn": {
+      "navigationProperties": [],
+      "properties": [
+        "appDisplayName",
+        "appId",
+        "appliedConditionalAccessPolicies",
+        "clientAppUsed",
+        "conditionalAccessStatus",
+        "correlationId",
+        "createdDateTime",
+        "deviceDetail",
+        "ipAddress",
+        "isInteractive",
+        "location",
+        "resourceDisplayName",
+        "resourceId",
+        "riskDetail",
+        "riskEventTypes",
+        "riskEventTypes_v2",
+        "riskLevelAggregated",
+        "riskLevelDuringSignIn",
+        "riskState",
+        "status",
+        "userDisplayName",
+        "userId",
+        "userPrincipalName"
+      ]
+    },
+    "simulation": {
+      "navigationProperties": [
+        "landingPage",
+        "loginPage",
+        "payload"
+      ],
+      "properties": [
+        "attackTechnique",
+        "attackType",
+        "automationId",
+        "completionDateTime",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "durationInDays",
+        "endUserNotificationSetting",
+        "excludedAccountTarget",
+        "includedAccountTarget",
+        "isAutomated",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "launchDateTime",
+        "oAuthConsentAppDetail",
+        "payloadDeliveryPlatform",
+        "report",
+        "status",
+        "trainingSetting"
+      ]
+    },
+    "simulationAutomation": {
+      "navigationProperties": [
+        "runs"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "lastRunDateTime",
+        "nextRunDateTime",
+        "status"
+      ]
+    },
+    "simulationAutomationRun": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "simulationId",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "singleValueLegacyExtendedProperty": {
+      "navigationProperties": [],
+      "properties": [
+        "value"
+      ]
+    },
+    "site": {
+      "navigationProperties": [
+        "analytics",
+        "columns",
+        "contentTypes",
+        "drive",
+        "drives",
+        "externalColumns",
+        "items",
+        "lists",
+        "onenote",
+        "operations",
+        "pages",
+        "permissions",
+        "sites",
+        "termStore",
+        "termStores"
+      ],
+      "properties": [
+        "displayName",
+        "error",
+        "isPersonalSite",
+        "root",
+        "sharepointIds",
+        "siteCollection"
+      ]
+    },
+    "sitePage": {
+      "navigationProperties": [
+        "canvasLayout",
+        "webParts"
+      ],
+      "properties": [
+        "promotionKind",
+        "reactions",
+        "showComments",
+        "showRecommendedPages",
+        "thumbnailWebUrl",
+        "titleArea"
+      ]
+    },
+    "siteProtectionRule": {
+      "navigationProperties": [],
+      "properties": [
+        "siteExpression"
+      ]
+    },
+    "siteProtectionUnit": {
+      "navigationProperties": [],
+      "properties": [
+        "siteId",
+        "siteName",
+        "siteWebUrl"
+      ]
+    },
+    "siteProtectionUnitsBulkAdditionJob": {
+      "navigationProperties": [],
+      "properties": [
+        "siteIds",
+        "siteWebUrls"
+      ]
+    },
+    "siteRestoreArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "restoredSiteId",
+        "restoredSiteName",
+        "restoredSiteWebUrl"
+      ]
+    },
+    "siteRestoreArtifactsBulkAdditionRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "siteIds",
+        "siteWebUrls"
+      ]
+    },
+    "skypeForBusinessUserConversationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "tenantId",
+        "userId"
+      ]
+    },
+    "skypeUserConversationMember": {
+      "navigationProperties": [],
+      "properties": [
+        "skypeId"
+      ]
+    },
+    "smsAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": []
+    },
+    "smsAuthenticationMethodTarget": {
+      "navigationProperties": [],
+      "properties": [
+        "isUsableForSignIn"
+      ]
+    },
+    "socialIdentityProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "clientId",
+        "clientSecret",
+        "identityProviderType"
+      ]
+    },
+    "softwareOathAuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "secretKey"
+      ]
+    },
+    "softwareOathAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": []
+    },
+    "softwareUpdateStatusSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "compliantDeviceCount",
+        "compliantUserCount",
+        "conflictDeviceCount",
+        "conflictUserCount",
+        "displayName",
+        "errorDeviceCount",
+        "errorUserCount",
+        "nonCompliantDeviceCount",
+        "nonCompliantUserCount",
+        "notApplicableDeviceCount",
+        "notApplicableUserCount",
+        "remediatedDeviceCount",
+        "remediatedUserCount",
+        "unknownDeviceCount",
+        "unknownUserCount"
+      ]
+    },
+    "solutionsRoot": {
+      "navigationProperties": [
+        "backupRestore",
+        "bookingBusinesses",
+        "bookingCurrencies",
+        "virtualEvents"
+      ],
+      "properties": []
+    },
+    "speakerAssignmentSubmission": {
+      "navigationProperties": [],
+      "properties": [
+        "assignmentId",
+        "averageWordsPerMinutePace",
+        "classId",
+        "fillerWordsOccurrencesCount",
+        "incorrectCameraDistanceOccurrencesCount",
+        "lengthOfSubmissionInSeconds",
+        "lostEyeContactOccurrencesCount",
+        "monotoneOccurrencesCount",
+        "nonInclusiveLanguageOccurrencesCount",
+        "obstructedViewOccurrencesCount",
+        "repetitiveLanguageOccurrencesCount",
+        "studentId",
+        "submissionDateTime",
+        "submissionId",
+        "topFillerWords",
+        "topMispronouncedWords",
+        "topNonInclusiveWordsAndPhrases",
+        "topRepetitiveWordsAndPhrases",
+        "wordsSpokenCount"
+      ]
+    },
+    "standardWebPart": {
+      "navigationProperties": [],
+      "properties": [
+        "containerTextWebPartId",
+        "data",
+        "webPartType"
+      ]
+    },
+    "startHoldMusicOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "stopHoldMusicOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "storage": {
+      "navigationProperties": [
+        "fileStorage",
+        "settings"
+      ],
+      "properties": []
+    },
+    "storageQuotaBreakdown": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "manageWebUrl",
+        "used"
+      ]
+    },
+    "storageSettings": {
+      "navigationProperties": [
+        "quota"
+      ],
+      "properties": []
+    },
+    "stsPolicy": {
+      "navigationProperties": [
+        "appliesTo"
+      ],
+      "properties": [
+        "definition",
+        "isOrganizationDefault"
+      ]
+    },
+    "subjectRightsRequest": {
+      "navigationProperties": [
+        "approvers",
+        "collaborators",
+        "notes",
+        "team"
+      ],
+      "properties": [
+        "assignedTo",
+        "closedDateTime",
+        "contentQuery",
+        "createdBy",
+        "createdDateTime",
+        "dataSubject",
+        "dataSubjectType",
+        "description",
+        "displayName",
+        "externalId",
+        "history",
+        "includeAllVersions",
+        "includeAuthoredContent",
+        "insight",
+        "internalDueDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "mailboxLocations",
+        "pauseAfterEstimate",
+        "regulations",
+        "siteLocations",
+        "stages",
+        "status",
+        "type"
+      ]
+    },
+    "subscribedSku": {
+      "navigationProperties": [],
+      "properties": [
+        "accountId",
+        "accountName",
+        "appliesTo",
+        "capabilityStatus",
+        "consumedUnits",
+        "prepaidUnits",
+        "servicePlans",
+        "skuId",
+        "skuPartNumber",
+        "subscriptionIds"
+      ]
+    },
+    "subscribeToToneOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "subscription": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationId",
+        "changeType",
+        "clientState",
+        "creatorId",
+        "encryptionCertificate",
+        "encryptionCertificateId",
+        "expirationDateTime",
+        "includeResourceData",
+        "latestSupportedTlsVersion",
+        "lifecycleNotificationUrl",
+        "notificationQueryOptions",
+        "notificationUrl",
+        "notificationUrlAppId",
+        "resource"
+      ]
+    },
+    "swapShiftsChangeRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "recipientShiftId"
+      ]
+    },
+    "synchronization": {
+      "navigationProperties": [
+        "jobs",
+        "templates"
+      ],
+      "properties": [
+        "secrets"
+      ]
+    },
+    "synchronizationJob": {
+      "navigationProperties": [
+        "bulkUpload",
+        "schema"
+      ],
+      "properties": [
+        "schedule",
+        "status",
+        "synchronizationJobSettings",
+        "templateId"
+      ]
+    },
+    "synchronizationSchema": {
+      "navigationProperties": [
+        "directories"
+      ],
+      "properties": [
+        "synchronizationRules",
+        "version"
+      ]
+    },
+    "synchronizationTemplate": {
+      "navigationProperties": [
+        "schema"
+      ],
+      "properties": [
+        "applicationId",
+        "default",
+        "description",
+        "discoverable",
+        "factoryTag",
+        "metadata"
+      ]
+    },
+    "targetDeviceGroup": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "targetedManagedAppConfiguration": {
+      "navigationProperties": [
+        "apps",
+        "assignments",
+        "deploymentSummary"
+      ],
+      "properties": [
+        "deployedAppCount",
+        "isAssigned"
+      ]
+    },
+    "targetedManagedAppPolicyAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "targetedManagedAppProtection": {
+      "navigationProperties": [
+        "assignments"
+      ],
+      "properties": [
+        "isAssigned"
+      ]
+    },
+    "taskFileAttachment": {
+      "navigationProperties": [],
+      "properties": [
+        "contentBytes"
+      ]
+    },
+    "team": {
+      "navigationProperties": [
+        "allChannels",
+        "channels",
+        "group",
+        "incomingChannels",
+        "installedApps",
+        "members",
+        "operations",
+        "permissionGrants",
+        "photo",
+        "primaryChannel",
+        "schedule",
+        "tags",
+        "template"
+      ],
+      "properties": [
+        "classification",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "firstChannelName",
+        "funSettings",
+        "guestSettings",
+        "internalId",
+        "isArchived",
+        "memberSettings",
+        "messagingSettings",
+        "specialization",
+        "summary",
+        "tenantId",
+        "visibility",
+        "webUrl"
+      ]
+    },
+    "teamInfo": {
+      "navigationProperties": [
+        "team"
+      ],
+      "properties": [
+        "displayName",
+        "tenantId"
+      ]
+    },
+    "teamsApp": {
+      "navigationProperties": [
+        "appDefinitions"
+      ],
+      "properties": [
+        "displayName",
+        "distributionMethod",
+        "externalId"
+      ]
+    },
+    "teamsAppDefinition": {
+      "navigationProperties": [
+        "bot"
+      ],
+      "properties": [
+        "authorization",
+        "createdBy",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "publishingState",
+        "shortDescription",
+        "teamsAppId",
+        "version"
+      ]
+    },
+    "teamsAppInstallation": {
+      "navigationProperties": [
+        "teamsApp",
+        "teamsAppDefinition"
+      ],
+      "properties": [
+        "consentedPermissionSet"
+      ]
+    },
+    "teamsAppSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "allowUserRequestsForAppAccess",
+        "isUserPersonalScopeResourceSpecificConsentEnabled"
+      ]
+    },
+    "teamsAsyncOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "attemptsCount",
+        "createdDateTime",
+        "error",
+        "lastActionDateTime",
+        "operationType",
+        "status",
+        "targetResourceId",
+        "targetResourceLocation"
+      ]
+    },
+    "teamsTab": {
+      "navigationProperties": [
+        "teamsApp"
+      ],
+      "properties": [
+        "configuration",
+        "displayName",
+        "webUrl"
+      ]
+    },
+    "teamsTemplate": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamwork": {
+      "navigationProperties": [
+        "deletedChats",
+        "deletedTeams",
+        "teamsAppSettings",
+        "workforceIntegrations"
+      ],
+      "properties": [
+        "isTeamsEnabled",
+        "region"
+      ]
+    },
+    "teamworkBot": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "teamworkHostedContent": {
+      "navigationProperties": [],
+      "properties": [
+        "contentBytes",
+        "contentType"
+      ]
+    },
+    "teamworkTag": {
+      "navigationProperties": [
+        "members"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "memberCount",
+        "tagType",
+        "teamId"
+      ]
+    },
+    "teamworkTagMember": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "tenantId",
+        "userId"
+      ]
+    },
+    "temporaryAccessPassAuthenticationMethod": {
+      "navigationProperties": [],
+      "properties": [
+        "isUsable",
+        "isUsableOnce",
+        "lifetimeInMinutes",
+        "methodUsabilityReason",
+        "startDateTime",
+        "temporaryAccessPass"
+      ]
+    },
+    "temporaryAccessPassAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": [
+        "defaultLength",
+        "defaultLifetimeInMinutes",
+        "isUsableOnce",
+        "maximumLifetimeInMinutes",
+        "minimumLifetimeInMinutes"
+      ]
+    },
+    "tenantAppManagementPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationRestrictions",
+        "isEnabled",
+        "servicePrincipalRestrictions"
+      ]
+    },
+    "tenantDataSecurityAndGovernance": {
+      "navigationProperties": [
+        "protectionScopes"
+      ],
+      "properties": []
+    },
+    "tenantProtectionScopeContainer": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "tenantRelationship": {
+      "navigationProperties": [
+        "delegatedAdminCustomers",
+        "delegatedAdminRelationships",
+        "multiTenantOrganization"
+      ],
+      "properties": []
+    },
+    "termsAndConditions": {
+      "navigationProperties": [
+        "acceptanceStatuses",
+        "assignments"
+      ],
+      "properties": [
+        "acceptanceStatement",
+        "bodyText",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedDateTime",
+        "title",
+        "version"
+      ]
+    },
+    "termsAndConditionsAcceptanceStatus": {
+      "navigationProperties": [
+        "termsAndConditions"
+      ],
+      "properties": [
+        "acceptedDateTime",
+        "acceptedVersion",
+        "userDisplayName",
+        "userPrincipalName"
+      ]
+    },
+    "termsAndConditionsAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "termsOfUseContainer": {
+      "navigationProperties": [
+        "agreementAcceptances",
+        "agreements"
+      ],
+      "properties": []
+    },
+    "textWebPart": {
+      "navigationProperties": [],
+      "properties": [
+        "innerHtml"
+      ]
+    },
+    "threatAssessmentRequest": {
+      "navigationProperties": [
+        "results"
+      ],
+      "properties": [
+        "category",
+        "contentType",
+        "createdBy",
+        "createdDateTime",
+        "expectedAssessment",
+        "requestSource",
+        "status"
+      ]
+    },
+    "threatAssessmentResult": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "message",
+        "resultType"
+      ]
+    },
+    "thumbnailSet": {
+      "navigationProperties": [],
+      "properties": [
+        "large",
+        "medium",
+        "small",
+        "source"
+      ]
+    },
+    "timeCard": {
+      "navigationProperties": [],
+      "properties": [
+        "breaks",
+        "clockInEvent",
+        "clockOutEvent",
+        "confirmedBy",
+        "notes",
+        "originalEntry",
+        "state",
+        "userId"
+      ]
+    },
+    "timeOff": {
+      "navigationProperties": [],
+      "properties": [
+        "draftTimeOff",
+        "isStagedForDeletion",
+        "sharedTimeOff",
+        "userId"
+      ]
+    },
+    "timeOffReason": {
+      "navigationProperties": [],
+      "properties": [
+        "code",
+        "displayName",
+        "iconType",
+        "isActive"
+      ]
+    },
+    "timeOffRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "startDateTime",
+        "timeOffReasonId"
+      ]
+    },
+    "todo": {
+      "navigationProperties": [
+        "lists"
+      ],
+      "properties": []
+    },
+    "todoTask": {
+      "navigationProperties": [
+        "attachments",
+        "attachmentSessions",
+        "checklistItems",
+        "extensions",
+        "linkedResources"
+      ],
+      "properties": [
+        "body",
+        "bodyLastModifiedDateTime",
+        "categories",
+        "completedDateTime",
+        "createdDateTime",
+        "dueDateTime",
+        "hasAttachments",
+        "importance",
+        "isReminderOn",
+        "lastModifiedDateTime",
+        "recurrence",
+        "reminderDateTime",
+        "startDateTime",
+        "status",
+        "title"
+      ]
+    },
+    "todoTaskList": {
+      "navigationProperties": [
+        "extensions",
+        "tasks"
+      ],
+      "properties": [
+        "displayName",
+        "isOwner",
+        "isShared",
+        "wellknownListName"
+      ]
+    },
+    "tokenIssuancePolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "tokenLifetimePolicy": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "training": {
+      "navigationProperties": [
+        "languageDetails"
+      ],
+      "properties": [
+        "availabilityStatus",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "durationInMinutes",
+        "hasEvaluation",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "source",
+        "supportedLocales",
+        "tags",
+        "type"
+      ]
+    },
+    "trainingLanguageDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "isDefaultLangauge",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "locale"
+      ]
+    },
+    "trending": {
+      "navigationProperties": [
+        "resource"
+      ],
+      "properties": [
+        "lastModifiedDateTime",
+        "resourceReference",
+        "resourceVisualization",
+        "weight"
+      ]
+    },
+    "unifiedRbacResourceAction": {
+      "navigationProperties": [],
+      "properties": [
+        "actionVerb",
+        "authenticationContextId",
+        "description",
+        "isAuthenticationContextSettable",
+        "name",
+        "resourceScopeId"
+      ]
+    },
+    "unifiedRbacResourceNamespace": {
+      "navigationProperties": [
+        "resourceActions"
+      ],
+      "properties": [
+        "name"
+      ]
+    },
+    "unifiedRoleAssignment": {
+      "navigationProperties": [
+        "appScope",
+        "directoryScope",
+        "principal",
+        "roleDefinition"
+      ],
+      "properties": [
+        "appScopeId",
+        "condition",
+        "directoryScopeId",
+        "principalId",
+        "roleDefinitionId"
+      ]
+    },
+    "unifiedRoleAssignmentSchedule": {
+      "navigationProperties": [
+        "activatedUsing"
+      ],
+      "properties": [
+        "assignmentType",
+        "memberType",
+        "scheduleInfo"
+      ]
+    },
+    "unifiedRoleAssignmentScheduleInstance": {
+      "navigationProperties": [
+        "activatedUsing"
+      ],
+      "properties": [
+        "assignmentType",
+        "endDateTime",
+        "memberType",
+        "roleAssignmentOriginId",
+        "roleAssignmentScheduleId",
+        "startDateTime"
+      ]
+    },
+    "unifiedRoleAssignmentScheduleRequest": {
+      "navigationProperties": [
+        "activatedUsing",
+        "appScope",
+        "directoryScope",
+        "principal",
+        "roleDefinition",
+        "targetSchedule"
+      ],
+      "properties": [
+        "action",
+        "appScopeId",
+        "directoryScopeId",
+        "isValidationOnly",
+        "justification",
+        "principalId",
+        "roleDefinitionId",
+        "scheduleInfo",
+        "targetScheduleId",
+        "ticketInfo"
+      ]
+    },
+    "unifiedRoleDefinition": {
+      "navigationProperties": [
+        "inheritsPermissionsFrom"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "isBuiltIn",
+        "isEnabled",
+        "resourceScopes",
+        "rolePermissions",
+        "templateId",
+        "version"
+      ]
+    },
+    "unifiedRoleEligibilitySchedule": {
+      "navigationProperties": [],
+      "properties": [
+        "memberType",
+        "scheduleInfo"
+      ]
+    },
+    "unifiedRoleEligibilityScheduleInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "memberType",
+        "roleEligibilityScheduleId",
+        "startDateTime"
+      ]
+    },
+    "unifiedRoleEligibilityScheduleRequest": {
+      "navigationProperties": [
+        "appScope",
+        "directoryScope",
+        "principal",
+        "roleDefinition",
+        "targetSchedule"
+      ],
+      "properties": [
+        "action",
+        "appScopeId",
+        "directoryScopeId",
+        "isValidationOnly",
+        "justification",
+        "principalId",
+        "roleDefinitionId",
+        "scheduleInfo",
+        "targetScheduleId",
+        "ticketInfo"
+      ]
+    },
+    "unifiedRoleManagementPolicy": {
+      "navigationProperties": [
+        "effectiveRules",
+        "rules"
+      ],
+      "properties": [
+        "description",
+        "displayName",
+        "isOrganizationDefault",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "scopeId",
+        "scopeType"
+      ]
+    },
+    "unifiedRoleManagementPolicyApprovalRule": {
+      "navigationProperties": [],
+      "properties": [
+        "setting"
+      ]
+    },
+    "unifiedRoleManagementPolicyAssignment": {
+      "navigationProperties": [
+        "policy"
+      ],
+      "properties": [
+        "policyId",
+        "roleDefinitionId",
+        "scopeId",
+        "scopeType"
+      ]
+    },
+    "unifiedRoleManagementPolicyAuthenticationContextRule": {
+      "navigationProperties": [],
+      "properties": [
+        "claimValue",
+        "isEnabled"
+      ]
+    },
+    "unifiedRoleManagementPolicyEnablementRule": {
+      "navigationProperties": [],
+      "properties": [
+        "enabledRules"
+      ]
+    },
+    "unifiedRoleManagementPolicyExpirationRule": {
+      "navigationProperties": [],
+      "properties": [
+        "isExpirationRequired",
+        "maximumDuration"
+      ]
+    },
+    "unifiedRoleManagementPolicyNotificationRule": {
+      "navigationProperties": [],
+      "properties": [
+        "isDefaultRecipientsEnabled",
+        "notificationLevel",
+        "notificationRecipients",
+        "notificationType",
+        "recipientType"
+      ]
+    },
+    "unifiedRoleManagementPolicyRule": {
+      "navigationProperties": [],
+      "properties": [
+        "target"
+      ]
+    },
+    "unifiedRoleScheduleBase": {
+      "navigationProperties": [
+        "appScope",
+        "directoryScope",
+        "principal",
+        "roleDefinition"
+      ],
+      "properties": [
+        "appScopeId",
+        "createdDateTime",
+        "createdUsing",
+        "directoryScopeId",
+        "modifiedDateTime",
+        "principalId",
+        "roleDefinitionId",
+        "status"
+      ]
+    },
+    "unifiedRoleScheduleInstanceBase": {
+      "navigationProperties": [
+        "appScope",
+        "directoryScope",
+        "principal",
+        "roleDefinition"
+      ],
+      "properties": [
+        "appScopeId",
+        "directoryScopeId",
+        "principalId",
+        "roleDefinitionId"
+      ]
+    },
+    "unifiedStorageQuota": {
+      "navigationProperties": [
+        "services"
+      ],
+      "properties": [
+        "deleted",
+        "manageWebUrl",
+        "remaining",
+        "state",
+        "total",
+        "used"
+      ]
+    },
+    "unitMap": {
+      "navigationProperties": [],
+      "properties": [
+        "placeId"
+      ]
+    },
+    "unmuteParticipantOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "updateRecordingStatusOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "urlAssessmentRequest": {
+      "navigationProperties": [],
+      "properties": [
+        "url"
+      ]
+    },
+    "usageRightsIncluded": {
+      "navigationProperties": [],
+      "properties": [
+        "ownerEmail",
+        "userEmail",
+        "value"
+      ]
+    },
+    "usedInsight": {
+      "navigationProperties": [
+        "resource"
+      ],
+      "properties": [
+        "lastUsed",
+        "resourceReference",
+        "resourceVisualization"
+      ]
+    },
+    "user": {
+      "navigationProperties": [
+        "activities",
+        "adhocCalls",
+        "agreementAcceptances",
+        "appRoleAssignments",
+        "authentication",
+        "calendar",
+        "calendarGroups",
+        "calendars",
+        "calendarView",
+        "chats",
+        "cloudClipboard",
+        "cloudPCs",
+        "contactFolders",
+        "contacts",
+        "createdObjects",
+        "dataSecurityAndGovernance",
+        "deviceManagementTroubleshootingEvents",
+        "directReports",
+        "drive",
+        "drives",
+        "employeeExperience",
+        "events",
+        "extensions",
+        "followedSites",
+        "inferenceClassification",
+        "insights",
+        "joinedTeams",
+        "licenseDetails",
+        "mailFolders",
+        "managedAppRegistrations",
+        "managedDevices",
+        "manager",
+        "memberOf",
+        "messages",
+        "oauth2PermissionGrants",
+        "onenote",
+        "onlineMeetings",
+        "onPremisesSyncBehavior",
+        "outlook",
+        "ownedDevices",
+        "ownedObjects",
+        "people",
+        "permissionGrants",
+        "photo",
+        "photos",
+        "planner",
+        "presence",
+        "registeredDevices",
+        "scopedRoleMemberOf",
+        "settings",
+        "solutions",
+        "sponsors",
+        "teamwork",
+        "todo",
+        "transitiveMemberOf"
+      ],
+      "properties": [
+        "aboutMe",
+        "accountEnabled",
+        "ageGroup",
+        "assignedLicenses",
+        "assignedPlans",
+        "authorizationInfo",
+        "birthday",
+        "businessPhones",
+        "city",
+        "companyName",
+        "consentProvidedForMinor",
+        "country",
+        "createdDateTime",
+        "creationType",
+        "customSecurityAttributes",
+        "department",
+        "deviceEnrollmentLimit",
+        "displayName",
+        "employeeHireDate",
+        "employeeId",
+        "employeeLeaveDateTime",
+        "employeeOrgData",
+        "employeeType",
+        "externalUserState",
+        "externalUserStateChangeDateTime",
+        "faxNumber",
+        "givenName",
+        "hireDate",
+        "identities",
+        "identityParentId",
+        "imAddresses",
+        "interests",
+        "isManagementRestricted",
+        "isResourceAccount",
+        "jobTitle",
+        "lastPasswordChangeDateTime",
+        "legalAgeGroupClassification",
+        "licenseAssignmentStates",
+        "mail",
+        "mailboxSettings",
+        "mailNickname",
+        "mobilePhone",
+        "mySite",
+        "officeLocation",
+        "onPremisesDistinguishedName",
+        "onPremisesDomainName",
+        "onPremisesExtensionAttributes",
+        "onPremisesImmutableId",
+        "onPremisesLastSyncDateTime",
+        "onPremisesProvisioningErrors",
+        "onPremisesSamAccountName",
+        "onPremisesSecurityIdentifier",
+        "onPremisesSyncEnabled",
+        "onPremisesUserPrincipalName",
+        "otherMails",
+        "passwordPolicies",
+        "passwordProfile",
+        "pastProjects",
+        "postalCode",
+        "preferredDataLocation",
+        "preferredLanguage",
+        "preferredName",
+        "print",
+        "provisionedPlans",
+        "proxyAddresses",
+        "responsibilities",
+        "schools",
+        "securityIdentifier",
+        "serviceProvisioningErrors",
+        "showInAddressList",
+        "signInActivity",
+        "signInSessionsValidFromDateTime",
+        "skills",
+        "state",
+        "streetAddress",
+        "surname",
+        "usageLocation",
+        "userPrincipalName",
+        "userType"
+      ]
+    },
+    "userActivity": {
+      "navigationProperties": [
+        "historyItems"
+      ],
+      "properties": [
+        "activationUrl",
+        "activitySourceHost",
+        "appActivityId",
+        "appDisplayName",
+        "contentInfo",
+        "contentUrl",
+        "createdDateTime",
+        "expirationDateTime",
+        "fallbackUrl",
+        "lastModifiedDateTime",
+        "status",
+        "userTimezone",
+        "visualElements"
+      ]
+    },
+    "userConsentRequest": {
+      "navigationProperties": [
+        "approval"
+      ],
+      "properties": [
+        "reason"
+      ]
+    },
+    "userDataSecurityAndGovernance": {
+      "navigationProperties": [
+        "activities",
+        "protectionScopes"
+      ],
+      "properties": []
+    },
+    "userExperienceAnalyticsAppHealthApplicationPerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDeviceCount",
+        "appCrashCount",
+        "appDisplayName",
+        "appHangCount",
+        "appHealthScore",
+        "appName",
+        "appPublisher",
+        "appUsageDuration",
+        "meanTimeToFailureInMinutes"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "appCrashCount",
+        "appDisplayName",
+        "appName",
+        "appPublisher",
+        "appVersion",
+        "deviceCountWithCrashes",
+        "isLatestUsedVersion",
+        "isMostUsedVersion"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDeviceId": {
+      "navigationProperties": [],
+      "properties": [
+        "appCrashCount",
+        "appDisplayName",
+        "appName",
+        "appPublisher",
+        "appVersion",
+        "deviceDisplayName",
+        "deviceId",
+        "processedDateTime"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthAppPerformanceByOSVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDeviceCount",
+        "appCrashCount",
+        "appDisplayName",
+        "appName",
+        "appPublisher",
+        "appUsageDuration",
+        "meanTimeToFailureInMinutes",
+        "osBuildNumber",
+        "osVersion"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthDeviceModelPerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDeviceCount",
+        "deviceManufacturer",
+        "deviceModel",
+        "healthStatus",
+        "meanTimeToFailureInMinutes",
+        "modelAppHealthScore"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthDevicePerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "appCrashCount",
+        "appHangCount",
+        "crashedAppCount",
+        "deviceAppHealthScore",
+        "deviceDisplayName",
+        "deviceId",
+        "deviceManufacturer",
+        "deviceModel",
+        "healthStatus",
+        "meanTimeToFailureInMinutes",
+        "processedDateTime"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthDevicePerformanceDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "appDisplayName",
+        "appPublisher",
+        "appVersion",
+        "deviceDisplayName",
+        "deviceId",
+        "eventDateTime",
+        "eventType"
+      ]
+    },
+    "userExperienceAnalyticsAppHealthOSVersionPerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "activeDeviceCount",
+        "meanTimeToFailureInMinutes",
+        "osBuildNumber",
+        "osVersion",
+        "osVersionAppHealthScore"
+      ]
+    },
+    "userExperienceAnalyticsBaseline": {
+      "navigationProperties": [
+        "appHealthMetrics",
+        "batteryHealthMetrics",
+        "bestPracticesMetrics",
+        "deviceBootPerformanceMetrics",
+        "rebootAnalyticsMetrics",
+        "resourcePerformanceMetrics",
+        "workFromAnywhereMetrics"
+      ],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "isBuiltIn"
+      ]
+    },
+    "userExperienceAnalyticsCategory": {
+      "navigationProperties": [
+        "metricValues"
+      ],
+      "properties": [
+        "insights"
+      ]
+    },
+    "userExperienceAnalyticsDevicePerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "averageBlueScreens",
+        "averageRestarts",
+        "blueScreenCount",
+        "bootScore",
+        "coreBootTimeInMs",
+        "coreLoginTimeInMs",
+        "deviceCount",
+        "deviceName",
+        "diskType",
+        "groupPolicyBootTimeInMs",
+        "groupPolicyLoginTimeInMs",
+        "healthStatus",
+        "loginScore",
+        "manufacturer",
+        "model",
+        "modelStartupPerformanceScore",
+        "operatingSystemVersion",
+        "responsiveDesktopTimeInMs",
+        "restartCount",
+        "startupPerformanceScore"
+      ]
+    },
+    "userExperienceAnalyticsDeviceScores": {
+      "navigationProperties": [],
+      "properties": [
+        "appReliabilityScore",
+        "batteryHealthScore",
+        "deviceName",
+        "endpointAnalyticsScore",
+        "healthStatus",
+        "manufacturer",
+        "model",
+        "startupPerformanceScore",
+        "workFromAnywhereScore"
+      ]
+    },
+    "userExperienceAnalyticsDeviceStartupHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "coreBootTimeInMs",
+        "coreLoginTimeInMs",
+        "deviceId",
+        "featureUpdateBootTimeInMs",
+        "groupPolicyBootTimeInMs",
+        "groupPolicyLoginTimeInMs",
+        "isFeatureUpdate",
+        "isFirstLogin",
+        "operatingSystemVersion",
+        "responsiveDesktopTimeInMs",
+        "restartCategory",
+        "restartFaultBucket",
+        "restartStopCode",
+        "startTime",
+        "totalBootTimeInMs",
+        "totalLoginTimeInMs"
+      ]
+    },
+    "userExperienceAnalyticsDeviceStartupProcess": {
+      "navigationProperties": [],
+      "properties": [
+        "managedDeviceId",
+        "processName",
+        "productName",
+        "publisher",
+        "startupImpactInMs"
+      ]
+    },
+    "userExperienceAnalyticsDeviceStartupProcessPerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "medianImpactInMs",
+        "processName",
+        "productName",
+        "publisher",
+        "totalImpactInMs"
+      ]
+    },
+    "userExperienceAnalyticsMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "unit",
+        "value"
+      ]
+    },
+    "userExperienceAnalyticsMetricHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceId",
+        "metricDateTime",
+        "metricType"
+      ]
+    },
+    "userExperienceAnalyticsModelScores": {
+      "navigationProperties": [],
+      "properties": [
+        "appReliabilityScore",
+        "batteryHealthScore",
+        "endpointAnalyticsScore",
+        "healthStatus",
+        "manufacturer",
+        "model",
+        "modelDeviceCount",
+        "startupPerformanceScore",
+        "workFromAnywhereScore"
+      ]
+    },
+    "userExperienceAnalyticsOverview": {
+      "navigationProperties": [],
+      "properties": [
+        "insights"
+      ]
+    },
+    "userExperienceAnalyticsScoreHistory": {
+      "navigationProperties": [],
+      "properties": [
+        "startupDateTime"
+      ]
+    },
+    "userExperienceAnalyticsWorkFromAnywhereDevice": {
+      "navigationProperties": [],
+      "properties": [
+        "autoPilotProfileAssigned",
+        "autoPilotRegistered",
+        "azureAdDeviceId",
+        "azureAdJoinType",
+        "azureAdRegistered",
+        "cloudIdentityScore",
+        "cloudManagementScore",
+        "cloudProvisioningScore",
+        "compliancePolicySetToIntune",
+        "deviceId",
+        "deviceName",
+        "healthStatus",
+        "isCloudManagedGatewayEnabled",
+        "managedBy",
+        "manufacturer",
+        "model",
+        "osCheckFailed",
+        "osDescription",
+        "osVersion",
+        "otherWorkloadsSetToIntune",
+        "ownership",
+        "processor64BitCheckFailed",
+        "processorCoreCountCheckFailed",
+        "processorFamilyCheckFailed",
+        "processorSpeedCheckFailed",
+        "ramCheckFailed",
+        "secureBootCheckFailed",
+        "serialNumber",
+        "storageCheckFailed",
+        "tenantAttached",
+        "tpmCheckFailed",
+        "upgradeEligibility",
+        "windowsScore",
+        "workFromAnywhereScore"
+      ]
+    },
+    "userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric": {
+      "navigationProperties": [],
+      "properties": [
+        "osCheckFailedPercentage",
+        "processor64BitCheckFailedPercentage",
+        "processorCoreCountCheckFailedPercentage",
+        "processorFamilyCheckFailedPercentage",
+        "processorSpeedCheckFailedPercentage",
+        "ramCheckFailedPercentage",
+        "secureBootCheckFailedPercentage",
+        "storageCheckFailedPercentage",
+        "totalDeviceCount",
+        "tpmCheckFailedPercentage",
+        "upgradeEligibleDeviceCount"
+      ]
+    },
+    "userExperienceAnalyticsWorkFromAnywhereMetric": {
+      "navigationProperties": [
+        "metricDevices"
+      ],
+      "properties": []
+    },
+    "userExperienceAnalyticsWorkFromAnywhereModelPerformance": {
+      "navigationProperties": [],
+      "properties": [
+        "cloudIdentityScore",
+        "cloudManagementScore",
+        "cloudProvisioningScore",
+        "healthStatus",
+        "manufacturer",
+        "model",
+        "modelDeviceCount",
+        "windowsScore",
+        "workFromAnywhereScore"
+      ]
+    },
+    "userFlowLanguageConfiguration": {
+      "navigationProperties": [
+        "defaultPages",
+        "overridesPages"
+      ],
+      "properties": [
+        "displayName",
+        "isEnabled"
+      ]
+    },
+    "userFlowLanguagePage": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "userInsightsSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled"
+      ]
+    },
+    "userInstallStateSummary": {
+      "navigationProperties": [
+        "deviceStates"
+      ],
+      "properties": [
+        "failedDeviceCount",
+        "installedDeviceCount",
+        "notInstalledDeviceCount",
+        "userName"
+      ]
+    },
+    "userProtectionScopeContainer": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "userRegistrationDetails": {
+      "navigationProperties": [],
+      "properties": [
+        "isAdmin",
+        "isMfaCapable",
+        "isMfaRegistered",
+        "isPasswordlessCapable",
+        "isSsprCapable",
+        "isSsprEnabled",
+        "isSsprRegistered",
+        "isSystemPreferredAuthenticationMethodEnabled",
+        "lastUpdatedDateTime",
+        "methodsRegistered",
+        "systemPreferredAuthenticationMethods",
+        "userDisplayName",
+        "userPreferredMethodForSecondaryAuthentication",
+        "userPrincipalName",
+        "userType"
+      ]
+    },
+    "userScopeTeamsAppInstallation": {
+      "navigationProperties": [
+        "chat"
+      ],
+      "properties": []
+    },
+    "userSettings": {
+      "navigationProperties": [
+        "exchange",
+        "itemInsights",
+        "shiftPreferences",
+        "storage",
+        "windows",
+        "workHoursAndLocations"
+      ],
+      "properties": [
+        "contributionToContentDiscoveryAsOrganizationDisabled",
+        "contributionToContentDiscoveryDisabled"
+      ]
+    },
+    "userSignInInsight": {
+      "navigationProperties": [],
+      "properties": [
+        "lastSignInDateTime"
+      ]
+    },
+    "userSolutionRoot": {
+      "navigationProperties": [
+        "workingTimeSchedule"
+      ],
+      "properties": []
+    },
+    "userStorage": {
+      "navigationProperties": [
+        "quota"
+      ],
+      "properties": []
+    },
+    "userTeamwork": {
+      "navigationProperties": [
+        "associatedTeams",
+        "installedApps"
+      ],
+      "properties": [
+        "locale",
+        "region"
+      ]
+    },
+    "verticalSection": {
+      "navigationProperties": [
+        "webparts"
+      ],
+      "properties": [
+        "emphasis"
+      ]
+    },
+    "virtualEndpoint": {
+      "navigationProperties": [
+        "auditEvents",
+        "cloudPCs",
+        "deviceImages",
+        "galleryImages",
+        "onPremisesConnections",
+        "provisioningPolicies",
+        "report",
+        "userSettings"
+      ],
+      "properties": []
+    },
+    "virtualEvent": {
+      "navigationProperties": [
+        "presenters",
+        "sessions"
+      ],
+      "properties": [
+        "createdBy",
+        "description",
+        "displayName",
+        "endDateTime",
+        "externalEventInformation",
+        "settings",
+        "startDateTime",
+        "status"
+      ]
+    },
+    "virtualEventPresenter": {
+      "navigationProperties": [],
+      "properties": [
+        "email",
+        "identity",
+        "presenterDetails"
+      ]
+    },
+    "virtualEventRegistration": {
+      "navigationProperties": [
+        "sessions"
+      ],
+      "properties": [
+        "cancelationDateTime",
+        "email",
+        "externalRegistrationInformation",
+        "firstName",
+        "lastName",
+        "preferredLanguage",
+        "preferredTimezone",
+        "registrationDateTime",
+        "registrationQuestionAnswers",
+        "status",
+        "userId"
+      ]
+    },
+    "virtualEventRegistrationConfiguration": {
+      "navigationProperties": [
+        "questions"
+      ],
+      "properties": [
+        "capacity",
+        "registrationWebUrl"
+      ]
+    },
+    "virtualEventRegistrationCustomQuestion": {
+      "navigationProperties": [],
+      "properties": [
+        "answerChoices",
+        "answerInputType"
+      ]
+    },
+    "virtualEventRegistrationPredefinedQuestion": {
+      "navigationProperties": [],
+      "properties": [
+        "label"
+      ]
+    },
+    "virtualEventRegistrationQuestionBase": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "isRequired"
+      ]
+    },
+    "virtualEventSession": {
+      "navigationProperties": [],
+      "properties": [
+        "endDateTime",
+        "startDateTime",
+        "videoOnDemandWebUrl"
+      ]
+    },
+    "virtualEventsRoot": {
+      "navigationProperties": [
+        "events",
+        "townhalls",
+        "webinars"
+      ],
+      "properties": []
+    },
+    "virtualEventTownhall": {
+      "navigationProperties": [],
+      "properties": [
+        "audience",
+        "coOrganizers",
+        "invitedAttendees",
+        "isInviteOnly"
+      ]
+    },
+    "virtualEventWebinar": {
+      "navigationProperties": [
+        "registrationConfiguration",
+        "registrations"
+      ],
+      "properties": [
+        "audience",
+        "coOrganizers"
+      ]
+    },
+    "virtualEventWebinarRegistrationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isManualApprovalEnabled",
+        "isWaitlistEnabled"
+      ]
+    },
+    "voiceAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": [
+        "isOfficePhoneAllowed"
+      ]
+    },
+    "vppToken": {
+      "navigationProperties": [],
+      "properties": [
+        "appleId",
+        "automaticallyUpdateApps",
+        "countryOrRegion",
+        "expirationDateTime",
+        "lastModifiedDateTime",
+        "lastSyncDateTime",
+        "lastSyncStatus",
+        "organizationName",
+        "state",
+        "token",
+        "vppTokenAccountType"
+      ]
+    },
+    "webApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appUrl",
+        "useManagedBrowser"
+      ]
+    },
+    "webApplicationFirewallProvider": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName"
+      ]
+    },
+    "webApplicationFirewallVerificationModel": {
+      "navigationProperties": [
+        "provider"
+      ],
+      "properties": [
+        "providerType",
+        "verificationResult",
+        "verifiedDetails",
+        "verifiedHost"
+      ]
+    },
+    "webPart": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "whatIfAnalysisResult": {
+      "navigationProperties": [],
+      "properties": [
+        "analysisReasons",
+        "policyApplies"
+      ]
+    },
+    "win32LobApp": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedArchitectures",
+        "applicableArchitectures",
+        "installCommandLine",
+        "installExperience",
+        "minimumCpuSpeedInMHz",
+        "minimumFreeDiskSpaceInMB",
+        "minimumMemoryInMB",
+        "minimumNumberOfProcessors",
+        "minimumSupportedWindowsRelease",
+        "msiInformation",
+        "returnCodes",
+        "rules",
+        "setupFilePath",
+        "uninstallCommandLine"
+      ]
+    },
+    "windows10CompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "bitLockerEnabled",
+        "codeIntegrityEnabled",
+        "earlyLaunchAntiMalwareDriverEnabled",
+        "mobileOsMaximumVersion",
+        "mobileOsMinimumVersion",
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredToUnlockFromIdle",
+        "passwordRequiredType",
+        "requireHealthyDeviceReport",
+        "secureBootEnabled",
+        "storageRequireEncryption"
+      ]
+    },
+    "windows10CustomConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "omaSettings"
+      ]
+    },
+    "windows10EndpointProtectionConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationGuardAllowPersistence",
+        "applicationGuardAllowPrintToLocalPrinters",
+        "applicationGuardAllowPrintToNetworkPrinters",
+        "applicationGuardAllowPrintToPDF",
+        "applicationGuardAllowPrintToXPS",
+        "applicationGuardBlockClipboardSharing",
+        "applicationGuardBlockFileTransfer",
+        "applicationGuardBlockNonEnterpriseContent",
+        "applicationGuardEnabled",
+        "applicationGuardForceAuditing",
+        "appLockerApplicationControl",
+        "bitLockerDisableWarningForOtherDiskEncryption",
+        "bitLockerEnableStorageCardEncryptionOnMobile",
+        "bitLockerEncryptDevice",
+        "bitLockerRemovableDrivePolicy",
+        "defenderAdditionalGuardedFolders",
+        "defenderAttackSurfaceReductionExcludedPaths",
+        "defenderExploitProtectionXml",
+        "defenderExploitProtectionXmlFileName",
+        "defenderGuardedFoldersAllowedAppPaths",
+        "defenderSecurityCenterBlockExploitProtectionOverride",
+        "firewallBlockStatefulFTP",
+        "firewallCertificateRevocationListCheckMethod",
+        "firewallIdleTimeoutForSecurityAssociationInSeconds",
+        "firewallIPSecExemptionsAllowDHCP",
+        "firewallIPSecExemptionsAllowICMP",
+        "firewallIPSecExemptionsAllowNeighborDiscovery",
+        "firewallIPSecExemptionsAllowRouterDiscovery",
+        "firewallMergeKeyingModuleSettings",
+        "firewallPacketQueueingMethod",
+        "firewallPreSharedKeyEncodingMethod",
+        "firewallProfileDomain",
+        "firewallProfilePrivate",
+        "firewallProfilePublic",
+        "smartScreenBlockOverrideForFiles",
+        "smartScreenEnableInShell"
+      ]
+    },
+    "windows10EnrollmentCompletionPageConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowNonBlockingAppInstallation"
+      ]
+    },
+    "windows10EnterpriseModernAppManagementConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "uninstallBuiltInApps"
+      ]
+    },
+    "windows10GeneralConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accountsBlockAddingNonMicrosoftAccountEmail",
+        "antiTheftModeBlocked",
+        "appsAllowTrustedAppsSideloading",
+        "appsBlockWindowsStoreOriginatedApps",
+        "bluetoothAllowedServices",
+        "bluetoothBlockAdvertising",
+        "bluetoothBlockDiscoverableMode",
+        "bluetoothBlocked",
+        "bluetoothBlockPrePairing",
+        "cameraBlocked",
+        "cellularBlockDataWhenRoaming",
+        "cellularBlockVpn",
+        "cellularBlockVpnWhenRoaming",
+        "certificatesBlockManualRootCertificateInstallation",
+        "connectedDevicesServiceBlocked",
+        "copyPasteBlocked",
+        "cortanaBlocked",
+        "defenderBlockEndUserAccess",
+        "defenderCloudBlockLevel",
+        "defenderDaysBeforeDeletingQuarantinedMalware",
+        "defenderDetectedMalwareActions",
+        "defenderFileExtensionsToExclude",
+        "defenderFilesAndFoldersToExclude",
+        "defenderMonitorFileActivity",
+        "defenderProcessesToExclude",
+        "defenderPromptForSampleSubmission",
+        "defenderRequireBehaviorMonitoring",
+        "defenderRequireCloudProtection",
+        "defenderRequireNetworkInspectionSystem",
+        "defenderRequireRealTimeMonitoring",
+        "defenderScanArchiveFiles",
+        "defenderScanDownloads",
+        "defenderScanIncomingMail",
+        "defenderScanMappedNetworkDrivesDuringFullScan",
+        "defenderScanMaxCpu",
+        "defenderScanNetworkFiles",
+        "defenderScanRemovableDrivesDuringFullScan",
+        "defenderScanScriptsLoadedInInternetExplorer",
+        "defenderScanType",
+        "defenderScheduledQuickScanTime",
+        "defenderScheduledScanTime",
+        "defenderSignatureUpdateIntervalInHours",
+        "defenderSystemScanSchedule",
+        "developerUnlockSetting",
+        "deviceManagementBlockFactoryResetOnMobile",
+        "deviceManagementBlockManualUnenroll",
+        "diagnosticsDataSubmissionMode",
+        "edgeAllowStartPagesModification",
+        "edgeBlockAccessToAboutFlags",
+        "edgeBlockAddressBarDropdown",
+        "edgeBlockAutofill",
+        "edgeBlockCompatibilityList",
+        "edgeBlockDeveloperTools",
+        "edgeBlocked",
+        "edgeBlockExtensions",
+        "edgeBlockInPrivateBrowsing",
+        "edgeBlockJavaScript",
+        "edgeBlockLiveTileDataCollection",
+        "edgeBlockPasswordManager",
+        "edgeBlockPopups",
+        "edgeBlockSearchSuggestions",
+        "edgeBlockSendingDoNotTrackHeader",
+        "edgeBlockSendingIntranetTrafficToInternetExplorer",
+        "edgeClearBrowsingDataOnExit",
+        "edgeCookiePolicy",
+        "edgeDisableFirstRunPage",
+        "edgeEnterpriseModeSiteListLocation",
+        "edgeFirstRunUrl",
+        "edgeHomepageUrls",
+        "edgeRequireSmartScreen",
+        "edgeSearchEngine",
+        "edgeSendIntranetTrafficToInternetExplorer",
+        "edgeSyncFavoritesWithInternetExplorer",
+        "enterpriseCloudPrintDiscoveryEndPoint",
+        "enterpriseCloudPrintDiscoveryMaxLimit",
+        "enterpriseCloudPrintMopriaDiscoveryResourceIdentifier",
+        "enterpriseCloudPrintOAuthAuthority",
+        "enterpriseCloudPrintOAuthClientIdentifier",
+        "enterpriseCloudPrintResourceIdentifier",
+        "experienceBlockDeviceDiscovery",
+        "experienceBlockErrorDialogWhenNoSIM",
+        "experienceBlockTaskSwitcher",
+        "gameDvrBlocked",
+        "internetSharingBlocked",
+        "locationServicesBlocked",
+        "lockScreenAllowTimeoutConfiguration",
+        "lockScreenBlockActionCenterNotifications",
+        "lockScreenBlockCortana",
+        "lockScreenBlockToastNotifications",
+        "lockScreenTimeoutInSeconds",
+        "logonBlockFastUserSwitching",
+        "microsoftAccountBlocked",
+        "microsoftAccountBlockSettingsSync",
+        "networkProxyApplySettingsDeviceWide",
+        "networkProxyAutomaticConfigurationUrl",
+        "networkProxyDisableAutoDetect",
+        "networkProxyServer",
+        "nfcBlocked",
+        "oneDriveDisableFileSync",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "passwordRequireWhenResumeFromIdleState",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "personalizationDesktopImageUrl",
+        "personalizationLockScreenImageUrl",
+        "privacyAdvertisingId",
+        "privacyAutoAcceptPairingAndConsentPrompts",
+        "privacyBlockInputPersonalization",
+        "resetProtectionModeBlocked",
+        "safeSearchFilter",
+        "screenCaptureBlocked",
+        "searchBlockDiacritics",
+        "searchDisableAutoLanguageDetection",
+        "searchDisableIndexerBackoff",
+        "searchDisableIndexingEncryptedItems",
+        "searchDisableIndexingRemovableDrive",
+        "searchEnableAutomaticIndexSizeManangement",
+        "searchEnableRemoteQueries",
+        "settingsBlockAccountsPage",
+        "settingsBlockAddProvisioningPackage",
+        "settingsBlockAppsPage",
+        "settingsBlockChangeLanguage",
+        "settingsBlockChangePowerSleep",
+        "settingsBlockChangeRegion",
+        "settingsBlockChangeSystemTime",
+        "settingsBlockDevicesPage",
+        "settingsBlockEaseOfAccessPage",
+        "settingsBlockEditDeviceName",
+        "settingsBlockGamingPage",
+        "settingsBlockNetworkInternetPage",
+        "settingsBlockPersonalizationPage",
+        "settingsBlockPrivacyPage",
+        "settingsBlockRemoveProvisioningPackage",
+        "settingsBlockSettingsApp",
+        "settingsBlockSystemPage",
+        "settingsBlockTimeLanguagePage",
+        "settingsBlockUpdateSecurityPage",
+        "sharedUserAppDataAllowed",
+        "smartScreenBlockPromptOverride",
+        "smartScreenBlockPromptOverrideForFiles",
+        "smartScreenEnableAppInstallControl",
+        "startBlockUnpinningAppsFromTaskbar",
+        "startMenuAppListVisibility",
+        "startMenuHideChangeAccountSettings",
+        "startMenuHideFrequentlyUsedApps",
+        "startMenuHideHibernate",
+        "startMenuHideLock",
+        "startMenuHidePowerButton",
+        "startMenuHideRecentJumpLists",
+        "startMenuHideRecentlyAddedApps",
+        "startMenuHideRestartOptions",
+        "startMenuHideShutDown",
+        "startMenuHideSignOut",
+        "startMenuHideSleep",
+        "startMenuHideSwitchAccount",
+        "startMenuHideUserTile",
+        "startMenuLayoutEdgeAssetsXml",
+        "startMenuLayoutXml",
+        "startMenuMode",
+        "startMenuPinnedFolderDocuments",
+        "startMenuPinnedFolderDownloads",
+        "startMenuPinnedFolderFileExplorer",
+        "startMenuPinnedFolderHomeGroup",
+        "startMenuPinnedFolderMusic",
+        "startMenuPinnedFolderNetwork",
+        "startMenuPinnedFolderPersonalFolder",
+        "startMenuPinnedFolderPictures",
+        "startMenuPinnedFolderSettings",
+        "startMenuPinnedFolderVideos",
+        "storageBlockRemovableStorage",
+        "storageRequireMobileDeviceEncryption",
+        "storageRestrictAppDataToSystemVolume",
+        "storageRestrictAppInstallToSystemVolume",
+        "tenantLockdownRequireNetworkDuringOutOfBoxExperience",
+        "usbBlocked",
+        "voiceRecordingBlocked",
+        "webRtcBlockLocalhostIpAddress",
+        "wiFiBlockAutomaticConnectHotspots",
+        "wiFiBlocked",
+        "wiFiBlockManualConfiguration",
+        "wiFiScanInterval",
+        "windowsSpotlightBlockConsumerSpecificFeatures",
+        "windowsSpotlightBlocked",
+        "windowsSpotlightBlockOnActionCenter",
+        "windowsSpotlightBlockTailoredExperiences",
+        "windowsSpotlightBlockThirdPartyNotifications",
+        "windowsSpotlightBlockWelcomeExperience",
+        "windowsSpotlightBlockWindowsTips",
+        "windowsSpotlightConfigureOnLockScreen",
+        "windowsStoreBlockAutoUpdate",
+        "windowsStoreBlocked",
+        "windowsStoreEnablePrivateStoreOnly",
+        "wirelessDisplayBlockProjectionToThisDevice",
+        "wirelessDisplayBlockUserInputFromReceiver",
+        "wirelessDisplayRequirePinForPairing"
+      ]
+    },
+    "windows10MobileCompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "bitLockerEnabled",
+        "codeIntegrityEnabled",
+        "earlyLaunchAntiMalwareDriverEnabled",
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "passwordRequireToUnlockFromIdle",
+        "secureBootEnabled",
+        "storageRequireEncryption"
+      ]
+    },
+    "windows10SecureAssessmentConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowPrinting",
+        "allowScreenCapture",
+        "allowTextSuggestion",
+        "configurationAccount",
+        "launchUri"
+      ]
+    },
+    "windows10TeamGeneralConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "azureOperationalInsightsBlockTelemetry",
+        "azureOperationalInsightsWorkspaceId",
+        "azureOperationalInsightsWorkspaceKey",
+        "connectAppBlockAutoLaunch",
+        "maintenanceWindowBlocked",
+        "maintenanceWindowDurationInHours",
+        "maintenanceWindowStartTime",
+        "miracastBlocked",
+        "miracastChannel",
+        "miracastRequirePin",
+        "settingsBlockMyMeetingsAndFiles",
+        "settingsBlockSessionResume",
+        "settingsBlockSigninSuggestions",
+        "settingsDefaultVolume",
+        "settingsScreenTimeoutInMinutes",
+        "settingsSessionTimeoutInMinutes",
+        "settingsSleepTimeoutInMinutes",
+        "welcomeScreenBackgroundImageUrl",
+        "welcomeScreenBlockAutomaticWakeUp",
+        "welcomeScreenMeetingInformation"
+      ]
+    },
+    "windows81CompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "storageRequireEncryption"
+      ]
+    },
+    "windows81GeneralConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "accountsBlockAddingNonMicrosoftAccountEmail",
+        "applyOnlyToWindows81",
+        "browserBlockAutofill",
+        "browserBlockAutomaticDetectionOfIntranetSites",
+        "browserBlockEnterpriseModeAccess",
+        "browserBlockJavaScript",
+        "browserBlockPlugins",
+        "browserBlockPopups",
+        "browserBlockSendingDoNotTrackHeader",
+        "browserBlockSingleWordEntryOnIntranetSites",
+        "browserEnterpriseModeSiteListLocation",
+        "browserInternetSecurityLevel",
+        "browserIntranetSecurityLevel",
+        "browserLoggingReportLocation",
+        "browserRequireFirewall",
+        "browserRequireFraudWarning",
+        "browserRequireHighSecurityForRestrictedSites",
+        "browserRequireSmartScreen",
+        "browserTrustedSitesSecurityLevel",
+        "cellularBlockDataRoaming",
+        "diagnosticsBlockDataSubmission",
+        "passwordBlockPicturePasswordAndPin",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequiredType",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "storageRequireDeviceEncryption",
+        "updatesRequireAutomaticUpdates",
+        "userAccountControlSettings",
+        "workFoldersUrl"
+      ]
+    },
+    "windowsAppX": {
+      "navigationProperties": [],
+      "properties": [
+        "applicableArchitectures",
+        "identityName",
+        "identityPublisherHash",
+        "identityResourceIdentifier",
+        "identityVersion",
+        "isBundle",
+        "minimumSupportedOperatingSystem"
+      ]
+    },
+    "windowsAutopilotDeploymentProfile": {
+      "navigationProperties": [
+        "assignedDevices"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "deviceNameTemplate",
+        "deviceType",
+        "displayName",
+        "hardwareHashExtractionEnabled",
+        "lastModifiedDateTime",
+        "locale",
+        "managementServiceAppId",
+        "outOfBoxExperienceSetting",
+        "preprovisioningAllowed",
+        "roleScopeTagIds"
+      ]
+    },
+    "windowsAutopilotDeploymentProfileAssignment": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "windowsAutopilotDeviceIdentity": {
+      "navigationProperties": [],
+      "properties": [
+        "addressableUserName",
+        "azureActiveDirectoryDeviceId",
+        "displayName",
+        "enrollmentState",
+        "groupTag",
+        "lastContactedDateTime",
+        "managedDeviceId",
+        "manufacturer",
+        "model",
+        "productKey",
+        "purchaseOrderIdentifier",
+        "resourceName",
+        "serialNumber",
+        "skuNumber",
+        "systemFamily",
+        "userPrincipalName"
+      ]
+    },
+    "windowsDefenderAdvancedThreatProtectionConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowSampleSharing",
+        "enableExpeditedTelemetryReporting"
+      ]
+    },
+    "windowsDeviceMalwareState": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformationUrl",
+        "category",
+        "detectionCount",
+        "displayName",
+        "executionState",
+        "initialDetectionDateTime",
+        "lastStateChangeDateTime",
+        "severity",
+        "state",
+        "threatState"
+      ]
+    },
+    "windowsHelloForBusinessAuthenticationMethod": {
+      "navigationProperties": [
+        "device"
+      ],
+      "properties": [
+        "displayName",
+        "keyStrength"
+      ]
+    },
+    "windowsInformationProtection": {
+      "navigationProperties": [
+        "assignments",
+        "exemptAppLockerFiles",
+        "protectedAppLockerFiles"
+      ],
+      "properties": [
+        "azureRightsManagementServicesAllowed",
+        "dataRecoveryCertificate",
+        "enforcementLevel",
+        "enterpriseDomain",
+        "enterpriseInternalProxyServers",
+        "enterpriseIPRanges",
+        "enterpriseIPRangesAreAuthoritative",
+        "enterpriseNetworkDomainNames",
+        "enterpriseProtectedDomainNames",
+        "enterpriseProxiedDomains",
+        "enterpriseProxyServers",
+        "enterpriseProxyServersAreAuthoritative",
+        "exemptApps",
+        "iconsVisible",
+        "indexingEncryptedStoresOrItemsBlocked",
+        "isAssigned",
+        "neutralDomainResources",
+        "protectedApps",
+        "protectionUnderLockConfigRequired",
+        "revokeOnUnenrollDisabled",
+        "rightsManagementServicesTemplateId",
+        "smbAutoEncryptedFileExtensions"
+      ]
+    },
+    "windowsInformationProtectionAppLearningSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "applicationName",
+        "applicationType",
+        "deviceCount"
+      ]
+    },
+    "windowsInformationProtectionAppLockerFile": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "file",
+        "fileHash",
+        "version"
+      ]
+    },
+    "windowsInformationProtectionNetworkLearningSummary": {
+      "navigationProperties": [],
+      "properties": [
+        "deviceCount",
+        "url"
+      ]
+    },
+    "windowsInformationProtectionPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "daysWithoutContactBeforeUnenroll",
+        "mdmEnrollmentUrl",
+        "minutesOfInactivityBeforeDeviceLock",
+        "numberOfPastPinsRemembered",
+        "passwordMaximumAttemptCount",
+        "pinExpirationDays",
+        "pinLowercaseLetters",
+        "pinMinimumLength",
+        "pinSpecialCharacters",
+        "pinUppercaseLetters",
+        "revokeOnMdmHandoffDisabled",
+        "windowsHelloForBusinessBlocked"
+      ]
+    },
+    "windowsMalwareInformation": {
+      "navigationProperties": [
+        "deviceMalwareStates"
+      ],
+      "properties": [
+        "additionalInformationUrl",
+        "category",
+        "displayName",
+        "lastDetectionDateTime",
+        "severity"
+      ]
+    },
+    "windowsMicrosoftEdgeApp": {
+      "navigationProperties": [],
+      "properties": [
+        "channel",
+        "displayLanguageLocale"
+      ]
+    },
+    "windowsMobileMSI": {
+      "navigationProperties": [],
+      "properties": [
+        "commandLine",
+        "ignoreVersionDetection",
+        "productCode",
+        "productVersion"
+      ]
+    },
+    "windowsPhone81CompliancePolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "osMaximumVersion",
+        "osMinimumVersion",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeLock",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "storageRequireEncryption"
+      ]
+    },
+    "windowsPhone81CustomConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "omaSettings"
+      ]
+    },
+    "windowsPhone81GeneralConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "applyOnlyToWindowsPhone81",
+        "appsBlockCopyPaste",
+        "bluetoothBlocked",
+        "cameraBlocked",
+        "cellularBlockWifiTethering",
+        "compliantAppListType",
+        "compliantAppsList",
+        "diagnosticDataBlockSubmission",
+        "emailBlockAddingAccounts",
+        "locationServicesBlocked",
+        "microsoftAccountBlocked",
+        "nfcBlocked",
+        "passwordBlockSimple",
+        "passwordExpirationDays",
+        "passwordMinimumCharacterSetCount",
+        "passwordMinimumLength",
+        "passwordMinutesOfInactivityBeforeScreenTimeout",
+        "passwordPreviousPasswordBlockCount",
+        "passwordRequired",
+        "passwordRequiredType",
+        "passwordSignInFailureCountBeforeFactoryReset",
+        "screenCaptureBlocked",
+        "storageBlockRemovableStorage",
+        "storageRequireEncryption",
+        "webBrowserBlocked",
+        "wifiBlockAutomaticConnectHotspots",
+        "wifiBlocked",
+        "wifiBlockHotspotReporting",
+        "windowsStoreBlocked"
+      ]
+    },
+    "windowsProtectionState": {
+      "navigationProperties": [
+        "detectedMalwareState"
+      ],
+      "properties": [
+        "antiMalwareVersion",
+        "controlledConfigurationEnabled",
+        "deviceState",
+        "engineVersion",
+        "fullScanOverdue",
+        "fullScanRequired",
+        "isVirtualMachine",
+        "lastFullScanDateTime",
+        "lastFullScanSignatureVersion",
+        "lastQuickScanDateTime",
+        "lastQuickScanSignatureVersion",
+        "lastReportedDateTime",
+        "malwareProtectionEnabled",
+        "networkInspectionSystemEnabled",
+        "productStatus",
+        "quickScanOverdue",
+        "realTimeProtectionEnabled",
+        "rebootRequired",
+        "signatureUpdateOverdue",
+        "signatureVersion",
+        "tamperProtectionEnabled"
+      ]
+    },
+    "windowsSetting": {
+      "navigationProperties": [
+        "instances"
+      ],
+      "properties": [
+        "payloadType",
+        "settingType",
+        "windowsDeviceId"
+      ]
+    },
+    "windowsSettingInstance": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "expirationDateTime",
+        "lastModifiedDateTime",
+        "payload"
+      ]
+    },
+    "windowsUniversalAppX": {
+      "navigationProperties": [
+        "committedContainedApps"
+      ],
+      "properties": [
+        "applicableArchitectures",
+        "applicableDeviceTypes",
+        "identityName",
+        "identityPublisherHash",
+        "identityResourceIdentifier",
+        "identityVersion",
+        "isBundle",
+        "minimumSupportedOperatingSystem"
+      ]
+    },
+    "windowsUniversalAppXContainedApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appUserModelId"
+      ]
+    },
+    "windowsUpdateForBusinessConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowWindows11Upgrade",
+        "automaticUpdateMode",
+        "autoRestartNotificationDismissal",
+        "businessReadyUpdatesOnly",
+        "deadlineForFeatureUpdatesInDays",
+        "deadlineForQualityUpdatesInDays",
+        "deadlineGracePeriodInDays",
+        "deliveryOptimizationMode",
+        "driversExcluded",
+        "engagedRestartDeadlineInDays",
+        "engagedRestartSnoozeScheduleInDays",
+        "engagedRestartTransitionScheduleInDays",
+        "featureUpdatesDeferralPeriodInDays",
+        "featureUpdatesPaused",
+        "featureUpdatesPauseExpiryDateTime",
+        "featureUpdatesPauseStartDate",
+        "featureUpdatesRollbackStartDateTime",
+        "featureUpdatesRollbackWindowInDays",
+        "featureUpdatesWillBeRolledBack",
+        "installationSchedule",
+        "microsoftUpdateServiceAllowed",
+        "postponeRebootUntilAfterDeadline",
+        "prereleaseFeatures",
+        "qualityUpdatesDeferralPeriodInDays",
+        "qualityUpdatesPaused",
+        "qualityUpdatesPauseExpiryDateTime",
+        "qualityUpdatesPauseStartDate",
+        "qualityUpdatesRollbackStartDateTime",
+        "qualityUpdatesWillBeRolledBack",
+        "scheduleImminentRestartWarningInMinutes",
+        "scheduleRestartWarningInHours",
+        "skipChecksBeforeRestart",
+        "updateNotificationLevel",
+        "updateWeeks",
+        "userPauseAccess",
+        "userWindowsUpdateScanAccess"
+      ]
+    },
+    "windowsWebApp": {
+      "navigationProperties": [],
+      "properties": [
+        "appUrl"
+      ]
+    },
+    "workbook": {
+      "navigationProperties": [
+        "application",
+        "comments",
+        "functions",
+        "names",
+        "operations",
+        "tables",
+        "worksheets"
+      ],
+      "properties": []
+    },
+    "workbookApplication": {
+      "navigationProperties": [],
+      "properties": [
+        "calculationMode"
+      ]
+    },
+    "workbookChart": {
+      "navigationProperties": [
+        "axes",
+        "dataLabels",
+        "format",
+        "legend",
+        "series",
+        "title",
+        "worksheet"
+      ],
+      "properties": [
+        "height",
+        "left",
+        "name",
+        "top",
+        "width"
+      ]
+    },
+    "workbookChartAreaFormat": {
+      "navigationProperties": [
+        "fill",
+        "font"
+      ],
+      "properties": []
+    },
+    "workbookChartAxes": {
+      "navigationProperties": [
+        "categoryAxis",
+        "seriesAxis",
+        "valueAxis"
+      ],
+      "properties": []
+    },
+    "workbookChartAxis": {
+      "navigationProperties": [
+        "format",
+        "majorGridlines",
+        "minorGridlines",
+        "title"
+      ],
+      "properties": [
+        "majorUnit",
+        "maximum",
+        "minimum",
+        "minorUnit"
+      ]
+    },
+    "workbookChartAxisFormat": {
+      "navigationProperties": [
+        "font",
+        "line"
+      ],
+      "properties": []
+    },
+    "workbookChartAxisTitle": {
+      "navigationProperties": [
+        "format"
+      ],
+      "properties": [
+        "text",
+        "visible"
+      ]
+    },
+    "workbookChartAxisTitleFormat": {
+      "navigationProperties": [
+        "font"
+      ],
+      "properties": []
+    },
+    "workbookChartDataLabelFormat": {
+      "navigationProperties": [
+        "fill",
+        "font"
+      ],
+      "properties": []
+    },
+    "workbookChartDataLabels": {
+      "navigationProperties": [
+        "format"
+      ],
+      "properties": [
+        "position",
+        "separator",
+        "showBubbleSize",
+        "showCategoryName",
+        "showLegendKey",
+        "showPercentage",
+        "showSeriesName",
+        "showValue"
+      ]
+    },
+    "workbookChartFill": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "workbookChartFont": {
+      "navigationProperties": [],
+      "properties": [
+        "bold",
+        "color",
+        "italic",
+        "name",
+        "size",
+        "underline"
+      ]
+    },
+    "workbookChartGridlines": {
+      "navigationProperties": [
+        "format"
+      ],
+      "properties": [
+        "visible"
+      ]
+    },
+    "workbookChartGridlinesFormat": {
+      "navigationProperties": [
+        "line"
+      ],
+      "properties": []
+    },
+    "workbookChartLegend": {
+      "navigationProperties": [
+        "format"
+      ],
+      "properties": [
+        "overlay",
+        "position",
+        "visible"
+      ]
+    },
+    "workbookChartLegendFormat": {
+      "navigationProperties": [
+        "fill",
+        "font"
+      ],
+      "properties": []
+    },
+    "workbookChartLineFormat": {
+      "navigationProperties": [],
+      "properties": [
+        "color"
+      ]
+    },
+    "workbookChartPoint": {
+      "navigationProperties": [
+        "format"
+      ],
+      "properties": [
+        "value"
+      ]
+    },
+    "workbookChartPointFormat": {
+      "navigationProperties": [
+        "fill"
+      ],
+      "properties": []
+    },
+    "workbookChartSeries": {
+      "navigationProperties": [
+        "format",
+        "points"
+      ],
+      "properties": [
+        "name"
+      ]
+    },
+    "workbookChartSeriesFormat": {
+      "navigationProperties": [
+        "fill",
+        "line"
+      ],
+      "properties": []
+    },
+    "workbookChartTitle": {
+      "navigationProperties": [
+        "format"
+      ],
+      "properties": [
+        "overlay",
+        "text",
+        "visible"
+      ]
+    },
+    "workbookChartTitleFormat": {
+      "navigationProperties": [
+        "fill",
+        "font"
+      ],
+      "properties": []
+    },
+    "workbookComment": {
+      "navigationProperties": [
+        "replies"
+      ],
+      "properties": [
+        "content",
+        "contentType"
+      ]
+    },
+    "workbookCommentReply": {
+      "navigationProperties": [],
+      "properties": [
+        "content",
+        "contentType"
+      ]
+    },
+    "workbookFilter": {
+      "navigationProperties": [],
+      "properties": [
+        "criteria"
+      ]
+    },
+    "workbookFormatProtection": {
+      "navigationProperties": [],
+      "properties": [
+        "formulaHidden",
+        "locked"
+      ]
+    },
+    "workbookFunctionResult": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "value"
+      ]
+    },
+    "workbookFunctions": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "workbookNamedItem": {
+      "navigationProperties": [
+        "worksheet"
+      ],
+      "properties": [
+        "comment",
+        "name",
+        "scope",
+        "type",
+        "value",
+        "visible"
+      ]
+    },
+    "workbookOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "resourceLocation",
+        "status"
+      ]
+    },
+    "workbookPivotTable": {
+      "navigationProperties": [
+        "worksheet"
+      ],
+      "properties": [
+        "name"
+      ]
+    },
+    "workbookRange": {
+      "navigationProperties": [
+        "format",
+        "sort",
+        "worksheet"
+      ],
+      "properties": [
+        "address",
+        "addressLocal",
+        "cellCount",
+        "columnCount",
+        "columnHidden",
+        "columnIndex",
+        "formulas",
+        "formulasLocal",
+        "formulasR1C1",
+        "hidden",
+        "numberFormat",
+        "rowCount",
+        "rowHidden",
+        "rowIndex",
+        "text",
+        "values",
+        "valueTypes"
+      ]
+    },
+    "workbookRangeBorder": {
+      "navigationProperties": [],
+      "properties": [
+        "color",
+        "sideIndex",
+        "style",
+        "weight"
+      ]
+    },
+    "workbookRangeFill": {
+      "navigationProperties": [],
+      "properties": [
+        "color"
+      ]
+    },
+    "workbookRangeFont": {
+      "navigationProperties": [],
+      "properties": [
+        "bold",
+        "color",
+        "italic",
+        "name",
+        "size",
+        "underline"
+      ]
+    },
+    "workbookRangeFormat": {
+      "navigationProperties": [
+        "borders",
+        "fill",
+        "font",
+        "protection"
+      ],
+      "properties": [
+        "columnWidth",
+        "horizontalAlignment",
+        "rowHeight",
+        "verticalAlignment",
+        "wrapText"
+      ]
+    },
+    "workbookRangeSort": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "workbookRangeView": {
+      "navigationProperties": [
+        "rows"
+      ],
+      "properties": [
+        "cellAddresses",
+        "columnCount",
+        "formulas",
+        "formulasLocal",
+        "formulasR1C1",
+        "index",
+        "numberFormat",
+        "rowCount",
+        "text",
+        "values",
+        "valueTypes"
+      ]
+    },
+    "workbookTable": {
+      "navigationProperties": [
+        "columns",
+        "rows",
+        "sort",
+        "worksheet"
+      ],
+      "properties": [
+        "highlightFirstColumn",
+        "highlightLastColumn",
+        "legacyId",
+        "name",
+        "showBandedColumns",
+        "showBandedRows",
+        "showFilterButton",
+        "showHeaders",
+        "showTotals",
+        "style"
+      ]
+    },
+    "workbookTableColumn": {
+      "navigationProperties": [
+        "filter"
+      ],
+      "properties": [
+        "index",
+        "name",
+        "values"
+      ]
+    },
+    "workbookTableRow": {
+      "navigationProperties": [],
+      "properties": [
+        "index",
+        "values"
+      ]
+    },
+    "workbookTableSort": {
+      "navigationProperties": [],
+      "properties": [
+        "fields",
+        "matchCase",
+        "method"
+      ]
+    },
+    "workbookWorksheet": {
+      "navigationProperties": [
+        "charts",
+        "names",
+        "pivotTables",
+        "protection",
+        "tables"
+      ],
+      "properties": [
+        "name",
+        "position",
+        "visibility"
+      ]
+    },
+    "workbookWorksheetProtection": {
+      "navigationProperties": [],
+      "properties": [
+        "options",
+        "protected"
+      ]
+    },
+    "workforceIntegration": {
+      "navigationProperties": [],
+      "properties": [
+        "apiVersion",
+        "displayName",
+        "eligibilityFilteringEnabledEntities",
+        "encryption",
+        "isActive",
+        "supportedEntities",
+        "url"
+      ]
+    },
+    "workHoursAndLocationsSetting": {
+      "navigationProperties": [
+        "occurrences",
+        "recurrences"
+      ],
+      "properties": [
+        "maxSharedWorkLocationDetails"
+      ]
+    },
+    "workingTimeSchedule": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "workPlanOccurrence": {
+      "navigationProperties": [],
+      "properties": [
+        "end",
+        "placeId",
+        "recurrenceId",
+        "start",
+        "timeOffDetails",
+        "workLocationType"
+      ]
+    },
+    "workPlanRecurrence": {
+      "navigationProperties": [],
+      "properties": [
+        "end",
+        "placeId",
+        "recurrence",
+        "start",
+        "workLocationType"
+      ]
+    },
+    "workspace": {
+      "navigationProperties": [],
+      "properties": [
+        "capacity",
+        "displayDeviceName",
+        "emailAddress",
+        "mode",
+        "nickname",
+        "placeId"
+      ]
+    },
+    "x509CertificateAuthenticationMethodConfiguration": {
+      "navigationProperties": [
+        "includeTargets"
+      ],
+      "properties": [
+        "authenticationModeConfiguration",
+        "certificateAuthorityScopes",
+        "certificateUserBindings",
+        "crlValidationConfiguration",
+        "issuerHintsConfiguration"
+      ]
+    },
+    "x509CertificateCombinationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "allowedIssuerSkis",
+        "allowedPolicyOIDs"
+      ]
+    }
+  },
+  "microsoft.graph.callRecords": {
+    "callRecord": {
+      "navigationProperties": [
+        "organizer_v2",
+        "participants_v2",
+        "sessions"
+      ],
+      "properties": [
+        "endDateTime",
+        "joinWebUrl",
+        "lastModifiedDateTime",
+        "modalities",
+        "organizer",
+        "participants",
+        "startDateTime",
+        "type",
+        "version"
+      ]
+    },
+    "organizer": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "participant": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "participantBase": {
+      "navigationProperties": [],
+      "properties": [
+        "administrativeUnitInfos",
+        "identity"
+      ]
+    },
+    "segment": {
+      "navigationProperties": [],
+      "properties": [
+        "callee",
+        "caller",
+        "endDateTime",
+        "failureInfo",
+        "media",
+        "startDateTime"
+      ]
+    },
+    "session": {
+      "navigationProperties": [
+        "segments"
+      ],
+      "properties": [
+        "callee",
+        "caller",
+        "endDateTime",
+        "failureInfo",
+        "isTest",
+        "modalities",
+        "startDateTime"
+      ]
+    }
+  },
+  "microsoft.graph.externalConnectors": {
+    "connectionOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "error",
+        "status"
+      ]
+    },
+    "external": {
+      "navigationProperties": [
+        "connections"
+      ],
+      "properties": []
+    },
+    "externalActivity": {
+      "navigationProperties": [
+        "performedBy"
+      ],
+      "properties": [
+        "startDateTime",
+        "type"
+      ]
+    },
+    "externalActivityResult": {
+      "navigationProperties": [],
+      "properties": [
+        "error"
+      ]
+    },
+    "externalConnection": {
+      "navigationProperties": [
+        "groups",
+        "items",
+        "operations",
+        "schema"
+      ],
+      "properties": [
+        "activitySettings",
+        "configuration",
+        "connectorId",
+        "contentCategory",
+        "description",
+        "name",
+        "searchSettings",
+        "state"
+      ]
+    },
+    "externalGroup": {
+      "navigationProperties": [
+        "members"
+      ],
+      "properties": [
+        "description",
+        "displayName"
+      ]
+    },
+    "externalItem": {
+      "navigationProperties": [
+        "activities"
+      ],
+      "properties": [
+        "acl",
+        "content",
+        "properties"
+      ]
+    },
+    "identity": {
+      "navigationProperties": [],
+      "properties": [
+        "type"
+      ]
+    },
+    "schema": {
+      "navigationProperties": [],
+      "properties": [
+        "baseType",
+        "properties"
+      ]
+    }
+  },
+  "microsoft.graph.identityGovernance": {
+    "customTaskExtension": {
+      "navigationProperties": [
+        "createdBy",
+        "lastModifiedBy"
+      ],
+      "properties": [
+        "callbackConfiguration",
+        "createdDateTime",
+        "lastModifiedDateTime"
+      ]
+    },
+    "insights": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "lifecycleManagementSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "emailSettings",
+        "workflowScheduleIntervalInHours"
+      ]
+    },
+    "lifecycleWorkflowsContainer": {
+      "navigationProperties": [
+        "customTaskExtensions",
+        "deletedItems",
+        "insights",
+        "settings",
+        "taskDefinitions",
+        "workflows",
+        "workflowTemplates"
+      ],
+      "properties": []
+    },
+    "run": {
+      "navigationProperties": [
+        "reprocessedRuns",
+        "taskProcessingResults",
+        "userProcessingResults"
+      ],
+      "properties": [
+        "activatedOnScope",
+        "completedDateTime",
+        "failedTasksCount",
+        "failedUsersCount",
+        "lastUpdatedDateTime",
+        "processingStatus",
+        "scheduledDateTime",
+        "startedDateTime",
+        "successfulUsersCount",
+        "totalTasksCount",
+        "totalUnprocessedTasksCount",
+        "totalUsersCount",
+        "workflowExecutionType"
+      ]
+    },
+    "task": {
+      "navigationProperties": [
+        "taskProcessingResults"
+      ],
+      "properties": [
+        "arguments",
+        "category",
+        "continueOnError",
+        "description",
+        "displayName",
+        "executionSequence",
+        "isEnabled",
+        "taskDefinitionId"
+      ]
+    },
+    "taskDefinition": {
+      "navigationProperties": [],
+      "properties": [
+        "category",
+        "continueOnError",
+        "description",
+        "displayName",
+        "parameters",
+        "version"
+      ]
+    },
+    "taskProcessingResult": {
+      "navigationProperties": [
+        "subject",
+        "task"
+      ],
+      "properties": [
+        "completedDateTime",
+        "createdDateTime",
+        "failureReason",
+        "processingStatus",
+        "startedDateTime"
+      ]
+    },
+    "taskReport": {
+      "navigationProperties": [
+        "task",
+        "taskDefinition",
+        "taskProcessingResults"
+      ],
+      "properties": [
+        "completedDateTime",
+        "failedUsersCount",
+        "lastUpdatedDateTime",
+        "processingStatus",
+        "runId",
+        "startedDateTime",
+        "successfulUsersCount",
+        "totalUsersCount",
+        "unprocessedUsersCount"
+      ]
+    },
+    "userProcessingResult": {
+      "navigationProperties": [
+        "reprocessedRuns",
+        "subject",
+        "taskProcessingResults"
+      ],
+      "properties": [
+        "completedDateTime",
+        "failedTasksCount",
+        "processingStatus",
+        "scheduledDateTime",
+        "startedDateTime",
+        "totalTasksCount",
+        "totalUnprocessedTasksCount",
+        "workflowExecutionType",
+        "workflowVersion"
+      ]
+    },
+    "workflow": {
+      "navigationProperties": [
+        "executionScope",
+        "runs",
+        "taskReports",
+        "userProcessingResults",
+        "versions"
+      ],
+      "properties": [
+        "deletedDateTime",
+        "id",
+        "nextScheduleRunDateTime",
+        "version"
+      ]
+    },
+    "workflowBase": {
+      "navigationProperties": [
+        "administrationScopeTargets",
+        "createdBy",
+        "lastModifiedBy",
+        "tasks"
+      ],
+      "properties": [
+        "category",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "executionConditions",
+        "isEnabled",
+        "isSchedulingEnabled",
+        "lastModifiedDateTime"
+      ]
+    },
+    "workflowTemplate": {
+      "navigationProperties": [
+        "tasks"
+      ],
+      "properties": [
+        "category",
+        "description",
+        "displayName",
+        "executionConditions"
+      ]
+    },
+    "workflowVersion": {
+      "navigationProperties": [],
+      "properties": [
+        "versionNumber"
+      ]
+    }
+  },
+  "microsoft.graph.partners.billing": {
+    "azureUsage": {
+      "navigationProperties": [
+        "billed",
+        "unbilled"
+      ],
+      "properties": []
+    },
+    "billedReconciliation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "billedUsage": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "billing": {
+      "navigationProperties": [
+        "manifests",
+        "operations",
+        "reconciliation",
+        "usage"
+      ],
+      "properties": []
+    },
+    "billingReconciliation": {
+      "navigationProperties": [
+        "billed",
+        "unbilled"
+      ],
+      "properties": []
+    },
+    "exportSuccessOperation": {
+      "navigationProperties": [
+        "resourceLocation"
+      ],
+      "properties": []
+    },
+    "failedOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "error"
+      ]
+    },
+    "manifest": {
+      "navigationProperties": [],
+      "properties": [
+        "blobCount",
+        "blobs",
+        "createdDateTime",
+        "dataFormat",
+        "eTag",
+        "partitionType",
+        "partnerTenantId",
+        "rootDirectory",
+        "sasToken",
+        "schemaVersion"
+      ]
+    },
+    "operation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "lastActionDateTime",
+        "status"
+      ]
+    },
+    "runningOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unbilledReconciliation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "unbilledUsage": {
+      "navigationProperties": [],
+      "properties": []
+    }
+  },
+  "microsoft.graph.search": {
+    "acronym": {
+      "navigationProperties": [],
+      "properties": [
+        "standsFor",
+        "state"
+      ]
+    },
+    "bookmark": {
+      "navigationProperties": [],
+      "properties": [
+        "availabilityEndDateTime",
+        "availabilityStartDateTime",
+        "categories",
+        "groupIds",
+        "isSuggested",
+        "keywords",
+        "languageTags",
+        "platforms",
+        "powerAppIds",
+        "state",
+        "targetedVariations"
+      ]
+    },
+    "qna": {
+      "navigationProperties": [],
+      "properties": [
+        "availabilityEndDateTime",
+        "availabilityStartDateTime",
+        "groupIds",
+        "isSuggested",
+        "keywords",
+        "languageTags",
+        "platforms",
+        "state",
+        "targetedVariations"
+      ]
+    },
+    "searchAnswer": {
+      "navigationProperties": [],
+      "properties": [
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "webUrl"
+      ]
+    }
+  },
+  "microsoft.graph.security": {
+    "alert": {
+      "navigationProperties": [],
+      "properties": [
+        "actorDisplayName",
+        "additionalData",
+        "alertPolicyId",
+        "alertWebUrl",
+        "assignedTo",
+        "category",
+        "classification",
+        "comments",
+        "createdDateTime",
+        "customDetails",
+        "description",
+        "detectionSource",
+        "detectorId",
+        "determination",
+        "evidence",
+        "firstActivityDateTime",
+        "incidentId",
+        "incidentWebUrl",
+        "investigationState",
+        "lastActivityDateTime",
+        "lastUpdateDateTime",
+        "mitreTechniques",
+        "productName",
+        "providerAlertId",
+        "recommendedActions",
+        "resolvedDateTime",
+        "serviceSource",
+        "severity",
+        "status",
+        "systemTags",
+        "tenantId",
+        "threatDisplayName",
+        "threatFamilyName",
+        "title"
+      ]
+    },
+    "article": {
+      "navigationProperties": [
+        "indicators"
+      ],
+      "properties": [
+        "body",
+        "createdDateTime",
+        "imageUrl",
+        "isFeatured",
+        "lastUpdatedDateTime",
+        "summary",
+        "tags",
+        "title"
+      ]
+    },
+    "articleIndicator": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "artifact": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "authorityTemplate": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "autoAuditingConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "isAutomatic"
+      ]
+    },
+    "case": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "status"
+      ]
+    },
+    "caseOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "action",
+        "completedDateTime",
+        "createdBy",
+        "createdDateTime",
+        "percentProgress",
+        "resultInfo",
+        "status"
+      ]
+    },
+    "casesRoot": {
+      "navigationProperties": [
+        "ediscoveryCases"
+      ],
+      "properties": []
+    },
+    "categoryTemplate": {
+      "navigationProperties": [
+        "subcategories"
+      ],
+      "properties": []
+    },
+    "citationTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "citationJurisdiction",
+        "citationUrl"
+      ]
+    },
+    "dataSet": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName"
+      ]
+    },
+    "dataSource": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName",
+        "holdStatus"
+      ]
+    },
+    "dataSourceContainer": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "displayName",
+        "holdStatus",
+        "lastModifiedDateTime",
+        "releasedDateTime",
+        "status"
+      ]
+    },
+    "departmentTemplate": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "dispositionReviewStage": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "reviewersEmailAddresses",
+        "stageNumber"
+      ]
+    },
+    "ediscoveryAddToReviewSetOperation": {
+      "navigationProperties": [
+        "reviewSet",
+        "search"
+      ],
+      "properties": [
+        "additionalDataOptions",
+        "cloudAttachmentVersion",
+        "documentVersion",
+        "itemsToInclude",
+        "reportFileMetadata"
+      ]
+    },
+    "ediscoveryCase": {
+      "navigationProperties": [
+        "caseMembers",
+        "custodians",
+        "noncustodialDataSources",
+        "operations",
+        "reviewSets",
+        "searches",
+        "settings",
+        "tags"
+      ],
+      "properties": [
+        "closedBy",
+        "closedDateTime",
+        "externalId"
+      ]
+    },
+    "ediscoveryCaseMember": {
+      "navigationProperties": [],
+      "properties": [
+        "displayName",
+        "recipientType",
+        "smtpAddress"
+      ]
+    },
+    "ediscoveryCaseSettings": {
+      "navigationProperties": [],
+      "properties": [
+        "caseType",
+        "ocr",
+        "redundancyDetection",
+        "reviewSetSettings",
+        "topicModeling"
+      ]
+    },
+    "ediscoveryCustodian": {
+      "navigationProperties": [
+        "lastIndexOperation",
+        "siteSources",
+        "unifiedGroupSources",
+        "userSources"
+      ],
+      "properties": [
+        "acknowledgedDateTime",
+        "email"
+      ]
+    },
+    "ediscoveryEstimateOperation": {
+      "navigationProperties": [
+        "search"
+      ],
+      "properties": [
+        "indexedItemCount",
+        "indexedItemsSize",
+        "mailboxCount",
+        "reportFileMetadata",
+        "siteCount",
+        "statisticsOptions",
+        "unindexedItemCount",
+        "unindexedItemsSize"
+      ]
+    },
+    "ediscoveryExportOperation": {
+      "navigationProperties": [
+        "reviewSet",
+        "reviewSetQuery"
+      ],
+      "properties": [
+        "description",
+        "exportFileMetadata",
+        "exportOptions",
+        "exportStructure",
+        "outputName"
+      ]
+    },
+    "ediscoveryHoldOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ediscoveryHoldPolicySyncOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "reportFileMetadata"
+      ]
+    },
+    "ediscoveryIndexOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ediscoveryNoncustodialDataSource": {
+      "navigationProperties": [
+        "dataSource",
+        "lastIndexOperation"
+      ],
+      "properties": []
+    },
+    "ediscoveryPurgeDataOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "reportFileMetadata"
+      ]
+    },
+    "ediscoveryReviewSet": {
+      "navigationProperties": [
+        "queries"
+      ],
+      "properties": []
+    },
+    "ediscoveryReviewSetQuery": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "ediscoveryReviewTag": {
+      "navigationProperties": [
+        "childTags",
+        "parent"
+      ],
+      "properties": [
+        "childSelectability"
+      ]
+    },
+    "ediscoverySearch": {
+      "navigationProperties": [
+        "additionalSources",
+        "addToReviewSetOperation",
+        "custodianSources",
+        "lastEstimateStatisticsOperation",
+        "noncustodialSources"
+      ],
+      "properties": [
+        "dataSourceScopes"
+      ]
+    },
+    "ediscoverySearchExportOperation": {
+      "navigationProperties": [
+        "search"
+      ],
+      "properties": [
+        "additionalOptions",
+        "cloudAttachmentVersion",
+        "description",
+        "displayName",
+        "documentVersion",
+        "exportCriteria",
+        "exportFileMetadata",
+        "exportFormat",
+        "exportLocation",
+        "exportSingleItems"
+      ]
+    },
+    "ediscoveryTagOperation": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "filePlanDescriptor": {
+      "navigationProperties": [
+        "authorityTemplate",
+        "categoryTemplate",
+        "citationTemplate",
+        "departmentTemplate",
+        "filePlanReferenceTemplate"
+      ],
+      "properties": [
+        "authority",
+        "category",
+        "citation",
+        "department",
+        "filePlanReference"
+      ]
+    },
+    "filePlanDescriptorTemplate": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "displayName"
+      ]
+    },
+    "filePlanReferenceTemplate": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "healthIssue": {
+      "navigationProperties": [],
+      "properties": [
+        "additionalInformation",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "domainNames",
+        "healthIssueType",
+        "issueTypeId",
+        "lastModifiedDateTime",
+        "recommendations",
+        "recommendedActionCommands",
+        "sensorDNSNames",
+        "severity",
+        "status"
+      ]
+    },
+    "host": {
+      "navigationProperties": [
+        "childHostPairs",
+        "components",
+        "cookies",
+        "hostPairs",
+        "parentHostPairs",
+        "passiveDns",
+        "passiveDnsReverse",
+        "ports",
+        "reputation",
+        "sslCertificates",
+        "subdomains",
+        "trackers",
+        "whois"
+      ],
+      "properties": [
+        "firstSeenDateTime",
+        "lastSeenDateTime"
+      ]
+    },
+    "hostComponent": {
+      "navigationProperties": [
+        "host"
+      ],
+      "properties": [
+        "category",
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "name",
+        "version"
+      ]
+    },
+    "hostCookie": {
+      "navigationProperties": [
+        "host"
+      ],
+      "properties": [
+        "domain",
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "name"
+      ]
+    },
+    "hostname": {
+      "navigationProperties": [],
+      "properties": [
+        "registrant",
+        "registrar"
+      ]
+    },
+    "hostPair": {
+      "navigationProperties": [
+        "childHost",
+        "parentHost"
+      ],
+      "properties": [
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "linkKind"
+      ]
+    },
+    "hostPort": {
+      "navigationProperties": [
+        "host",
+        "mostRecentSslCertificate"
+      ],
+      "properties": [
+        "banners",
+        "firstSeenDateTime",
+        "lastScanDateTime",
+        "lastSeenDateTime",
+        "port",
+        "protocol",
+        "services",
+        "status",
+        "timesObserved"
+      ]
+    },
+    "hostReputation": {
+      "navigationProperties": [],
+      "properties": [
+        "classification",
+        "rules",
+        "score"
+      ]
+    },
+    "hostSslCertificate": {
+      "navigationProperties": [
+        "host",
+        "sslCertificate"
+      ],
+      "properties": [
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "ports"
+      ]
+    },
+    "hostTracker": {
+      "navigationProperties": [
+        "host"
+      ],
+      "properties": [
+        "firstSeenDateTime",
+        "kind",
+        "lastSeenDateTime",
+        "value"
+      ]
+    },
+    "identityAccounts": {
+      "navigationProperties": [],
+      "properties": [
+        "accounts",
+        "cloudSecurityIdentifier",
+        "displayName",
+        "domain",
+        "isEnabled",
+        "onPremisesSecurityIdentifier"
+      ]
+    },
+    "identityContainer": {
+      "navigationProperties": [
+        "healthIssues",
+        "identityAccounts",
+        "sensorCandidateActivationConfiguration",
+        "sensorCandidates",
+        "sensors",
+        "settings"
+      ],
+      "properties": []
+    },
+    "incident": {
+      "navigationProperties": [
+        "alerts"
+      ],
+      "properties": [
+        "assignedTo",
+        "classification",
+        "comments",
+        "createdDateTime",
+        "customTags",
+        "description",
+        "determination",
+        "displayName",
+        "incidentWebUrl",
+        "lastModifiedBy",
+        "lastUpdateDateTime",
+        "priorityScore",
+        "redirectIncidentId",
+        "resolvingComment",
+        "severity",
+        "status",
+        "summary",
+        "systemTags",
+        "tenantId"
+      ]
+    },
+    "indicator": {
+      "navigationProperties": [
+        "artifact"
+      ],
+      "properties": [
+        "source"
+      ]
+    },
+    "intelligenceProfile": {
+      "navigationProperties": [
+        "indicators"
+      ],
+      "properties": [
+        "aliases",
+        "countriesOrRegionsOfOrigin",
+        "description",
+        "firstActiveDateTime",
+        "kind",
+        "summary",
+        "targets",
+        "title",
+        "tradecraft"
+      ]
+    },
+    "intelligenceProfileIndicator": {
+      "navigationProperties": [],
+      "properties": [
+        "firstSeenDateTime",
+        "lastSeenDateTime"
+      ]
+    },
+    "ipAddress": {
+      "navigationProperties": [],
+      "properties": [
+        "autonomousSystem",
+        "countryOrRegion",
+        "hostingProvider",
+        "netblock"
+      ]
+    },
+    "labelsRoot": {
+      "navigationProperties": [
+        "authorities",
+        "categories",
+        "citations",
+        "departments",
+        "filePlanReferences",
+        "retentionLabels"
+      ],
+      "properties": []
+    },
+    "networkAdapter": {
+      "navigationProperties": [],
+      "properties": [
+        "isEnabled",
+        "name"
+      ]
+    },
+    "passiveDnsRecord": {
+      "navigationProperties": [
+        "artifact",
+        "parentHost"
+      ],
+      "properties": [
+        "collectedDateTime",
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "recordType"
+      ]
+    },
+    "retentionEvent": {
+      "navigationProperties": [
+        "retentionEventType"
+      ],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "eventPropagationResults",
+        "eventQueries",
+        "eventStatus",
+        "eventTriggerDateTime",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "lastStatusUpdateDateTime"
+      ]
+    },
+    "retentionEventType": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "retentionLabel": {
+      "navigationProperties": [
+        "descriptors",
+        "dispositionReviewStages",
+        "retentionEventType"
+      ],
+      "properties": [
+        "actionAfterRetentionPeriod",
+        "behaviorDuringRetentionPeriod",
+        "createdBy",
+        "createdDateTime",
+        "defaultRecordBehavior",
+        "descriptionForAdmins",
+        "descriptionForUsers",
+        "displayName",
+        "isInUse",
+        "labelToBeApplied",
+        "lastModifiedBy",
+        "lastModifiedDateTime",
+        "retentionDuration",
+        "retentionTrigger"
+      ]
+    },
+    "search": {
+      "navigationProperties": [],
+      "properties": [
+        "contentQuery",
+        "createdBy",
+        "createdDateTime",
+        "description",
+        "displayName",
+        "lastModifiedBy",
+        "lastModifiedDateTime"
+      ]
+    },
+    "sensor": {
+      "navigationProperties": [
+        "healthIssues"
+      ],
+      "properties": [
+        "createdDateTime",
+        "deploymentStatus",
+        "displayName",
+        "domainName",
+        "healthStatus",
+        "openHealthIssuesCount",
+        "sensorType",
+        "serviceStatus",
+        "settings",
+        "version"
+      ]
+    },
+    "sensorCandidate": {
+      "navigationProperties": [],
+      "properties": [
+        "computerDnsName",
+        "domainName",
+        "lastSeenDateTime",
+        "senseClientVersion"
+      ]
+    },
+    "sensorCandidateActivationConfiguration": {
+      "navigationProperties": [],
+      "properties": [
+        "activationMode"
+      ]
+    },
+    "settingsContainer": {
+      "navigationProperties": [
+        "autoAuditingConfiguration"
+      ],
+      "properties": []
+    },
+    "siteSource": {
+      "navigationProperties": [
+        "site"
+      ],
+      "properties": []
+    },
+    "sslCertificate": {
+      "navigationProperties": [
+        "relatedHosts"
+      ],
+      "properties": [
+        "expirationDateTime",
+        "fingerprint",
+        "firstSeenDateTime",
+        "issueDateTime",
+        "issuer",
+        "lastSeenDateTime",
+        "serialNumber",
+        "sha1",
+        "subject"
+      ]
+    },
+    "subcategoryTemplate": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "subdomain": {
+      "navigationProperties": [
+        "host"
+      ],
+      "properties": [
+        "firstSeenDateTime"
+      ]
+    },
+    "tag": {
+      "navigationProperties": [],
+      "properties": [
+        "createdBy",
+        "description",
+        "displayName",
+        "lastModifiedDateTime"
+      ]
+    },
+    "threatIntelligence": {
+      "navigationProperties": [
+        "articleIndicators",
+        "articles",
+        "hostComponents",
+        "hostCookies",
+        "hostPairs",
+        "hostPorts",
+        "hosts",
+        "hostSslCertificates",
+        "hostTrackers",
+        "intelligenceProfileIndicators",
+        "intelProfiles",
+        "passiveDnsRecords",
+        "sslCertificates",
+        "subdomains",
+        "vulnerabilities",
+        "whoisHistoryRecords",
+        "whoisRecords"
+      ],
+      "properties": []
+    },
+    "triggersRoot": {
+      "navigationProperties": [
+        "retentionEvents"
+      ],
+      "properties": []
+    },
+    "triggerTypesRoot": {
+      "navigationProperties": [
+        "retentionEventTypes"
+      ],
+      "properties": []
+    },
+    "unclassifiedArtifact": {
+      "navigationProperties": [],
+      "properties": [
+        "kind",
+        "value"
+      ]
+    },
+    "unifiedGroupSource": {
+      "navigationProperties": [
+        "group"
+      ],
+      "properties": [
+        "includedSources"
+      ]
+    },
+    "user": {
+      "navigationProperties": [],
+      "properties": [
+        "emailAddress",
+        "userPrincipalName"
+      ]
+    },
+    "userSource": {
+      "navigationProperties": [],
+      "properties": [
+        "email",
+        "includedSources",
+        "siteWebUrl"
+      ]
+    },
+    "vulnerability": {
+      "navigationProperties": [
+        "articles",
+        "components"
+      ],
+      "properties": [
+        "activeExploitsObserved",
+        "commonWeaknessEnumerationIds",
+        "createdDateTime",
+        "cvss2Summary",
+        "cvss3Summary",
+        "description",
+        "exploits",
+        "exploitsAvailable",
+        "hasChatter",
+        "lastModifiedDateTime",
+        "priorityScore",
+        "publishedDateTime",
+        "references",
+        "remediation",
+        "severity"
+      ]
+    },
+    "vulnerabilityComponent": {
+      "navigationProperties": [],
+      "properties": [
+        "name"
+      ]
+    },
+    "whoisBaseRecord": {
+      "navigationProperties": [
+        "host"
+      ],
+      "properties": [
+        "abuse",
+        "admin",
+        "billing",
+        "domainStatus",
+        "expirationDateTime",
+        "firstSeenDateTime",
+        "lastSeenDateTime",
+        "lastUpdateDateTime",
+        "nameservers",
+        "noc",
+        "rawWhoisText",
+        "registrant",
+        "registrar",
+        "registrationDateTime",
+        "technical",
+        "whoisServer",
+        "zone"
+      ]
+    },
+    "whoisHistoryRecord": {
+      "navigationProperties": [],
+      "properties": []
+    },
+    "whoisRecord": {
+      "navigationProperties": [
+        "history"
+      ],
+      "properties": []
+    }
+  },
+  "microsoft.graph.teamsAdministration": {
+    "numberAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "activationState",
+        "assignmentCategory",
+        "assignmentStatus",
+        "assignmentTargetId",
+        "capabilities",
+        "city",
+        "civicAddressId",
+        "isoCountryCode",
+        "locationId",
+        "networkSiteId",
+        "numberSource",
+        "numberType",
+        "operatorId",
+        "portInStatus",
+        "reverseNumberLookupOptions",
+        "supportedCustomerActions",
+        "telephoneNumber"
+      ]
+    },
+    "policyIdentifierDetail": {
+      "navigationProperties": [],
+      "properties": [
+        "name",
+        "policyId"
+      ]
+    },
+    "teamsAdminRoot": {
+      "navigationProperties": [
+        "policy",
+        "telephoneNumberManagement",
+        "userConfigurations"
+      ],
+      "properties": []
+    },
+    "teamsPolicyAssignment": {
+      "navigationProperties": [
+        "userAssignments"
+      ],
+      "properties": []
+    },
+    "teamsPolicyUserAssignment": {
+      "navigationProperties": [],
+      "properties": [
+        "policyId",
+        "policyType",
+        "userId"
+      ]
+    },
+    "teamsUserConfiguration": {
+      "navigationProperties": [
+        "user"
+      ],
+      "properties": [
+        "accountType",
+        "createdDateTime",
+        "effectivePolicyAssignments",
+        "featureTypes",
+        "isEnterpriseVoiceEnabled",
+        "modifiedDateTime",
+        "telephoneNumbers",
+        "tenantId",
+        "userPrincipalName"
+      ]
+    },
+    "telephoneNumberLongRunningOperation": {
+      "navigationProperties": [],
+      "properties": [
+        "createdDateTime",
+        "numbers",
+        "status"
+      ]
+    },
+    "telephoneNumberManagementRoot": {
+      "navigationProperties": [
+        "numberAssignments",
+        "operations"
+      ],
+      "properties": []
+    }
+  },
+  "microsoft.graph.termStore": {
+    "group": {
+      "navigationProperties": [
+        "sets"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "displayName",
+        "parentSiteId",
+        "scope"
+      ]
+    },
+    "relation": {
+      "navigationProperties": [
+        "fromTerm",
+        "set",
+        "toTerm"
+      ],
+      "properties": [
+        "relationship"
+      ]
+    },
+    "set": {
+      "navigationProperties": [
+        "children",
+        "parentGroup",
+        "relations",
+        "terms"
+      ],
+      "properties": [
+        "createdDateTime",
+        "description",
+        "localizedNames",
+        "properties"
+      ]
+    },
+    "store": {
+      "navigationProperties": [
+        "groups",
+        "sets"
+      ],
+      "properties": [
+        "defaultLanguageTag",
+        "languageTags"
+      ]
+    },
+    "term": {
+      "navigationProperties": [
+        "children",
+        "relations",
+        "set"
+      ],
+      "properties": [
+        "createdDateTime",
+        "descriptions",
+        "labels",
+        "lastModifiedDateTime",
+        "properties"
+      ]
+    }
+  }
+}

--- a/schemas/type-mappings/v1.0-entity-types.json
+++ b/schemas/type-mappings/v1.0-entity-types.json
@@ -561,6 +561,50 @@
         "hostPrefix"
       ]
     },
+    "alert": {
+      "navigationProperties": [],
+      "properties": [
+        "activityGroupName",
+        "alertDetections",
+        "assignedTo",
+        "azureSubscriptionId",
+        "azureTenantId",
+        "category",
+        "closedDateTime",
+        "cloudAppStates",
+        "comments",
+        "confidence",
+        "createdDateTime",
+        "description",
+        "detectionIds",
+        "eventDateTime",
+        "feedback",
+        "fileStates",
+        "historyStates",
+        "hostStates",
+        "incidentIds",
+        "investigationSecurityStates",
+        "lastEventDateTime",
+        "lastModifiedDateTime",
+        "malwareStates",
+        "messageSecurityStates",
+        "networkConnections",
+        "processes",
+        "recommendedActions",
+        "registryKeyStates",
+        "securityResources",
+        "severity",
+        "sourceMaterials",
+        "status",
+        "tags",
+        "title",
+        "triggers",
+        "uriClickSecurityStates",
+        "userStates",
+        "vendorInformation",
+        "vulnerabilityStates"
+      ]
+    },
     "allowedValue": {
       "navigationProperties": [],
       "properties": [
@@ -4255,7 +4299,8 @@
         "attestationLevel",
         "displayName",
         "model",
-        "passkeyType"
+        "passkeyType",
+        "publicKeyCredential"
       ]
     },
     "fido2AuthenticationMethodConfiguration": {
@@ -6667,6 +6712,18 @@
       ],
       "properties": []
     },
+    "ownerlessGroupPolicy": {
+      "navigationProperties": [],
+      "properties": [
+        "emailInfo",
+        "enabledGroupIds",
+        "isEnabled",
+        "maxMembersToNotify",
+        "notificationDurationInWeeks",
+        "policyWebUrl",
+        "targetOwners"
+      ]
+    },
     "participant": {
       "navigationProperties": [],
       "properties": [
@@ -7009,6 +7066,7 @@
         "featureRolloutPolicies",
         "homeRealmDiscoveryPolicies",
         "identitySecurityDefaultsEnforcementPolicy",
+        "ownerlessGroupPolicy",
         "permissionGrantPolicies",
         "roleManagementPolicies",
         "roleManagementPolicyAssignments",
@@ -8052,6 +8110,7 @@
     },
     "security": {
       "navigationProperties": [
+        "alerts",
         "alerts_v2",
         "attackSimulation",
         "cases",
@@ -12005,6 +12064,7 @@
         "completedDateTime",
         "createdDateTime",
         "failureReason",
+        "processingInfo",
         "processingStatus",
         "startedDateTime"
       ]
@@ -12234,6 +12294,7 @@
         "alertPolicyId",
         "alertWebUrl",
         "assignedTo",
+        "categories",
         "category",
         "classification",
         "comments",

--- a/schemas/type-mappings/v1.0-enum-types.json
+++ b/schemas/type-mappings/v1.0-enum-types.json
@@ -1,0 +1,7149 @@
+{
+  "microsoft.graph": {
+    "accessPackageAssignmentFilterByCurrentUserOptions": [
+      "createdBy",
+      "target",
+      "targetAgentIdentitySponsorOrOwner",
+      "targetManager",
+      "unknownFutureValue"
+    ],
+    "accessPackageAssignmentRequestFilterByCurrentUserOptions": [
+      "approver",
+      "createdBy",
+      "requestForOthers",
+      "target",
+      "targetAgentIdentitySponsorOrOwner",
+      "targetManager",
+      "targetOrRequestor",
+      "unknownFutureValue"
+    ],
+    "accessPackageAssignmentState": [
+      "delivered",
+      "delivering",
+      "deliveryFailed",
+      "expired",
+      "partiallyDelivered",
+      "unknownFutureValue"
+    ],
+    "accessPackageCatalogState": [
+      "published",
+      "unknownFutureValue",
+      "unpublished"
+    ],
+    "accessPackageCatalogType": [
+      "serviceDefault",
+      "serviceManaged",
+      "unknownFutureValue",
+      "userManaged"
+    ],
+    "accessPackageCustomExtensionStage": [
+      "assignmentFourteenDaysBeforeExpiration",
+      "assignmentOneDayBeforeExpiration",
+      "assignmentRequestApproved",
+      "assignmentRequestCreated",
+      "assignmentRequestGranted",
+      "assignmentRequestRemoved",
+      "unknownFutureValue"
+    ],
+    "accessPackageExternalUserLifecycleAction": [
+      "blockSignIn",
+      "blockSignInAndDelete",
+      "none",
+      "unknownFutureValue"
+    ],
+    "accessPackageFilterByCurrentUserOptions": [
+      "allowedRequestor",
+      "unknownFutureValue"
+    ],
+    "accessPackageRequestState": [
+      "canceled",
+      "delivered",
+      "delivering",
+      "deliveryFailed",
+      "denied",
+      "partiallyDelivered",
+      "pendingApproval",
+      "scheduled",
+      "submitted",
+      "unknownFutureValue"
+    ],
+    "accessPackageRequestType": [
+      "adminAdd",
+      "adminRemove",
+      "adminUpdate",
+      "approverRemove",
+      "notSpecified",
+      "onBehalfAdd",
+      "systemAdd",
+      "systemRemove",
+      "systemUpdate",
+      "unknownFutureValue",
+      "userAdd",
+      "userRemove",
+      "userUpdate"
+    ],
+    "accessPackageSubjectType": [
+      "notSpecified",
+      "servicePrincipal",
+      "unknownFutureValue",
+      "user"
+    ],
+    "accessReviewExpirationBehavior": [
+      "acceptAccessRecommendation",
+      "keepAccess",
+      "removeAccess",
+      "unknownFutureValue"
+    ],
+    "accessReviewHistoryDecisionFilter": [
+      "approve",
+      "deny",
+      "dontKnow",
+      "notNotified",
+      "notReviewed",
+      "unknownFutureValue"
+    ],
+    "accessReviewHistoryStatus": [
+      "done",
+      "error",
+      "inprogress",
+      "requested",
+      "unknownFutureValue"
+    ],
+    "accessReviewInstanceDecisionItemFilterByCurrentUserOptions": [
+      "reviewer",
+      "unknownFutureValue"
+    ],
+    "accessReviewInstanceFilterByCurrentUserOptions": [
+      "reviewer",
+      "unknownFutureValue"
+    ],
+    "accessReviewScheduleDefinitionFilterByCurrentUserOptions": [
+      "reviewer",
+      "unknownFutureValue"
+    ],
+    "accessReviewStageFilterByCurrentUserOptions": [
+      "reviewer",
+      "unknownFutureValue"
+    ],
+    "accountTargetContentType": [
+      "addressBook",
+      "includeAll",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "actionState": [
+      "active",
+      "canceled",
+      "done",
+      "failed",
+      "none",
+      "notSupported",
+      "pending"
+    ],
+    "activityDomain": [
+      "personal",
+      "unknown",
+      "unrestricted",
+      "work"
+    ],
+    "activityType": [
+      "servicePrincipal",
+      "signin",
+      "unknownFutureValue",
+      "user"
+    ],
+    "advancedConfigState": [
+      "default",
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "agreementAcceptanceState": [
+      "accepted",
+      "declined",
+      "unknownFutureValue"
+    ],
+    "aiInteractionType": [
+      "aiResponse",
+      "unknownFutureValue",
+      "userPrompt"
+    ],
+    "alertFeedback": [
+      "benignPositive",
+      "falsePositive",
+      "truePositive",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alertSeverity": [
+      "high",
+      "informational",
+      "low",
+      "medium",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alertStatus": [
+      "dismissed",
+      "inProgress",
+      "newAlert",
+      "resolved",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "allowedLobbyAdmitterRoles": [
+      "organizerAndCoOrganizers",
+      "organizerAndCoOrganizersAndPresenters",
+      "unknownFutureValue"
+    ],
+    "allowedTargetScope": [
+      "allConfiguredConnectedOrganizationUsers",
+      "allDirectoryAgentIdentities",
+      "allDirectoryServicePrincipals",
+      "allDirectoryUsers",
+      "allExternalUsers",
+      "allMemberUsers",
+      "notSpecified",
+      "specificConnectedOrganizationUsers",
+      "specificDirectoryServicePrincipals",
+      "specificDirectoryUsers",
+      "unknownFutureValue"
+    ],
+    "allowInvitesFrom": [
+      "adminsAndGuestInviters",
+      "adminsGuestInvitersAndAllMembers",
+      "everyone",
+      "none",
+      "unknownFutureValue"
+    ],
+    "androidRequiredPasswordType": [
+      "alphabetic",
+      "alphanumeric",
+      "alphanumericWithSymbols",
+      "any",
+      "deviceDefault",
+      "lowSecurityBiometric",
+      "numeric",
+      "numericComplex"
+    ],
+    "androidWorkProfileCrossProfileDataSharingType": [
+      "allowPersonalToWork",
+      "deviceDefault",
+      "noRestrictions",
+      "preventAny"
+    ],
+    "androidWorkProfileDefaultAppPermissionPolicyType": [
+      "autoDeny",
+      "autoGrant",
+      "deviceDefault",
+      "prompt"
+    ],
+    "androidWorkProfileRequiredPasswordType": [
+      "alphanumericWithSymbols",
+      "atLeastAlphabetic",
+      "atLeastAlphanumeric",
+      "atLeastNumeric",
+      "deviceDefault",
+      "lowSecurityBiometric",
+      "numericComplex",
+      "required"
+    ],
+    "answerInputType": [
+      "radioButton",
+      "text",
+      "unknownFutureValue"
+    ],
+    "appCredentialRestrictionType": [
+      "customPasswordAddition",
+      "passwordAddition",
+      "passwordLifetime",
+      "symmetricKeyAddition",
+      "symmetricKeyLifetime",
+      "unknownFutureValue"
+    ],
+    "appKeyCredentialRestrictionType": [
+      "asymmetricKeyLifetime",
+      "unknownFutureValue"
+    ],
+    "applicationGuardBlockClipboardSharingType": [
+      "blockBoth",
+      "blockContainerToHost",
+      "blockHostToContainer",
+      "blockNone",
+      "notConfigured"
+    ],
+    "applicationGuardBlockFileTransferType": [
+      "blockImageAndTextFile",
+      "blockImageFile",
+      "blockNone",
+      "blockTextFile",
+      "notConfigured"
+    ],
+    "applicationType": [
+      "desktop",
+      "universal"
+    ],
+    "appliedConditionalAccessPolicyResult": [
+      "failure",
+      "notApplied",
+      "notEnabled",
+      "reportOnlyFailure",
+      "reportOnlyInterrupted",
+      "reportOnlyNotApplied",
+      "reportOnlySuccess",
+      "success",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "appListType": [
+      "appsInListCompliant",
+      "appsNotInListCompliant",
+      "none"
+    ],
+    "appLockerApplicationControlType": [
+      "auditComponentsAndStoreApps",
+      "auditComponentsStoreAppsAndSmartlocker",
+      "enforceComponentsAndStoreApps",
+      "enforceComponentsStoreAppsAndSmartlocker",
+      "notConfigured"
+    ],
+    "appLogDecryptionAlgorithm": [
+      "aes256",
+      "unknownFutureValue"
+    ],
+    "appLogUploadState": [
+      "completed",
+      "failed",
+      "pending",
+      "unknownFutureValue"
+    ],
+    "appManagementRestrictionState": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "approvalFilterByCurrentUserOptions": [
+      "approver",
+      "createdBy",
+      "target",
+      "unknownFutureValue"
+    ],
+    "appsUpdateChannelType": [
+      "current",
+      "monthlyEnterprise",
+      "semiAnnual",
+      "unknownFutureValue"
+    ],
+    "artifactRestoreStatus": [
+      "added",
+      "failed",
+      "inProgress",
+      "scheduled",
+      "scheduling",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "assignmentScheduleFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "assignmentScheduleInstanceFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "assignmentScheduleRequestFilterByCurrentUserOptions": [
+      "approver",
+      "createdBy",
+      "principal",
+      "unknownFutureValue"
+    ],
+    "assignmentType": [
+      "peerRecommended",
+      "recommended",
+      "required",
+      "unknownFutureValue"
+    ],
+    "attachmentType": [
+      "file",
+      "item",
+      "reference"
+    ],
+    "attackSimulationOperationType": [
+      "createSimualation",
+      "unknownFutureValue",
+      "updateSimulation"
+    ],
+    "attendeeType": [
+      "optional",
+      "required",
+      "resource"
+    ],
+    "attestationEnforcement": [
+      "disabled",
+      "registrationOnly",
+      "unknownFutureValue"
+    ],
+    "attestationLevel": [
+      "attested",
+      "notAttested",
+      "unknownFutureValue"
+    ],
+    "attributeDefinitionMetadata": [
+      "BaseAttributeName",
+      "ComplexObjectDefinition",
+      "IsContainer",
+      "IsCustomerDefined",
+      "IsDomainQualified",
+      "LinkPropertyNames",
+      "LinkTypeName",
+      "MaximumLength",
+      "ReferencedProperty"
+    ],
+    "attributeFlowBehavior": [
+      "FlowAlways",
+      "FlowWhenChanged"
+    ],
+    "attributeFlowType": [
+      "Always",
+      "AttributeAddOnly",
+      "MultiValueAddOnly",
+      "ObjectAddOnly",
+      "ValueAddOnly"
+    ],
+    "attributeMappingSourceType": [
+      "Attribute",
+      "Constant",
+      "Function"
+    ],
+    "attributeType": [
+      "Binary",
+      "Boolean",
+      "DateTime",
+      "Integer",
+      "Reference",
+      "String"
+    ],
+    "auditLogRecordType": [],
+    "auditLogUserType": [],
+    "authenticationAttributeCollectionInputType": [
+      "boolean",
+      "checkboxMultiSelect",
+      "radioSingleSelect",
+      "text",
+      "unknownFutureValue"
+    ],
+    "authenticationMethodFeature": [
+      "mfaCapable",
+      "passwordlessCapable",
+      "ssprCapable",
+      "ssprEnabled",
+      "ssprRegistered",
+      "unknownFutureValue"
+    ],
+    "authenticationMethodKeyStrength": [
+      "normal",
+      "unknown",
+      "weak"
+    ],
+    "authenticationMethodModes": [
+      "deviceBasedPush",
+      "email",
+      "federatedMultiFactor",
+      "federatedSingleFactor",
+      "fido2",
+      "hardwareOath",
+      "microsoftAuthenticatorPush",
+      "password",
+      "qrCodePin",
+      "sms",
+      "softwareOath",
+      "temporaryAccessPassMultiUse",
+      "temporaryAccessPassOneTime",
+      "unknownFutureValue",
+      "voice",
+      "windowsHelloForBusiness",
+      "x509CertificateMultiFactor",
+      "x509CertificateSingleFactor"
+    ],
+    "authenticationMethodPlatform": [
+      "android",
+      "iOS",
+      "linux",
+      "macOS",
+      "unknown",
+      "unknownFutureValue",
+      "windows"
+    ],
+    "authenticationMethodSignInState": [
+      "notAllowedByPolicy",
+      "notConfigured",
+      "notEnabled",
+      "notSupported",
+      "phoneNumberNotUnique",
+      "ready",
+      "unknownFutureValue"
+    ],
+    "authenticationMethodsPolicyMigrationState": [
+      "migrationComplete",
+      "migrationInProgress",
+      "preMigration",
+      "unknownFutureValue"
+    ],
+    "authenticationMethodState": [
+      "disabled",
+      "enabled"
+    ],
+    "authenticationMethodTargetType": [
+      "group",
+      "unknownFutureValue",
+      "user"
+    ],
+    "authenticationPhoneType": [
+      "alternateMobile",
+      "mobile",
+      "office",
+      "unknownFutureValue"
+    ],
+    "authenticationProtocol": [
+      "saml",
+      "unknownFutureValue",
+      "wsFed"
+    ],
+    "authenticationStrengthPolicyType": [
+      "builtIn",
+      "custom",
+      "unknownFutureValue"
+    ],
+    "authenticationStrengthRequirements": [
+      "mfa",
+      "none",
+      "unknownFutureValue"
+    ],
+    "automaticRepliesStatus": [
+      "alwaysEnabled",
+      "disabled",
+      "scheduled"
+    ],
+    "automaticUpdateMode": [
+      "autoInstallAndRebootAtMaintenanceTime",
+      "autoInstallAndRebootAtScheduledTime",
+      "autoInstallAndRebootWithoutEndUserControl",
+      "autoInstallAtMaintenanceTime",
+      "notifyDownload",
+      "userDefined"
+    ],
+    "autoRestartNotificationDismissalMethod": [
+      "automatic",
+      "notConfigured",
+      "unknownFutureValue",
+      "user"
+    ],
+    "b2bIdentityProvidersType": [
+      "azureActiveDirectory",
+      "defaultConfiguredIdp",
+      "emailOneTimePasscode",
+      "externalFederation",
+      "microsoftAccount",
+      "socialIdentityProviders",
+      "unknownFutureValue"
+    ],
+    "backupServiceConsumer": [
+      "firstparty",
+      "thirdparty",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "backupServiceStatus": [
+      "disabled",
+      "enabled",
+      "protectionChangeLocked",
+      "restoreLocked",
+      "unknownFutureValue"
+    ],
+    "baseAuthenticationMethod": [
+      "email",
+      "federation",
+      "fido2",
+      "hardwareOath",
+      "microsoftAuthenticator",
+      "password",
+      "qrCodePin",
+      "sms",
+      "softwareOath",
+      "temporaryAccessPass",
+      "unknownFutureValue",
+      "voice",
+      "windowsHelloForBusiness",
+      "x509Certificate"
+    ],
+    "baselineParameterType": [
+      "boolean",
+      "integer",
+      "string",
+      "unknownFutureValue"
+    ],
+    "binaryOperator": [
+      "and",
+      "or"
+    ],
+    "bitLockerEncryptionMethod": [
+      "aesCbc128",
+      "aesCbc256",
+      "xtsAes128",
+      "xtsAes256"
+    ],
+    "bodyType": [
+      "html",
+      "text"
+    ],
+    "bookingPageAccessControl": [
+      "restrictedToOrganization",
+      "unknownFutureValue",
+      "unrestricted"
+    ],
+    "bookingPriceType": [
+      "callUs",
+      "fixedPrice",
+      "free",
+      "hourly",
+      "notSet",
+      "priceVaries",
+      "startingAt",
+      "undefined",
+      "unknownFutureValue"
+    ],
+    "bookingReminderRecipients": [
+      "allAttendees",
+      "customer",
+      "staff",
+      "unknownFutureValue"
+    ],
+    "bookingsAvailabilityStatus": [
+      "available",
+      "busy",
+      "outOfOffice",
+      "slotsAvailable",
+      "unknownFutureValue"
+    ],
+    "bookingsServiceAvailabilityType": [
+      "bookWhenStaffAreFree",
+      "customWeeklyHours",
+      "notBookable",
+      "unknownFutureValue"
+    ],
+    "bookingStaffMembershipStatus": [
+      "active",
+      "pendingAcceptance",
+      "rejectedByStaff",
+      "unknownFutureValue"
+    ],
+    "bookingStaffRole": [
+      "administrator",
+      "externalGuest",
+      "guest",
+      "scheduler",
+      "teamMember",
+      "unknownFutureValue",
+      "viewer"
+    ],
+    "bookingType": [
+      "reserved",
+      "standard",
+      "unknown"
+    ],
+    "broadcastMeetingAudience": [
+      "everyone",
+      "organization",
+      "roleIsAttendee",
+      "unknownFutureValue"
+    ],
+    "browserSharedCookieSourceEnvironment": [
+      "both",
+      "internetExplorer11",
+      "microsoftEdge",
+      "unknownFutureValue"
+    ],
+    "browserSharedCookieStatus": [
+      "pendingAdd",
+      "pendingDelete",
+      "pendingEdit",
+      "published",
+      "unknownFutureValue"
+    ],
+    "browserSiteCompatibilityMode": [
+      "default",
+      "internetExplorer10",
+      "internetExplorer11",
+      "internetExplorer5",
+      "internetExplorer7",
+      "internetExplorer7Enterprise",
+      "internetExplorer8",
+      "internetExplorer8Enterprise",
+      "internetExplorer9",
+      "unknownFutureValue"
+    ],
+    "browserSiteListStatus": [
+      "draft",
+      "pending",
+      "published",
+      "unknownFutureValue"
+    ],
+    "browserSiteMergeType": [
+      "default",
+      "noMerge",
+      "unknownFutureValue"
+    ],
+    "browserSiteStatus": [
+      "pendingAdd",
+      "pendingDelete",
+      "pendingEdit",
+      "published",
+      "unknownFutureValue"
+    ],
+    "browserSiteTargetEnvironment": [
+      "configurable",
+      "internetExplorer11",
+      "internetExplorerMode",
+      "microsoftEdge",
+      "none",
+      "unknownFutureValue"
+    ],
+    "bucketAggregationSortProperty": [
+      "count",
+      "keyAsNumber",
+      "keyAsString",
+      "unknownFutureValue"
+    ],
+    "calendarColor": [
+      "auto",
+      "lightBlue",
+      "lightBrown",
+      "lightGray",
+      "lightGreen",
+      "lightOrange",
+      "lightPink",
+      "lightRed",
+      "lightTeal",
+      "lightYellow",
+      "maxColor"
+    ],
+    "calendarRoleType": [
+      "custom",
+      "delegateWithoutPrivateEventAccess",
+      "delegateWithPrivateEventAccess",
+      "freeBusyRead",
+      "limitedRead",
+      "none",
+      "read",
+      "write"
+    ],
+    "calendarSharingAction": [
+      "accept",
+      "acceptAndViewCalendar",
+      "addThisCalendar",
+      "viewCalendar"
+    ],
+    "calendarSharingActionImportance": [
+      "primary",
+      "secondary"
+    ],
+    "calendarSharingActionType": [
+      "accept"
+    ],
+    "callDirection": [
+      "incoming",
+      "outgoing"
+    ],
+    "callEventType": [
+      "callEnded",
+      "callStarted",
+      "rosterUpdated",
+      "unknownFutureValue"
+    ],
+    "callRecordingStatus": [
+      "chunkFinished",
+      "failure",
+      "initial",
+      "success",
+      "unknownFutureValue"
+    ],
+    "callState": [
+      "established",
+      "establishing",
+      "hold",
+      "incoming",
+      "redirecting",
+      "terminated",
+      "terminating",
+      "transferAccepted",
+      "transferring",
+      "unknownFutureValue"
+    ],
+    "callTranscriptionState": [
+      "active",
+      "inactive",
+      "notStarted",
+      "unknownFutureValue"
+    ],
+    "categoryColor": [
+      "none",
+      "preset0",
+      "preset1",
+      "preset10",
+      "preset11",
+      "preset12",
+      "preset13",
+      "preset14",
+      "preset15",
+      "preset16",
+      "preset17",
+      "preset18",
+      "preset19",
+      "preset2",
+      "preset20",
+      "preset21",
+      "preset22",
+      "preset23",
+      "preset24",
+      "preset3",
+      "preset4",
+      "preset5",
+      "preset6",
+      "preset7",
+      "preset8",
+      "preset9"
+    ],
+    "certificateAuthorityType": [
+      "intermediate",
+      "root",
+      "unknownFutureValue"
+    ],
+    "certificateStatus": [
+      "notProvisioned",
+      "provisioned"
+    ],
+    "changeType": [
+      "created",
+      "deleted",
+      "updated"
+    ],
+    "channelLayoutType": [
+      "chat",
+      "post",
+      "unknownFutureValue"
+    ],
+    "channelMembershipType": [
+      "private",
+      "shared",
+      "standard",
+      "unknownFutureValue"
+    ],
+    "chatMessageActions": [
+      "actionUndefined",
+      "reactionAdded",
+      "reactionRemoved",
+      "unknownFutureValue"
+    ],
+    "chatMessageImportance": [
+      "high",
+      "normal",
+      "unknownFutureValue",
+      "urgent"
+    ],
+    "chatMessagePolicyViolationDlpActionTypes": [
+      "blockAccess",
+      "blockAccessExternal",
+      "none",
+      "notifySender"
+    ],
+    "chatMessagePolicyViolationUserActionTypes": [
+      "none",
+      "override",
+      "reportFalsePositive"
+    ],
+    "chatMessagePolicyViolationVerdictDetailsTypes": [
+      "allowFalsePositiveOverride",
+      "allowOverrideWithJustification",
+      "allowOverrideWithoutJustification",
+      "none"
+    ],
+    "chatMessageType": [
+      "chatEvent",
+      "message",
+      "systemEventMessage",
+      "typing",
+      "unknownFutureValue"
+    ],
+    "chatType": [
+      "group",
+      "meeting",
+      "oneOnOne",
+      "unknownFutureValue"
+    ],
+    "checkInMethod": [
+      "inferred",
+      "manual",
+      "unknownFutureValue",
+      "unspecified",
+      "verified"
+    ],
+    "clickSource": [
+      "phishingUrl",
+      "qrCode",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "clonableTeamParts": [
+      "apps",
+      "channels",
+      "members",
+      "settings",
+      "tabs"
+    ],
+    "cloudAppSecuritySessionControlType": [
+      "blockDownloads",
+      "mcasConfigured",
+      "monitorOnly",
+      "unknownFutureValue"
+    ],
+    "cloudPcAuditActivityOperationType": [
+      "create",
+      "delete",
+      "patch",
+      "unknownFutureValue"
+    ],
+    "cloudPcAuditActivityResult": [
+      "clientError",
+      "failure",
+      "success",
+      "timeout",
+      "unknownFutureValue"
+    ],
+    "cloudPcAuditCategory": [
+      "cloudPC",
+      "unknownFutureValue"
+    ],
+    "cloudPcDeviceImageErrorCode": [
+      "internalServerError",
+      "osVersionNotSupported",
+      "paidSourceImageNotSupport",
+      "sourceImageInvalid",
+      "sourceImageNotFound",
+      "sourceImageNotGeneralized",
+      "sourceImageNotSupportCustomizeVMName",
+      "sourceImageSizeExceedsLimitation",
+      "unknownFutureValue",
+      "vmAlreadyAzureAdjoined"
+    ],
+    "cloudPcDeviceImageOsStatus": [
+      "supported",
+      "supportedWithWarning",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "cloudPcDeviceImageStatus": [
+      "failed",
+      "pending",
+      "ready",
+      "unknownFutureValue"
+    ],
+    "cloudPcDomainJoinType": [
+      "azureADJoin",
+      "hybridAzureADJoin",
+      "unknownFutureValue"
+    ],
+    "cloudPcGalleryImageStatus": [
+      "notSupported",
+      "supported",
+      "supportedWithWarning",
+      "unknownFutureValue"
+    ],
+    "cloudPcOnPremisesConnectionHealthCheckErrorType": [
+      "adJoinCheckAccessDenied",
+      "adJoinCheckAccountLockedOrDisabled",
+      "adJoinCheckAccountQuotaExceeded",
+      "adJoinCheckComputerObjectAlreadyExists",
+      "adJoinCheckCredentialsExpired",
+      "adJoinCheckFqdnNotFound",
+      "adJoinCheckIncorrectCredentials",
+      "adJoinCheckOrganizationalUnitIncorrectFormat",
+      "adJoinCheckOrganizationalUnitNotFound",
+      "adJoinCheckServerNotOperational",
+      "adJoinCheckUnknownError",
+      "azureAdDeviceSyncCheckConnectDisabled",
+      "azureAdDeviceSyncCheckDeviceNotFound",
+      "azureAdDeviceSyncCheckDurationExceeded",
+      "azureAdDeviceSyncCheckLongSyncCircle",
+      "azureAdDeviceSyncCheckScpNotConfigured",
+      "azureAdDeviceSyncCheckTransientServiceError",
+      "azureAdDeviceSyncCheckUnknownError",
+      "dnsCheckFqdnNotFound",
+      "dnsCheckNameWithInvalidCharacter",
+      "dnsCheckUnknownError",
+      "endpointConnectivityCheckAzureADUrlNotAllowListed",
+      "endpointConnectivityCheckCloudPcUrlNotAllowListed",
+      "endpointConnectivityCheckIntuneUrlNotAllowListed",
+      "endpointConnectivityCheckLocaleUrlNotAllowListed",
+      "endpointConnectivityCheckUnknownError",
+      "endpointConnectivityCheckWVDUrlNotAllowListed",
+      "internalServerErrorAllocateResourceFailed",
+      "internalServerErrorDeploymentCanceled",
+      "internalServerErrorUnableToRunDscScript",
+      "internalServerErrorVMDeploymentTimeout",
+      "internalServerUnknownError",
+      "permissionCheckNoResourceGroupNetworkContributorRole",
+      "permissionCheckNoResourceGroupOwnerRole",
+      "permissionCheckNoSubscriptionReaderRole",
+      "permissionCheckNoVNetContributorRole",
+      "permissionCheckNoWindows365NetworkInterfaceContributorRole",
+      "permissionCheckNoWindows365NetworkUserRole",
+      "permissionCheckTransientServiceError",
+      "permissionCheckUnknownError",
+      "resourceAvailabilityCheckAzurePolicyViolation",
+      "resourceAvailabilityCheckDeploymentQuotaLimitReached",
+      "resourceAvailabilityCheckGeneralSubscriptionError",
+      "resourceAvailabilityCheckIntuneCustomWindowsRestrictionViolation",
+      "resourceAvailabilityCheckIntuneDefaultWindowsRestrictionViolation",
+      "resourceAvailabilityCheckNoIntuneReaderRoleError",
+      "resourceAvailabilityCheckNoSubnetIP",
+      "resourceAvailabilityCheckResourceGroupBeingDeleted",
+      "resourceAvailabilityCheckResourceGroupInvalid",
+      "resourceAvailabilityCheckResourceGroupLockedForDelete",
+      "resourceAvailabilityCheckResourceGroupLockedForReadonly",
+      "resourceAvailabilityCheckSubnetDelegationFailed",
+      "resourceAvailabilityCheckSubnetInvalid",
+      "resourceAvailabilityCheckSubnetWithExternalResources",
+      "resourceAvailabilityCheckSubscriptionDisabled",
+      "resourceAvailabilityCheckSubscriptionNotFound",
+      "resourceAvailabilityCheckSubscriptionTransferred",
+      "resourceAvailabilityCheckTransientServiceError",
+      "resourceAvailabilityCheckUnknownError",
+      "resourceAvailabilityCheckUnsupportedVNetRegion",
+      "resourceAvailabilityCheckVNetBeingMoved",
+      "resourceAvailabilityCheckVNetInvalid",
+      "ssoCheckKerberosConfigurationError",
+      "udpConnectivityCheckStunUrlNotAllowListed",
+      "udpConnectivityCheckTurnUrlNotAllowListed",
+      "udpConnectivityCheckUnknownError",
+      "udpConnectivityCheckUrlsNotAllowListed",
+      "unknownFutureValue"
+    ],
+    "cloudPcOnPremisesConnectionStatus": [
+      "failed",
+      "informational",
+      "passed",
+      "pending",
+      "running",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "cloudPcOnPremisesConnectionType": [
+      "azureADJoin",
+      "hybridAzureADJoin",
+      "unknownFutureValue"
+    ],
+    "cloudPcOperatingSystem": [
+      "unknownFutureValue",
+      "windows10",
+      "windows11"
+    ],
+    "cloudPcProvisioningPolicyImageType": [
+      "custom",
+      "gallery",
+      "unknownFutureValue"
+    ],
+    "cloudPcProvisioningType": [
+      "dedicated",
+      "shared",
+      "unknownFutureValue"
+    ],
+    "cloudPcRecommendationReportType": [
+      "cloudPcUsageCategoryReport",
+      "unknownFutureValue"
+    ],
+    "cloudPcRegionGroup": [
+      "asia",
+      "australia",
+      "canada",
+      "default",
+      "euap",
+      "europeUnion",
+      "france",
+      "germany",
+      "india",
+      "japan",
+      "norway",
+      "southAmerica",
+      "southKorea",
+      "switzerland",
+      "unitedKingdom",
+      "unknownFutureValue",
+      "usCentral",
+      "usEast",
+      "usGovernment",
+      "usGovernmentDOD",
+      "usWest"
+    ],
+    "cloudPcRestorePointFrequencyType": [
+      "default",
+      "fourHours",
+      "sixHours",
+      "sixteenHours",
+      "twelveHours",
+      "twentyFourHours",
+      "unknownFutureValue"
+    ],
+    "cloudPcUserAccountType": [
+      "administrator",
+      "standardUser",
+      "unknownFutureValue"
+    ],
+    "coachmarkLocationType": [
+      "displayName",
+      "externalTag",
+      "fromEmail",
+      "messageBody",
+      "subject",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "columnTypes": [
+      "approvalStatus",
+      "boolean",
+      "calculated",
+      "choice",
+      "currency",
+      "dateTime",
+      "geolocation",
+      "location",
+      "lookup",
+      "multichoice",
+      "multiterm",
+      "note",
+      "number",
+      "term",
+      "text",
+      "thumbnail",
+      "unknownFutureValue",
+      "url",
+      "user"
+    ],
+    "communityPrivacy": [
+      "private",
+      "public",
+      "unknownFutureValue"
+    ],
+    "complianceState": [
+      "compliant",
+      "configManager",
+      "conflict",
+      "error",
+      "inGracePeriod",
+      "noncompliant",
+      "unknown"
+    ],
+    "complianceStatus": [
+      "compliant",
+      "conflict",
+      "error",
+      "nonCompliant",
+      "notApplicable",
+      "notAssigned",
+      "remediated",
+      "unknown"
+    ],
+    "conditionalAccessClientApp": [
+      "all",
+      "browser",
+      "easSupported",
+      "exchangeActiveSync",
+      "mobileAppsAndDesktopClients",
+      "other",
+      "unknownFutureValue"
+    ],
+    "conditionalAccessDevicePlatform": [
+      "all",
+      "android",
+      "iOS",
+      "linux",
+      "macOS",
+      "unknownFutureValue",
+      "windows",
+      "windowsPhone"
+    ],
+    "conditionalAccessExternalTenantsMembershipKind": [
+      "all",
+      "enumerated",
+      "unknownFutureValue"
+    ],
+    "conditionalAccessGrantControl": [
+      "approvedApplication",
+      "block",
+      "compliantApplication",
+      "compliantDevice",
+      "domainJoinedDevice",
+      "mfa",
+      "passwordChange",
+      "riskRemediation",
+      "unknownFutureValue"
+    ],
+    "conditionalAccessGuestOrExternalUserTypes": [
+      "b2bCollaborationGuest",
+      "b2bCollaborationMember",
+      "b2bDirectConnectUser",
+      "internalGuest",
+      "none",
+      "otherExternalUser",
+      "serviceProvider",
+      "unknownFutureValue"
+    ],
+    "conditionalAccessInsiderRiskLevels": [
+      "elevated",
+      "minor",
+      "moderate",
+      "unknownFutureValue"
+    ],
+    "conditionalAccessPolicyState": [
+      "disabled",
+      "enabled",
+      "enabledForReportingButNotEnforced"
+    ],
+    "conditionalAccessStatus": [
+      "failure",
+      "notApplied",
+      "success",
+      "unknownFutureValue"
+    ],
+    "conditionalAccessTransferMethods": [
+      "authenticationTransfer",
+      "deviceCodeFlow",
+      "none",
+      "unknownFutureValue"
+    ],
+    "confirmedBy": [
+      "manager",
+      "none",
+      "unknownFutureValue",
+      "user"
+    ],
+    "connectedOrganizationState": [
+      "configured",
+      "proposed",
+      "unknownFutureValue"
+    ],
+    "connectionDirection": [
+      "inbound",
+      "outbound",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "connectionStatus": [
+      "attempted",
+      "blocked",
+      "failed",
+      "succeeded",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "consentRequestFilterByCurrentUserOptions": [
+      "reviewer",
+      "unknownFutureValue"
+    ],
+    "contactRelationship": [
+      "aide",
+      "child",
+      "doctor",
+      "guardian",
+      "other",
+      "parent",
+      "relative",
+      "unknownFutureValue"
+    ],
+    "contentProcessingErrorType": [
+      "permanent",
+      "transient",
+      "unknownFutureValue"
+    ],
+    "countryLookupMethodType": [
+      "authenticatorAppGps",
+      "clientIpAddress",
+      "unknownFutureValue"
+    ],
+    "courseStatus": [
+      "completed",
+      "inProgress",
+      "notStarted",
+      "unknownFutureValue"
+    ],
+    "crossTenantAccessPolicyTargetConfigurationAccessType": [
+      "allowed",
+      "blocked",
+      "unknownFutureValue"
+    ],
+    "crossTenantAccessPolicyTargetType": [
+      "application",
+      "group",
+      "unknownFutureValue",
+      "user"
+    ],
+    "customExtensionCalloutInstanceStatus": [
+      "callbackReceived",
+      "callbackTimedOut",
+      "calloutFailed",
+      "calloutSent",
+      "unknownFutureValue",
+      "waitingForCallback"
+    ],
+    "dataPolicyOperationStatus": [
+      "complete",
+      "failed",
+      "notStarted",
+      "running",
+      "unknownFutureValue"
+    ],
+    "dataSubjectType": [
+      "currentEmployee",
+      "customer",
+      "faculty",
+      "formerEmployee",
+      "other",
+      "prospectiveEmployee",
+      "student",
+      "teacher",
+      "unknownFutureValue"
+    ],
+    "dayOfWeek": [
+      "friday",
+      "monday",
+      "saturday",
+      "sunday",
+      "thursday",
+      "tuesday",
+      "wednesday"
+    ],
+    "defenderCloudBlockLevelType": [
+      "high",
+      "highPlus",
+      "notConfigured",
+      "zeroTolerance"
+    ],
+    "defenderMonitorFileActivity": [
+      "disable",
+      "monitorAllFiles",
+      "monitorIncomingFilesOnly",
+      "monitorOutgoingFilesOnly",
+      "userDefined"
+    ],
+    "defenderPromptForSampleSubmission": [
+      "alwaysPrompt",
+      "neverSendData",
+      "promptBeforeSendingPersonalData",
+      "sendAllDataWithoutPrompting",
+      "userDefined"
+    ],
+    "defenderScanType": [
+      "disabled",
+      "full",
+      "quick",
+      "userDefined"
+    ],
+    "defenderThreatAction": [
+      "allow",
+      "block",
+      "clean",
+      "deviceDefault",
+      "quarantine",
+      "remove",
+      "userDefined"
+    ],
+    "delegatedAdminAccessAssignmentStatus": [
+      "active",
+      "deleted",
+      "deleting",
+      "error",
+      "pending",
+      "unknownFutureValue"
+    ],
+    "delegatedAdminAccessContainerType": [
+      "securityGroup",
+      "unknownFutureValue"
+    ],
+    "delegatedAdminRelationshipOperationType": [
+      "delegatedAdminAccessAssignmentUpdate",
+      "delegatedAdminRelationshipUpdate",
+      "unknownFutureValue"
+    ],
+    "delegatedAdminRelationshipRequestAction": [
+      "approve",
+      "lockForApproval",
+      "reject",
+      "terminate",
+      "unknownFutureValue"
+    ],
+    "delegatedAdminRelationshipRequestStatus": [
+      "created",
+      "failed",
+      "pending",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "delegatedAdminRelationshipStatus": [
+      "activating",
+      "active",
+      "approvalPending",
+      "approved",
+      "created",
+      "expired",
+      "expiring",
+      "terminated",
+      "terminating",
+      "terminationRequested",
+      "unknownFutureValue"
+    ],
+    "delegateMeetingMessageDeliveryOptions": [
+      "sendToDelegateAndInformationToPrincipal",
+      "sendToDelegateAndPrincipal",
+      "sendToDelegateOnly"
+    ],
+    "destinationType": [
+      "inPlace",
+      "new",
+      "unknownFutureValue"
+    ],
+    "detectedAppPlatformType": [
+      "androidDedicatedAndFullyManaged",
+      "androidDeviceAdministrator",
+      "androidOSP",
+      "androidWorkProfile",
+      "chromeOS",
+      "ios",
+      "macOS",
+      "unknown",
+      "unknownFutureValue",
+      "windows",
+      "windowsHolographic",
+      "windowsMobile"
+    ],
+    "deviceComplianceActionType": [
+      "block",
+      "noAction",
+      "notification",
+      "pushNotification",
+      "removeResourceAccessProfiles",
+      "retire",
+      "wipe"
+    ],
+    "deviceEnrollmentFailureReason": [
+      "accountValidation",
+      "authentication",
+      "authorization",
+      "badRequest",
+      "clientDisconnected",
+      "deviceNotSupported",
+      "enrollmentRestrictionsEnforced",
+      "featureNotSupported",
+      "inMaintenance",
+      "unknown",
+      "userAbandonment",
+      "userValidation"
+    ],
+    "deviceEnrollmentType": [
+      "appleBulkWithoutUser",
+      "appleBulkWithUser",
+      "appleUserEnrollment",
+      "appleUserEnrollmentWithServiceAccount",
+      "deviceEnrollmentManager",
+      "unknown",
+      "unknownFutureValue",
+      "userEnrollment",
+      "windowsAutoEnrollment",
+      "windowsAzureADJoin",
+      "windowsAzureADJoinUsingDeviceAuth",
+      "windowsBulkAzureDomainJoin",
+      "windowsBulkUserless",
+      "windowsCoManagement"
+    ],
+    "deviceLogCollectionTemplateType": [
+      "predefined",
+      "unknownFutureValue"
+    ],
+    "deviceManagementExchangeAccessState": [
+      "allowed",
+      "blocked",
+      "none",
+      "quarantined",
+      "unknown"
+    ],
+    "deviceManagementExchangeAccessStateReason": [
+      "azureADBlockDueToAccessPolicy",
+      "compliant",
+      "compromisedPassword",
+      "deviceNotKnownWithManagedApp",
+      "exchangeDeviceRule",
+      "exchangeGlobalRule",
+      "exchangeIndividualRule",
+      "exchangeMailboxPolicy",
+      "exchangeUpgrade",
+      "mfaRequired",
+      "none",
+      "notCompliant",
+      "notEnrolled",
+      "other",
+      "unknown",
+      "unknownLocation"
+    ],
+    "deviceManagementExchangeConnectorStatus": [
+      "connected",
+      "connectionPending",
+      "disconnected",
+      "none",
+      "unknownFutureValue"
+    ],
+    "deviceManagementExchangeConnectorSyncType": [
+      "deltaSync",
+      "fullSync"
+    ],
+    "deviceManagementExchangeConnectorType": [
+      "dedicated",
+      "hosted",
+      "onPremises",
+      "serviceToService",
+      "unknownFutureValue"
+    ],
+    "deviceManagementExportJobLocalizationType": [
+      "localizedValuesAsAdditionalColumn",
+      "replaceLocalizableValues"
+    ],
+    "deviceManagementPartnerAppType": [
+      "multiTenantApp",
+      "singleTenantApp",
+      "unknown"
+    ],
+    "deviceManagementPartnerTenantState": [
+      "enabled",
+      "rejected",
+      "terminated",
+      "unavailable",
+      "unknown",
+      "unresponsive"
+    ],
+    "deviceManagementReportFileFormat": [
+      "csv",
+      "json",
+      "pdf",
+      "unknownFutureValue"
+    ],
+    "deviceManagementReportStatus": [
+      "completed",
+      "failed",
+      "inProgress",
+      "notStarted",
+      "unknown"
+    ],
+    "deviceManagementSubscriptionState": [
+      "active",
+      "blocked",
+      "deleted",
+      "disabled",
+      "lockedOut",
+      "pending",
+      "warning"
+    ],
+    "devicePlatformType": [
+      "android",
+      "androidAOSP",
+      "androidForWork",
+      "androidMobileApplicationManagement",
+      "androidWorkProfile",
+      "iOS",
+      "iOSMobileApplicationManagement",
+      "macOS",
+      "unknown",
+      "unknownFutureValue",
+      "windows10AndLater",
+      "windows81AndLater",
+      "windowsPhone81"
+    ],
+    "deviceRegistrationState": [
+      "approvalPending",
+      "certificateReset",
+      "keyConflict",
+      "notRegistered",
+      "notRegisteredPendingEnrollment",
+      "registered",
+      "revoked",
+      "unknown"
+    ],
+    "deviceThreatProtectionLevel": [
+      "high",
+      "low",
+      "medium",
+      "notSet",
+      "secured",
+      "unavailable"
+    ],
+    "diagnosticDataSubmissionMode": [
+      "basic",
+      "enhanced",
+      "full",
+      "none",
+      "userDefined"
+    ],
+    "directoryDefinitionDiscoverabilities": [
+      "AttributeDataTypes",
+      "AttributeNames",
+      "AttributeReadOnly",
+      "None",
+      "ReferenceAttributes",
+      "UnknownFutureValue"
+    ],
+    "disableReason": [
+      "invalidBillingProfile",
+      "none",
+      "unknownFutureValue",
+      "userRequested"
+    ],
+    "diskType": [
+      "hdd",
+      "ssd",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "dlpAction": [
+      "blockAccess",
+      "browserRestriction",
+      "deviceRestriction",
+      "generateAlert",
+      "generateIncidentReportAction",
+      "notifyUser",
+      "restrictAccess",
+      "restrictWebGrounding",
+      "sPBlockAnonymousAccess",
+      "sPRuntimeAccessControl",
+      "sPSharingGenerateIncidentReport",
+      "sPSharingNotifyUser",
+      "unknownFutureValue"
+    ],
+    "driftStatus": [
+      "active",
+      "fixed",
+      "unknownFutureValue"
+    ],
+    "driveItemSourceApplication": [
+      "loki",
+      "loop",
+      "office",
+      "oneDrive",
+      "other",
+      "powerPoint",
+      "sharePoint",
+      "stream",
+      "teams",
+      "unknownFutureValue",
+      "yammer"
+    ],
+    "edgeCookiePolicy": [
+      "allow",
+      "blockAll",
+      "blockThirdParty",
+      "userDefined"
+    ],
+    "edgeSearchEngineType": [
+      "bing",
+      "default"
+    ],
+    "editionUpgradeLicenseType": [
+      "licenseFile",
+      "productKey"
+    ],
+    "educationAddedStudentAction": [
+      "assignIfOpen",
+      "none",
+      "unknownFutureValue"
+    ],
+    "educationAddToCalendarOptions": [
+      "none",
+      "studentsAndPublisher",
+      "studentsAndTeamOwners",
+      "studentsOnly",
+      "unknownFutureValue"
+    ],
+    "educationAssignmentStatus": [
+      "assigned",
+      "draft",
+      "inactive",
+      "published",
+      "unknownFutureValue"
+    ],
+    "educationExternalSource": [
+      "manual",
+      "sis",
+      "unknownFutureValue"
+    ],
+    "educationFeedbackResourceOutcomeStatus": [
+      "failedPublish",
+      "notPublished",
+      "pendingPublish",
+      "published",
+      "unknownFutureValue"
+    ],
+    "educationGender": [
+      "female",
+      "male",
+      "other",
+      "unknownFutureValue"
+    ],
+    "educationModuleStatus": [
+      "draft",
+      "published",
+      "unknownFutureValue"
+    ],
+    "educationSpeechType": [
+      "informative",
+      "personal",
+      "persuasive",
+      "unknownFutureValue"
+    ],
+    "educationSubmissionStatus": [
+      "excused",
+      "reassigned",
+      "released",
+      "returned",
+      "submitted",
+      "unknownFutureValue",
+      "working"
+    ],
+    "educationUserRole": [
+      "none",
+      "student",
+      "teacher",
+      "unknownFutureValue"
+    ],
+    "eligibilityFilteringEnabledEntities": [
+      "none",
+      "offerShiftRequest",
+      "swapRequest",
+      "timeOffReason",
+      "unknownFutureValue"
+    ],
+    "eligibilityScheduleFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "eligibilityScheduleInstanceFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "eligibilityScheduleRequestFilterByCurrentUserOptions": [
+      "approver",
+      "createdBy",
+      "principal",
+      "unknownFutureValue"
+    ],
+    "emailRole": [
+      "recipient",
+      "sender",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "enablement": [
+      "disabled",
+      "enabled",
+      "notConfigured"
+    ],
+    "endpointType": [
+      "default",
+      "skypeForBusiness",
+      "skypeForBusinessVoipPhone",
+      "unknownFutureValue",
+      "voicemail"
+    ],
+    "endUserNotificationPreference": [
+      "custom",
+      "microsoft",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "endUserNotificationSettingType": [
+      "noNotification",
+      "noTraining",
+      "trainingSelected",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "endUserNotificationType": [
+      "noTraining",
+      "positiveReinforcement",
+      "trainingAssignment",
+      "trainingReminder",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "engagementAsyncOperationType": [
+      "createCommunity",
+      "unknownFutureValue"
+    ],
+    "engagementConversationMessageReactionType": [
+      "agree",
+      "angry",
+      "brain",
+      "bullseye",
+      "celebrate",
+      "confirmed",
+      "crying",
+      "excited",
+      "goofy",
+      "happy",
+      "heartBroken",
+      "intenseLaugh",
+      "laugh",
+      "like",
+      "love",
+      "medal",
+      "mindBlown",
+      "praise",
+      "sad",
+      "scared",
+      "shocked",
+      "silly",
+      "smile",
+      "starStruck",
+      "support",
+      "surprised",
+      "takingNotes",
+      "thank",
+      "thinking",
+      "unknownFutureValue",
+      "watching"
+    ],
+    "engagementConversationModerationState": [
+      "dismissed",
+      "pendingReview",
+      "published",
+      "unknownFutureValue"
+    ],
+    "engagementCreationMode": [
+      "migration",
+      "none",
+      "unknownFutureValue"
+    ],
+    "enrollmentState": [
+      "enrolled",
+      "failed",
+      "notContacted",
+      "pendingReset",
+      "unknown"
+    ],
+    "entityType": [
+      "acronym",
+      "bookmark",
+      "chatMessage",
+      "drive",
+      "driveItem",
+      "event",
+      "externalItem",
+      "list",
+      "listItem",
+      "message",
+      "person",
+      "site",
+      "unknownFutureValue"
+    ],
+    "entryExportStatus": [
+      "Error",
+      "Noop",
+      "PermanentError",
+      "RetryableError",
+      "Success"
+    ],
+    "entrySyncOperation": [
+      "Add",
+      "Delete",
+      "None",
+      "Update"
+    ],
+    "errorCorrectionLevel": [
+      "h",
+      "l",
+      "m",
+      "q",
+      "unknownFutureValue"
+    ],
+    "escrowBehavior": [
+      "Default",
+      "IgnoreLookupReferenceResolutionFailure"
+    ],
+    "eventType": [
+      "exception",
+      "occurrence",
+      "seriesMaster",
+      "singleInstance"
+    ],
+    "exchangeIdFormat": [
+      "entryId",
+      "ewsId",
+      "immutableEntryId",
+      "restId",
+      "restImmutableEntryId"
+    ],
+    "exchangeMessageTraceStatus": [
+      "delivered",
+      "expanded",
+      "failed",
+      "filteredAsSpam",
+      "gettingStatus",
+      "pending",
+      "quarantined",
+      "unknownFutureValue"
+    ],
+    "executionMode": [
+      "evaluateInline",
+      "evaluateOffline",
+      "unknownFutureValue"
+    ],
+    "expirationPatternType": [
+      "afterDateTime",
+      "afterDuration",
+      "noExpiration",
+      "notSpecified"
+    ],
+    "externalAudienceScope": [
+      "all",
+      "contactsOnly",
+      "none"
+    ],
+    "externalEmailOtpState": [
+      "default",
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "featureTargetType": [
+      "administrativeUnit",
+      "group",
+      "role",
+      "unknownFutureValue"
+    ],
+    "featureType": [
+      "registration",
+      "reset",
+      "unknownFutureValue"
+    ],
+    "federatedIdpMfaBehavior": [
+      "acceptIfMfaDoneByFederatedIdp",
+      "enforceMfaByFederatedIdp",
+      "rejectMfaByFederatedIdp",
+      "unknownFutureValue"
+    ],
+    "fido2RestrictionEnforcementType": [
+      "allow",
+      "block",
+      "unknownFutureValue"
+    ],
+    "fileHashType": [
+      "authenticodeHash256",
+      "ctph",
+      "lsHash",
+      "md5",
+      "sha1",
+      "sha256",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "fileStorageContainerBillingClassification": [
+      "directToCustomer",
+      "standard",
+      "trial",
+      "unknownFutureValue"
+    ],
+    "fileStorageContainerBillingStatus": [
+      "invalid",
+      "unknownFutureValue",
+      "valid"
+    ],
+    "fileStorageContainerStatus": [
+      "active",
+      "inactive",
+      "unknownFutureValue"
+    ],
+    "fileStorageContainerTypeAppPermission": [
+      "addPermissions",
+      "create",
+      "delete",
+      "deleteOwnPermission",
+      "deletePermissions",
+      "enumeratePermissions",
+      "full",
+      "manageContent",
+      "managePermissions",
+      "none",
+      "read",
+      "readContent",
+      "unknownFutureValue",
+      "updatePermissions",
+      "write",
+      "writeContent"
+    ],
+    "fileStorageContainerTypeSettingsOverride": [
+      "isDiscoverabilityEnabled",
+      "isItemVersioningEnabled",
+      "isSearchEnabled",
+      "itemMajorVersionLimit",
+      "maxStoragePerContainerInBytes",
+      "unknownFutureValue",
+      "urlTemplate"
+    ],
+    "filterMode": [
+      "exclude",
+      "include"
+    ],
+    "firewallCertificateRevocationListCheckMethodType": [
+      "attempt",
+      "deviceDefault",
+      "none",
+      "require"
+    ],
+    "firewallPacketQueueingMethodType": [
+      "deviceDefault",
+      "disabled",
+      "queueBoth",
+      "queueInbound",
+      "queueOutbound"
+    ],
+    "firewallPreSharedKeyEncodingMethodType": [
+      "deviceDefault",
+      "none",
+      "utF8"
+    ],
+    "followupFlagStatus": [
+      "complete",
+      "flagged",
+      "notFlagged"
+    ],
+    "freeBusyStatus": [
+      "busy",
+      "free",
+      "oof",
+      "tentative",
+      "unknown",
+      "workingElsewhere"
+    ],
+    "giphyRatingType": [
+      "moderate",
+      "strict",
+      "unknownFutureValue"
+    ],
+    "groupType": [
+      "azureAD",
+      "unifiedGroups",
+      "unknownFutureValue"
+    ],
+    "horizontalSectionLayoutType": [
+      "fullWidth",
+      "none",
+      "oneColumn",
+      "oneThirdLeftColumn",
+      "oneThirdRightColumn",
+      "threeColumns",
+      "twoColumns",
+      "unknownFutureValue"
+    ],
+    "identityUserFlowAttributeDataType": [
+      "boolean",
+      "dateTime",
+      "int64",
+      "string",
+      "stringCollection",
+      "unknownFutureValue"
+    ],
+    "identityUserFlowAttributeInputType": [
+      "checkboxMultiSelect",
+      "dateTimeDropdown",
+      "dropdownSingleSelect",
+      "emailBox",
+      "radioSingleSelect",
+      "textBox"
+    ],
+    "identityUserFlowAttributeType": [
+      "builtIn",
+      "custom",
+      "required",
+      "unknownFutureValue"
+    ],
+    "imageTaggingChoice": [
+      "basic",
+      "disabled",
+      "enhanced",
+      "unknownFutureValue"
+    ],
+    "importance": [
+      "high",
+      "low",
+      "normal"
+    ],
+    "importedWindowsAutopilotDeviceIdentityImportStatus": [
+      "complete",
+      "error",
+      "partial",
+      "pending",
+      "unknown"
+    ],
+    "importedWindowsAutopilotDeviceIdentityUploadStatus": [
+      "complete",
+      "error",
+      "noUpload",
+      "pending"
+    ],
+    "includedUserRoles": [
+      "admin",
+      "all",
+      "privilegedAdmin",
+      "unknownFutureValue",
+      "user"
+    ],
+    "includedUserTypes": [
+      "all",
+      "guest",
+      "member",
+      "unknownFutureValue"
+    ],
+    "incompatiblePrinterSettings": [
+      "hide",
+      "show",
+      "unknownFutureValue"
+    ],
+    "inferenceClassificationType": [
+      "focused",
+      "other"
+    ],
+    "initiatorType": [
+      "application",
+      "system",
+      "unknownFutureValue",
+      "user"
+    ],
+    "insiderRiskLevel": [
+      "elevated",
+      "minor",
+      "moderate",
+      "none",
+      "unknownFutureValue"
+    ],
+    "installIntent": [
+      "available",
+      "availableWithoutEnrollment",
+      "required",
+      "uninstall"
+    ],
+    "installState": [
+      "failed",
+      "installed",
+      "notApplicable",
+      "notInstalled",
+      "uninstallFailed",
+      "unknown"
+    ],
+    "internetSiteSecurityLevel": [
+      "high",
+      "medium",
+      "mediumHigh",
+      "userDefined"
+    ],
+    "iosNotificationAlertType": [
+      "banner",
+      "deviceDefault",
+      "modal",
+      "none"
+    ],
+    "iosUpdatesInstallStatus": [
+      "available",
+      "deviceOsHigherThanDesiredOsVersion",
+      "downloadFailed",
+      "downloading",
+      "downloadInsufficientNetwork",
+      "downloadInsufficientPower",
+      "downloadInsufficientSpace",
+      "downloadRequiresComputer",
+      "idle",
+      "installFailed",
+      "installing",
+      "installInsufficientPower",
+      "installInsufficientSpace",
+      "installPhoneCallInProgress",
+      "notSupportedOperation",
+      "sharedDeviceUserLoggedInError",
+      "success",
+      "unknown"
+    ],
+    "labelActionSource": [
+      "automatic",
+      "manual",
+      "none",
+      "recommended",
+      "unknownFutureValue"
+    ],
+    "layoutTemplateType": [
+      "default",
+      "unknownFutureValue",
+      "verticalSplit"
+    ],
+    "level": [
+      "advanced",
+      "beginner",
+      "intermediate",
+      "unknownFutureValue"
+    ],
+    "lifecycleEventType": [
+      "missed",
+      "reauthorizationRequired",
+      "subscriptionRemoved"
+    ],
+    "lobbyBypassScope": [
+      "everyone",
+      "invited",
+      "organization",
+      "organizationAndFederated",
+      "organizationExcludingGuests",
+      "organizer",
+      "unknownFutureValue"
+    ],
+    "locationType": [
+      "businessAddress",
+      "conferenceRoom",
+      "default",
+      "geoCoordinates",
+      "homeAddress",
+      "hotel",
+      "localBusiness",
+      "postalAddress",
+      "restaurant",
+      "streetAddress"
+    ],
+    "locationUniqueIdType": [
+      "bing",
+      "directory",
+      "locationStore",
+      "private",
+      "unknown"
+    ],
+    "logonType": [
+      "batch",
+      "interactive",
+      "network",
+      "remoteInteractive",
+      "service",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "longRunningOperationStatus": [
+      "failed",
+      "notStarted",
+      "running",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "mailDestinationRoutingReason": [
+      "advancedSpamFiltering",
+      "autoPurgeToDeleted",
+      "autoPurgeToInbox",
+      "autoPurgeToJunk",
+      "blockedSender",
+      "domainAllowList",
+      "domainBlockList",
+      "firstTimeSender",
+      "junk",
+      "mailFlowRule",
+      "none",
+      "notInAddressBook",
+      "notJunk",
+      "outbound",
+      "safeSender",
+      "unknownFutureValue"
+    ],
+    "mailTipsType": [
+      "automaticReplies",
+      "customMailTip",
+      "deliveryRestriction",
+      "externalMemberCount",
+      "mailboxFullStatus",
+      "maxMessageSize",
+      "moderationStatus",
+      "recipientScope",
+      "recipientSuggestions",
+      "totalMemberCount"
+    ],
+    "managedAppAvailability": [
+      "global",
+      "lineOfBusiness"
+    ],
+    "managedAppClipboardSharingLevel": [
+      "allApps",
+      "blocked",
+      "managedApps",
+      "managedAppsWithPasteIn"
+    ],
+    "managedAppDataEncryptionType": [
+      "afterDeviceRestart",
+      "useDeviceSettings",
+      "whenDeviceLocked",
+      "whenDeviceLockedExceptOpenFiles"
+    ],
+    "managedAppDataStorageLocation": [
+      "box",
+      "localStorage",
+      "oneDriveForBusiness",
+      "sharePoint"
+    ],
+    "managedAppDataTransferLevel": [
+      "allApps",
+      "managedApps",
+      "none"
+    ],
+    "managedAppFlaggedReason": [
+      "none",
+      "rootedDevice"
+    ],
+    "managedAppPinCharacterSet": [
+      "alphanumericAndSymbol",
+      "numeric"
+    ],
+    "managedBrowserType": [
+      "microsoftEdge",
+      "notConfigured"
+    ],
+    "managedDeviceOwnerType": [
+      "company",
+      "personal",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "managedDevicePartnerReportedHealthState": [
+      "activated",
+      "compromised",
+      "deactivated",
+      "highSeverity",
+      "lowSeverity",
+      "mediumSeverity",
+      "misconfigured",
+      "secured",
+      "unknown",
+      "unresponsive"
+    ],
+    "managementAgentType": [
+      "configurationManagerClient",
+      "configurationManagerClientMdm",
+      "configurationManagerClientMdmEas",
+      "eas",
+      "easIntuneClient",
+      "easMdm",
+      "googleCloudDevicePolicyController",
+      "intuneClient",
+      "jamf",
+      "mdm",
+      "microsoft365ManagedMdm",
+      "msSense",
+      "unknown"
+    ],
+    "managementState": [
+      "deletePending",
+      "discovered",
+      "managed",
+      "retireCanceled",
+      "retireFailed",
+      "retireIssued",
+      "retirePending",
+      "unhealthy",
+      "unknownFutureValue",
+      "wipeCanceled",
+      "wipeFailed",
+      "wipeIssued",
+      "wipePending"
+    ],
+    "maxWorkLocationDetails": [
+      "approximate",
+      "none",
+      "specific",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "mdmAppConfigKeyType": [
+      "booleanType",
+      "integerType",
+      "realType",
+      "stringType",
+      "tokenType"
+    ],
+    "mdmAuthority": [
+      "intune",
+      "office365",
+      "sccm",
+      "unknown"
+    ],
+    "mediaDirection": [
+      "inactive",
+      "receiveOnly",
+      "sendOnly",
+      "sendReceive"
+    ],
+    "mediaSourceContentCategory": [
+      "chat",
+      "comment",
+      "liveStream",
+      "meeting",
+      "note",
+      "presentation",
+      "profile",
+      "screenRecording",
+      "story",
+      "unknownFutureValue"
+    ],
+    "mediaState": [
+      "active",
+      "inactive",
+      "unknownFutureValue"
+    ],
+    "meetingAudience": [
+      "everyone",
+      "organization",
+      "unknownFutureValue"
+    ],
+    "meetingChatHistoryDefaultMode": [
+      "all",
+      "none",
+      "unknownFutureValue"
+    ],
+    "meetingChatMode": [
+      "disabled",
+      "enabled",
+      "limited",
+      "unknownFutureValue"
+    ],
+    "meetingLiveShareOptions": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "meetingMessageType": [
+      "meetingAccepted",
+      "meetingCancelled",
+      "meetingDeclined",
+      "meetingRequest",
+      "meetingTenativelyAccepted",
+      "none"
+    ],
+    "meetingRequestType": [
+      "fullUpdate",
+      "informationalUpdate",
+      "newMeetingRequest",
+      "none",
+      "outdated",
+      "principalWantsCopy",
+      "silentUpdate"
+    ],
+    "messageActionFlag": [
+      "any",
+      "call",
+      "doNotForward",
+      "followUp",
+      "forward",
+      "fyi",
+      "noResponseNecessary",
+      "read",
+      "reply",
+      "replyToAll",
+      "review"
+    ],
+    "microsoftAuthenticatorAuthenticationMode": [
+      "any",
+      "deviceBasedPush",
+      "push"
+    ],
+    "microsoftEdgeChannel": [
+      "beta",
+      "dev",
+      "stable",
+      "unknownFutureValue"
+    ],
+    "microsoftManagedDesktopType": [
+      "notManaged",
+      "premiumManaged",
+      "standardManaged",
+      "starterManaged",
+      "unknownFutureValue"
+    ],
+    "microsoftStoreForBusinessLicenseType": [
+      "offline",
+      "online"
+    ],
+    "migrationMode": [
+      "completed",
+      "inProgress",
+      "unknownFutureValue"
+    ],
+    "migrationStatus": [
+      "additionalStepsRequired",
+      "needsReview",
+      "ready",
+      "unknownFutureValue"
+    ],
+    "miracastChannel": [
+      "eight",
+      "eleven",
+      "five",
+      "forty",
+      "fortyEight",
+      "fortyFour",
+      "four",
+      "nine",
+      "one",
+      "oneHundredFiftySeven",
+      "oneHundredFiftyThree",
+      "oneHundredFortyNine",
+      "oneHundredSixtyFive",
+      "oneHundredSixtyOne",
+      "seven",
+      "six",
+      "ten",
+      "thirtySix",
+      "three",
+      "two",
+      "userDefined"
+    ],
+    "mobileAppContentFileUploadState": [
+      "azureStorageUriRenewalFailed",
+      "azureStorageUriRenewalPending",
+      "azureStorageUriRenewalSuccess",
+      "azureStorageUriRenewalTimedOut",
+      "azureStorageUriRequestFailed",
+      "azureStorageUriRequestPending",
+      "azureStorageUriRequestSuccess",
+      "azureStorageUriRequestTimedOut",
+      "commitFileFailed",
+      "commitFilePending",
+      "commitFileSuccess",
+      "commitFileTimedOut",
+      "error",
+      "success",
+      "transientError",
+      "unknown"
+    ],
+    "mobileAppPublishingState": [
+      "notPublished",
+      "processing",
+      "published"
+    ],
+    "mobileThreatPartnerTenantState": [
+      "available",
+      "enabled",
+      "unavailable",
+      "unknownFutureValue",
+      "unresponsive"
+    ],
+    "modality": [
+      "audio",
+      "data",
+      "unknownFutureValue",
+      "video",
+      "videoBasedScreenSharing"
+    ],
+    "monitorMode": [
+      "monitorOnly",
+      "unknownFutureValue"
+    ],
+    "monitorRunStatus": [
+      "failed",
+      "partiallySuccessful",
+      "successful",
+      "unknownFutureValue"
+    ],
+    "monitorStatus": [
+      "active",
+      "inactive",
+      "unknownFutureValue"
+    ],
+    "multiFactorAuthConfiguration": [
+      "notRequired",
+      "required",
+      "unknownFutureValue"
+    ],
+    "multiTenantOrganizationMemberProcessingStatus": [
+      "failed",
+      "notStarted",
+      "running",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "multiTenantOrganizationMemberRole": [
+      "member",
+      "owner",
+      "unknownFutureValue"
+    ],
+    "multiTenantOrganizationMemberState": [
+      "active",
+      "pending",
+      "removed",
+      "unknownFutureValue"
+    ],
+    "multiTenantOrganizationState": [
+      "active",
+      "inactive",
+      "unknownFutureValue"
+    ],
+    "mutability": [
+      "Immutable",
+      "ReadOnly",
+      "ReadWrite",
+      "WriteOnly"
+    ],
+    "nativeAuthenticationApisEnabled": [
+      "all",
+      "none",
+      "unknownFutureValue"
+    ],
+    "notificationDeliveryFrequency": [
+      "biWeekly",
+      "unknown",
+      "unknownFutureValue",
+      "weekly"
+    ],
+    "notificationDeliveryPreference": [
+      "deliverAfterCampaignEnd",
+      "deliverImmedietly",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "notificationTemplateBrandingOptions": [
+      "includeCompanyLogo",
+      "includeCompanyName",
+      "includeCompanyPortalLink",
+      "includeContactInformation",
+      "includeDeviceDetails",
+      "none",
+      "unknownFutureValue"
+    ],
+    "oAuthAppScope": [
+      "readAllChat",
+      "readAllFile",
+      "readAndWriteMail",
+      "readCalendar",
+      "readContact",
+      "readMail",
+      "sendMail",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "objectDefinitionMetadata": [
+      "BaseObjectName",
+      "ConnectorDataStorageRequired",
+      "Extensions",
+      "IsSoftDeletionSupported",
+      "IsSynchronizeAllSupported",
+      "PropertyNameAccountEnabled",
+      "PropertyNameSoftDeleted"
+    ],
+    "objectFlowTypes": [
+      "Add",
+      "Delete",
+      "None",
+      "Update"
+    ],
+    "objectMappingMetadata": [
+      "DisableMonitoringForChanges",
+      "Disposition",
+      "EscrowBehavior",
+      "ExcludeFromReporting",
+      "IsCustomerDefined",
+      "OriginalJoiningProperty",
+      "Unsynchronized"
+    ],
+    "obliterationBehavior": [
+      "always",
+      "default",
+      "doNotObliterate",
+      "obliterateWithWarning",
+      "unknownFutureValue"
+    ],
+    "oidcResponseType": [
+      "code",
+      "id_token",
+      "token",
+      "unknownFutureValue"
+    ],
+    "onenotePatchActionType": [
+      "Append",
+      "Delete",
+      "Insert",
+      "Prepend",
+      "Replace"
+    ],
+    "onenotePatchInsertPosition": [
+      "After",
+      "Before"
+    ],
+    "onenoteSourceService": [
+      "OneDrive",
+      "OneDriveForBusiness",
+      "OnPremOneDriveForBusiness",
+      "Unknown"
+    ],
+    "onenoteUserRole": [
+      "Contributor",
+      "None",
+      "Owner",
+      "Reader"
+    ],
+    "onlineMeetingContentSharingDisabledReason": [
+      "unknownFutureValue",
+      "watermarkProtection"
+    ],
+    "onlineMeetingPresenters": [
+      "everyone",
+      "organization",
+      "organizer",
+      "roleIsPresenter",
+      "unknownFutureValue"
+    ],
+    "onlineMeetingProviderType": [
+      "skypeForBusiness",
+      "skypeForConsumer",
+      "teamsForBusiness",
+      "unknown"
+    ],
+    "onlineMeetingRole": [
+      "attendee",
+      "coorganizer",
+      "presenter",
+      "producer",
+      "unknownFutureValue"
+    ],
+    "onlineMeetingVideoDisabledReason": [
+      "unknownFutureValue",
+      "watermarkProtection"
+    ],
+    "onPremisesDirectorySynchronizationDeletionPreventionType": [
+      "disabled",
+      "enabledForCount",
+      "enabledForPercentage",
+      "unknownFutureValue"
+    ],
+    "operatingSystemUpgradeEligibility": [
+      "capable",
+      "notCapable",
+      "unknown",
+      "unknownFutureValue",
+      "upgraded"
+    ],
+    "operationResult": [
+      "failure",
+      "success",
+      "timeout",
+      "unknownFutureValue"
+    ],
+    "operationStatus": [
+      "Completed",
+      "Failed",
+      "NotStarted",
+      "Running"
+    ],
+    "outlierContainerType": [
+      "group",
+      "unknownFutureValue"
+    ],
+    "outlierMemberType": [
+      "unknownFutureValue",
+      "user"
+    ],
+    "pageLayoutType": [
+      "article",
+      "home",
+      "microsoftReserved",
+      "unknownFutureValue"
+    ],
+    "pagePromotionType": [
+      "microsoftReserved",
+      "newsPost",
+      "page",
+      "unknownFutureValue"
+    ],
+    "partnerTenantType": [
+      "breadthPartner",
+      "breadthPartnerDelegatedAdmin",
+      "microsoftSupport",
+      "resellerPartnerDelegatedAdmin",
+      "syndicatePartner",
+      "unknownFutureValue",
+      "valueAddedResellerPartnerDelegatedAdmin"
+    ],
+    "passkeyType": [
+      "deviceBound",
+      "synced",
+      "unknownFutureValue"
+    ],
+    "passkeyTypes": [
+      "deviceBound",
+      "synced",
+      "unknownFutureValue"
+    ],
+    "payloadBrand": [
+      "adobe",
+      "americanExpress",
+      "capitalOne",
+      "dhl",
+      "docuSign",
+      "dropbox",
+      "facebook",
+      "firstAmerican",
+      "microsoft",
+      "netflix",
+      "other",
+      "scotiabank",
+      "sendGrid",
+      "stewartTitle",
+      "syrinxCloud",
+      "teams",
+      "tesco",
+      "unknown",
+      "unknownFutureValue",
+      "wellsFargo",
+      "zoom"
+    ],
+    "payloadComplexity": [
+      "high",
+      "low",
+      "medium",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "payloadDeliveryPlatform": [
+      "email",
+      "sms",
+      "teams",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "payloadIndustry": [
+      "banking",
+      "businessServices",
+      "construction",
+      "consulting",
+      "consumerServices",
+      "courierServices",
+      "education",
+      "energy",
+      "financialServices",
+      "government",
+      "healthcare",
+      "hospitality",
+      "insurance",
+      "IT",
+      "legal",
+      "manufacturing",
+      "other",
+      "realEstate",
+      "retail",
+      "telecom",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "payloadTheme": [
+      "accountActivation",
+      "accountVerification",
+      "advertisement",
+      "billing",
+      "cleanUpMail",
+      "controversial",
+      "documentReceived",
+      "employeeEngagement",
+      "expense",
+      "fax",
+      "financeReport",
+      "incomingMessages",
+      "invoice",
+      "itemReceived",
+      "loginAlert",
+      "mailReceived",
+      "other",
+      "password",
+      "payment",
+      "payroll",
+      "personalizedOffer",
+      "quarantine",
+      "remoteWork",
+      "reviewMessage",
+      "securityUpdate",
+      "serviceSuspended",
+      "signatureRequired",
+      "unknown",
+      "unknownFutureValue",
+      "upgradeMailboxStorage",
+      "verifyMailbox",
+      "voicemail"
+    ],
+    "permissionClassificationType": [
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "permissionType": [
+      "application",
+      "delegated",
+      "delegatedUserConsentable"
+    ],
+    "persistentBrowserSessionMode": [
+      "always",
+      "never"
+    ],
+    "phoneType": [
+      "assistant",
+      "business",
+      "businessFax",
+      "home",
+      "homeFax",
+      "mobile",
+      "other",
+      "otherFax",
+      "pager",
+      "radio"
+    ],
+    "physicalAddressType": [
+      "business",
+      "home",
+      "other",
+      "unknown"
+    ],
+    "placeFeatureEnablement": [
+      "disabled",
+      "enabled",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "plannerContainerType": [
+      "group",
+      "roster",
+      "unknownFutureValue"
+    ],
+    "plannerPreviewType": [
+      "automatic",
+      "checklist",
+      "description",
+      "noPreview",
+      "reference"
+    ],
+    "policyPivotProperty": [
+      "activity",
+      "location",
+      "none",
+      "unknownFutureValue"
+    ],
+    "policyPlatformType": [
+      "all",
+      "android",
+      "androidForWork",
+      "iOS",
+      "macOS",
+      "windows10AndLater",
+      "windows81AndLater",
+      "windowsPhone81"
+    ],
+    "postType": [
+      "quick",
+      "regular",
+      "strategic",
+      "unknownFutureValue"
+    ],
+    "prereleaseFeatures": [
+      "notAllowed",
+      "settingsAndExperimentations",
+      "settingsOnly",
+      "userDefined"
+    ],
+    "printColorMode": [
+      "auto",
+      "blackAndWhite",
+      "color",
+      "grayscale",
+      "unknownFutureValue"
+    ],
+    "printDuplexMode": [
+      "flipOnLongEdge",
+      "flipOnShortEdge",
+      "oneSided",
+      "unknownFutureValue"
+    ],
+    "printerFeedOrientation": [
+      "longEdgeFirst",
+      "shortEdgeFirst",
+      "unknownFutureValue"
+    ],
+    "printerProcessingState": [
+      "idle",
+      "processing",
+      "stopped",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "printerProcessingStateDetail": [
+      "alertRemovalOfBinaryChangeEntry",
+      "banderAdded",
+      "banderAlmostEmpty",
+      "banderAlmostFull",
+      "banderAtLimit",
+      "banderClosed",
+      "banderConfigurationChange",
+      "banderCoverClosed",
+      "banderCoverOpen",
+      "banderEmpty",
+      "banderFull",
+      "banderInterlockClosed",
+      "banderInterlockOpen",
+      "banderJam",
+      "banderLifeAlmostOver",
+      "banderLifeOver",
+      "banderMemoryExhausted",
+      "banderMissing",
+      "banderMotorFailure",
+      "banderNearLimit",
+      "banderOffline",
+      "banderOpened",
+      "banderOverTemperature",
+      "banderPowerSaver",
+      "banderRecoverableFailure",
+      "banderRecoverableStorage",
+      "banderRemoved",
+      "banderResourceAdded",
+      "banderResourceRemoved",
+      "banderThermistorFailure",
+      "banderTimingFailure",
+      "banderTurnedOff",
+      "banderTurnedOn",
+      "banderUnderTemperature",
+      "banderUnrecoverableFailure",
+      "banderUnrecoverableStorageError",
+      "banderWarmingUp",
+      "binderAdded",
+      "binderAlmostEmpty",
+      "binderAlmostFull",
+      "binderAtLimit",
+      "binderClosed",
+      "binderConfigurationChange",
+      "binderCoverClosed",
+      "binderCoverOpen",
+      "binderEmpty",
+      "binderFull",
+      "binderInterlockClosed",
+      "binderInterlockOpen",
+      "binderJam",
+      "binderLifeAlmostOver",
+      "binderLifeOver",
+      "binderMemoryExhausted",
+      "binderMissing",
+      "binderMotorFailure",
+      "binderNearLimit",
+      "binderOffline",
+      "binderOpened",
+      "binderOverTemperature",
+      "binderPowerSaver",
+      "binderRecoverableFailure",
+      "binderRecoverableStorage",
+      "binderRemoved",
+      "binderResourceAdded",
+      "binderResourceRemoved",
+      "binderThermistorFailure",
+      "binderTimingFailure",
+      "binderTurnedOff",
+      "binderTurnedOn",
+      "binderUnderTemperature",
+      "binderUnrecoverableFailure",
+      "binderUnrecoverableStorageError",
+      "binderWarmingUp",
+      "cameraFailure",
+      "chamberCooling",
+      "chamberFailure",
+      "chamberHeating",
+      "chamberTemperatureHigh",
+      "chamberTemperatureLow",
+      "cleanerLifeAlmostOver",
+      "cleanerLifeOver",
+      "configurationChange",
+      "connectingToDevice",
+      "coverOpen",
+      "deactivated",
+      "deleted",
+      "developerEmpty",
+      "developerLow",
+      "dieCutterAdded",
+      "dieCutterAlmostEmpty",
+      "dieCutterAlmostFull",
+      "dieCutterAtLimit",
+      "dieCutterClosed",
+      "dieCutterConfigurationChange",
+      "dieCutterCoverClosed",
+      "dieCutterCoverOpen",
+      "dieCutterEmpty",
+      "dieCutterFull",
+      "dieCutterInterlockClosed",
+      "dieCutterInterlockOpen",
+      "dieCutterJam",
+      "dieCutterLifeAlmostOver",
+      "dieCutterLifeOver",
+      "dieCutterMemoryExhausted",
+      "dieCutterMissing",
+      "dieCutterMotorFailure",
+      "dieCutterNearLimit",
+      "dieCutterOffline",
+      "dieCutterOpened",
+      "dieCutterOverTemperature",
+      "dieCutterPowerSaver",
+      "dieCutterRecoverableFailure",
+      "dieCutterRecoverableStorage",
+      "dieCutterRemoved",
+      "dieCutterResourceAdded",
+      "dieCutterResourceRemoved",
+      "dieCutterThermistorFailure",
+      "dieCutterTimingFailure",
+      "dieCutterTurnedOff",
+      "dieCutterTurnedOn",
+      "dieCutterUnderTemperature",
+      "dieCutterUnrecoverableFailure",
+      "dieCutterUnrecoverableStorageError",
+      "dieCutterWarmingUp",
+      "doorOpen",
+      "extruderCooling",
+      "extruderFailure",
+      "extruderHeating",
+      "extruderJam",
+      "extruderTemperatureHigh",
+      "extruderTemperatureLow",
+      "fanFailure",
+      "faxModemLifeAlmostOver",
+      "faxModemLifeOver",
+      "faxModemMissing",
+      "faxModemTurnedOff",
+      "faxModemTurnedOn",
+      "folderAdded",
+      "folderAlmostEmpty",
+      "folderAlmostFull",
+      "folderAtLimit",
+      "folderClosed",
+      "folderConfigurationChange",
+      "folderCoverClosed",
+      "folderCoverOpen",
+      "folderEmpty",
+      "folderFull",
+      "folderInterlockClosed",
+      "folderInterlockOpen",
+      "folderJam",
+      "folderLifeAlmostOver",
+      "folderLifeOver",
+      "folderMemoryExhausted",
+      "folderMissing",
+      "folderMotorFailure",
+      "folderNearLimit",
+      "folderOffline",
+      "folderOpened",
+      "folderOverTemperature",
+      "folderPowerSaver",
+      "folderRecoverableFailure",
+      "folderRecoverableStorage",
+      "folderRemoved",
+      "folderResourceAdded",
+      "folderResourceRemoved",
+      "folderThermistorFailure",
+      "folderTimingFailure",
+      "folderTurnedOff",
+      "folderTurnedOn",
+      "folderUnderTemperature",
+      "folderUnrecoverableFailure",
+      "folderUnrecoverableStorageError",
+      "folderWarmingUp",
+      "fuserOverTemp",
+      "fuserUnderTemp",
+      "hibernate",
+      "holdNewJobs",
+      "identifyPrinterRequested",
+      "imprinterAdded",
+      "imprinterAlmostEmpty",
+      "imprinterAlmostFull",
+      "imprinterAtLimit",
+      "imprinterClosed",
+      "imprinterConfigurationChange",
+      "imprinterCoverClosed",
+      "imprinterCoverOpen",
+      "imprinterEmpty",
+      "imprinterFull",
+      "imprinterInterlockClosed",
+      "imprinterInterlockOpen",
+      "imprinterJam",
+      "imprinterLifeAlmostOver",
+      "imprinterLifeOver",
+      "imprinterMemoryExhausted",
+      "imprinterMissing",
+      "imprinterMotorFailure",
+      "imprinterNearLimit",
+      "imprinterOffline",
+      "imprinterOpened",
+      "imprinterOverTemperature",
+      "imprinterPowerSaver",
+      "imprinterRecoverableFailure",
+      "imprinterRecoverableStorage",
+      "imprinterRemoved",
+      "imprinterResourceAdded",
+      "imprinterResourceRemoved",
+      "imprinterThermistorFailure",
+      "imprinterTimingFailure",
+      "imprinterTurnedOff",
+      "imprinterTurnedOn",
+      "imprinterUnderTemperature",
+      "imprinterUnrecoverableFailure",
+      "imprinterUnrecoverableStorageError",
+      "imprinterWarmingUp",
+      "inputCannotFeedSizeSelected",
+      "inputManualInputRequest",
+      "inputMediaColorChange",
+      "inputMediaFormPartsChange",
+      "inputMediaSizeChange",
+      "inputMediaTrayFailure",
+      "inputMediaTrayFeedError",
+      "inputMediaTrayJam",
+      "inputMediaTypeChange",
+      "inputMediaWeightChange",
+      "inputPickRollerFailure",
+      "inputPickRollerLifeOver",
+      "inputPickRollerLifeWarn",
+      "inputPickRollerMissing",
+      "inputTrayElevationFailure",
+      "inputTrayMissing",
+      "inputTrayPositionFailure",
+      "inserterAdded",
+      "inserterAlmostEmpty",
+      "inserterAlmostFull",
+      "inserterAtLimit",
+      "inserterClosed",
+      "inserterConfigurationChange",
+      "inserterCoverClosed",
+      "inserterCoverOpen",
+      "inserterEmpty",
+      "inserterFull",
+      "inserterInterlockClosed",
+      "inserterInterlockOpen",
+      "inserterJam",
+      "inserterLifeAlmostOver",
+      "inserterLifeOver",
+      "inserterMemoryExhausted",
+      "inserterMissing",
+      "inserterMotorFailure",
+      "inserterNearLimit",
+      "inserterOffline",
+      "inserterOpened",
+      "inserterOverTemperature",
+      "inserterPowerSaver",
+      "inserterRecoverableFailure",
+      "inserterRecoverableStorage",
+      "inserterRemoved",
+      "inserterResourceAdded",
+      "inserterResourceRemoved",
+      "inserterThermistorFailure",
+      "inserterTimingFailure",
+      "inserterTurnedOff",
+      "inserterTurnedOn",
+      "inserterUnderTemperature",
+      "inserterUnrecoverableFailure",
+      "inserterUnrecoverableStorageError",
+      "inserterWarmingUp",
+      "interlockClosed",
+      "interlockOpen",
+      "interpreterCartridgeAdded",
+      "interpreterCartridgeDeleted",
+      "interpreterComplexPageEncountered",
+      "interpreterMemoryDecrease",
+      "interpreterMemoryIncrease",
+      "interpreterResourceAdded",
+      "interpreterResourceDeleted",
+      "interpreterResourceUnavailable",
+      "lampAtEol",
+      "lampFailure",
+      "lampNearEol",
+      "laserAtEol",
+      "laserFailure",
+      "laserNearEol",
+      "makeEnvelopeAdded",
+      "makeEnvelopeAlmostEmpty",
+      "makeEnvelopeAlmostFull",
+      "makeEnvelopeAtLimit",
+      "makeEnvelopeClosed",
+      "makeEnvelopeConfigurationChange",
+      "makeEnvelopeCoverClosed",
+      "makeEnvelopeCoverOpen",
+      "makeEnvelopeEmpty",
+      "makeEnvelopeFull",
+      "makeEnvelopeInterlockClosed",
+      "makeEnvelopeInterlockOpen",
+      "makeEnvelopeJam",
+      "makeEnvelopeLifeAlmostOver",
+      "makeEnvelopeLifeOver",
+      "makeEnvelopeMemoryExhausted",
+      "makeEnvelopeMissing",
+      "makeEnvelopeMotorFailure",
+      "makeEnvelopeNearLimit",
+      "makeEnvelopeOffline",
+      "makeEnvelopeOpened",
+      "makeEnvelopeOverTemperature",
+      "makeEnvelopePowerSaver",
+      "makeEnvelopeRecoverableFailure",
+      "makeEnvelopeRecoverableStorage",
+      "makeEnvelopeRemoved",
+      "makeEnvelopeResourceAdded",
+      "makeEnvelopeResourceRemoved",
+      "makeEnvelopeThermistorFailure",
+      "makeEnvelopeTimingFailure",
+      "makeEnvelopeTurnedOff",
+      "makeEnvelopeTurnedOn",
+      "makeEnvelopeUnderTemperature",
+      "makeEnvelopeUnrecoverableFailure",
+      "makeEnvelopeUnrecoverableStorageError",
+      "makeEnvelopeWarmingUp",
+      "markerAdjustingPrintQuality",
+      "markerCleanerMissing",
+      "markerDeveloperAlmostEmpty",
+      "markerDeveloperEmpty",
+      "markerDeveloperMissing",
+      "markerFuserMissing",
+      "markerFuserThermistorFailure",
+      "markerFuserTimingFailure",
+      "markerInkAlmostEmpty",
+      "markerInkEmpty",
+      "markerInkMissing",
+      "markerOpcMissing",
+      "markerPrintRibbonAlmostEmpty",
+      "markerPrintRibbonEmpty",
+      "markerPrintRibbonMissing",
+      "markerSupplyAlmostEmpty",
+      "markerSupplyEmpty",
+      "markerSupplyLow",
+      "markerSupplyMissing",
+      "markerTonerCartridgeMissing",
+      "markerTonerMissing",
+      "markerWasteAlmostFull",
+      "markerWasteFull",
+      "markerWasteInkReceptacleAlmostFull",
+      "markerWasteInkReceptacleFull",
+      "markerWasteInkReceptacleMissing",
+      "markerWasteMissing",
+      "markerWasteTonerReceptacleAlmostFull",
+      "markerWasteTonerReceptacleFull",
+      "markerWasteTonerReceptacleMissing",
+      "materialEmpty",
+      "materialLow",
+      "materialNeeded",
+      "mediaDrying",
+      "mediaEmpty",
+      "mediaJam",
+      "mediaLow",
+      "mediaNeeded",
+      "mediaPathCannotDuplexMediaSelected",
+      "mediaPathFailure",
+      "mediaPathInputEmpty",
+      "mediaPathInputFeedError",
+      "mediaPathInputJam",
+      "mediaPathInputRequest",
+      "mediaPathJam",
+      "mediaPathMediaTrayAlmostFull",
+      "mediaPathMediaTrayFull",
+      "mediaPathMediaTrayMissing",
+      "mediaPathOutputFeedError",
+      "mediaPathOutputFull",
+      "mediaPathOutputJam",
+      "mediaPathPickRollerFailure",
+      "mediaPathPickRollerLifeOver",
+      "mediaPathPickRollerLifeWarn",
+      "mediaPathPickRollerMissing",
+      "motorFailure",
+      "movingToPaused",
+      "none",
+      "opticalPhotoConductorLifeOver",
+      "opticalPhotoConductorNearEndOfLife",
+      "other",
+      "outputAreaAlmostFull",
+      "outputAreaFull",
+      "outputMailboxSelectFailure",
+      "outputMediaTrayFailure",
+      "outputMediaTrayFeedError",
+      "outputMediaTrayJam",
+      "outputTrayMissing",
+      "paused",
+      "perforaterAdded",
+      "perforaterAlmostEmpty",
+      "perforaterAlmostFull",
+      "perforaterAtLimit",
+      "perforaterClosed",
+      "perforaterConfigurationChange",
+      "perforaterCoverClosed",
+      "perforaterCoverOpen",
+      "perforaterEmpty",
+      "perforaterFull",
+      "perforaterInterlockClosed",
+      "perforaterInterlockOpen",
+      "perforaterJam",
+      "perforaterLifeAlmostOver",
+      "perforaterLifeOver",
+      "perforaterMemoryExhausted",
+      "perforaterMissing",
+      "perforaterMotorFailure",
+      "perforaterNearLimit",
+      "perforaterOffline",
+      "perforaterOpened",
+      "perforaterOverTemperature",
+      "perforaterPowerSaver",
+      "perforaterRecoverableFailure",
+      "perforaterRecoverableStorage",
+      "perforaterRemoved",
+      "perforaterResourceAdded",
+      "perforaterResourceRemoved",
+      "perforaterThermistorFailure",
+      "perforaterTimingFailure",
+      "perforaterTurnedOff",
+      "perforaterTurnedOn",
+      "perforaterUnderTemperature",
+      "perforaterUnrecoverableFailure",
+      "perforaterUnrecoverableStorageError",
+      "perforaterWarmingUp",
+      "platformCooling",
+      "platformFailure",
+      "platformHeating",
+      "platformTemperatureHigh",
+      "platformTemperatureLow",
+      "powerDown",
+      "powerUp",
+      "printerManualReset",
+      "printerNmsReset",
+      "printerReadyToPrint",
+      "puncherAdded",
+      "puncherAlmostEmpty",
+      "puncherAlmostFull",
+      "puncherAtLimit",
+      "puncherClosed",
+      "puncherConfigurationChange",
+      "puncherCoverClosed",
+      "puncherCoverOpen",
+      "puncherEmpty",
+      "puncherFull",
+      "puncherInterlockClosed",
+      "puncherInterlockOpen",
+      "puncherJam",
+      "puncherLifeAlmostOver",
+      "puncherLifeOver",
+      "puncherMemoryExhausted",
+      "puncherMissing",
+      "puncherMotorFailure",
+      "puncherNearLimit",
+      "puncherOffline",
+      "puncherOpened",
+      "puncherOverTemperature",
+      "puncherPowerSaver",
+      "puncherRecoverableFailure",
+      "puncherRecoverableStorage",
+      "puncherRemoved",
+      "puncherResourceAdded",
+      "puncherResourceRemoved",
+      "puncherThermistorFailure",
+      "puncherTimingFailure",
+      "puncherTurnedOff",
+      "puncherTurnedOn",
+      "puncherUnderTemperature",
+      "puncherUnrecoverableFailure",
+      "puncherUnrecoverableStorageError",
+      "puncherWarmingUp",
+      "resuming",
+      "scanMediaPathFailure",
+      "scanMediaPathInputEmpty",
+      "scanMediaPathInputFeedError",
+      "scanMediaPathInputJam",
+      "scanMediaPathInputRequest",
+      "scanMediaPathJam",
+      "scanMediaPathOutputFeedError",
+      "scanMediaPathOutputFull",
+      "scanMediaPathOutputJam",
+      "scanMediaPathPickRollerFailure",
+      "scanMediaPathPickRollerLifeOver",
+      "scanMediaPathPickRollerLifeWarn",
+      "scanMediaPathPickRollerMissing",
+      "scanMediaPathTrayAlmostFull",
+      "scanMediaPathTrayFull",
+      "scanMediaPathTrayMissing",
+      "scannerLightFailure",
+      "scannerLightLifeAlmostOver",
+      "scannerLightLifeOver",
+      "scannerLightMissing",
+      "scannerSensorFailure",
+      "scannerSensorLifeAlmostOver",
+      "scannerSensorLifeOver",
+      "scannerSensorMissing",
+      "separationCutterAdded",
+      "separationCutterAlmostEmpty",
+      "separationCutterAlmostFull",
+      "separationCutterAtLimit",
+      "separationCutterClosed",
+      "separationCutterConfigurationChange",
+      "separationCutterCoverClosed",
+      "separationCutterCoverOpen",
+      "separationCutterEmpty",
+      "separationCutterFull",
+      "separationCutterInterlockClosed",
+      "separationCutterInterlockOpen",
+      "separationCutterJam",
+      "separationCutterLifeAlmostOver",
+      "separationCutterLifeOver",
+      "separationCutterMemoryExhausted",
+      "separationCutterMissing",
+      "separationCutterMotorFailure",
+      "separationCutterNearLimit",
+      "separationCutterOffline",
+      "separationCutterOpened",
+      "separationCutterOverTemperature",
+      "separationCutterPowerSaver",
+      "separationCutterRecoverableFailure",
+      "separationCutterRecoverableStorage",
+      "separationCutterRemoved",
+      "separationCutterResourceAdded",
+      "separationCutterResourceRemoved",
+      "separationCutterThermistorFailure",
+      "separationCutterTimingFailure",
+      "separationCutterTurnedOff",
+      "separationCutterTurnedOn",
+      "separationCutterUnderTemperature",
+      "separationCutterUnrecoverableFailure",
+      "separationCutterUnrecoverableStorageError",
+      "separationCutterWarmingUp",
+      "sheetRotatorAdded",
+      "sheetRotatorAlmostEmpty",
+      "sheetRotatorAlmostFull",
+      "sheetRotatorAtLimit",
+      "sheetRotatorClosed",
+      "sheetRotatorConfigurationChange",
+      "sheetRotatorCoverClosed",
+      "sheetRotatorCoverOpen",
+      "sheetRotatorEmpty",
+      "sheetRotatorFull",
+      "sheetRotatorInterlockClosed",
+      "sheetRotatorInterlockOpen",
+      "sheetRotatorJam",
+      "sheetRotatorLifeAlmostOver",
+      "sheetRotatorLifeOver",
+      "sheetRotatorMemoryExhausted",
+      "sheetRotatorMissing",
+      "sheetRotatorMotorFailure",
+      "sheetRotatorNearLimit",
+      "sheetRotatorOffline",
+      "sheetRotatorOpened",
+      "sheetRotatorOverTemperature",
+      "sheetRotatorPowerSaver",
+      "sheetRotatorRecoverableFailure",
+      "sheetRotatorRecoverableStorage",
+      "sheetRotatorRemoved",
+      "sheetRotatorResourceAdded",
+      "sheetRotatorResourceRemoved",
+      "sheetRotatorThermistorFailure",
+      "sheetRotatorTimingFailure",
+      "sheetRotatorTurnedOff",
+      "sheetRotatorTurnedOn",
+      "sheetRotatorUnderTemperature",
+      "sheetRotatorUnrecoverableFailure",
+      "sheetRotatorUnrecoverableStorageError",
+      "sheetRotatorWarmingUp",
+      "shutdown",
+      "slitterAdded",
+      "slitterAlmostEmpty",
+      "slitterAlmostFull",
+      "slitterAtLimit",
+      "slitterClosed",
+      "slitterConfigurationChange",
+      "slitterCoverClosed",
+      "slitterCoverOpen",
+      "slitterEmpty",
+      "slitterFull",
+      "slitterInterlockClosed",
+      "slitterInterlockOpen",
+      "slitterJam",
+      "slitterLifeAlmostOver",
+      "slitterLifeOver",
+      "slitterMemoryExhausted",
+      "slitterMissing",
+      "slitterMotorFailure",
+      "slitterNearLimit",
+      "slitterOffline",
+      "slitterOpened",
+      "slitterOverTemperature",
+      "slitterPowerSaver",
+      "slitterRecoverableFailure",
+      "slitterRecoverableStorage",
+      "slitterRemoved",
+      "slitterResourceAdded",
+      "slitterResourceRemoved",
+      "slitterThermistorFailure",
+      "slitterTimingFailure",
+      "slitterTurnedOff",
+      "slitterTurnedOn",
+      "slitterUnderTemperature",
+      "slitterUnrecoverableFailure",
+      "slitterUnrecoverableStorageError",
+      "slitterWarmingUp",
+      "spoolAreaFull",
+      "stackerAdded",
+      "stackerAlmostEmpty",
+      "stackerAlmostFull",
+      "stackerAtLimit",
+      "stackerClosed",
+      "stackerConfigurationChange",
+      "stackerCoverClosed",
+      "stackerCoverOpen",
+      "stackerEmpty",
+      "stackerFull",
+      "stackerInterlockClosed",
+      "stackerInterlockOpen",
+      "stackerJam",
+      "stackerLifeAlmostOver",
+      "stackerLifeOver",
+      "stackerMemoryExhausted",
+      "stackerMissing",
+      "stackerMotorFailure",
+      "stackerNearLimit",
+      "stackerOffline",
+      "stackerOpened",
+      "stackerOverTemperature",
+      "stackerPowerSaver",
+      "stackerRecoverableFailure",
+      "stackerRecoverableStorage",
+      "stackerRemoved",
+      "stackerResourceAdded",
+      "stackerResourceRemoved",
+      "stackerThermistorFailure",
+      "stackerTimingFailure",
+      "stackerTurnedOff",
+      "stackerTurnedOn",
+      "stackerUnderTemperature",
+      "stackerUnrecoverableFailure",
+      "stackerUnrecoverableStorageError",
+      "stackerWarmingUp",
+      "standby",
+      "staplerAdded",
+      "staplerAlmostEmpty",
+      "staplerAlmostFull",
+      "staplerAtLimit",
+      "staplerClosed",
+      "staplerConfigurationChange",
+      "staplerCoverClosed",
+      "staplerCoverOpen",
+      "staplerEmpty",
+      "staplerFull",
+      "staplerInterlockClosed",
+      "staplerInterlockOpen",
+      "staplerJam",
+      "staplerLifeAlmostOver",
+      "staplerLifeOver",
+      "staplerMemoryExhausted",
+      "staplerMissing",
+      "staplerMotorFailure",
+      "staplerNearLimit",
+      "staplerOffline",
+      "staplerOpened",
+      "staplerOverTemperature",
+      "staplerPowerSaver",
+      "staplerRecoverableFailure",
+      "staplerRecoverableStorage",
+      "staplerRemoved",
+      "staplerResourceAdded",
+      "staplerResourceRemoved",
+      "staplerThermistorFailure",
+      "staplerTimingFailure",
+      "staplerTurnedOff",
+      "staplerTurnedOn",
+      "staplerUnderTemperature",
+      "staplerUnrecoverableFailure",
+      "staplerUnrecoverableStorageError",
+      "staplerWarmingUp",
+      "stitcherAdded",
+      "stitcherAlmostEmpty",
+      "stitcherAlmostFull",
+      "stitcherAtLimit",
+      "stitcherClosed",
+      "stitcherConfigurationChange",
+      "stitcherCoverClosed",
+      "stitcherCoverOpen",
+      "stitcherEmpty",
+      "stitcherFull",
+      "stitcherInterlockClosed",
+      "stitcherInterlockOpen",
+      "stitcherJam",
+      "stitcherLifeAlmostOver",
+      "stitcherLifeOver",
+      "stitcherMemoryExhausted",
+      "stitcherMissing",
+      "stitcherMotorFailure",
+      "stitcherNearLimit",
+      "stitcherOffline",
+      "stitcherOpened",
+      "stitcherOverTemperature",
+      "stitcherPowerSaver",
+      "stitcherRecoverableFailure",
+      "stitcherRecoverableStorage",
+      "stitcherRemoved",
+      "stitcherResourceAdded",
+      "stitcherResourceRemoved",
+      "stitcherThermistorFailure",
+      "stitcherTimingFailure",
+      "stitcherTurnedOff",
+      "stitcherTurnedOn",
+      "stitcherUnderTemperature",
+      "stitcherUnrecoverableFailure",
+      "stitcherUnrecoverableStorageError",
+      "stitcherWarmingUp",
+      "stoppedPartially",
+      "stopping",
+      "subunitAdded",
+      "subunitAlmostEmpty",
+      "subunitAlmostFull",
+      "subunitAtLimit",
+      "subunitClosed",
+      "subunitCoolingDown",
+      "subunitEmpty",
+      "subunitFull",
+      "subunitLifeAlmostOver",
+      "subunitLifeOver",
+      "subunitMemoryExhausted",
+      "subunitMissing",
+      "subunitMotorFailure",
+      "subunitNearLimit",
+      "subunitOffline",
+      "subunitOpened",
+      "subunitOverTemperature",
+      "subunitPowerSaver",
+      "subunitRecoverableFailure",
+      "subunitRecoverableStorage",
+      "subunitRemoved",
+      "subunitResourceAdded",
+      "subunitResourceRemoved",
+      "subunitThermistorFailure",
+      "subunitTimingFailure",
+      "subunitTurnedOff",
+      "subunitTurnedOn",
+      "subunitUnderTemperature",
+      "subunitUnrecoverableFailure",
+      "subunitUnrecoverableStorage",
+      "subunitWarmingUp",
+      "suspend",
+      "testing",
+      "timedOut",
+      "tonerEmpty",
+      "tonerLow",
+      "trimmerAdded",
+      "trimmerAlmostEmpty",
+      "trimmerAlmostFull",
+      "trimmerAtLimit",
+      "trimmerClosed",
+      "trimmerConfigurationChange",
+      "trimmerCoverClosed",
+      "trimmerCoverOpen",
+      "trimmerEmpty",
+      "trimmerFull",
+      "trimmerInterlockClosed",
+      "trimmerInterlockOpen",
+      "trimmerJam",
+      "trimmerLifeAlmostOver",
+      "trimmerLifeOver",
+      "trimmerMemoryExhausted",
+      "trimmerMissing",
+      "trimmerMotorFailure",
+      "trimmerNearLimit",
+      "trimmerOffline",
+      "trimmerOpened",
+      "trimmerOverTemperature",
+      "trimmerPowerSaver",
+      "trimmerRecoverableFailure",
+      "trimmerRecoverableStorage",
+      "trimmerRemoved",
+      "trimmerResourceAdded",
+      "trimmerResourceRemoved",
+      "trimmerThermistorFailure",
+      "trimmerTimingFailure",
+      "trimmerTurnedOff",
+      "trimmerTurnedOn",
+      "trimmerUnderTemperature",
+      "trimmerUnrecoverableFailure",
+      "trimmerUnrecoverableStorageError",
+      "trimmerWarmingUp",
+      "unknown",
+      "unknownFutureValue",
+      "wrapperAdded",
+      "wrapperAlmostEmpty",
+      "wrapperAlmostFull",
+      "wrapperAtLimit",
+      "wrapperClosed",
+      "wrapperConfigurationChange",
+      "wrapperCoverClosed",
+      "wrapperCoverOpen",
+      "wrapperEmpty",
+      "wrapperFull",
+      "wrapperInterlockClosed",
+      "wrapperInterlockOpen",
+      "wrapperJam",
+      "wrapperLifeAlmostOver",
+      "wrapperLifeOver",
+      "wrapperMemoryExhausted",
+      "wrapperMissing",
+      "wrapperMotorFailure",
+      "wrapperNearLimit",
+      "wrapperOffline",
+      "wrapperOpened",
+      "wrapperOverTemperature",
+      "wrapperPowerSaver",
+      "wrapperRecoverableFailure",
+      "wrapperRecoverableStorage",
+      "wrapperRemoved",
+      "wrapperResourceAdded",
+      "wrapperResourceRemoved",
+      "wrapperThermistorFailure",
+      "wrapperTimingFailure",
+      "wrapperTurnedOff",
+      "wrapperTurnedOn",
+      "wrapperUnderTemperature",
+      "wrapperUnrecoverableFailure",
+      "wrapperUnrecoverableStorageError",
+      "wrapperWarmingUp"
+    ],
+    "printEvent": [
+      "jobStarted",
+      "unknownFutureValue"
+    ],
+    "printFinishing": [
+      "bale",
+      "bind",
+      "bindBottom",
+      "bindLeft",
+      "bindRight",
+      "bindTop",
+      "bookletMaker",
+      "coat",
+      "cover",
+      "fold",
+      "foldAccordion",
+      "foldDoubleGate",
+      "foldEngineeringZ",
+      "foldGate",
+      "foldHalf",
+      "foldHalfZ",
+      "foldLeftGate",
+      "foldLetter",
+      "foldParallel",
+      "foldPoster",
+      "foldRightGate",
+      "foldZ",
+      "laminate",
+      "none",
+      "punch",
+      "punchBottomLeft",
+      "punchBottomRight",
+      "punchDualBottom",
+      "punchDualLeft",
+      "punchDualRight",
+      "punchDualTop",
+      "punchQuadBottom",
+      "punchQuadLeft",
+      "punchQuadRight",
+      "punchQuadTop",
+      "punchTopLeft",
+      "punchTopRight",
+      "punchTripleBottom",
+      "punchTripleLeft",
+      "punchTripleRight",
+      "punchTripleTop",
+      "saddleStitch",
+      "staple",
+      "stapleBottomLeft",
+      "stapleBottomRight",
+      "stapleDualBottom",
+      "stapleDualLeft",
+      "stapleDualRight",
+      "stapleDualTop",
+      "stapleTopLeft",
+      "stapleTopRight",
+      "stapleTripleBottom",
+      "stapleTripleLeft",
+      "stapleTripleRight",
+      "stapleTripleTop",
+      "stitchBottomEdge",
+      "stitchEdge",
+      "stitchLeftEdge",
+      "stitchRightEdge",
+      "stitchTopEdge",
+      "trim",
+      "trimAfterCopies",
+      "trimAfterDocuments",
+      "trimAfterJob",
+      "trimAfterPages",
+      "unknownFutureValue"
+    ],
+    "printJobProcessingState": [
+      "aborted",
+      "canceled",
+      "completed",
+      "paused",
+      "pending",
+      "processing",
+      "stopped",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "printJobStateDetail": [
+      "completedSuccessfully",
+      "completedWithErrors",
+      "completedWithWarnings",
+      "interpreting",
+      "releaseWait",
+      "transforming",
+      "unknownFutureValue",
+      "uploadPending"
+    ],
+    "printMultipageLayout": [
+      "clockwiseFromBottomLeft",
+      "clockwiseFromBottomRight",
+      "clockwiseFromTopLeft",
+      "clockwiseFromTopRight",
+      "counterclockwiseFromBottomLeft",
+      "counterclockwiseFromBottomRight",
+      "counterclockwiseFromTopLeft",
+      "counterclockwiseFromTopRight",
+      "unknownFutureValue"
+    ],
+    "printOperationProcessingState": [
+      "failed",
+      "notStarted",
+      "running",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "printOrientation": [
+      "landscape",
+      "portrait",
+      "reverseLandscape",
+      "reversePortrait",
+      "unknownFutureValue"
+    ],
+    "printQuality": [
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "printScaling": [
+      "auto",
+      "fill",
+      "fit",
+      "none",
+      "shrinkToFit",
+      "unknownFutureValue"
+    ],
+    "printTaskProcessingState": [
+      "aborted",
+      "completed",
+      "pending",
+      "processing",
+      "unknownFutureValue"
+    ],
+    "privilegedAccessGroupAssignmentType": [
+      "activated",
+      "assigned",
+      "unknownFutureValue"
+    ],
+    "privilegedAccessGroupMemberType": [
+      "direct",
+      "group",
+      "unknownFutureValue"
+    ],
+    "privilegedAccessGroupRelationships": [
+      "member",
+      "owner",
+      "unknownFutureValue"
+    ],
+    "processIntegrityLevel": [
+      "high",
+      "low",
+      "medium",
+      "system",
+      "unknown",
+      "unknownFutureValue",
+      "untrusted"
+    ],
+    "promptLoginBehavior": [
+      "disabled",
+      "nativeSupport",
+      "translateToFreshPasswordAuthentication",
+      "unknownFutureValue"
+    ],
+    "protectionPolicyStatus": [
+      "active",
+      "activeWithErrors",
+      "inactive",
+      "unknownFutureValue",
+      "updating"
+    ],
+    "protectionRuleStatus": [
+      "active",
+      "completed",
+      "completedWithErrors",
+      "deleteRequested",
+      "draft",
+      "unknownFutureValue",
+      "updateRequested"
+    ],
+    "protectionScopeState": [
+      "modified",
+      "notModified",
+      "unknownFutureValue"
+    ],
+    "protectionSource": [
+      "dynamicRule",
+      "manual",
+      "none",
+      "unknownFutureValue"
+    ],
+    "protectionUnitsBulkJobStatus": [
+      "active",
+      "completed",
+      "completedWithErrors",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "protectionUnitStatus": [
+      "cancelOffboardRequested",
+      "offboarded",
+      "offboardRequested",
+      "protected",
+      "protectRequested",
+      "removeRequested",
+      "unknownFutureValue",
+      "unprotected",
+      "unprotectRequested"
+    ],
+    "provisioningAction": [
+      "create",
+      "delete",
+      "disable",
+      "other",
+      "stagedDelete",
+      "unknownFutureValue",
+      "update"
+    ],
+    "provisioningResult": [
+      "failure",
+      "skipped",
+      "success",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "provisioningStatusErrorCategory": [
+      "failure",
+      "nonServiceFailure",
+      "success",
+      "unknownFutureValue"
+    ],
+    "provisioningStepType": [
+      "export",
+      "import",
+      "matching",
+      "processing",
+      "referenceResolution",
+      "scoping",
+      "unknownFutureValue"
+    ],
+    "quarantineReason": [
+      "EncounteredBaseEscrowThreshold",
+      "EncounteredEscrowProportionThreshold",
+      "EncounteredQuarantineException",
+      "EncounteredTotalEscrowThreshold",
+      "IngestionInterrupted",
+      "QuarantinedOnDemand",
+      "TooManyDeletes",
+      "Unknown"
+    ],
+    "ratingAppsType": [
+      "agesAbove12",
+      "agesAbove17",
+      "agesAbove4",
+      "agesAbove9",
+      "allAllowed",
+      "allBlocked"
+    ],
+    "ratingAustraliaMoviesType": [
+      "agesAbove15",
+      "agesAbove18",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "mature",
+      "parentalGuidance"
+    ],
+    "ratingAustraliaTelevisionType": [
+      "agesAbove15",
+      "agesAbove15AdultViolence",
+      "allAllowed",
+      "allBlocked",
+      "children",
+      "general",
+      "mature",
+      "parentalGuidance",
+      "preschoolers"
+    ],
+    "ratingCanadaMoviesType": [
+      "agesAbove14",
+      "agesAbove18",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "parentalGuidance",
+      "restricted"
+    ],
+    "ratingCanadaTelevisionType": [
+      "agesAbove14",
+      "agesAbove18",
+      "allAllowed",
+      "allBlocked",
+      "children",
+      "childrenAbove8",
+      "general",
+      "parentalGuidance"
+    ],
+    "ratingFranceMoviesType": [
+      "agesAbove10",
+      "agesAbove12",
+      "agesAbove16",
+      "agesAbove18",
+      "allAllowed",
+      "allBlocked"
+    ],
+    "ratingFranceTelevisionType": [
+      "agesAbove10",
+      "agesAbove12",
+      "agesAbove16",
+      "agesAbove18",
+      "allAllowed",
+      "allBlocked"
+    ],
+    "ratingGermanyMoviesType": [
+      "adults",
+      "agesAbove12",
+      "agesAbove16",
+      "agesAbove6",
+      "allAllowed",
+      "allBlocked",
+      "general"
+    ],
+    "ratingGermanyTelevisionType": [
+      "adults",
+      "agesAbove12",
+      "agesAbove16",
+      "agesAbove6",
+      "allAllowed",
+      "allBlocked",
+      "general"
+    ],
+    "ratingIrelandMoviesType": [
+      "adults",
+      "agesAbove12",
+      "agesAbove15",
+      "agesAbove16",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "parentalGuidance"
+    ],
+    "ratingIrelandTelevisionType": [
+      "allAllowed",
+      "allBlocked",
+      "children",
+      "general",
+      "mature",
+      "parentalSupervision",
+      "youngAdults"
+    ],
+    "ratingJapanMoviesType": [
+      "agesAbove15",
+      "agesAbove18",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "parentalGuidance"
+    ],
+    "ratingJapanTelevisionType": [
+      "allAllowed",
+      "allBlocked",
+      "explicitAllowed"
+    ],
+    "ratingNewZealandMoviesType": [
+      "agesAbove13",
+      "agesAbove15",
+      "agesAbove16",
+      "agesAbove16Restricted",
+      "agesAbove18",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "mature",
+      "parentalGuidance",
+      "restricted"
+    ],
+    "ratingNewZealandTelevisionType": [
+      "adults",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "parentalGuidance"
+    ],
+    "ratingUnitedKingdomMoviesType": [
+      "adults",
+      "agesAbove12Cinema",
+      "agesAbove12Video",
+      "agesAbove15",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "parentalGuidance",
+      "universalChildren"
+    ],
+    "ratingUnitedKingdomTelevisionType": [
+      "allAllowed",
+      "allBlocked",
+      "caution"
+    ],
+    "ratingUnitedStatesMoviesType": [
+      "adults",
+      "allAllowed",
+      "allBlocked",
+      "general",
+      "parentalGuidance",
+      "parentalGuidance13",
+      "restricted"
+    ],
+    "ratingUnitedStatesTelevisionType": [
+      "adults",
+      "allAllowed",
+      "allBlocked",
+      "childrenAbove14",
+      "childrenAbove7",
+      "childrenAll",
+      "general",
+      "parentalGuidance"
+    ],
+    "readingCoachStoryType": [
+      "aiGenerated",
+      "readWorks",
+      "unknownFutureValue",
+      "userProvided"
+    ],
+    "recipientScopeType": [
+      "external",
+      "externalNonPartner",
+      "externalPartner",
+      "internal",
+      "none"
+    ],
+    "recordingStatus": [
+      "failed",
+      "notRecording",
+      "recording",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "recurrencePatternType": [
+      "absoluteMonthly",
+      "absoluteYearly",
+      "daily",
+      "relativeMonthly",
+      "relativeYearly",
+      "weekly"
+    ],
+    "recurrenceRangeType": [
+      "endDate",
+      "noEnd",
+      "numbered"
+    ],
+    "registryHive": [
+      "currentConfig",
+      "currentUser",
+      "localMachineSam",
+      "localMachineSecurity",
+      "localMachineSoftware",
+      "localMachineSystem",
+      "unknown",
+      "unknownFutureValue",
+      "usersDefault"
+    ],
+    "registryOperation": [
+      "create",
+      "delete",
+      "modify",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "registryValueType": [
+      "binary",
+      "dword",
+      "dwordBigEndian",
+      "dwordLittleEndian",
+      "expandSz",
+      "link",
+      "multiSz",
+      "none",
+      "qword",
+      "qwordlittleEndian",
+      "sz",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "rejectReason": [
+      "busy",
+      "forbidden",
+      "none",
+      "unknownFutureValue"
+    ],
+    "remindBeforeTimeInMinutesType": [
+      "mins15",
+      "unknownFutureValue"
+    ],
+    "remoteAssistanceOnboardingStatus": [
+      "notOnboarded",
+      "onboarded",
+      "onboarding"
+    ],
+    "requiredPasswordType": [
+      "alphanumeric",
+      "deviceDefault",
+      "numeric"
+    ],
+    "resourceAccessStatus": [
+      "failure",
+      "none",
+      "success",
+      "unknownFutureValue"
+    ],
+    "resourceAccessType": [
+      "create",
+      "none",
+      "read",
+      "unknownFutureValue",
+      "write"
+    ],
+    "resourceLinkType": [
+      "unknownFutureValue",
+      "url"
+    ],
+    "responseEmotionType": [
+      "ambitious",
+      "angry",
+      "annoyed",
+      "anxious",
+      "apathetic",
+      "ashamed",
+      "awed",
+      "bored",
+      "calm",
+      "cheerful",
+      "comfortable",
+      "concerned",
+      "confident",
+      "confused",
+      "content",
+      "creative",
+      "curious",
+      "depressed",
+      "determined",
+      "disappointed",
+      "energized",
+      "excited",
+      "exhausted",
+      "focused",
+      "frightened",
+      "frustrated",
+      "fulfilled",
+      "glad",
+      "grateful",
+      "happy",
+      "hopeless",
+      "hurt",
+      "included",
+      "inspired",
+      "jealous",
+      "lonely",
+      "miserable",
+      "motivated",
+      "nervous",
+      "none",
+      "optimistic",
+      "overwhelmed",
+      "peaceful",
+      "pensive",
+      "proud",
+      "reserved",
+      "restless",
+      "sad",
+      "sensitive",
+      "shocked",
+      "skeptical",
+      "stressed",
+      "stuck",
+      "successful",
+      "tired",
+      "unknownFutureValue",
+      "valuable",
+      "worthless"
+    ],
+    "responseFeedbackType": [
+      "neutral",
+      "none",
+      "notDetected",
+      "pleasant",
+      "unknownFutureValue",
+      "unpleasant",
+      "veryPleasant",
+      "veryUnpleasant"
+    ],
+    "responseType": [
+      "accepted",
+      "declined",
+      "none",
+      "notResponded",
+      "organizer",
+      "tentativelyAccepted"
+    ],
+    "restorableArtifact": [
+      "message",
+      "unknownFutureValue"
+    ],
+    "restoreArtifactsBulkRequestStatus": [
+      "active",
+      "completed",
+      "completedWithErrors",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "restoreJobType": [
+      "bulk",
+      "standard",
+      "unknownFutureValue"
+    ],
+    "restorePointPreference": [
+      "latest",
+      "oldest",
+      "unknownFutureValue"
+    ],
+    "restorePointTags": [
+      "fastRestore",
+      "none",
+      "unknownFutureValue"
+    ],
+    "restoreSessionStatus": [
+      "activating",
+      "active",
+      "completed",
+      "completedWithError",
+      "draft",
+      "failed",
+      "unknownFutureValue"
+    ],
+    "restrictionAction": [
+      "audit",
+      "block",
+      "warn"
+    ],
+    "retrievalDataSource": [
+      "externalItem",
+      "oneDriveBusiness",
+      "sharePoint",
+      "unknownFutureValue"
+    ],
+    "retrievalEntityType": [
+      "drive",
+      "driveItem",
+      "externalItem",
+      "list",
+      "listItem",
+      "site",
+      "unknownFutureValue"
+    ],
+    "riskDetail": [
+      "adminConfirmedAccountSafe",
+      "adminConfirmedServicePrincipalCompromised",
+      "adminConfirmedSigninCompromised",
+      "adminConfirmedSigninSafe",
+      "adminConfirmedUserCompromised",
+      "adminDismissedAllRiskForServicePrincipal",
+      "adminDismissedAllRiskForUser",
+      "adminDismissedRiskForSignIn",
+      "adminGeneratedTemporaryPassword",
+      "aiConfirmedSigninSafe",
+      "hidden",
+      "m365DAdminDismissedDetection",
+      "none",
+      "unknownFutureValue",
+      "userChangedPasswordOnPremises",
+      "userPassedMFADrivenByRiskBasedPolicy",
+      "userPerformedSecuredPasswordChange",
+      "userPerformedSecuredPasswordReset"
+    ],
+    "riskDetectionTimingType": [
+      "nearRealtime",
+      "notDefined",
+      "offline",
+      "realtime",
+      "unknownFutureValue"
+    ],
+    "riskEventType": [
+      "adminConfirmedUserCompromised",
+      "anonymizedIPAddress",
+      "generic",
+      "investigationsThreatIntelligence",
+      "investigationsThreatIntelligenceSigninLinked",
+      "leakedCredentials",
+      "maliciousIPAddress",
+      "maliciousIPAddressValidCredentialsBlockedIP",
+      "malwareInfectedIPAddress",
+      "mcasImpossibleTravel",
+      "mcasSuspiciousInboxManipulationRules",
+      "suspiciousIPAddress",
+      "unfamiliarFeatures",
+      "unknownFutureValue",
+      "unlikelyTravel"
+    ],
+    "riskLevel": [
+      "hidden",
+      "high",
+      "low",
+      "medium",
+      "none",
+      "unknownFutureValue"
+    ],
+    "riskState": [
+      "atRisk",
+      "confirmedCompromised",
+      "confirmedSafe",
+      "dismissed",
+      "none",
+      "remediated",
+      "unknownFutureValue"
+    ],
+    "roleAssignmentScheduleFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "roleAssignmentScheduleInstanceFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "roleAssignmentScheduleRequestFilterByCurrentUserOptions": [
+      "approver",
+      "createdBy",
+      "principal",
+      "unknownFutureValue"
+    ],
+    "roleEligibilityScheduleFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "roleEligibilityScheduleInstanceFilterByCurrentUserOptions": [
+      "principal",
+      "unknownFutureValue"
+    ],
+    "roleEligibilityScheduleRequestFilterByCurrentUserOptions": [
+      "approver",
+      "createdBy",
+      "principal",
+      "unknownFutureValue"
+    ],
+    "routingMode": [
+      "multicast",
+      "oneToOne",
+      "unknownFutureValue"
+    ],
+    "routingType": [
+      "forwarded",
+      "lookup",
+      "selfFork",
+      "unknownFutureValue"
+    ],
+    "runAsAccountType": [
+      "system",
+      "user"
+    ],
+    "safeSearchFilterType": [
+      "moderate",
+      "strict",
+      "userDefined"
+    ],
+    "scheduleChangeRequestActor": [
+      "manager",
+      "recipient",
+      "sender",
+      "system",
+      "unknownFutureValue"
+    ],
+    "scheduleChangeState": [
+      "approved",
+      "declined",
+      "pending",
+      "unknownFutureValue"
+    ],
+    "scheduleEntityTheme": [
+      "blue",
+      "darkBlue",
+      "darkGreen",
+      "darkPink",
+      "darkPurple",
+      "darkYellow",
+      "gray",
+      "green",
+      "pink",
+      "purple",
+      "unknownFutureValue",
+      "white",
+      "yellow"
+    ],
+    "scheduleRequestActions": [
+      "adminAssign",
+      "adminExtend",
+      "adminRemove",
+      "adminRenew",
+      "adminUpdate",
+      "selfActivate",
+      "selfDeactivate",
+      "selfExtend",
+      "selfRenew",
+      "unknownFutureValue"
+    ],
+    "scopeCollectionKind": [
+      "allAllowed",
+      "enumerated",
+      "none",
+      "scopeKindNotSet",
+      "unknownFutureValue"
+    ],
+    "scopeOperatorMultiValuedComparisonType": [
+      "All",
+      "Any"
+    ],
+    "scopeOperatorType": [
+      "Binary",
+      "Unary"
+    ],
+    "screenSharingRole": [
+      "sharer",
+      "viewer"
+    ],
+    "searchAlterationType": [
+      "modification",
+      "suggestion",
+      "unknownFutureValue"
+    ],
+    "searchContent": [
+      "privateContent",
+      "sharedContent",
+      "unknownFutureValue"
+    ],
+    "sectionEmphasisType": [
+      "neutral",
+      "none",
+      "soft",
+      "strong",
+      "unknownFutureValue"
+    ],
+    "securityNetworkProtocol": [
+      "ggp",
+      "icmp",
+      "icmpV6",
+      "idp",
+      "igmp",
+      "ip",
+      "ipSecAuthenticationHeader",
+      "ipSecEncapsulatingSecurityPayload",
+      "ipv4",
+      "ipv6",
+      "ipv6DestinationOptions",
+      "ipv6FragmentHeader",
+      "ipv6NoNextHeader",
+      "ipv6RoutingHeader",
+      "ipx",
+      "nd",
+      "pup",
+      "raw",
+      "spx",
+      "spxII",
+      "tcp",
+      "udp",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "securityResourceType": [
+      "attacked",
+      "related",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "selectionLikelihoodInfo": [
+      "high",
+      "notSpecified"
+    ],
+    "sendDtmfCompletionReason": [
+      "completedSuccessfully",
+      "mediaOperationCanceled",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "sensitivity": [
+      "confidential",
+      "normal",
+      "personal",
+      "private"
+    ],
+    "sensitivityLabelAssignmentMethod": [
+      "auto",
+      "privileged",
+      "standard",
+      "unknownFutureValue"
+    ],
+    "serviceAppStatus": [
+      "active",
+      "inactive",
+      "pendingActive",
+      "pendingInactive",
+      "unknownFutureValue"
+    ],
+    "serviceHealthClassificationType": [
+      "advisory",
+      "incident",
+      "unknownFutureValue"
+    ],
+    "serviceHealthOrigin": [
+      "customer",
+      "microsoft",
+      "thirdParty",
+      "unknownFutureValue"
+    ],
+    "serviceHealthStatus": [
+      "confirmed",
+      "extendedRecovery",
+      "falsePositive",
+      "investigating",
+      "investigationSuspended",
+      "mitigated",
+      "mitigatedExternal",
+      "postIncidentReviewPublished",
+      "reported",
+      "resolved",
+      "resolvedExternal",
+      "restoringService",
+      "serviceDegradation",
+      "serviceInterruption",
+      "serviceOperational",
+      "serviceRestored",
+      "unknownFutureValue",
+      "verifyingService"
+    ],
+    "serviceUpdateCategory": [
+      "planForChange",
+      "preventOrFixIssue",
+      "stayInformed",
+      "unknownFutureValue"
+    ],
+    "serviceUpdateSeverity": [
+      "critical",
+      "high",
+      "normal",
+      "unknownFutureValue"
+    ],
+    "settingSourceType": [
+      "deviceConfiguration",
+      "deviceIntent"
+    ],
+    "sharedPCAccountDeletionPolicyType": [
+      "diskSpaceThreshold",
+      "diskSpaceThresholdOrInactiveThreshold",
+      "immediate"
+    ],
+    "sharedPCAllowedAccountType": [
+      "domain",
+      "guest"
+    ],
+    "sharePointMigrationJobErrorLevel": [
+      "error",
+      "fatalError",
+      "important",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "sharePointMigrationObjectType": [
+      "alert",
+      "file",
+      "folder",
+      "invalid",
+      "list",
+      "listItem",
+      "sharedWithObject",
+      "site",
+      "unknownFutureValue",
+      "web"
+    ],
+    "sharingCapabilities": [
+      "disabled",
+      "existingExternalUserSharingOnly",
+      "externalUserAndGuestSharing",
+      "externalUserSharingOnly",
+      "unknownFutureValue"
+    ],
+    "sharingDomainRestrictionMode": [
+      "allowList",
+      "blockList",
+      "none",
+      "unknownFutureValue"
+    ],
+    "signInFrequencyAuthenticationType": [
+      "primaryAndSecondaryAuthentication",
+      "secondaryAuthentication",
+      "unknownFutureValue"
+    ],
+    "signInFrequencyInterval": [
+      "everyTime",
+      "timeBased",
+      "unknownFutureValue"
+    ],
+    "signinFrequencyType": [
+      "days",
+      "hours"
+    ],
+    "signInUserType": [
+      "guest",
+      "member",
+      "unknownFutureValue"
+    ],
+    "simulationAttackTechnique": [
+      "attachmentMalware",
+      "credentialHarvesting",
+      "driveByUrl",
+      "linkInAttachment",
+      "linkToMalwareFile",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "simulationAttackType": [
+      "cloud",
+      "endpoint",
+      "social",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "simulationAutomationRunStatus": [
+      "failed",
+      "running",
+      "skipped",
+      "succeeded",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "simulationAutomationStatus": [
+      "completed",
+      "draft",
+      "notRunning",
+      "running",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "simulationContentSource": [
+      "global",
+      "tenant",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "simulationContentStatus": [
+      "archive",
+      "delete",
+      "draft",
+      "ready",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "simulationStatus": [
+      "cancelled",
+      "draft",
+      "excluded",
+      "failed",
+      "running",
+      "scheduled",
+      "succeeded",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "siteArchiveStatus": [
+      "fullyArchived",
+      "reactivating",
+      "recentlyArchived",
+      "unknownFutureValue"
+    ],
+    "siteLockState": [
+      "lockedNoAccess",
+      "lockedNoAdditions",
+      "lockedReadOnly",
+      "unknownFutureValue",
+      "unlocked"
+    ],
+    "siteSecurityLevel": [
+      "high",
+      "low",
+      "medium",
+      "mediumHigh",
+      "mediumLow",
+      "userDefined"
+    ],
+    "snapshotJobStatus": [
+      "failed",
+      "notStarted",
+      "partiallySuccessful",
+      "running",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "socialIdentitySourceType": [
+      "facebook",
+      "unknownFutureValue"
+    ],
+    "stagedFeatureName": [
+      "certificateBasedAuthentication",
+      "emailAsAlternateId",
+      "multiFactorAuthentication",
+      "passthroughAuthentication",
+      "passwordHashSync",
+      "seamlessSso",
+      "unknownFutureValue"
+    ],
+    "stateManagementSetting": [
+      "allowed",
+      "blocked",
+      "notConfigured"
+    ],
+    "status": [
+      "active",
+      "deleted",
+      "ignored",
+      "unknownFutureValue",
+      "updated"
+    ],
+    "subjectRightsRequestStage": [
+      "approval",
+      "caseResolved",
+      "contentDeletion",
+      "contentEstimate",
+      "contentRetrieval",
+      "contentReview",
+      "generateReport",
+      "unknownFutureValue"
+    ],
+    "subjectRightsRequestStageStatus": [
+      "completed",
+      "current",
+      "failed",
+      "notStarted",
+      "unknownFutureValue"
+    ],
+    "subjectRightsRequestStatus": [
+      "active",
+      "closed",
+      "unknownFutureValue"
+    ],
+    "subjectRightsRequestType": [
+      "access",
+      "delete",
+      "export",
+      "tagForAction",
+      "unknownFutureValue"
+    ],
+    "synchronizationDisposition": [
+      "Discard",
+      "Escrow",
+      "Normal"
+    ],
+    "synchronizationJobRestartScope": [
+      "ConnectorDataStore",
+      "Escrows",
+      "ForceDeletes",
+      "Full",
+      "None",
+      "QuarantineState",
+      "Watermark"
+    ],
+    "synchronizationMetadata": [
+      "ConfigurationFields",
+      "GalleryApplicationIdentifier",
+      "GalleryApplicationKey",
+      "IsOAuthEnabled",
+      "IsSynchronizationAgentAssignmentRequired",
+      "IsSynchronizationAgentRequired",
+      "IsSynchronizationInPreview",
+      "OAuthSettings",
+      "SynchronizationLearnMoreIbizaFwLink"
+    ],
+    "synchronizationScheduleState": [
+      "Active",
+      "Disabled",
+      "Paused"
+    ],
+    "synchronizationSecret": [
+      "AppKey",
+      "ApplicationTemplateIdentifier",
+      "AuthenticationType",
+      "BaseAddress",
+      "ClientIdentifier",
+      "ClientSecret",
+      "CompanyId",
+      "ConnectionString",
+      "ConsumerKey",
+      "ConsumerSecret",
+      "Domain",
+      "EnforceDomain",
+      "HardDeletesEnabled",
+      "InstanceName",
+      "None",
+      "Oauth2AccessToken",
+      "Oauth2AccessTokenCreationTime",
+      "Oauth2AuthorizationCode",
+      "Oauth2AuthorizationUri",
+      "Oauth2ClientId",
+      "Oauth2ClientSecret",
+      "Oauth2RedirectUri",
+      "Oauth2RefreshToken",
+      "Oauth2TokenExchangeUri",
+      "Password",
+      "PerformInboundEntitlementGrants",
+      "Sandbox",
+      "SandboxName",
+      "SecretToken",
+      "Server",
+      "SingleSignOnType",
+      "SkipOutOfScopeDeletions",
+      "SyncAgentADContainer",
+      "SyncAgentCompatibilityKey",
+      "SyncAll",
+      "SynchronizationSchedule",
+      "SyncNotificationSettings",
+      "SystemOfRecord",
+      "TestReferences",
+      "TokenExpiration",
+      "TokenKey",
+      "UpdateKeyOnSoftDelete",
+      "Url",
+      "UserName",
+      "ValidateDomain"
+    ],
+    "synchronizationStatusCode": [
+      "Active",
+      "NotConfigured",
+      "NotRun",
+      "Paused",
+      "Quarantine"
+    ],
+    "synchronizationTaskExecutionResult": [
+      "EntryLevelErrors",
+      "Failed",
+      "Succeeded"
+    ],
+    "targetedManagedAppGroupType": [
+      "allApps",
+      "allCoreMicrosoftApps",
+      "allMicrosoftApps",
+      "selectedPublicApps"
+    ],
+    "targettedUserType": [
+      "allUsers",
+      "clicked",
+      "compromised",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "taskStatus": [
+      "completed",
+      "deferred",
+      "inProgress",
+      "notStarted",
+      "waitingOnOthers"
+    ],
+    "teamsAppDistributionMethod": [
+      "organization",
+      "sideloaded",
+      "store",
+      "unknownFutureValue"
+    ],
+    "teamsAppPublishingState": [
+      "published",
+      "rejected",
+      "submitted",
+      "unknownFutureValue"
+    ],
+    "teamsAppResourceSpecificPermissionType": [
+      "application",
+      "delegated",
+      "unknownFutureValue"
+    ],
+    "teamsAsyncOperationStatus": [
+      "failed",
+      "inProgress",
+      "invalid",
+      "notStarted",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "teamsAsyncOperationType": [
+      "archiveChannel",
+      "archiveTeam",
+      "cloneTeam",
+      "createChannel",
+      "createTeam",
+      "invalid",
+      "teamifyGroup",
+      "unarchiveChannel",
+      "unarchiveTeam",
+      "unknownFutureValue"
+    ],
+    "teamSpecialization": [
+      "educationClass",
+      "educationProfessionalLearningCommunity",
+      "educationStaff",
+      "educationStandard",
+      "healthcareCareCoordination",
+      "healthcareStandard",
+      "none",
+      "unknownFutureValue"
+    ],
+    "teamVisibilityType": [
+      "hiddenMembership",
+      "private",
+      "public",
+      "unknownFutureValue"
+    ],
+    "teamworkActivityTopicSource": [
+      "entityUrl",
+      "text"
+    ],
+    "teamworkApplicationIdentityType": [
+      "aadApplication",
+      "bot",
+      "office365Connector",
+      "outgoingWebhook",
+      "tenantBot",
+      "unknownFutureValue"
+    ],
+    "teamworkCallEventType": [
+      "call",
+      "meeting",
+      "screenShare",
+      "unknownFutureValue"
+    ],
+    "teamworkConversationIdentityType": [
+      "channel",
+      "chat",
+      "team",
+      "unknownFutureValue"
+    ],
+    "teamworkTagType": [
+      "standard",
+      "unknownFutureValue"
+    ],
+    "teamworkUserIdentityType": [
+      "aadUser",
+      "anonymousGuest",
+      "emailUser",
+      "federatedUser",
+      "onPremiseAadUser",
+      "personalMicrosoftAccountUser",
+      "phoneUser",
+      "skypeUser",
+      "unknownFutureValue"
+    ],
+    "templateApplicationLevel": [
+      "existingPartners",
+      "newPartners",
+      "none",
+      "unknownFutureValue"
+    ],
+    "templateScenarios": [
+      "emergingThreats",
+      "new",
+      "protectAdmins",
+      "remoteWork",
+      "secureFoundation",
+      "unknownFutureValue",
+      "zeroTrust"
+    ],
+    "threatAssessmentContentType": [
+      "file",
+      "mail",
+      "url"
+    ],
+    "threatAssessmentRequestSource": [
+      "administrator",
+      "undefined",
+      "user"
+    ],
+    "threatAssessmentResultType": [
+      "checkPolicy",
+      "rescan",
+      "unknownFutureValue"
+    ],
+    "threatAssessmentStatus": [
+      "completed",
+      "pending"
+    ],
+    "threatCategory": [
+      "malware",
+      "phishing",
+      "spam",
+      "undefined",
+      "unknownFutureValue"
+    ],
+    "threatExpectedAssessment": [
+      "block",
+      "unblock"
+    ],
+    "timeCardState": [
+      "clockedIn",
+      "clockedOut",
+      "onBreak",
+      "unknownFutureValue"
+    ],
+    "timeOffReasonIconType": [
+      "cake",
+      "calendar",
+      "car",
+      "clock",
+      "cup",
+      "doctor",
+      "dog",
+      "firstAid",
+      "globe",
+      "juryDuty",
+      "none",
+      "notWorking",
+      "phone",
+      "piggyBank",
+      "pin",
+      "plane",
+      "running",
+      "sunny",
+      "trafficCone",
+      "umbrella",
+      "unknownFutureValue",
+      "weather"
+    ],
+    "timeZoneStandard": [
+      "iana",
+      "windows"
+    ],
+    "titleAreaLayoutType": [
+      "colorBlock",
+      "imageAndTitle",
+      "overlap",
+      "plain",
+      "unknownFutureValue"
+    ],
+    "titleAreaTextAlignmentType": [
+      "center",
+      "left",
+      "unknownFutureValue"
+    ],
+    "tokenIssuerType": [
+      "ADFederationServices",
+      "ADFederationServicesMFAAdapter",
+      "AzureAD",
+      "AzureADBackupAuth",
+      "NPSExtension",
+      "UnknownFutureValue"
+    ],
+    "tone": [
+      "a",
+      "b",
+      "c",
+      "d",
+      "flash",
+      "pound",
+      "star",
+      "tone0",
+      "tone1",
+      "tone2",
+      "tone3",
+      "tone4",
+      "tone5",
+      "tone6",
+      "tone7",
+      "tone8",
+      "tone9"
+    ],
+    "trainingAssignedTo": [
+      "allUsers",
+      "clickedPayload",
+      "compromised",
+      "didNothing",
+      "none",
+      "readButNotClicked",
+      "reportedPhish",
+      "unknownFutureValue"
+    ],
+    "trainingAvailabilityStatus": [
+      "archive",
+      "available",
+      "delete",
+      "notAvailable",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "trainingCompletionDuration": [
+      "fortnite",
+      "month",
+      "unknownFutureValue",
+      "week"
+    ],
+    "trainingSettingType": [
+      "custom",
+      "microsoftCustom",
+      "microsoftManaged",
+      "noTraining",
+      "unknownFutureValue"
+    ],
+    "trainingStatus": [
+      "assigned",
+      "completed",
+      "inProgress",
+      "overdue",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "trainingType": [
+      "phishing",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "unifiedRoleManagementPolicyRuleTargetOperations": [
+      "activate",
+      "all",
+      "assign",
+      "deactivate",
+      "extend",
+      "remove",
+      "renew",
+      "unknownFutureValue",
+      "update"
+    ],
+    "unifiedRoleScheduleRequestActions": [
+      "adminAssign",
+      "adminExtend",
+      "adminRemove",
+      "adminRenew",
+      "adminUpdate",
+      "selfActivate",
+      "selfDeactivate",
+      "selfExtend",
+      "selfRenew",
+      "unknownFutureValue"
+    ],
+    "usageRights": [
+      "accessDenied",
+      "comment",
+      "docEdit",
+      "edit",
+      "editRightsData",
+      "encryptedProtectionTypeNotSupportedException",
+      "exception",
+      "export",
+      "extract",
+      "forward",
+      "labelNotFoundException",
+      "objModel",
+      "owner",
+      "print",
+      "purviewClaimsChallengeNotSupportedException",
+      "reply",
+      "replyAll",
+      "unknown",
+      "unknownFutureValue",
+      "userDefinedProtectionTypeNotSupportedException",
+      "view",
+      "viewRightsData"
+    ],
+    "userAccountSecurityType": [
+      "administrator",
+      "power",
+      "standard",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "userAction": [
+      "registerOrJoinDevices",
+      "registerSecurityInformation",
+      "unknownFutureValue"
+    ],
+    "userActivityType": [
+      "downloadFile",
+      "downloadText",
+      "unknownFutureValue",
+      "uploadFile",
+      "uploadText"
+    ],
+    "userActivityTypes": [
+      "downloadFile",
+      "downloadText",
+      "none",
+      "unknownFutureValue",
+      "uploadFile",
+      "uploadText"
+    ],
+    "userDefaultAuthenticationMethod": [
+      "none",
+      "oath",
+      "push",
+      "sms",
+      "unknownFutureValue",
+      "voiceAlternateMobile",
+      "voiceMobile",
+      "voiceOffice"
+    ],
+    "userExperienceAnalyticsHealthState": [
+      "insufficientData",
+      "meetingGoals",
+      "needsAttention",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "userExperienceAnalyticsInsightSeverity": [
+      "error",
+      "informational",
+      "none",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "userExperienceAnalyticsOperatingSystemRestartCategory": [
+      "blueScreen",
+      "bootError",
+      "longPowerButtonPress",
+      "restartWithoutUpdate",
+      "restartWithUpdate",
+      "shutdownWithoutUpdate",
+      "shutdownWithUpdate",
+      "unknown",
+      "unknownFutureValue",
+      "update"
+    ],
+    "userExperienceAnalyticsSummarizedBy": [
+      "allRegressions",
+      "manufacturerRegression",
+      "model",
+      "modelRegression",
+      "none",
+      "operatingSystemVersionRegression",
+      "unknownFutureValue"
+    ],
+    "userFlowType": [
+      "passwordReset",
+      "profileUpdate",
+      "resourceOwner",
+      "signIn",
+      "signUp",
+      "signUpOrSignIn",
+      "unknownFutureValue"
+    ],
+    "userPurpose": [
+      "equipment",
+      "linked",
+      "others",
+      "room",
+      "shared",
+      "unknownFutureValue",
+      "user"
+    ],
+    "userScopeType": [
+      "group",
+      "tenant",
+      "unknownFutureValue",
+      "user"
+    ],
+    "userSignInRecommendationScope": [
+      "application",
+      "tenant",
+      "unknownFutureValue"
+    ],
+    "userType": [
+      "guest",
+      "member",
+      "unknownFutureValue"
+    ],
+    "virtualAppointmentMessageType": [
+      "cancellation",
+      "confirmation",
+      "reschedule",
+      "unknownFutureValue"
+    ],
+    "virtualEventAttendeeRegistrationStatus": [
+      "canceled",
+      "pendingApproval",
+      "registered",
+      "rejectedByOrganizer",
+      "unknownFutureValue",
+      "waitlisted"
+    ],
+    "virtualEventRegistrationPredefinedQuestionLabel": [
+      "city",
+      "countryOrRegion",
+      "industry",
+      "jobTitle",
+      "organization",
+      "postalCode",
+      "state",
+      "street",
+      "unknownFutureValue"
+    ],
+    "virtualEventRegistrationQuestionAnswerInputType": [
+      "boolean",
+      "multiChoice",
+      "multilineText",
+      "singleChoice",
+      "text",
+      "unknownFutureValue"
+    ],
+    "virtualEventStatus": [
+      "canceled",
+      "draft",
+      "published",
+      "unknownFutureValue"
+    ],
+    "visibilitySetting": [
+      "hide",
+      "notConfigured",
+      "show"
+    ],
+    "volumeType": [
+      "fixedDataVolume",
+      "operatingSystemVolume",
+      "removableDataVolume",
+      "unknownFutureValue"
+    ],
+    "vppTokenAccountType": [
+      "business",
+      "education"
+    ],
+    "vppTokenState": [
+      "assignedToExternalMDM",
+      "expired",
+      "invalid",
+      "unknown",
+      "valid"
+    ],
+    "vppTokenSyncStatus": [
+      "completed",
+      "failed",
+      "inProgress",
+      "none"
+    ],
+    "weakAlgorithms": [
+      "rsaSha1",
+      "unknownFutureValue"
+    ],
+    "webApplicationFirewallDnsRecordType": [
+      "cname",
+      "unknownFutureValue"
+    ],
+    "webApplicationFirewallProviderType": [
+      "akamai",
+      "cloudflare",
+      "unknownFutureValue"
+    ],
+    "webApplicationFirewallVerificationStatus": [
+      "failure",
+      "success",
+      "unknownFutureValue",
+      "warning"
+    ],
+    "webBrowserCookieSettings": [
+      "allowAlways",
+      "allowCurrentWebSite",
+      "allowFromWebsitesVisited",
+      "blockAlways",
+      "browserDefault"
+    ],
+    "websiteType": [
+      "blog",
+      "home",
+      "other",
+      "profile",
+      "work"
+    ],
+    "weekIndex": [
+      "first",
+      "fourth",
+      "last",
+      "second",
+      "third"
+    ],
+    "weeklySchedule": [
+      "everyday",
+      "friday",
+      "monday",
+      "saturday",
+      "sunday",
+      "thursday",
+      "tuesday",
+      "userDefined",
+      "wednesday"
+    ],
+    "welcomeScreenMeetingInformation": [
+      "showOrganizerAndTimeAndSubject",
+      "showOrganizerAndTimeOnly",
+      "userDefined"
+    ],
+    "wellknownListName": [
+      "defaultList",
+      "flaggedEmails",
+      "none",
+      "unknownFutureValue"
+    ],
+    "whatIfAnalysisReasons": [
+      "application",
+      "authenticationContext",
+      "authenticationFlow",
+      "clientApps",
+      "devicePlatform",
+      "devices",
+      "emptyPolicy",
+      "insiderRisk",
+      "invalidCondition",
+      "invalidPolicy",
+      "location",
+      "notEnoughInformation",
+      "notSet",
+      "policyNotEnabled",
+      "signInRisk",
+      "time",
+      "unknownFutureValue",
+      "userActions",
+      "userRisk",
+      "users",
+      "workloadIdentities"
+    ],
+    "win32LobAppDeliveryOptimizationPriority": [
+      "foreground",
+      "notConfigured"
+    ],
+    "win32LobAppFileSystemOperationType": [
+      "createdDate",
+      "exists",
+      "modifiedDate",
+      "notConfigured",
+      "sizeInMB",
+      "version"
+    ],
+    "win32LobAppMsiPackageType": [
+      "dualPurpose",
+      "perMachine",
+      "perUser"
+    ],
+    "win32LobAppNotification": [
+      "hideAll",
+      "showAll",
+      "showReboot"
+    ],
+    "win32LobAppPowerShellScriptRuleOperationType": [
+      "boolean",
+      "dateTime",
+      "float",
+      "integer",
+      "notConfigured",
+      "string",
+      "version"
+    ],
+    "win32LobAppRegistryRuleOperationType": [
+      "doesNotExist",
+      "exists",
+      "integer",
+      "notConfigured",
+      "string",
+      "version"
+    ],
+    "win32LobAppRestartBehavior": [
+      "allow",
+      "basedOnReturnCode",
+      "force",
+      "suppress"
+    ],
+    "win32LobAppReturnCodeType": [
+      "failed",
+      "hardReboot",
+      "retry",
+      "softReboot",
+      "success"
+    ],
+    "win32LobAppRuleOperator": [
+      "equal",
+      "greaterThan",
+      "greaterThanOrEqual",
+      "lessThan",
+      "lessThanOrEqual",
+      "notConfigured",
+      "notEqual"
+    ],
+    "win32LobAppRuleType": [
+      "detection",
+      "requirement"
+    ],
+    "win32LobAutoUpdateSupersededAppsState": [
+      "enabled",
+      "notConfigured",
+      "unknownFutureValue"
+    ],
+    "windows10EditionType": [
+      "windows10Education",
+      "windows10EducationN",
+      "windows10Enterprise",
+      "windows10EnterpriseN",
+      "windows10HolographicEnterprise",
+      "windows10MobileEnterprise",
+      "windows10Professional",
+      "windows10ProfessionalEducation",
+      "windows10ProfessionalEducationN",
+      "windows10ProfessionalN",
+      "windows10ProfessionalWorkstation",
+      "windows10ProfessionalWorkstationN"
+    ],
+    "windows365SwitchCompatibilityFailureReasonType": [
+      "hardwareNotSupported",
+      "osVersionNotSupported",
+      "unknownFutureValue"
+    ],
+    "windowsArchitecture": [
+      "arm",
+      "neutral",
+      "none",
+      "x64",
+      "x86"
+    ],
+    "windowsAutopilotDeviceType": [
+      "holoLens",
+      "unknownFutureValue",
+      "windowsPc"
+    ],
+    "windowsDefenderProductStatus": [
+      "asSignaturesOutOfDate",
+      "avSignaturesOutOfDate",
+      "noFullScanHappenedForSpecifiedPeriod",
+      "noQuickScanHappenedForSpecifiedPeriod",
+      "noStatus",
+      "noStatusFlagsSet",
+      "offlineScanRequired",
+      "pendingFullScanDueToThreatAction",
+      "pendingManualStepsDueToThreatAction",
+      "pendingRebootDueToThreatAction",
+      "platformAboutToBeOutdated",
+      "platformOutOfDate",
+      "platformUpdateInProgress",
+      "productExpired",
+      "productRunningInEvaluationMode",
+      "productRunningInNonGenuineMode",
+      "samplesPendingSubmission",
+      "serviceNotRunning",
+      "serviceShutdownAsPartOfSystemShutdown",
+      "serviceStartedWithoutMalwareProtection",
+      "signatureOrPlatformEndOfLifeIsPastOrIsImpending",
+      "systemInitiatedCleanInProgress",
+      "systemInitiatedScanInProgress",
+      "threatRemediationFailedCritically",
+      "threatRemediationFailedNonCritically",
+      "windowsSModeSignaturesInUseOnNonWin10SInstall"
+    ],
+    "windowsDeliveryOptimizationMode": [
+      "bypassMode",
+      "httpOnly",
+      "httpWithInternetPeering",
+      "httpWithPeeringNat",
+      "httpWithPeeringPrivateGroup",
+      "simpleDownload",
+      "userDefined"
+    ],
+    "windowsDeviceHealthState": [
+      "clean",
+      "critical",
+      "fullScanPending",
+      "manualStepsPending",
+      "offlineScanPending",
+      "rebootPending"
+    ],
+    "windowsDeviceType": [
+      "desktop",
+      "holographic",
+      "mobile",
+      "none",
+      "team",
+      "unknownFutureValue"
+    ],
+    "windowsDeviceUsageType": [
+      "shared",
+      "singleUser",
+      "unknownFutureValue"
+    ],
+    "windowsHelloForBusinessPinUsage": [
+      "allowed",
+      "disallowed",
+      "required"
+    ],
+    "windowsInformationProtectionEnforcementLevel": [
+      "encryptAndAuditOnly",
+      "encryptAuditAndBlock",
+      "encryptAuditAndPrompt",
+      "noProtection"
+    ],
+    "windowsInformationProtectionPinCharacterRequirements": [
+      "allow",
+      "notAllow",
+      "requireAtLeastOne"
+    ],
+    "windowsMalwareCategory": [
+      "adware",
+      "aolExploit",
+      "backdoor",
+      "behavior",
+      "browserModifier",
+      "browserPlugin",
+      "cookie",
+      "dialer",
+      "emailFlooder",
+      "enterpriseUnwantedSoftware",
+      "exploit",
+      "filesharingProgram",
+      "hipsRule",
+      "hostileActiveXControl",
+      "icqExploit",
+      "invalid",
+      "jokeProgram",
+      "keylogger",
+      "known",
+      "malwareCreationTool",
+      "monitoringSoftware",
+      "nuker",
+      "passwordStealer",
+      "policy",
+      "potentialUnwantedSoftware",
+      "ransom",
+      "remote_Control_Software",
+      "remoteAccessTrojan",
+      "remoteControlSoftware",
+      "securityDisabler",
+      "settingsModifier",
+      "softwareBundler",
+      "spp",
+      "spyware",
+      "stealthNotifier",
+      "tool",
+      "toolBar",
+      "trojan",
+      "trojanDenialOfService",
+      "trojanDownloader",
+      "trojanDropper",
+      "trojanFtp",
+      "trojanMassMailer",
+      "trojanMonitoringSoftware",
+      "trojanProxyServer",
+      "trojanTelnet",
+      "unknown",
+      "virus",
+      "vulnerability",
+      "worm"
+    ],
+    "windowsMalwareExecutionState": [
+      "allowed",
+      "blocked",
+      "notRunning",
+      "running",
+      "unknown"
+    ],
+    "windowsMalwareSeverity": [
+      "high",
+      "low",
+      "moderate",
+      "severe",
+      "unknown"
+    ],
+    "windowsMalwareState": [
+      "abandoned",
+      "allowed",
+      "allowFailed",
+      "blocked",
+      "blockFailed",
+      "cleaned",
+      "cleanFailed",
+      "detected",
+      "quarantined",
+      "quarantineFailed",
+      "removed",
+      "removeFailed",
+      "unknown"
+    ],
+    "windowsMalwareThreatState": [
+      "actionFailed",
+      "active",
+      "allowed",
+      "cleaned",
+      "fullScanRequired",
+      "manualStepsRequired",
+      "noStatusCleared",
+      "quarantined",
+      "rebootRequired",
+      "remediatedWithNonCriticalFailures",
+      "removed"
+    ],
+    "windowsSettingType": [
+      "backup",
+      "roaming",
+      "unknownFutureValue"
+    ],
+    "windowsSpotlightEnablementSettings": [
+      "disabled",
+      "enabled",
+      "notConfigured"
+    ],
+    "windowsStartMenuAppListVisibilityType": [
+      "collapse",
+      "disableSettingsApp",
+      "remove",
+      "userDefined"
+    ],
+    "windowsStartMenuModeType": [
+      "fullScreen",
+      "nonFullScreen",
+      "userDefined"
+    ],
+    "windowsUpdateForBusinessUpdateWeeks": [
+      "everyWeek",
+      "firstWeek",
+      "fourthWeek",
+      "secondWeek",
+      "thirdWeek",
+      "unknownFutureValue",
+      "userDefined"
+    ],
+    "windowsUpdateNotificationDisplayOption": [
+      "defaultNotifications",
+      "disableAllNotifications",
+      "notConfigured",
+      "restartWarningsOnly",
+      "unknownFutureValue"
+    ],
+    "windowsUpdateType": [
+      "all",
+      "businessReadyOnly",
+      "userDefined",
+      "windowsInsiderBuildFast",
+      "windowsInsiderBuildRelease",
+      "windowsInsiderBuildSlow"
+    ],
+    "windowsUserAccountControlSettings": [
+      "alwaysNotify",
+      "neverNotify",
+      "notifyOnAppChanges",
+      "notifyOnAppChangesWithoutDimming",
+      "userDefined"
+    ],
+    "windowsUserType": [
+      "administrator",
+      "standard",
+      "unknownFutureValue"
+    ],
+    "workbookOperationStatus": [
+      "failed",
+      "notStarted",
+      "running",
+      "succeeded"
+    ],
+    "workforceIntegrationEncryptionProtocol": [
+      "sharedSecret",
+      "unknownFutureValue"
+    ],
+    "workforceIntegrationSupportedEntities": [
+      "none",
+      "offerShiftRequest",
+      "openShift",
+      "openShiftRequest",
+      "shift",
+      "swapRequest",
+      "timeCard",
+      "timeOff",
+      "timeOffReason",
+      "timeOffRequest",
+      "unknownFutureValue",
+      "userShiftPreferences"
+    ],
+    "workLocationSource": [
+      "automatic",
+      "manual",
+      "none",
+      "scheduled",
+      "unknownFutureValue"
+    ],
+    "workLocationType": [
+      "office",
+      "remote",
+      "timeOff",
+      "unknownFutureValue",
+      "unspecified"
+    ],
+    "workLocationUpdateScope": [
+      "currentDay",
+      "currentSegment",
+      "unknownFutureValue"
+    ],
+    "x509CertificateAffinityLevel": [
+      "high",
+      "low",
+      "unknownFutureValue"
+    ],
+    "x509CertificateAuthenticationMode": [
+      "unknownFutureValue",
+      "x509CertificateMultiFactor",
+      "x509CertificateSingleFactor"
+    ],
+    "x509CertificateCRLValidationConfigurationState": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "x509CertificateIssuerHintsState": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "x509CertificateRuleType": [
+      "issuerSubject",
+      "issuerSubjectAndPolicyOID",
+      "policyOID",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.callRecords": {
+    "audioCodec": [
+      "amrWide",
+      "cn",
+      "g722",
+      "g7221",
+      "g7221c",
+      "g729",
+      "invalid",
+      "muchv2",
+      "multiChannelAudio",
+      "opus",
+      "pcma",
+      "pcmu",
+      "rtAudio16",
+      "rtAudio8",
+      "satin",
+      "satinFullband",
+      "silk",
+      "silkNarrow",
+      "silkWide",
+      "siren",
+      "unknown",
+      "unknownFutureValue",
+      "xmsRta"
+    ],
+    "callType": [
+      "groupCall",
+      "peerToPeer",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "clientPlatform": [
+      "android",
+      "holoLens",
+      "iOS",
+      "ipPhone",
+      "macOS",
+      "roomSystem",
+      "surfaceHub",
+      "unknown",
+      "unknownFutureValue",
+      "web",
+      "windows"
+    ],
+    "failureStage": [
+      "callSetup",
+      "midcall",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "mediaStreamDirection": [
+      "calleeToCaller",
+      "callerToCallee"
+    ],
+    "modality": [
+      "audio",
+      "data",
+      "screenSharing",
+      "unknownFutureValue",
+      "video",
+      "videoBasedScreenSharing"
+    ],
+    "networkConnectionType": [
+      "mobile",
+      "tunnel",
+      "unknown",
+      "unknownFutureValue",
+      "wifi",
+      "wired"
+    ],
+    "networkTransportProtocol": [
+      "tcp",
+      "udp",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "productFamily": [
+      "azureCommunicationServices",
+      "lync",
+      "skypeForBusiness",
+      "teams",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "pstnCallDurationSource": [
+      "microsoft",
+      "operator"
+    ],
+    "serviceRole": [
+      "audioTeleconferencerController",
+      "conferencingAnnouncementService",
+      "conferencingAttendant",
+      "customBot",
+      "exchangeUnifiedMessagingService",
+      "gateway",
+      "mediaController",
+      "mediationServer",
+      "mediationServerCloudConnectorEdition",
+      "responseGroupService",
+      "responseGroupServiceAnnouncementService",
+      "skypeForBusinessApplicationSharingMcu",
+      "skypeForBusinessAttendant",
+      "skypeForBusinessAudioVideoMcu",
+      "skypeForBusinessAutoAttendant",
+      "skypeForBusinessCallQueues",
+      "skypeForBusinessMicrosoftTeamsGateway",
+      "skypeForBusinessUnifiedCommunicationApplicationPlatform",
+      "skypeTranslator",
+      "unknown",
+      "unknownFutureValue",
+      "voicemail"
+    ],
+    "userFeedbackRating": [
+      "bad",
+      "excellent",
+      "fair",
+      "good",
+      "notRated",
+      "poor",
+      "unknownFutureValue"
+    ],
+    "videoCodec": [
+      "av1",
+      "h263",
+      "h264",
+      "h264s",
+      "h264uc",
+      "h265",
+      "invalid",
+      "rtvc1",
+      "rtVideo",
+      "unknown",
+      "unknownFutureValue",
+      "xrtvc1"
+    ],
+    "wifiBand": [
+      "frequency24GHz",
+      "frequency50GHz",
+      "frequency60GHz",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "wifiRadioType": [
+      "unknown",
+      "unknownFutureValue",
+      "wifi80211a",
+      "wifi80211ac",
+      "wifi80211ax",
+      "wifi80211b",
+      "wifi80211g",
+      "wifi80211n"
+    ]
+  },
+  "microsoft.graph.externalConnectors": {
+    "accessType": [
+      "deny",
+      "grant",
+      "unknownFutureValue"
+    ],
+    "aclType": [
+      "everyone",
+      "everyoneExceptGuests",
+      "externalGroup",
+      "group",
+      "unknownFutureValue",
+      "user"
+    ],
+    "connectionOperationStatus": [
+      "completed",
+      "failed",
+      "inprogress",
+      "unknownFutureValue",
+      "unspecified"
+    ],
+    "connectionState": [
+      "draft",
+      "limitExceeded",
+      "obsolete",
+      "ready",
+      "unknownFutureValue"
+    ],
+    "contentCategory": [
+      "crm",
+      "dashboard",
+      "email",
+      "fileRepository",
+      "knowledgeBase",
+      "learningManagement",
+      "media",
+      "meetingTranscripts",
+      "messaging",
+      "people",
+      "qna",
+      "taskManagement",
+      "uncategorized",
+      "unknownFutureValue",
+      "wikis"
+    ],
+    "externalActivityType": [
+      "commented",
+      "created",
+      "modified",
+      "unknownFutureValue",
+      "viewed"
+    ],
+    "externalItemContentType": [
+      "html",
+      "text",
+      "unknownFutureValue"
+    ],
+    "identityType": [
+      "externalGroup",
+      "group",
+      "unknownFutureValue",
+      "user"
+    ],
+    "label": [
+      "assignedToPeople",
+      "authors",
+      "closedBy",
+      "closedDate",
+      "containerName",
+      "containerUrl",
+      "createdBy",
+      "createdDateTime",
+      "dueDate",
+      "fileExtension",
+      "fileName",
+      "iconUrl",
+      "itemParentId",
+      "itemPath",
+      "itemType",
+      "lastModifiedBy",
+      "lastModifiedDateTime",
+      "numberOfReactions",
+      "parentUrl",
+      "personAccount",
+      "personAddresses",
+      "personAlternateContacts",
+      "personAnniversaries",
+      "personAssistants",
+      "personAwards",
+      "personCertifications",
+      "personColleagues",
+      "personCurrentPosition",
+      "personEmails",
+      "personEmergencyContacts",
+      "personManager",
+      "personName",
+      "personNote",
+      "personPhones",
+      "personProjects",
+      "personSkills",
+      "personWebAccounts",
+      "personWebSite",
+      "priority",
+      "priorityNormalized",
+      "reportedBy",
+      "secondaryId",
+      "severity",
+      "sprintName",
+      "state",
+      "tags",
+      "title",
+      "unknownFutureValue",
+      "url"
+    ],
+    "propertyType": [
+      "boolean",
+      "dateTime",
+      "dateTimeCollection",
+      "double",
+      "doubleCollection",
+      "int64",
+      "int64Collection",
+      "principal",
+      "principalCollection",
+      "string",
+      "stringCollection",
+      "unknownFutureValue"
+    ],
+    "ruleOperation": [
+      "contains",
+      "equals",
+      "greaterThan",
+      "lessThan",
+      "notContains",
+      "notEquals",
+      "null",
+      "startsWith",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.identityGovernance": {
+    "activationTaskScopeType": [
+      "allTasks",
+      "failedTasks",
+      "unknownFutureValue"
+    ],
+    "activationUserScopeType": [
+      "allUsers",
+      "failedUsers",
+      "unknownFutureValue"
+    ],
+    "customTaskExtensionOperationStatus": [
+      "completed",
+      "failed",
+      "unknownFutureValue"
+    ],
+    "lifecycleTaskCategory": [
+      "joiner",
+      "leaver",
+      "mover",
+      "unknownFutureValue"
+    ],
+    "lifecycleWorkflowCategory": [
+      "joiner",
+      "leaver",
+      "mover",
+      "unknownFutureValue"
+    ],
+    "lifecycleWorkflowProcessingStatus": [
+      "canceled",
+      "completed",
+      "completedWithErrors",
+      "failed",
+      "inProgress",
+      "queued",
+      "unknownFutureValue"
+    ],
+    "membershipChangeType": [
+      "add",
+      "remove",
+      "unknownFutureValue"
+    ],
+    "valueType": [
+      "bool",
+      "enum",
+      "int",
+      "string",
+      "unknownFutureValue"
+    ],
+    "workflowExecutionType": [
+      "activatedWithScope",
+      "onDemand",
+      "scheduled",
+      "unknownFutureValue"
+    ],
+    "workflowTriggerTimeBasedAttribute": [
+      "createdDateTime",
+      "employeeHireDate",
+      "employeeLeaveDateTime",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.partners.billing": {
+    "attributeSet": [
+      "basic",
+      "full",
+      "unknownFutureValue"
+    ],
+    "billingPeriod": [
+      "current",
+      "last",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.search": {
+    "answerState": [
+      "draft",
+      "excluded",
+      "published",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.security": {
+    "action": [
+      "disable",
+      "enable",
+      "forcePasswordReset",
+      "markUserAsCompromised",
+      "requireUserToSignInAgain",
+      "revokeAllSessions",
+      "unknownFutureValue"
+    ],
+    "actionAfterRetentionPeriod": [
+      "delete",
+      "none",
+      "relabel",
+      "startDispositionReview",
+      "unknownFutureValue"
+    ],
+    "additionalDataOptions": [
+      "advancedIndexing",
+      "allItemsInFolder",
+      "allVersions",
+      "htmlTranscripts",
+      "linkedFiles",
+      "listAttachments",
+      "locationsWithoutHits",
+      "messageConversationExpansion",
+      "unknownFutureValue"
+    ],
+    "additionalOptions": [
+      "advancedIndexing",
+      "allDocumentVersions",
+      "allItemsInFolder",
+      "cloudAttachments",
+      "condensePaths",
+      "friendlyName",
+      "htmlTranscripts",
+      "includeFolderAndPath",
+      "includeReport",
+      "listAttachments",
+      "none",
+      "splitSource",
+      "subfolderContents",
+      "teamsAndYammerConversations",
+      "unknownFutureValue"
+    ],
+    "aiAgentPlatform": [
+      "azureAIFoundry",
+      "copilot",
+      "copilotStudio",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alertClassification": [
+      "falsePositive",
+      "informationalExpectedActivity",
+      "truePositive",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alertDetermination": [
+      "apt",
+      "compromisedAccount",
+      "confirmedActivity",
+      "lineOfBusinessApplication",
+      "maliciousUserActivity",
+      "malware",
+      "multiStagedAttack",
+      "notEnoughDataToValidate",
+      "notMalicious",
+      "other",
+      "phishing",
+      "securityPersonnel",
+      "securityTesting",
+      "unknown",
+      "unknownFutureValue",
+      "unwantedSoftware"
+    ],
+    "alertSeverity": [
+      "high",
+      "informational",
+      "low",
+      "medium",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alertStatus": [
+      "inProgress",
+      "new",
+      "resolved",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "antispamTeamsDirection": [
+      "inbound",
+      "intraorg",
+      "outbound",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "behaviorDuringRetentionPeriod": [
+      "doNotRetain",
+      "retain",
+      "retainAsRecord",
+      "retainAsRegulatoryRecord",
+      "unknownFutureValue"
+    ],
+    "caseAction": [
+      "addToReviewSet",
+      "applyTags",
+      "contentExport",
+      "convertToPdf",
+      "estimateStatistics",
+      "exportReport",
+      "exportResult",
+      "holdPolicySync",
+      "holdUpdate",
+      "index",
+      "purgeData",
+      "unknownFutureValue"
+    ],
+    "caseOperationStatus": [
+      "failed",
+      "notStarted",
+      "partiallySucceeded",
+      "running",
+      "submissionFailed",
+      "succeeded",
+      "unknownFutureValue"
+    ],
+    "caseStatus": [
+      "active",
+      "closed",
+      "closedWithError",
+      "closing",
+      "pendingDelete",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "caseType": [
+      "premium",
+      "standard",
+      "unknownFutureValue"
+    ],
+    "childSelectability": [
+      "Many",
+      "One",
+      "unknownFutureValue"
+    ],
+    "cloudAttachmentVersion": [
+      "all",
+      "latest",
+      "recent10",
+      "recent100",
+      "unknownFutureValue"
+    ],
+    "containerPortProtocol": [
+      "sctp",
+      "tcp",
+      "udp",
+      "unknownFutureValue"
+    ],
+    "contentFormat": [
+      "html",
+      "markdown",
+      "text",
+      "unknownFutureValue"
+    ],
+    "dataSourceContainerStatus": [
+      "active",
+      "released",
+      "unknownFutureValue"
+    ],
+    "dataSourceHoldStatus": [
+      "applied",
+      "applying",
+      "notApplied",
+      "partial",
+      "removing",
+      "unknownFutureValue"
+    ],
+    "dataSourceScopes": [
+      "allCaseCustodians",
+      "allCaseNoncustodialDataSources",
+      "allTenantMailboxes",
+      "allTenantSites",
+      "none",
+      "unknownFutureValue"
+    ],
+    "defaultRecordBehavior": [
+      "startLocked",
+      "startUnlocked",
+      "unknownFutureValue"
+    ],
+    "defenderAvStatus": [
+      "disabled",
+      "notReporting",
+      "notSupported",
+      "notUpdated",
+      "unknown",
+      "unknownFutureValue",
+      "updated"
+    ],
+    "deploymentStatus": [
+      "disconnected",
+      "notConfigured",
+      "outdated",
+      "startFailure",
+      "syncing",
+      "unknownFutureValue",
+      "unreachable",
+      "updateFailed",
+      "updating",
+      "upToDate"
+    ],
+    "detectionSource": [
+      "antivirus",
+      "appGovernanceDetection",
+      "appGovernancePolicy",
+      "automatedInvestigation",
+      "azureAdIdentityProtection",
+      "builtInMl",
+      "cloudAppSecurity",
+      "customDetection",
+      "customTi",
+      "manual",
+      "microsoft365Defender",
+      "microsoftDataLossPrevention",
+      "microsoftDefenderForAIServices",
+      "microsoftDefenderForApiManagement",
+      "microsoftDefenderForAppService",
+      "microsoftDefenderForCloud",
+      "microsoftDefenderForContainers",
+      "microsoftDefenderForDatabases",
+      "microsoftDefenderForDNS",
+      "microsoftDefenderForEndpoint",
+      "microsoftDefenderForIdentity",
+      "microsoftDefenderForIoT",
+      "microsoftDefenderForKeyVault",
+      "microsoftDefenderForNetwork",
+      "microsoftDefenderForOffice365",
+      "microsoftDefenderForResourceManager",
+      "microsoftDefenderForServers",
+      "microsoftDefenderForStorage",
+      "microsoftDefenderThreatIntelligenceAnalytics",
+      "microsoftInsiderRiskManagement",
+      "microsoftSentinel",
+      "microsoftThreatExperts",
+      "microsoftThreatIntelligence",
+      "nrtAlerts",
+      "scheduledAlerts",
+      "securityCopilot",
+      "smartScreen",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "detectionStatus": [
+      "blocked",
+      "detected",
+      "prevented",
+      "unknownFutureValue"
+    ],
+    "deviceHealthStatus": [
+      "active",
+      "impairedCommunication",
+      "inactive",
+      "noSensorData",
+      "noSensorDataImpairedCommunication",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "deviceRiskScore": [
+      "high",
+      "informational",
+      "low",
+      "medium",
+      "none",
+      "unknownFutureValue"
+    ],
+    "documentVersion": [
+      "all",
+      "latest",
+      "recent10",
+      "recent100",
+      "unknownFutureValue"
+    ],
+    "eventPropagationStatus": [
+      "failed",
+      "inProcessing",
+      "none",
+      "success",
+      "unknownFutureValue"
+    ],
+    "eventStatusType": [
+      "error",
+      "notAvaliable",
+      "pending",
+      "success",
+      "unknownFutureValue"
+    ],
+    "evidenceRemediationStatus": [
+      "active",
+      "blocked",
+      "declined",
+      "none",
+      "notFound",
+      "partiallyRemediated",
+      "pendingApproval",
+      "prevented",
+      "remediated",
+      "running",
+      "unknownFutureValue",
+      "unremediated"
+    ],
+    "evidenceRole": [
+      "added",
+      "attacked",
+      "attacker",
+      "commandAndControl",
+      "compromised",
+      "contextual",
+      "created",
+      "destination",
+      "edited",
+      "loaded",
+      "policyViolator",
+      "scanned",
+      "source",
+      "suspicious",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "evidenceVerdict": [
+      "malicious",
+      "noThreatsFound",
+      "suspicious",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "exportCriteria": [
+      "partiallyIndexed",
+      "searchHits",
+      "unknownFutureValue"
+    ],
+    "exportFileStructure": [
+      "directory",
+      "msg",
+      "none",
+      "pst",
+      "unknownFutureValue"
+    ],
+    "exportFormat": [
+      "eml",
+      "msg",
+      "pst",
+      "unknownFutureValue"
+    ],
+    "exportLocation": [
+      "nonresponsiveLocations",
+      "responsiveLocations",
+      "unknownFutureValue"
+    ],
+    "exportOptions": [
+      "condensePaths",
+      "friendlyName",
+      "includeFolderAndPath",
+      "originalFiles",
+      "pdfReplacement",
+      "splitSource",
+      "tags",
+      "text",
+      "unknownFutureValue"
+    ],
+    "fileHashAlgorithm": [
+      "md5",
+      "sha1",
+      "sha256",
+      "sha256ac",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "googleCloudLocationType": [
+      "global",
+      "regional",
+      "unknown",
+      "unknownFutureValue",
+      "zonal"
+    ],
+    "healthIssueSeverity": [
+      "high",
+      "low",
+      "medium",
+      "unknownFutureValue"
+    ],
+    "healthIssueStatus": [
+      "closed",
+      "open",
+      "suppressed",
+      "unknownFutureValue"
+    ],
+    "healthIssueType": [
+      "global",
+      "sensor",
+      "unknownFutureValue"
+    ],
+    "hostPortProtocol": [
+      "tcp",
+      "udp",
+      "unknownFutureValue"
+    ],
+    "hostPortStatus": [
+      "closed",
+      "filtered",
+      "open",
+      "unknownFutureValue"
+    ],
+    "hostReputationClassification": [
+      "malicious",
+      "neutral",
+      "suspicious",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "hostReputationRuleSeverity": [
+      "high",
+      "low",
+      "medium",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "identityProvider": [
+      "activeDirectory",
+      "entraID",
+      "okta",
+      "unknownFutureValue"
+    ],
+    "incidentStatus": [
+      "active",
+      "awaitingAction",
+      "inProgress",
+      "redirected",
+      "resolved",
+      "unknownFutureValue"
+    ],
+    "indicatorSource": [
+      "microsoft",
+      "osint",
+      "public",
+      "unknownFutureValue"
+    ],
+    "intelligenceProfileKind": [
+      "actor",
+      "tool",
+      "unknownFutureValue"
+    ],
+    "investigationState": [
+      "benign",
+      "failed",
+      "innerFailure",
+      "partiallyInvestigated",
+      "partiallyRemediated",
+      "pendingApproval",
+      "pendingResource",
+      "preexistingAlert",
+      "queued",
+      "running",
+      "successfullyRemediated",
+      "suppressedAlert",
+      "terminated",
+      "terminatedBySystem",
+      "terminatedByUser",
+      "unknown",
+      "unknownFutureValue",
+      "unsupportedAlertType",
+      "unsupportedOs"
+    ],
+    "ioTDeviceImportanceType": [
+      "high",
+      "low",
+      "normal",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "itemsToInclude": [
+      "partiallyIndexed",
+      "searchHits",
+      "unknownFutureValue"
+    ],
+    "kubernetesPlatform": [
+      "aks",
+      "arc",
+      "eks",
+      "gke",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "kubernetesServiceType": [
+      "clusterIP",
+      "externalName",
+      "loadBalancer",
+      "nodePort",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "mailboxConfigurationType": [
+      "ewsSettings",
+      "mailDelegation",
+      "mailForwardingRule",
+      "owaSettings",
+      "unknownFutureValue",
+      "userInboxRule"
+    ],
+    "onboardingStatus": [
+      "canBeOnboarded",
+      "insufficientInfo",
+      "onboarded",
+      "unknownFutureValue",
+      "unsupported"
+    ],
+    "protocolType": [
+      "tcp",
+      "udp",
+      "unknownFutureValue"
+    ],
+    "purgeAreas": [
+      "mailboxes",
+      "teamsMessages",
+      "unknownFutureValue"
+    ],
+    "purgeType": [
+      "permanentlyDelete",
+      "recoverable",
+      "unknownFutureValue"
+    ],
+    "queryType": [
+      "files",
+      "messages",
+      "unknownFutureValue"
+    ],
+    "recipientType": [
+      "roleGroup",
+      "unknownFutureValue",
+      "user"
+    ],
+    "retentionTrigger": [
+      "dateCreated",
+      "dateLabeled",
+      "dateModified",
+      "dateOfEvent",
+      "unknownFutureValue"
+    ],
+    "reviewSetSettings": [
+      "disableGrouping",
+      "none",
+      "unknownFutureValue"
+    ],
+    "sensorCandidateActivationMode": [
+      "automated",
+      "manual",
+      "unknownFutureValue"
+    ],
+    "sensorHealthStatus": [
+      "healthy",
+      "notHealthyHigh",
+      "notHealthyLow",
+      "notHealthyMedium",
+      "unknownFutureValue"
+    ],
+    "sensorType": [
+      "adConnectIntegrated",
+      "adcsIntegrated",
+      "adfsIntegrated",
+      "domainControllerIntegrated",
+      "domainControllerStandalone",
+      "unknownFutureValue"
+    ],
+    "servicePrincipalType": [
+      "application",
+      "legacy",
+      "managedIdentity",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "serviceSource": [
+      "azureAdIdentityProtection",
+      "dataLossPrevention",
+      "microsoft365Defender",
+      "microsoftAppGovernance",
+      "microsoftDefenderForCloud",
+      "microsoftDefenderForCloudApps",
+      "microsoftDefenderForEndpoint",
+      "microsoftDefenderForIdentity",
+      "microsoftDefenderForOffice365",
+      "microsoftInsiderRiskManagement",
+      "microsoftSentinel",
+      "microsoftThreatIntelligence",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "serviceStatus": [
+      "disabled",
+      "onboarding",
+      "running",
+      "starting",
+      "stopped",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "sourceType": [
+      "mailbox",
+      "site",
+      "unknownFutureValue"
+    ],
+    "statisticsOptions": [
+      "advancedIndexing",
+      "includeQueryStats",
+      "includeRefiners",
+      "includeUnindexedStats",
+      "locationsWithoutHits",
+      "unknownFutureValue"
+    ],
+    "teamsDeliveryLocation": [
+      "failed",
+      "quarantine",
+      "teams",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "teamsMessageDeliveryAction": [
+      "blocked",
+      "delivered",
+      "deliveredAsSpam",
+      "replaced",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "vmCloudProvider": [
+      "azure",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "vulnerabilitySeverity": [
+      "critical",
+      "high",
+      "low",
+      "medium",
+      "none",
+      "unknownFutureValue"
+    ],
+    "whoisDomainStatus": [
+      "clientDeleteProhibited",
+      "clientHold",
+      "clientRenewProhibited",
+      "clientTransferProhibited",
+      "clientUpdateProhibited",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.teamsAdministration": {
+    "accountType": [
+      "guest",
+      "ineligibleUser",
+      "resourceAccount",
+      "sfbOnPremUser",
+      "unknown",
+      "unknownFutureValue",
+      "user"
+    ],
+    "activationState": [
+      "activated",
+      "assignmentFailed",
+      "assignmentPending",
+      "unknownFutureValue",
+      "updateFailed",
+      "updatePending"
+    ],
+    "assignmentCategory": [
+      "alternate",
+      "primary",
+      "private",
+      "unknownFutureValue"
+    ],
+    "assignmentStatus": [
+      "conferenceAssigned",
+      "internalError",
+      "policyAssigned",
+      "thirdPartyAppAssigned",
+      "unassigned",
+      "unknownFutureValue",
+      "userAssigned",
+      "voiceApplicationAssigned"
+    ],
+    "assignmentType": [
+      "direct",
+      "group",
+      "unknownFutureValue"
+    ],
+    "customerAction": [
+      "locationUpdate",
+      "release",
+      "unknownFutureValue"
+    ],
+    "numberCapability": [
+      "conferenceAssignment",
+      "teamsPhoneMobile",
+      "unknownFutureValue",
+      "userAssignment",
+      "voiceApplicationAssignment"
+    ],
+    "numberSource": [
+      "online",
+      "onPremises",
+      "unknownFutureValue"
+    ],
+    "numberType": [
+      "callingPlan",
+      "directRouting",
+      "internalError",
+      "operatorConnect",
+      "unknownFutureValue"
+    ],
+    "portInStatus": [
+      "completed",
+      "firmOrderCommitmentAccepted",
+      "unknownFutureValue"
+    ],
+    "reverseNumberLookupOption": [
+      "skipInternalVoip",
+      "unknownFutureValue"
+    ]
+  },
+  "microsoft.graph.termStore": {
+    "relationType": [
+      "pin",
+      "reuse",
+      "unknownFutureValue"
+    ],
+    "termGroupScope": [
+      "global",
+      "siteCollection",
+      "system",
+      "unknownFutureValue"
+    ]
+  }
+}

--- a/schemas/type-mappings/v1.0-enum-types.json
+++ b/schemas/type-mappings/v1.0-enum-types.json
@@ -168,29 +168,6 @@
       "unknownFutureValue",
       "userPrompt"
     ],
-    "alertFeedback": [
-      "benignPositive",
-      "falsePositive",
-      "truePositive",
-      "unknown",
-      "unknownFutureValue"
-    ],
-    "alertSeverity": [
-      "high",
-      "informational",
-      "low",
-      "medium",
-      "unknown",
-      "unknownFutureValue"
-    ],
-    "alertStatus": [
-      "dismissed",
-      "inProgress",
-      "newAlert",
-      "resolved",
-      "unknown",
-      "unknownFutureValue"
-    ],
     "allowedLobbyAdmitterRoles": [
       "organizerAndCoOrganizers",
       "organizerAndCoOrganizersAndPresenters",
@@ -657,6 +634,28 @@
       "roleIsAttendee",
       "unknownFutureValue"
     ],
+    "browsableResourceType": [
+      "documentLibrary",
+      "folder",
+      "none",
+      "site",
+      "unknownFutureValue"
+    ],
+    "browseQueryOrder": [
+      "nameAsc",
+      "nameDsc",
+      "pathAsc",
+      "pathDsc",
+      "unknownFutureValue"
+    ],
+    "browseQueryResponseItemType": [
+      "documentLibrary",
+      "file",
+      "folder",
+      "none",
+      "site",
+      "unknownFutureValue"
+    ],
     "browserSharedCookieSourceEnvironment": [
       "both",
       "internetExplorer11",
@@ -706,6 +705,12 @@
       "internetExplorerMode",
       "microsoftEdge",
       "none",
+      "unknownFutureValue"
+    ],
+    "browseSessionStatus": [
+      "created",
+      "creating",
+      "failed",
       "unknownFutureValue"
     ],
     "bucketAggregationSortProperty": [
@@ -886,6 +891,10 @@
       "unknownFutureValue",
       "unspecified",
       "verified"
+    ],
+    "claimBindingSource": [
+      "directory",
+      "unknownFutureValue"
     ],
     "clickSource": [
       "phishingUrl",
@@ -1229,20 +1238,6 @@
     "connectedOrganizationState": [
       "configured",
       "proposed",
-      "unknownFutureValue"
-    ],
-    "connectionDirection": [
-      "inbound",
-      "outbound",
-      "unknown",
-      "unknownFutureValue"
-    ],
-    "connectionStatus": [
-      "attempted",
-      "blocked",
-      "failed",
-      "succeeded",
-      "unknown",
       "unknownFutureValue"
     ],
     "consentRequestFilterByCurrentUserOptions": [
@@ -1740,12 +1735,6 @@
       "principal",
       "unknownFutureValue"
     ],
-    "emailRole": [
-      "recipient",
-      "sender",
-      "unknown",
-      "unknownFutureValue"
-    ],
     "enablement": [
       "disabled",
       "enabled",
@@ -1938,16 +1927,6 @@
     "fido2RestrictionEnforcementType": [
       "allow",
       "block",
-      "unknownFutureValue"
-    ],
-    "fileHashType": [
-      "authenticodeHash256",
-      "ctph",
-      "lsHash",
-      "md5",
-      "sha1",
-      "sha256",
-      "unknown",
       "unknownFutureValue"
     ],
     "fileStorageContainerBillingClassification": [
@@ -2226,15 +2205,6 @@
       "private",
       "unknown"
     ],
-    "logonType": [
-      "batch",
-      "interactive",
-      "network",
-      "remoteInteractive",
-      "service",
-      "unknown",
-      "unknownFutureValue"
-    ],
     "longRunningOperationStatus": [
       "failed",
       "notStarted",
@@ -2358,6 +2328,11 @@
       "wipeFailed",
       "wipeIssued",
       "wipePending"
+    ],
+    "matchConfidenceLevel": [
+      "exact",
+      "relaxed",
+      "unknownFutureValue"
     ],
     "maxWorkLocationDetails": [
       "approximate",
@@ -3965,15 +3940,6 @@
       "owner",
       "unknownFutureValue"
     ],
-    "processIntegrityLevel": [
-      "high",
-      "low",
-      "medium",
-      "system",
-      "unknown",
-      "unknownFutureValue",
-      "untrusted"
-    ],
     "promptLoginBehavior": [
       "disabled",
       "nativeSupport",
@@ -4267,39 +4233,6 @@
       "noEnd",
       "numbered"
     ],
-    "registryHive": [
-      "currentConfig",
-      "currentUser",
-      "localMachineSam",
-      "localMachineSecurity",
-      "localMachineSoftware",
-      "localMachineSystem",
-      "unknown",
-      "unknownFutureValue",
-      "usersDefault"
-    ],
-    "registryOperation": [
-      "create",
-      "delete",
-      "modify",
-      "unknown",
-      "unknownFutureValue"
-    ],
-    "registryValueType": [
-      "binary",
-      "dword",
-      "dwordBigEndian",
-      "dwordLittleEndian",
-      "expandSz",
-      "link",
-      "multiSz",
-      "none",
-      "qword",
-      "qwordlittleEndian",
-      "sz",
-      "unknown",
-      "unknownFutureValue"
-    ],
     "rejectReason": [
       "busy",
       "forbidden",
@@ -4428,6 +4361,7 @@
     ],
     "restoreJobType": [
       "bulk",
+      "granular",
       "standard",
       "unknownFutureValue"
     ],
@@ -4483,6 +4417,7 @@
       "aiConfirmedSigninSafe",
       "hidden",
       "m365DAdminDismissedDetection",
+      "microsoftRevokedSessions",
       "none",
       "unknownFutureValue",
       "userChangedPasswordOnPremises",
@@ -4653,38 +4588,6 @@
       "none",
       "soft",
       "strong",
-      "unknownFutureValue"
-    ],
-    "securityNetworkProtocol": [
-      "ggp",
-      "icmp",
-      "icmpV6",
-      "idp",
-      "igmp",
-      "ip",
-      "ipSecAuthenticationHeader",
-      "ipSecEncapsulatingSecurityPayload",
-      "ipv4",
-      "ipv6",
-      "ipv6DestinationOptions",
-      "ipv6FragmentHeader",
-      "ipv6NoNextHeader",
-      "ipv6RoutingHeader",
-      "ipx",
-      "nd",
-      "pup",
-      "raw",
-      "spx",
-      "spxII",
-      "tcp",
-      "udp",
-      "unknown",
-      "unknownFutureValue"
-    ],
-    "securityResourceType": [
-      "attacked",
-      "related",
-      "unknown",
       "unknownFutureValue"
     ],
     "selectionLikelihoodInfo": [
@@ -5373,13 +5276,6 @@
       "view",
       "viewRightsData"
     ],
-    "userAccountSecurityType": [
-      "administrator",
-      "power",
-      "standard",
-      "unknown",
-      "unknownFutureValue"
-    ],
     "userAction": [
       "registerOrJoinDevices",
       "registerSecurityInformation",
@@ -5477,6 +5373,17 @@
     "userType": [
       "guest",
       "member",
+      "unknownFutureValue"
+    ],
+    "verifiedIdProfileState": [
+      "disabled",
+      "enabled",
+      "unknownFutureValue"
+    ],
+    "verifiedIdUsageConfigurationPurpose": [
+      "all",
+      "onboarding",
+      "recovery",
       "unknownFutureValue"
     ],
     "virtualAppointmentMessageType": [

--- a/schemas/type-mappings/v1.0-enum-types.json
+++ b/schemas/type-mappings/v1.0-enum-types.json
@@ -168,6 +168,29 @@
       "unknownFutureValue",
       "userPrompt"
     ],
+    "alertFeedback": [
+      "benignPositive",
+      "falsePositive",
+      "truePositive",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alertSeverity": [
+      "high",
+      "informational",
+      "low",
+      "medium",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "alertStatus": [
+      "dismissed",
+      "inProgress",
+      "newAlert",
+      "resolved",
+      "unknown",
+      "unknownFutureValue"
+    ],
     "allowedLobbyAdmitterRoles": [
       "organizerAndCoOrganizers",
       "organizerAndCoOrganizersAndPresenters",
@@ -1240,6 +1263,20 @@
       "proposed",
       "unknownFutureValue"
     ],
+    "connectionDirection": [
+      "inbound",
+      "outbound",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "connectionStatus": [
+      "attempted",
+      "blocked",
+      "failed",
+      "succeeded",
+      "unknown",
+      "unknownFutureValue"
+    ],
     "consentRequestFilterByCurrentUserOptions": [
       "reviewer",
       "unknownFutureValue"
@@ -1735,6 +1772,12 @@
       "principal",
       "unknownFutureValue"
     ],
+    "emailRole": [
+      "recipient",
+      "sender",
+      "unknown",
+      "unknownFutureValue"
+    ],
     "enablement": [
       "disabled",
       "enabled",
@@ -1927,6 +1970,16 @@
     "fido2RestrictionEnforcementType": [
       "allow",
       "block",
+      "unknownFutureValue"
+    ],
+    "fileHashType": [
+      "authenticodeHash256",
+      "ctph",
+      "lsHash",
+      "md5",
+      "sha1",
+      "sha256",
+      "unknown",
       "unknownFutureValue"
     ],
     "fileStorageContainerBillingClassification": [
@@ -2204,6 +2257,15 @@
       "locationStore",
       "private",
       "unknown"
+    ],
+    "logonType": [
+      "batch",
+      "interactive",
+      "network",
+      "remoteInteractive",
+      "service",
+      "unknown",
+      "unknownFutureValue"
     ],
     "longRunningOperationStatus": [
       "failed",
@@ -2594,6 +2656,12 @@
       "includeContactInformation",
       "includeDeviceDetails",
       "none",
+      "unknownFutureValue"
+    ],
+    "notifyMembers": [
+      "all",
+      "allowSelected",
+      "blockSelected",
       "unknownFutureValue"
     ],
     "oAuthAppScope": [
@@ -3940,6 +4008,15 @@
       "owner",
       "unknownFutureValue"
     ],
+    "processIntegrityLevel": [
+      "high",
+      "low",
+      "medium",
+      "system",
+      "unknown",
+      "unknownFutureValue",
+      "untrusted"
+    ],
     "promptLoginBehavior": [
       "disabled",
       "nativeSupport",
@@ -4232,6 +4309,39 @@
       "endDate",
       "noEnd",
       "numbered"
+    ],
+    "registryHive": [
+      "currentConfig",
+      "currentUser",
+      "localMachineSam",
+      "localMachineSecurity",
+      "localMachineSoftware",
+      "localMachineSystem",
+      "unknown",
+      "unknownFutureValue",
+      "usersDefault"
+    ],
+    "registryOperation": [
+      "create",
+      "delete",
+      "modify",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "registryValueType": [
+      "binary",
+      "dword",
+      "dwordBigEndian",
+      "dwordLittleEndian",
+      "expandSz",
+      "link",
+      "multiSz",
+      "none",
+      "qword",
+      "qwordlittleEndian",
+      "sz",
+      "unknown",
+      "unknownFutureValue"
     ],
     "rejectReason": [
       "busy",
@@ -4588,6 +4698,38 @@
       "none",
       "soft",
       "strong",
+      "unknownFutureValue"
+    ],
+    "securityNetworkProtocol": [
+      "ggp",
+      "icmp",
+      "icmpV6",
+      "idp",
+      "igmp",
+      "ip",
+      "ipSecAuthenticationHeader",
+      "ipSecEncapsulatingSecurityPayload",
+      "ipv4",
+      "ipv6",
+      "ipv6DestinationOptions",
+      "ipv6FragmentHeader",
+      "ipv6NoNextHeader",
+      "ipv6RoutingHeader",
+      "ipx",
+      "nd",
+      "pup",
+      "raw",
+      "spx",
+      "spxII",
+      "tcp",
+      "udp",
+      "unknown",
+      "unknownFutureValue"
+    ],
+    "securityResourceType": [
+      "attacked",
+      "related",
+      "unknown",
       "unknownFutureValue"
     ],
     "selectionLikelihoodInfo": [
@@ -5275,6 +5417,13 @@
       "userDefinedProtectionTypeNotSupportedException",
       "view",
       "viewRightsData"
+    ],
+    "userAccountSecurityType": [
+      "administrator",
+      "power",
+      "standard",
+      "unknown",
+      "unknownFutureValue"
     ],
     "userAction": [
       "registerOrJoinDevices",
@@ -6180,13 +6329,18 @@
       "personCertifications",
       "personColleagues",
       "personCurrentPosition",
+      "personEducationalActivities",
       "personEmails",
       "personEmergencyContacts",
+      "personInterests",
+      "personLanguages",
       "personManager",
       "personName",
       "personNote",
+      "personPatents",
       "personPhones",
       "personProjects",
+      "personPublications",
       "personSkills",
       "personWebAccounts",
       "personWebSite",

--- a/scripts/check-casing-changes.ps1
+++ b/scripts/check-casing-changes.ps1
@@ -88,7 +88,7 @@ function Test-EnumTypeCasing {
             # Check enum type name
             $violation = Find-CasingViolation -CurrentName $enumName -BaselineNames $baselineTypeNames
             if ($null -ne $violation) {
-                Write-Host "  VIOLATION: EnumType name casing changed in [$namespace]: '$violation' -> '$enumName'" -ForegroundColor Red
+                Write-Host "  VIOLATION: EnumType name casing changed in [$Version][$namespace]: '$violation' -> '$enumName'" -ForegroundColor Red
                 $violations++
             }
 
@@ -109,7 +109,7 @@ function Test-EnumTypeCasing {
                     $memberViolation = Find-CasingViolation -CurrentName $memberName -BaselineNames $baselineMembers
                     if ($null -ne $memberViolation) {
                         $displayEnumName = if ($null -ne $violation) { $violation } else { $enumName }
-                        Write-Host "  VIOLATION: Enum member casing changed in [$namespace].${displayEnumName}: '$memberViolation' -> '$memberName'" -ForegroundColor Red
+                        Write-Host "  VIOLATION: Enum member casing changed in [$Version][$namespace].${displayEnumName}: '$memberViolation' -> '$memberName'" -ForegroundColor Red
                         $violations++
                     }
                 }
@@ -157,7 +157,7 @@ function Test-TypeCasing {
             # Check type name
             $violation = Find-CasingViolation -CurrentName $typeName -BaselineNames $baselineTypeNames
             if ($null -ne $violation) {
-                Write-Host "  VIOLATION: $TypeKind name casing changed in [$namespace]: '$violation' -> '$typeName'" -ForegroundColor Red
+                Write-Host "  VIOLATION: $TypeKind name casing changed in [$Version][$namespace]: '$violation' -> '$typeName'" -ForegroundColor Red
                 $violations++
             }
 
@@ -178,7 +178,7 @@ function Test-TypeCasing {
                     $propViolation = Find-CasingViolation -CurrentName $propName -BaselineNames $baselineProps
                     if ($null -ne $propViolation) {
                         $displayTypeName = if ($null -ne $violation) { $violation } else { $typeName }
-                        Write-Host "  VIOLATION: Property casing changed in [$namespace].${displayTypeName}: '$propViolation' -> '$propName'" -ForegroundColor Red
+                        Write-Host "  VIOLATION: Property casing changed in [$Version][$namespace].${displayTypeName}: '$propViolation' -> '$propName'" -ForegroundColor Red
                         $violations++
                     }
                 }
@@ -191,7 +191,7 @@ function Test-TypeCasing {
                     $navPropViolation = Find-CasingViolation -CurrentName $navPropName -BaselineNames $baselineNavProps
                     if ($null -ne $navPropViolation) {
                         $displayTypeName = if ($null -ne $violation) { $violation } else { $typeName }
-                        Write-Host "  VIOLATION: NavigationProperty casing changed in [$namespace].${displayTypeName}: '$navPropViolation' -> '$navPropName'" -ForegroundColor Red
+                        Write-Host "  VIOLATION: NavigationProperty casing changed in [$Version][$namespace].${displayTypeName}: '$navPropViolation' -> '$navPropName'" -ForegroundColor Red
                         $violations++
                     }
                 }

--- a/scripts/check-casing-changes.ps1
+++ b/scripts/check-casing-changes.ps1
@@ -1,0 +1,272 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+.Synopsis
+    Checks for casing-only changes in type/enum names and members/properties in CSDL files.
+.Description
+    Compares modified CSDL files against the committed type-mapping JSON baselines to detect
+    unintentional casing changes. A casing change is when a name matches case-insensitively
+    but differs case-sensitively from the baseline.
+
+    New types/members (not in baseline) are allowed. Only existing names with changed casing are flagged.
+.Example
+    ./scripts/check-casing-changes.ps1 -CsdlFiles @("schemas/beta-Prod.csdl")
+.Example
+    ./scripts/check-casing-changes.ps1 -RepoDirectory C:/github/msgraph-metadata -CsdlFiles @("schemas/beta-Prod.csdl", "schemas/v1.0-Prod.csdl")
+.Parameter RepoDirectory
+    Full path to the root directory of the msgraph-metadata checkout. Defaults to the parent of the script directory.
+.Parameter CsdlFiles
+    Array of CSDL file paths (relative to RepoDirectory) to check for casing changes.
+#>
+
+param(
+    [string]$RepoDirectory = (Split-Path -Parent $PSScriptRoot),
+    [Parameter(Mandatory=$true)][string[]]$CsdlFiles
+)
+
+$edmNamespace = "http://docs.oasis-open.org/odata/ns/edm"
+$edmxNamespace = "http://docs.oasis-open.org/odata/ns/edmx"
+$mappingsDirectory = Join-Path $RepoDirectory "schemas" "type-mappings"
+
+$totalViolations = 0
+
+function Find-CasingViolation {
+    <#
+    .Synopsis
+        Checks if a name from the CSDL has a casing-only change compared to baseline names.
+        Returns the baseline name if a violation is found, $null otherwise.
+    #>
+    param(
+        [string]$CurrentName,
+        [string[]]$BaselineNames
+    )
+
+    foreach ($baselineName in $BaselineNames) {
+        if ($CurrentName -ceq $baselineName) {
+            # Exact match — no violation
+            return $null
+        }
+        if ($CurrentName -eq $baselineName) {
+            # Case-insensitive match but case-sensitive mismatch — violation
+            return $baselineName
+        }
+    }
+    # Not found in baseline — new name, no violation
+    return $null
+}
+
+function Test-EnumTypeCasing {
+    param(
+        [System.Xml.XmlDocument]$Csdl,
+        [System.Xml.XmlNamespaceManager]$NsMgr,
+        [PSCustomObject]$Baseline,
+        [string]$Version
+    )
+
+    $violations = 0
+    $schemas = $Csdl.DocumentElement.SelectNodes("//edmx:Edmx/edmx:DataServices/edm:Schema", $NsMgr)
+
+    foreach ($schema in $schemas) {
+        $namespace = $schema.GetAttribute("Namespace")
+        $enumTypes = $schema.SelectNodes("edm:EnumType", $NsMgr)
+
+        if ($enumTypes.Count -eq 0) { continue }
+
+        # Get baseline names for this namespace
+        $baselineNs = $null
+        if ($Baseline.PSObject.Properties.Name -contains $namespace) {
+            $baselineNs = $Baseline.$namespace
+        }
+        if ($null -eq $baselineNs) { continue }
+
+        $baselineTypeNames = @($baselineNs.PSObject.Properties.Name)
+
+        foreach ($enumType in $enumTypes) {
+            $enumName = $enumType.GetAttribute("Name")
+
+            # Check enum type name
+            $violation = Find-CasingViolation -CurrentName $enumName -BaselineNames $baselineTypeNames
+            if ($null -ne $violation) {
+                Write-Host "  VIOLATION: EnumType name casing changed in [$namespace]: '$violation' -> '$enumName'" -ForegroundColor Red
+                $violations++
+            }
+
+            # Check enum members (only if the enum exists in baseline with matching name)
+            $baselineEnum = $null
+            if ($baselineNs.PSObject.Properties.Name -contains $enumName) {
+                $baselineEnum = $baselineNs.$enumName
+            } elseif ($null -ne $violation) {
+                # Use the old-cased name to find baseline members
+                $baselineEnum = $baselineNs.$violation
+            }
+
+            if ($null -ne $baselineEnum) {
+                $baselineMembers = @($baselineEnum)
+                $members = $enumType.SelectNodes("edm:Member", $NsMgr)
+                foreach ($member in $members) {
+                    $memberName = $member.GetAttribute("Name")
+                    $memberViolation = Find-CasingViolation -CurrentName $memberName -BaselineNames $baselineMembers
+                    if ($null -ne $memberViolation) {
+                        $displayEnumName = if ($null -ne $violation) { $violation } else { $enumName }
+                        Write-Host "  VIOLATION: Enum member casing changed in [$namespace].${displayEnumName}: '$memberViolation' -> '$memberName'" -ForegroundColor Red
+                        $violations++
+                    }
+                }
+            }
+        }
+    }
+
+    return $violations
+}
+
+function Test-TypeCasing {
+    <#
+    .Synopsis
+        Checks ComplexType or EntityType casing against baseline.
+    #>
+    param(
+        [System.Xml.XmlDocument]$Csdl,
+        [System.Xml.XmlNamespaceManager]$NsMgr,
+        [PSCustomObject]$Baseline,
+        [string]$TypeKind,
+        [string]$Version
+    )
+
+    $violations = 0
+    $schemas = $Csdl.DocumentElement.SelectNodes("//edmx:Edmx/edmx:DataServices/edm:Schema", $NsMgr)
+
+    foreach ($schema in $schemas) {
+        $namespace = $schema.GetAttribute("Namespace")
+        $types = $schema.SelectNodes("edm:$TypeKind", $NsMgr)
+
+        if ($types.Count -eq 0) { continue }
+
+        # Get baseline names for this namespace
+        $baselineNs = $null
+        if ($Baseline.PSObject.Properties.Name -contains $namespace) {
+            $baselineNs = $Baseline.$namespace
+        }
+        if ($null -eq $baselineNs) { continue }
+
+        $baselineTypeNames = @($baselineNs.PSObject.Properties.Name)
+
+        foreach ($type in $types) {
+            $typeName = $type.GetAttribute("Name")
+
+            # Check type name
+            $violation = Find-CasingViolation -CurrentName $typeName -BaselineNames $baselineTypeNames
+            if ($null -ne $violation) {
+                Write-Host "  VIOLATION: $TypeKind name casing changed in [$namespace]: '$violation' -> '$typeName'" -ForegroundColor Red
+                $violations++
+            }
+
+            # Check properties and navigation properties (only if type exists in baseline)
+            $baselineType = $null
+            if ($baselineNs.PSObject.Properties.Name -contains $typeName) {
+                $baselineType = $baselineNs.$typeName
+            } elseif ($null -ne $violation) {
+                $baselineType = $baselineNs.$violation
+            }
+
+            if ($null -ne $baselineType) {
+                # Check properties
+                $baselineProps = @($baselineType.properties)
+                $properties = $type.SelectNodes("edm:Property", $NsMgr)
+                foreach ($prop in $properties) {
+                    $propName = $prop.GetAttribute("Name")
+                    $propViolation = Find-CasingViolation -CurrentName $propName -BaselineNames $baselineProps
+                    if ($null -ne $propViolation) {
+                        $displayTypeName = if ($null -ne $violation) { $violation } else { $typeName }
+                        Write-Host "  VIOLATION: Property casing changed in [$namespace].${displayTypeName}: '$propViolation' -> '$propName'" -ForegroundColor Red
+                        $violations++
+                    }
+                }
+
+                # Check navigation properties
+                $baselineNavProps = @($baselineType.navigationProperties)
+                $navProperties = $type.SelectNodes("edm:NavigationProperty", $NsMgr)
+                foreach ($navProp in $navProperties) {
+                    $navPropName = $navProp.GetAttribute("Name")
+                    $navPropViolation = Find-CasingViolation -CurrentName $navPropName -BaselineNames $baselineNavProps
+                    if ($null -ne $navPropViolation) {
+                        $displayTypeName = if ($null -ne $violation) { $violation } else { $typeName }
+                        Write-Host "  VIOLATION: NavigationProperty casing changed in [$namespace].${displayTypeName}: '$navPropViolation' -> '$navPropName'" -ForegroundColor Red
+                        $violations++
+                    }
+                }
+            }
+        }
+    }
+
+    return $violations
+}
+
+# Main execution
+foreach ($csdlFile in $CsdlFiles) {
+    $csdlPath = Join-Path $RepoDirectory $csdlFile
+    if (-not (Test-Path $csdlPath)) {
+        Write-Error "CSDL file not found: $csdlPath"
+        $totalViolations++
+        continue
+    }
+
+    # Determine version from filename (e.g., "beta-Prod.csdl" -> "beta", "v1.0-Prod.csdl" -> "v1.0")
+    $fileName = [System.IO.Path]::GetFileNameWithoutExtension($csdlFile)
+    $version = $fileName -replace '-Prod$', ''
+
+    Write-Host "Checking casing in: $csdlFile (version: $version)" -ForegroundColor Cyan
+
+    # Verify mapping files exist
+    $enumMappingPath = Join-Path $mappingsDirectory "$version-enum-types.json"
+    $complexMappingPath = Join-Path $mappingsDirectory "$version-complex-types.json"
+    $entityMappingPath = Join-Path $mappingsDirectory "$version-entity-types.json"
+
+    $missingMappings = @()
+    if (-not (Test-Path $enumMappingPath)) { $missingMappings += $enumMappingPath }
+    if (-not (Test-Path $complexMappingPath)) { $missingMappings += $complexMappingPath }
+    if (-not (Test-Path $entityMappingPath)) { $missingMappings += $entityMappingPath }
+
+    if ($missingMappings.Count -gt 0) {
+        Write-Error "Missing mapping file(s): $($missingMappings -join ', ')"
+        Write-Error "Run ./scripts/generate-type-mappings.ps1 to generate them."
+        $totalViolations++
+        continue
+    }
+
+    # Load CSDL
+    Write-Host "  Loading CSDL..."
+    $csdl = [xml](Get-Content $csdlPath -Raw)
+    $nsMgr = New-Object System.Xml.XmlNamespaceManager($csdl.NameTable)
+    $nsMgr.AddNamespace("edmx", $edmxNamespace)
+    $nsMgr.AddNamespace("edm", $edmNamespace)
+
+    # Load baselines
+    Write-Host "  Loading baseline mappings..."
+    $enumBaseline = Get-Content $enumMappingPath -Raw | ConvertFrom-Json
+    $complexBaseline = Get-Content $complexMappingPath -Raw | ConvertFrom-Json
+    $entityBaseline = Get-Content $entityMappingPath -Raw | ConvertFrom-Json
+
+    # Check EnumTypes
+    Write-Host "  Checking EnumType casing..."
+    $totalViolations += Test-EnumTypeCasing -Csdl $csdl -NsMgr $nsMgr -Baseline $enumBaseline -Version $version
+
+    # Check ComplexTypes
+    Write-Host "  Checking ComplexType casing..."
+    $totalViolations += Test-TypeCasing -Csdl $csdl -NsMgr $nsMgr -Baseline $complexBaseline -TypeKind "ComplexType" -Version $version
+
+    # Check EntityTypes
+    Write-Host "  Checking EntityType casing..."
+    $totalViolations += Test-TypeCasing -Csdl $csdl -NsMgr $nsMgr -Baseline $entityBaseline -TypeKind "EntityType" -Version $version
+}
+
+Write-Host ""
+if ($totalViolations -gt 0) {
+    Write-Host "FAILED: Found $totalViolations casing violation(s)." -ForegroundColor Red
+    Write-Host "If these changes are intentional, update the mapping files by running:" -ForegroundColor Yellow
+    Write-Host "  ./scripts/generate-type-mappings.ps1" -ForegroundColor Yellow
+    exit 1
+} else {
+    Write-Host "PASSED: No casing violations detected." -ForegroundColor Green
+    exit 0
+}

--- a/scripts/generate-type-mappings.ps1
+++ b/scripts/generate-type-mappings.ps1
@@ -1,0 +1,233 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+.Synopsis
+    Generates JSON mapping files for all types and enums in CSDL schema files.
+.Description
+    Parses CSDL (Common Schema Definition Language) files to extract EnumType, ComplexType,
+    and EntityType definitions with their members/properties. Outputs separate JSON files
+    per type kind per version for use in casing validation checks.
+.Example
+    ./scripts/generate-type-mappings.ps1
+    Generates mapping files for both beta and v1.0 in schemas/type-mappings/
+.Example
+    ./scripts/generate-type-mappings.ps1 -RepoDirectory C:/github/msgraph-metadata -Versions @("beta")
+    Generates mapping files for beta only.
+.Parameter RepoDirectory
+    Full path to the root directory of the msgraph-metadata checkout. Defaults to the parent of the script directory.
+.Parameter Versions
+    Array of API versions to process. Defaults to @("beta", "v1.0").
+#>
+
+param(
+    [string]$RepoDirectory = (Split-Path -Parent $PSScriptRoot),
+    [string[]]$Versions = @("beta", "v1.0")
+)
+
+$edmNamespace = "http://docs.oasis-open.org/odata/ns/edm"
+$edmxNamespace = "http://docs.oasis-open.org/odata/ns/edmx"
+$outputDirectory = Join-Path $RepoDirectory "schemas" "type-mappings"
+
+if (-not (Test-Path $outputDirectory)) {
+    New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+}
+
+function Get-SortedHashtable {
+    <#
+    .Synopsis
+        Converts a hashtable/dictionary to an ordered dictionary with sorted keys, recursively.
+        String arrays are also sorted for stable diffs.
+    #>
+    param([System.Collections.IDictionary]$Hashtable)
+
+    $sorted = [ordered]@{}
+    foreach ($key in ($Hashtable.Keys | Sort-Object)) {
+        $value = $Hashtable[$key]
+        if ($value -is [System.Collections.IDictionary]) {
+            $sorted[$key] = Get-SortedHashtable $value
+        } elseif ($value -is [array] -and $value.Count -gt 0 -and $value[0] -is [string]) {
+            $sorted[$key] = @($value | Sort-Object)
+        } else {
+            $sorted[$key] = $value
+        }
+    }
+    return $sorted
+}
+
+function Export-EnumTypes {
+    param(
+        [System.Xml.XmlDocument]$Csdl,
+        [System.Xml.XmlNamespaceManager]$NsMgr,
+        [string]$OutputPath
+    )
+
+    $result = @{}
+    $schemas = $Csdl.DocumentElement.SelectNodes("//edmx:Edmx/edmx:DataServices/edm:Schema", $NsMgr)
+
+    foreach ($schema in $schemas) {
+        $namespace = $schema.GetAttribute("Namespace")
+        $enumTypes = $schema.SelectNodes("edm:EnumType", $NsMgr)
+
+        if ($enumTypes.Count -eq 0) { continue }
+
+        $nsMap = @{}
+        foreach ($enumType in $enumTypes) {
+            $enumName = $enumType.GetAttribute("Name")
+            $members = @(foreach ($member in $enumType.SelectNodes("edm:Member", $NsMgr)) {
+                $member.GetAttribute("Name")
+            })
+            $nsMap[$enumName] = $members
+        }
+        $result[$namespace] = $nsMap
+    }
+
+    $sorted = Get-SortedHashtable $result
+    $sorted | ConvertTo-Json -Depth 10 | Set-Content -Path $OutputPath -Encoding UTF8
+    Write-Host "  Generated: $OutputPath ($($schemas.Count) schemas processed)"
+}
+
+function Export-ComplexTypes {
+    param(
+        [System.Xml.XmlDocument]$Csdl,
+        [System.Xml.XmlNamespaceManager]$NsMgr,
+        [string]$OutputPath
+    )
+
+    $result = @{}
+    $schemas = $Csdl.DocumentElement.SelectNodes("//edmx:Edmx/edmx:DataServices/edm:Schema", $NsMgr)
+
+    foreach ($schema in $schemas) {
+        $namespace = $schema.GetAttribute("Namespace")
+        $complexTypes = $schema.SelectNodes("edm:ComplexType", $NsMgr)
+
+        if ($complexTypes.Count -eq 0) { continue }
+
+        $nsMap = @{}
+        foreach ($complexType in $complexTypes) {
+            $typeName = $complexType.GetAttribute("Name")
+            $properties = @(foreach ($prop in $complexType.SelectNodes("edm:Property", $NsMgr)) {
+                $prop.GetAttribute("Name")
+            })
+            $navigationProperties = @(foreach ($navProp in $complexType.SelectNodes("edm:NavigationProperty", $NsMgr)) {
+                $navProp.GetAttribute("Name")
+            })
+            $nsMap[$typeName] = [ordered]@{
+                properties = $properties
+                navigationProperties = $navigationProperties
+            }
+        }
+        $result[$namespace] = $nsMap
+    }
+
+    $sorted = Get-SortedHashtable $result
+    $sorted | ConvertTo-Json -Depth 10 | Set-Content -Path $OutputPath -Encoding UTF8
+    Write-Host "  Generated: $OutputPath ($($schemas.Count) schemas processed)"
+}
+
+function Export-EntityTypes {
+    param(
+        [System.Xml.XmlDocument]$Csdl,
+        [System.Xml.XmlNamespaceManager]$NsMgr,
+        [string]$OutputPath
+    )
+
+    $result = @{}
+    $schemas = $Csdl.DocumentElement.SelectNodes("//edmx:Edmx/edmx:DataServices/edm:Schema", $NsMgr)
+
+    foreach ($schema in $schemas) {
+        $namespace = $schema.GetAttribute("Namespace")
+        $entityTypes = $schema.SelectNodes("edm:EntityType", $NsMgr)
+
+        if ($entityTypes.Count -eq 0) { continue }
+
+        $nsMap = @{}
+        foreach ($entityType in $entityTypes) {
+            $typeName = $entityType.GetAttribute("Name")
+            $properties = @(foreach ($prop in $entityType.SelectNodes("edm:Property", $NsMgr)) {
+                $prop.GetAttribute("Name")
+            })
+            $navigationProperties = @(foreach ($navProp in $entityType.SelectNodes("edm:NavigationProperty", $NsMgr)) {
+                $navProp.GetAttribute("Name")
+            })
+            $nsMap[$typeName] = [ordered]@{
+                properties = $properties
+                navigationProperties = $navigationProperties
+            }
+        }
+        $result[$namespace] = $nsMap
+    }
+
+    $sorted = Get-SortedHashtable $result
+    $sorted | ConvertTo-Json -Depth 10 | Set-Content -Path $OutputPath -Encoding UTF8
+    Write-Host "  Generated: $OutputPath ($($schemas.Count) schemas processed)"
+}
+
+# Build list of jobs to run (version × type kind)
+$jobs = @()
+foreach ($version in $Versions) {
+    $csdlPath = Join-Path $RepoDirectory "schemas" "$version-Prod.csdl"
+    if (-not (Test-Path $csdlPath)) {
+        Write-Error "CSDL file not found: $csdlPath"
+        continue
+    }
+
+    $jobs += @{
+        Version = $version
+        CsdlPath = $csdlPath
+        TypeKind = "enum-types"
+        ExportFunction = "Export-EnumTypes"
+    }
+    $jobs += @{
+        Version = $version
+        CsdlPath = $csdlPath
+        TypeKind = "complex-types"
+        ExportFunction = "Export-ComplexTypes"
+    }
+    $jobs += @{
+        Version = $version
+        CsdlPath = $csdlPath
+        TypeKind = "entity-types"
+        ExportFunction = "Export-EntityTypes"
+    }
+}
+
+Write-Host "Generating type mapping files..." -ForegroundColor Cyan
+Write-Host "Output directory: $outputDirectory"
+Write-Host ""
+
+# Process each job. We load the CSDL once per version and reuse it.
+$loadedCsdls = @{}
+foreach ($job in $jobs) {
+    $version = $job.Version
+    $csdlPath = $job.CsdlPath
+    $typeKind = $job.TypeKind
+    $outputPath = Join-Path $outputDirectory "$version-$typeKind.json"
+
+    # Load and cache CSDL per version
+    if (-not $loadedCsdls.ContainsKey($version)) {
+        Write-Host "Loading $version CSDL from: $csdlPath"
+        $csdl = [xml](Get-Content $csdlPath -Raw)
+        $nsMgr = New-Object System.Xml.XmlNamespaceManager($csdl.NameTable)
+        $nsMgr.AddNamespace("edmx", $edmxNamespace)
+        $nsMgr.AddNamespace("edm", $edmNamespace)
+        $loadedCsdls[$version] = @{ Csdl = $csdl; NsMgr = $nsMgr }
+    }
+
+    $cached = $loadedCsdls[$version]
+
+    switch ($job.ExportFunction) {
+        "Export-EnumTypes" {
+            Export-EnumTypes -Csdl $cached.Csdl -NsMgr $cached.NsMgr -OutputPath $outputPath
+        }
+        "Export-ComplexTypes" {
+            Export-ComplexTypes -Csdl $cached.Csdl -NsMgr $cached.NsMgr -OutputPath $outputPath
+        }
+        "Export-EntityTypes" {
+            Export-EntityTypes -Csdl $cached.Csdl -NsMgr $cached.NsMgr -OutputPath $outputPath
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "Type mapping generation complete!" -ForegroundColor Green


### PR DESCRIPTION
Adds a check to our schema syncs so casing changes in entityTypes, complexTypes, and enumTypes are flagged. The following is achieved by:
- Add script to create json files containing maps for entityTypes, complexTypes, and enumTypes for both v1.0 and beta. 
- Add a second script to compare the casing of type names in the schema csdl files to what is stored in the json maps. 
- An error is thrown if a type exists in the json map and the csdl with different casing; new types and deleted types are not flagged.
- Adds a github action that runs on pull requests making changes to the schema csdl files. This would target the pr's created by our generation pipeline. Will flag changes to casing changes as breaking. 
- If a pr is approved and merged then the action runs the mapping script again to set a new baseline for what is contained in our csdl files. 

Source of issue described here: https://github.com/microsoft/kiota/issues/7654?reload=1?reload=1
