### PR TITLE
Add FilterRestrictions annotation transform to `managedDevice` entity type

### DIFF
--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -2247,10 +2247,13 @@
     </xsl:template>
 
     <!-- Add FilterRestrictions to managedDevice entity type -->
+    <!-- Skip if the annotation is already present, so upstream metadata gaining it does not produce a duplicate -->
      <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.managedDevice']">
        <xsl:copy>
          <xsl:copy-of select="@*|node()"/>
-         <xsl:call-template name="ManagedDeviceFilterRestrictionsTemplate"/>
+         <xsl:if test="not(edm:Annotation[@Term='Org.OData.Capabilities.V1.FilterRestrictions'])">
+           <xsl:call-template name="ManagedDeviceFilterRestrictionsTemplate"/>
+         </xsl:if>
        </xsl:copy>
     </xsl:template>
 

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1400,6 +1400,57 @@
             </xsl:element>
         </xsl:element>
     </xsl:template>
+    <xsl:template name="ManagedDeviceFilterRestrictionsTemplate">
+        <xsl:element name="Annotation">
+            <xsl:attribute name="Term">Org.OData.Capabilities.V1.FilterRestrictions</xsl:attribute>
+            <xsl:element name="Record" namespace="{namespace-uri()}">
+                <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">Filterable</xsl:attribute>
+                    <xsl:attribute name="Bool">true</xsl:attribute>
+                </xsl:element>
+                <xsl:element name="PropertyValue">
+                    <xsl:attribute name="Property">NonFilterableProperties</xsl:attribute>
+                    <xsl:element name="Collection">
+                        <xsl:element name="PropertyPath">activationLockBypassCode</xsl:element>
+                        <xsl:element name="PropertyPath">androidSecurityPatchLevel</xsl:element>
+                        <xsl:element name="PropertyPath">azureADRegistered</xsl:element>
+                        <xsl:element name="PropertyPath">configurationManagerClientEnabledFeatures</xsl:element>
+                        <xsl:element name="PropertyPath">deviceActionResults</xsl:element>
+                        <xsl:element name="PropertyPath">deviceEnrollmentType</xsl:element>
+                        <xsl:element name="PropertyPath">deviceHealthAttestationState</xsl:element>
+                        <xsl:element name="PropertyPath">deviceRegistrationState</xsl:element>
+                        <xsl:element name="PropertyPath">easActivated</xsl:element>
+                        <xsl:element name="PropertyPath">easActivationDateTime</xsl:element>
+                        <xsl:element name="PropertyPath">easDeviceId</xsl:element>
+                        <xsl:element name="PropertyPath">enrollmentProfileName</xsl:element>
+                        <xsl:element name="PropertyPath">ethernetMacAddress</xsl:element>
+                        <xsl:element name="PropertyPath">exchangeAccessStateReason</xsl:element>
+                        <xsl:element name="PropertyPath">exchangeLastSuccessfulSyncDateTime</xsl:element>
+                        <xsl:element name="PropertyPath">freeStorageSpaceInBytes</xsl:element>
+                        <xsl:element name="PropertyPath">iccid</xsl:element>
+                        <xsl:element name="PropertyPath">isEncrypted</xsl:element>
+                        <xsl:element name="PropertyPath">isSupervised</xsl:element>
+                        <xsl:element name="PropertyPath">managedDeviceName</xsl:element>
+                        <xsl:element name="PropertyPath">managedDeviceOwnerType</xsl:element>
+                        <xsl:element name="PropertyPath">managementCertificateExpirationDate</xsl:element>
+                        <xsl:element name="PropertyPath">meid</xsl:element>
+                        <xsl:element name="PropertyPath">notes</xsl:element>
+                        <xsl:element name="PropertyPath">partnerReportedThreatState</xsl:element>
+                        <xsl:element name="PropertyPath">physicalMemoryInBytes</xsl:element>
+                        <xsl:element name="PropertyPath">remoteAssistanceSessionErrorDetails</xsl:element>
+                        <xsl:element name="PropertyPath">remoteAssistanceSessionUrl</xsl:element>
+                        <xsl:element name="PropertyPath">requireUserEnrollmentApproval</xsl:element>
+                        <xsl:element name="PropertyPath">subscriberCarrier</xsl:element>
+                        <xsl:element name="PropertyPath">totalStorageSpaceInBytes</xsl:element>
+                        <xsl:element name="PropertyPath">udid</xsl:element>
+                        <xsl:element name="PropertyPath">userDisplayName</xsl:element>
+                        <xsl:element name="PropertyPath">userId</xsl:element>
+                        <xsl:element name="PropertyPath">wiFiMacAddress</xsl:element>
+                    </xsl:element>
+                </xsl:element>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
     <xsl:template name="ExpandRestrictionsTemplate">
         <xsl:param name = "expandable" />
             <xsl:attribute name="Term">Org.OData.Capabilities.V1.ExpandRestrictions</xsl:attribute>
@@ -1788,6 +1839,16 @@
                        <xsl:call-template name="FilterRestrictionsTemplate">
                            <xsl:with-param name="filterable">false</xsl:with-param>
                        </xsl:call-template>
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
+
+            <!-- Add FilterRestrictions to managedDevice entity type -->
+            <xsl:choose>
+                <xsl:when test="not(edm:Annotations[@Target='microsoft.graph.managedDevice'])">
+                    <xsl:element name="Annotations">
+                       <xsl:attribute name="Target">microsoft.graph.managedDevice</xsl:attribute>
+                       <xsl:call-template name="ManagedDeviceFilterRestrictionsTemplate"/>
                     </xsl:element>
                 </xsl:when>
             </xsl:choose>
@@ -2182,6 +2243,14 @@
              <xsl:call-template name="FilterRestrictionsTemplate">
                <xsl:with-param name="filterable">false</xsl:with-param>
              </xsl:call-template>
+       </xsl:copy>
+    </xsl:template>
+
+    <!-- Add FilterRestrictions to managedDevice entity type -->
+     <xsl:template match="edm:Schema[@Namespace='microsoft.graph']/edm:Annotations[@Target='microsoft.graph.managedDevice']">
+       <xsl:copy>
+         <xsl:copy-of select="@*|node()"/>
+         <xsl:call-template name="ManagedDeviceFilterRestrictionsTemplate"/>
        </xsl:copy>
     </xsl:template>
 

--- a/transforms/csdl/preprocess_csdl.xsl
+++ b/transforms/csdl/preprocess_csdl.xsl
@@ -1428,6 +1428,7 @@
                         <xsl:element name="PropertyPath">exchangeLastSuccessfulSyncDateTime</xsl:element>
                         <xsl:element name="PropertyPath">freeStorageSpaceInBytes</xsl:element>
                         <xsl:element name="PropertyPath">iccid</xsl:element>
+                        <xsl:element name="PropertyPath">id</xsl:element>
                         <xsl:element name="PropertyPath">isEncrypted</xsl:element>
                         <xsl:element name="PropertyPath">isSupervised</xsl:element>
                         <xsl:element name="PropertyPath">managedDeviceName</xsl:element>

--- a/transforms/csdl/preprocess_csdl_test_input.xml
+++ b/transforms/csdl/preprocess_csdl_test_input.xml
@@ -276,6 +276,9 @@
                     </Record>
                 </Annotation>
             </Annotations>
+            <Annotations Target="microsoft.graph.managedDevice">
+                <Annotation Term="Org.OData.Core.V1.Description" String="Devices that are managed or pre-enrolled through Intune. Limited support for $filter: Only properties whose descriptions mention support for $filter may be used, and combinations of those filtered properties must use 'and', not 'or'." />
+            </Annotations>
             <Annotations Target="microsoft.graph.managedDevice/users">
                 <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
                     <Record>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -934,6 +934,53 @@
           </Record>
         </Annotation>
       </Annotations>
+      <Annotations Target="microsoft.graph.managedDevice">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Devices that are managed or pre-enrolled through Intune. Limited support for $filter: Only properties whose descriptions mention support for $filter may be used, and combinations of those filtered properties must use 'and', not 'or'." />
+        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+          <Record>
+            <PropertyValue Property="Filterable" Bool="true" />
+            <PropertyValue Property="NonFilterableProperties">
+              <Collection>
+                <PropertyPath>activationLockBypassCode</PropertyPath>
+                <PropertyPath>androidSecurityPatchLevel</PropertyPath>
+                <PropertyPath>azureADRegistered</PropertyPath>
+                <PropertyPath>configurationManagerClientEnabledFeatures</PropertyPath>
+                <PropertyPath>deviceActionResults</PropertyPath>
+                <PropertyPath>deviceEnrollmentType</PropertyPath>
+                <PropertyPath>deviceHealthAttestationState</PropertyPath>
+                <PropertyPath>deviceRegistrationState</PropertyPath>
+                <PropertyPath>easActivated</PropertyPath>
+                <PropertyPath>easActivationDateTime</PropertyPath>
+                <PropertyPath>easDeviceId</PropertyPath>
+                <PropertyPath>enrollmentProfileName</PropertyPath>
+                <PropertyPath>ethernetMacAddress</PropertyPath>
+                <PropertyPath>exchangeAccessStateReason</PropertyPath>
+                <PropertyPath>exchangeLastSuccessfulSyncDateTime</PropertyPath>
+                <PropertyPath>freeStorageSpaceInBytes</PropertyPath>
+                <PropertyPath>iccid</PropertyPath>
+                <PropertyPath>isEncrypted</PropertyPath>
+                <PropertyPath>isSupervised</PropertyPath>
+                <PropertyPath>managedDeviceName</PropertyPath>
+                <PropertyPath>managedDeviceOwnerType</PropertyPath>
+                <PropertyPath>managementCertificateExpirationDate</PropertyPath>
+                <PropertyPath>meid</PropertyPath>
+                <PropertyPath>notes</PropertyPath>
+                <PropertyPath>partnerReportedThreatState</PropertyPath>
+                <PropertyPath>physicalMemoryInBytes</PropertyPath>
+                <PropertyPath>remoteAssistanceSessionErrorDetails</PropertyPath>
+                <PropertyPath>remoteAssistanceSessionUrl</PropertyPath>
+                <PropertyPath>requireUserEnrollmentApproval</PropertyPath>
+                <PropertyPath>subscriberCarrier</PropertyPath>
+                <PropertyPath>totalStorageSpaceInBytes</PropertyPath>
+                <PropertyPath>udid</PropertyPath>
+                <PropertyPath>userDisplayName</PropertyPath>
+                <PropertyPath>userId</PropertyPath>
+                <PropertyPath>wiFiMacAddress</PropertyPath>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
       <Annotations Target="microsoft.graph.managedDevice/users">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
           <Record>

--- a/transforms/csdl/preprocess_csdl_test_output.xml
+++ b/transforms/csdl/preprocess_csdl_test_output.xml
@@ -958,6 +958,7 @@
                 <PropertyPath>exchangeLastSuccessfulSyncDateTime</PropertyPath>
                 <PropertyPath>freeStorageSpaceInBytes</PropertyPath>
                 <PropertyPath>iccid</PropertyPath>
+                <PropertyPath>id</PropertyPath>
                 <PropertyPath>isEncrypted</PropertyPath>
                 <PropertyPath>isSupervised</PropertyPath>
                 <PropertyPath>managedDeviceName</PropertyPath>


### PR DESCRIPTION
Fixes #1193

`microsoft.graph.managedDevice` carries a description saying that `$filter` is only supported on some of its properties, but it has no `FilterRestrictions` annotation. With the annotation missing, `Filterable` defaults to true and the metadata tells every generated client that the whole collection can be filtered.

This adds the annotation, following the same approach as #227 for `directorySetting`.

### What the change does

`transforms/csdl/preprocess_csdl.xsl` gets a new named template `ManagedDeviceFilterRestrictionsTemplate` that emits `Filterable` true plus a `NonFilterableProperties` collection, and two call sites mirroring the `directorySetting` ones. One handles the case where `Annotations Target="microsoft.graph.managedDevice"` already exists, which is what happens in both v1.0 and beta today, and the other creates the element if it is ever absent.

I did not reuse the existing `FilterRestrictionsTemplate` because it only emits the `Filterable` flag and there is no way to pass it a property list.

### How the property list was built

I took the list from the metadata itself rather than from the API docs. A property counts as filterable if its own `Core.V1.Description` mentions `$filter`, which is exactly the rule the entity description states.

v1.0 has 56 properties, 20 of them filterable. Beta has 83 properties, 22 filterable, the two extra ones being `deviceType` and `ownerType`. The 36 properties listed in `NonFilterableProperties` are the ones that are not filterable in either version, so the same annotation is correct for v1.0 and beta. `deviceType` and `ownerType` are deliberately left out for that reason.

`id` is one of the 36. `managedDevice` doesn't declare its own `id`, it inherits it from `microsoft.graph.entity`, but that's not a reason to leave it out: `microsoft.graph.security.intelligenceProfile`, also `BaseType="graph.entity"`, already lists its inherited `id` in `NonFilterableProperties` in this same schema file. The OData spec only restricts `RequiredProperties` to a type's own properties; `NonFilterableProperties` has no such restriction. And the service backs this up directly: `$filter=id eq '<value>'` against `managedDevice` returns HTTP 400 "Unsupported parameter found in query", which is the same failure this issue is about.

For reference, the 20 properties documented as filterable in v1.0 are `azureADDeviceId`, `complianceGracePeriodExpirationDateTime`, `complianceState`, `deviceCategoryDisplayName`, `deviceName`, `emailAddress`, `enrolledDateTime`, `exchangeAccessState`, `imei`, `jailBroken`, `lastSyncDateTime`, `managementAgent`, `managementState`, `manufacturer`, `model`, `operatingSystem`, `osVersion`, `phoneNumber`, `serialNumber` and `userPrincipalName`.

### Testing

I added a type level `Annotations` element for `managedDevice` to `preprocess_csdl_test_input.xml` so the test exercises the same path that runs against the real schema, then regenerated `preprocess_csdl_test_output.xml` with `transform.ps1`. The output keeps the existing description and appends the new annotation with all 36 property paths. No other part of the output changed.

One note on the `directorySetting` template I copied from: it sets an attribute after copying child nodes, which XSLT ignores at that point. I left that out of the new template since `@*|node()` already copies the target attribute.

Happy to adjust the property list, or to redo this through `additions/main.tsp` instead if you would rather have new capability annotations go that route.

